### PR TITLE
Use async_set_value function instead

### DIFF
--- a/custom_components/spook/services/input_number_decrement.py
+++ b/custom_components/spook/services/input_number_decrement.py
@@ -38,7 +38,7 @@ class SpookService(AbstractSpookEntityComponentService, ReplaceExistingService):
             )
             raise ValueError(msg)
 
-        await entity.set_value(
+        await entity.async_set_value(
             max(
                 entity._current_value + amount,  # noqa: SLF001
                 entity._minimum,  # noqa: SLF001

--- a/custom_components/spook/services/input_number_increment.py
+++ b/custom_components/spook/services/input_number_increment.py
@@ -38,7 +38,7 @@ class SpookService(AbstractSpookEntityComponentService, ReplaceExistingService):
             )
             raise ValueError(msg)
 
-        await entity.set_value(
+        await entity.async_set_value(
             min(
                 entity._current_value + amount,  # noqa: SLF001
                 entity._maximum,  # noqa: SLF001

--- a/custom_components/spook/services/input_number_max.py
+++ b/custom_components/spook/services/input_number_max.py
@@ -20,4 +20,4 @@ class SpookService(AbstractSpookEntityComponentService):
     async def async_handle_service(self, entity: InputNumber, _: ServiceCall) -> None:
         """Handle the service call."""
         # pylint: disable-next=protected-access
-        await entity.set_value(entity._maximum)  # noqa: SLF001
+        await entity.async_set_value(entity._maximum)  # noqa: SLF001

--- a/custom_components/spook/services/input_number_min.py
+++ b/custom_components/spook/services/input_number_min.py
@@ -20,4 +20,4 @@ class SpookService(AbstractSpookEntityComponentService):
     async def async_handle_service(self, entity: InputNumber, _: ServiceCall) -> None:
         """Handle the service call."""
         # pylint: disable-next=protected-access
-        await entity.set_value(entity._minimum)  # noqa: SLF001
+        await entity.async_set_value(entity._minimum)  # noqa: SLF001

--- a/custom_components/spook/services/number_decrement.py
+++ b/custom_components/spook/services/number_decrement.py
@@ -37,4 +37,4 @@ class SpookService(AbstractSpookEntityComponentService):
         if entity.min_value is not None:
             value = max(value, entity.min_value)
 
-        await entity.set_native_value(value)
+        await entity.async_set_native_value(value)

--- a/custom_components/spook/services/number_increment.py
+++ b/custom_components/spook/services/number_increment.py
@@ -37,4 +37,4 @@ class SpookService(AbstractSpookEntityComponentService):
         if entity.max_value is not None:
             value = min(value, entity.max_value)
 
-        await entity.set_native_value(value)
+        await entity.async_set_native_value(value)


### PR DESCRIPTION
For me the `input_number` services does not work, throwing this error:

```
2023-03-26 20:28:54.837 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [2569077664] Error handling message: Unknown error (unknown_error) Simon from 192.168.0.169 (Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 26, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 647, in handle_execute_script
    await script_obj.async_run(msg.get("variables"), context=context)
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 1524, in async_run
    await asyncio.shield(run.async_run())
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 409, in async_run
    await self._async_step(log_exceptions=False)
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 453, in _async_step
    self._handle_exception(
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 476, in _handle_exception
    raise exception
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 451, in _async_step
    await getattr(self, handler)()
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 684, in _async_call_service_step
    await service_task
  File "/usr/src/homeassistant/homeassistant/core.py", line 1808, in async_call
    task.result()
  File "/usr/src/homeassistant/homeassistant/core.py", line 1845, in _execute_service
    await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 213, in handle_service
    await service.entity_service_call(
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 686, in entity_service_call
    future.result()  # pop exception if have
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 961, in async_request_call
    await coro
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 726, in _handle_entity_call
    await result
  File "/config/custom_components/spook/services/input_number_decrement.py", line 41, in async_handle_service
    await entity.set_value(
AttributeError: 'InputNumber' object has no attribute 'set_value'
```

It seems there the `set_value` function is async, and should be prefixed with `async_` https://github.com/home-assistant/core/blob/89355e087952417a6824507fd3b197f9d0520e19/homeassistant/components/input_number/__init__.py#L305

This is tested locally and it works for me.