### PR TITLE
Add aladdin_connect and scrape as known obsolete YAML

### DIFF
--- a/custom_components/spook/repairs/obsolete_platform_yaml_config.py
+++ b/custom_components/spook/repairs/obsolete_platform_yaml_config.py
@@ -16,6 +16,7 @@ class SpookRepair(AbstractSpookSingleShotRepairs):
     repair = "obsolete_platform_yaml_config"
 
     KNOWN_REMOVED_DOMAINS = {
+        "aladdin_connect",
         "cert_expiry",
         "dlink",
         "dsmr_reader",
@@ -27,6 +28,7 @@ class SpookRepair(AbstractSpookSingleShotRepairs):
         "mqtt",
         "pushbullet",
         "radiotherm",
+        "scrape",
         "season",
         "soundtouch",
         "tautulli",


### PR DESCRIPTION
`aladdin_connect` and `scrap` platforms are no longer configured via YAML.
Currently deprecated and fully removed in Home Assistant 2023.4
