### PR TITLE
Fix service description schema for number.increment & input_number.increment

### DIFF
--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -256,7 +256,7 @@ number_increment:
     Increase a number entity value by a certain amount.
   target:
     entity:
-      domain: input_number
+      domain: number
   fields:
     step:
       name: Amount
@@ -306,7 +306,7 @@ input_number_increment:
     Increase an input number entity value by a certain amount.
   target:
     entity:
-      domain: number
+      domain: input_number
   fields:
     step:
       name: Amount


### PR DESCRIPTION
Fixes a mixup in the service description schema, causing the selector to mix things up.

fixes #25 