### PR TITLE
Add services for enabling/disabling polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ or to be supported, or well, for starters, to be a good idea.
   - [Sensors](#sensors)
   - [Switches](#switches)
 - [Services](#services)
+
   - [Service: Import Blueprint](#service-import-blueprint)
   - [Service: Disable an integration](#service-disable-an-integration)
+  - [Service: Enable an integration](#service-enable-an-integration)
+  - [Service: Disable polling for updates](#service-disable-an-integration)
   - [Service: Enable an integration](#service-enable-an-integration)
   - [Service: Disable a device](#service-disable-a-device)
   - [Service: Enable a device](#service-enable-a-device)
@@ -67,8 +70,10 @@ or to be supported, or well, for starters, to be a good idea.
   - [Service: Remove repair issue](#service-remove-repair-issue)
   - [Service: Ignore all repair issues](#service-ignore-all-repair-issues)
   - [Service: Unignore all repair issues](#service-unignore-all-repair-issues)
+
   - [Service: Boo! 👻](#service-boo-)
   - [Service: Random fail](#service-random-fail)
+
 - [Entity services](#entity-services)
   - [Service for `input_number`: Decrease value](#service-for-input_number-decrease-value)
   - [Service for `input_number`: Increase value](#service-for-input_number-increase-value)
@@ -232,6 +237,21 @@ Call it using: [`homeassistant.hide_entity`](https://my.home-assistant.io/redire
 Call it using: [`homeassistant.unhide_entity`](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.unhide_entity)
 
 > Do the math... this service does the reverse of [`homeassistant.hide_entity`](#service-hide-an-entity). _#reveal_
+
+## Service: Disable polling for updates
+
+Call it using: [`homeassistant.disable_polling`](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_polling)
+
+> This service can be used to disable polling for updates on an integration
+> configuration entry (those you see on your integrations dashboard). _#stopit_
+
+## Service: Enable polling for updates
+
+Call it using: [`homeassistant.enable_polling`](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_polling)
+
+> This service can be used to enable polling for updates on an integration
+> configuration entry (those you see on your integrations dashboard).
+> This service does the reverse of [`homeassistant.disable_polling`](#service-disable-polling) > _#poking_
 
 ## Service: Ignore all discovered devices & services
 

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -135,6 +135,30 @@ homeassistant_ignore_all_discovered:
       selector:
         text:
 
+homeassistant_disable_polling:
+  name: Disable polling for updates 👻
+  description: >-
+    Disables polling for updates for an integration configuration entry.
+  fields:
+    config_entry_id:
+      name: Config entry
+      description: The integration configuration entry to disable polling for.
+      required: true
+      selector:
+        config_entry:
+
+homeassistant_enable_polling:
+  name: Enable polling for updates 👻
+  description: >-
+    Enables polling for updates for an integration configuration entry.
+  fields:
+    config_entry_id:
+      name: Config entry
+      description: The integration configuration entry to enable polling for.
+      required: true
+      selector:
+        config_entry:
+
 homeassistant_remove_all_orphaned_entities:
   name: Remove all orphaned entities 👻
   description: >-

--- a/custom_components/spook/services/homeassistant_disable_polling.py
+++ b/custom_components/spook/services/homeassistant_disable_polling.py
@@ -1,0 +1,37 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+
+from . import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant Core integration service to disable polling."""
+
+    domain = DOMAIN
+    service = "disable_polling"
+    schema = {vol.Required("config_entry_id"): cv.string}
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        if not (
+            entry := self.hass.config_entries.async_get_entry(
+                call.data["config_entry_id"],
+            )
+        ):
+            msg = f"Config entry not found: {call.data['config_entry_id']}"
+            raise HomeAssistantError(msg)
+
+        self.hass.config_entries.async_update_entry(
+            entry,
+            pref_disable_polling=True,
+        )

--- a/custom_components/spook/services/homeassistant_enable_polling.py
+++ b/custom_components/spook/services/homeassistant_enable_polling.py
@@ -1,0 +1,37 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+
+from . import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant Core integration service to enable polling."""
+
+    domain = DOMAIN
+    service = "enable_polling"
+    schema = {vol.Required("config_entry_id"): cv.string}
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        if not (
+            entry := self.hass.config_entries.async_get_entry(
+                call.data["config_entry_id"],
+            )
+        ):
+            msg = f"Config entry not found: {call.data['config_entry_id']}"
+            raise HomeAssistantError(msg)
+
+        self.hass.config_entries.async_update_entry(
+            entry,
+            pref_disable_polling=False,
+        )


### PR DESCRIPTION
Adds two new services:

- `homeassistant.disable_polling`
- `homeassistant.enable_polling`

Was suggested in #42 