### PR TITLE
Ignore Templates when detecting unused entities

### DIFF
--- a/custom_components/spook/repairs/automation_unknown_entity_references.py
+++ b/custom_components/spook/repairs/automation_unknown_entity_references.py
@@ -96,7 +96,8 @@ class SpookRepair(AbstractSpookRepair):
                 entity_id
                 for entity_id in entity.referenced_entities
                 if (
-                    not entity_id.startswith(
+                    isinstance(entity_id, str)
+                    and not entity_id.startswith(
                         (
                             "device_tracker.",
                             "group.",

--- a/custom_components/spook/repairs/script_unknown_entity_references.py
+++ b/custom_components/spook/repairs/script_unknown_entity_references.py
@@ -97,7 +97,8 @@ class SpookRepair(AbstractSpookRepair):
                 entity_id
                 for entity_id in entity.script.referenced_entities
                 if (
-                    not entity_id.startswith(
+                    isinstance(entity_id, str)
+                    and not entity_id.startswith(
                         (
                             "device_tracker.",
                             "group.",


### PR DESCRIPTION
Fixes #17 for now.

The problem and solutions are somewhere else.
The question is: Where does this happen? Why are templates ending up here in the first place and why aren't the entities extracted from the template render in the first place?

For now, ignoring templates in Spook to at least aid with avoiding false positives.

