### PR TITLE
Add input_number.shuffle & sort service

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ or to be supported, or well, for starters, to be a good idea.
   - [Service for `input_number`: Min value](#service-for-input_number-min-value)
   - [Service for `input_number`: Max value](#service-for-input_number-max-value)
   - [Service for `input_select`: Select random option](#service-for-input_select-select-random-option)
+  - [Service for `input_select`: Shuffle options](#service-for-input_select-shuffle-options)
+  - [Service for `input_select`: Sort options](#service-for-input_select-sort-options)
   - [Service for `number`: Decrease value](#service-for-number-decrease-value)
   - [Service for `number`: Increase value](#service-for-number-increase-value)
   - [Service for `number`: Min value](#service-for-number-min-value)
@@ -342,6 +344,22 @@ Call it using: [`input_select.random`](https://my.home-assistant.io/redirect/dev
 
 > This service select a random option from the list of options of a select entity.
 > Optionally this can be limited to a set of given options. _#shuffle_
+
+## Service for `input_select`: Shuffle options
+
+Call it using: [`input_select.shuffle`](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.shuffle)
+
+> Shuffles the list of selectable options for an `input_select` entity.
+> Note: This is not persistent and will be undone once reloaded or
+> Home Assistant restarts. _#31254_
+
+## Service for `input_select`: Sort options
+
+Call it using: [`input_select.sort`](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.sort)
+
+> Sorts the list of selectable options for an `input_select` entity.
+> Note: This is not persistent and will be undone once reloaded or
+> Home Assistant restarts. _#12345_
 
 ## Service for `number`: Decrease value
 

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -233,6 +233,26 @@ input_select_random:
       selector:
         object:
 
+input_select_shuffle:
+  name: Shuffle options 👻
+  description: >-
+    Shuffles the list of selectable options for an `input_select` entity.
+    This is not persistent and will be undone once reloaded or Home Assistant
+    restarts.
+  target:
+    entity:
+      domain: input_select
+
+input_select_sort:
+  name: Sort options 👻
+  description: >-
+    Sorts the list of selectable options for an `input_select` entity.
+    This is not persistent and will be undone once reloaded or Home Assistant
+    restarts.
+  target:
+    entity:
+      domain: input_select
+
 number_decrement:
   name: Decrease value 👻
   description: >-

--- a/custom_components/spook/services/input_select_shuffle.py
+++ b/custom_components/spook/services/input_select_shuffle.py
@@ -1,0 +1,33 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+from homeassistant.components.input_select import DOMAIN, InputSelect
+
+from . import AbstractSpookEntityComponentService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookEntityComponentService):
+    """Input select entity service, shuffling the positions.
+
+    These changes are not permanent, and will be lost when input select entities
+    are loaded/changed, or when Home Assistant is restarted.
+    """
+
+    domain = DOMAIN
+    service = "shuffle"
+
+    async def async_handle_service(
+        self,
+        entity: InputSelect,
+        _call: ServiceCall,
+    ) -> None:
+        """Handle the service call."""
+        # pylint: disable-next=protected-access
+        random.shuffle(entity._attr_options)  # noqa: SLF001
+        entity.async_write_ha_state()

--- a/custom_components/spook/services/input_select_sort.py
+++ b/custom_components/spook/services/input_select_sort.py
@@ -1,0 +1,32 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.input_select import DOMAIN, InputSelect
+
+from . import AbstractSpookEntityComponentService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookEntityComponentService):
+    """Input select entity service, sorting the positions.
+
+    These changes are not permanent, and will be lost when input select entities
+    are loaded/changed, or when Home Assistant is restarted.
+    """
+
+    domain = DOMAIN
+    service = "sort"
+
+    async def async_handle_service(
+        self,
+        entity: InputSelect,
+        _call: ServiceCall,
+    ) -> None:
+        """Handle the service call."""
+        # pylint: disable-next=protected-access
+        entity._attr_options.sort()  # noqa: SLF001
+        entity.async_write_ha_state()


### PR DESCRIPTION
Adds a couple of non-persistent service calls for `input_number`.

- `input_number.shuffle`
- `input_number.sort`
