### PR TITLE
Rename remove all orphaned entities service to delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,17 +260,17 @@ Call it using: [`homeassistant.ignore_all_discovered`](https://my.home-assistant
 > Click ignore on all discovered items on the integration dashboard; optionally
 > only for specific integration (e.g., bluetooth). _#talktothehand_
 
-## Service: Remove all orphaned entities
+## Service: Delete all orphaned entities
 
-Call it using: [`homeassistant.remove_all_orphaned_entities`](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_all_orphaned_entities)
+Call it using: [`homeassistant.delete_all_orphaned_entities`](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_all_orphaned_entities)
 
-> Removes all orphaned entities that no longer have an integration that claim/provide
+> Deletes all orphaned entities that no longer have an integration that claim/provide
 > them. Please note, if the integration was just removed, it might need a restart
 > for Home Assistant to realize they are orphaned. _#annie_
 
 > **WARNING** Entities might have been marked orphaned because an
 > integration is offline or not working since Home Assistant started. Calling
-> this service will remove those entities as well.
+> this service will delete those entities as well.
 
 ## Service: Import statistics
 

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -190,16 +190,16 @@ homeassistant_enable_polling:
       selector:
         config_entry:
 
-homeassistant_remove_all_orphaned_entities:
-  name: Remove all orphaned entities 👻
+homeassistant_delete_all_orphaned_entities:
+  name: Delete all orphaned entities 👻
   description: >-
-    Removes all orphaned entities that no longer have an integration that
+    Deletes all orphaned entities that no longer have an integration that
     claim/provide them. Please note, if the integration was just removed,
     it might need a restart for Home Assistant to realize they are orphaned.
 
     **WARNING** Entities might have been marked orphaned because an
     integration is offline or not working since Home Assistant started. Calling
-    this service will remove those entities as well.
+    this service will delete those entities as well.
 
 recorder_import_statistics:
   name: Import statistics 👻

--- a/custom_components/spook/services/homeassistant_delete_all_orphaned_entities.py
+++ b/custom_components/spook/services/homeassistant_delete_all_orphaned_entities.py
@@ -14,10 +14,10 @@ if TYPE_CHECKING:
 
 
 class SpookService(AbstractSpookAdminService):
-    """Home Assistant Core integration service to remove all orphaned entities."""
+    """Home Assistant Core integration service to delete all orphaned entities."""
 
     domain = DOMAIN
-    service = "remove_all_orphaned_entities"
+    service = "delete_all_orphaned_entities"
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""


### PR DESCRIPTION
Renames the `homeassistant.remove_all_orphaned_entities` to `homeassistant.delete_all_orphaned_entities`.

Delete better reflects the destructive nature.