### PR TITLE
Small adjustment to CI & Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "schedule": ["before 2am"],
   "rebaseWhen": "behind-base-branch",
   "dependencyDashboard": true,
   "labels": ["dependencies", "no-stale"],

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,8 +3,13 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+  pull_request_target:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+  workflow_call:
 
 jobs:
   pr_labels:
@@ -14,6 +19,7 @@ jobs:
       - name: 🏷 Verify PR has a valid label
         uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:
+          pull-request-number: "${{ github.event.pull_request.number }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: >-
             breaking-change, bugfix, documentation, enhancement,


### PR DESCRIPTION
- Fixes an incorrect failure with PRs from forked repositories
- Let Renovate run on its own schedule