### PR TITLE
Add repair: Find missing source in integration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,12 @@ about these things using an Home Assistant repair issue. _#whoyougonnacall_
 
 Currently Spook will detect the following issues:
 
+## Obsolete integration YAML configuration
+
+> Finds YAML configuration for an integrations that no longer support it.
+> Unless you like having unneeded shizzle in your YAML, it can be removed
+> safely. _#ghostbusters_
+
 ## Automations: Find use of non-existing areas, devices and entities
 
 > Finds automations that use non-existing areas, devices or entities in, for
@@ -443,11 +449,11 @@ postives remain, and it has been extended to catch more situations._
 
 _Intention to contribute back to Home Assistant Core._
 
-## Obsolete integration YAML configuration
+## Riemann sum integral: Detect missing source sensor
 
-> Finds YAML configuration for an integrations that no longer support it.
-> Unless you like having unneeded shizzle in your YAML, it can be removed
-> safely. _#ghostbusters_
+> Finds integrals that are missing a source sensor. _#missinglink_
+
+_Intention to contribute back to Home Assistant Core._
 
 ## Scripts: Find use of non-existing areas, devices and entities
 

--- a/custom_components/spook/repairs/integration_unknown_source.py
+++ b/custom_components/spook/repairs/integration_unknown_source.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components import sensor
-from homeassistant.components.integration.const import DOMAIN
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
@@ -19,7 +18,7 @@ if TYPE_CHECKING:
 class SpookRepair(AbstractSpookRepair):
     """Spook repair tries to find unknown source entites for integration."""
 
-    domain = DOMAIN
+    domain = "integration"
     repair = "integration_unknown_source"
     events = {
         EVENT_COMPONENT_LOADED,

--- a/custom_components/spook/repairs/integration_unknown_source.py
+++ b/custom_components/spook/repairs/integration_unknown_source.py
@@ -1,0 +1,67 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import sensor
+from homeassistant.components.integration.const import DOMAIN
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
+
+from ..const import LOGGER
+from . import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from homeassistant.components.integration.sensor import IntegrationSensor
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair tries to find unknown source entites for integration."""
+
+    domain = DOMAIN
+    repair = "integration_unknown_source"
+    events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+        "event_integration_reloaded",
+    }
+
+    async def async_inspect(self) -> None:
+        """Trigger a inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        platforms: list[EntityPlatform] | None
+        if not (platforms := self.hass.data[DATA_ENTITY_PLATFORM].get(self.domain)):
+            return  # Nothing to do.
+
+        entity_ids = {
+            entity.entity_id for entity in self.entity_registry.entities.values()
+        }.union(self.hass.states.async_entity_ids())
+
+        for platform in platforms:
+            # We only care about the sensor domain
+            if platform.domain != sensor.DOMAIN:
+                continue
+
+            entity: IntegrationSensor
+            for entity in platform.entities.values():
+                # pylint: disable-next=protected-access
+                source = entity._sensor_source_id  # noqa: SLF001
+                if source not in entity_ids:
+                    self.async_create_issue(
+                        issue_id=entity.entity_id,
+                        translation_placeholders={
+                            "entity_id": entity.entity_id,
+                            "helper": entity.name,
+                            "source": source,
+                        },
+                    )
+                    LOGGER.debug(
+                        "Spook found unknown source entity %s in %s "
+                        "and created an issue for it",
+                        source,
+                        entity.entity_id,
+                    )
+                else:
+                    self.async_delete_issue(entity.entity_id)

--- a/custom_components/spook/repairs/integration_unknown_source.py
+++ b/custom_components/spook/repairs/integration_unknown_source.py
@@ -1,8 +1,6 @@
 """Spook - Not your homie."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from homeassistant.components import sensor
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
@@ -10,9 +8,6 @@ from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPl
 
 from ..const import LOGGER
 from . import AbstractSpookRepair
-
-if TYPE_CHECKING:
-    from homeassistant.components.integration.sensor import IntegrationSensor
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -43,7 +38,6 @@ class SpookRepair(AbstractSpookRepair):
             if platform.domain != sensor.DOMAIN:
                 continue
 
-            entity: IntegrationSensor
             for entity in platform.entities.values():
                 # pylint: disable-next=protected-access
                 source = entity._sensor_source_id  # noqa: SLF001

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -37,6 +37,10 @@
       "title": "Unknown group members in: {group}",
       "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Not your homie."
     },
+    "integration_unknown_source": {
+      "title": "Unknown source: {helper}",
+      "description": "Spook has found a ghost in your Riemann sum integral helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Not your homie."
+    },
     "obsolete_integration_yaml_config": {
       "title": "Obsolete YAML for: {domain}",
       "description": "Spook has found a ghost in your YAML configuration 👻\n\nWhile floating around, Spook came aroud YAML configuration for the `{domain}` integration, which is obsolete (as it is no longer configured via YAML) and thus should be removed/cleaned up. This issue will automatically disappear once your configuration has been adjusted and Home Assistant has been restarted.\n\nSpook 👻 Not your homie."


### PR DESCRIPTION
New detection that finds missing source entities in integration helpers

![image](https://user-images.githubusercontent.com/195327/224375761-285e7f58-139c-43e1-bf89-926b91bbed54.png)
