### PR TITLE
Add repair: Find missing source switches for switch_as_x helpers

### DIFF
--- a/custom_components/spook/repairs/switch_as_x_unknown_source.py
+++ b/custom_components/spook/repairs/switch_as_x_unknown_source.py
@@ -1,0 +1,55 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
+
+from ..const import LOGGER
+from . import AbstractSpookRepair
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair tries to find unknown source entites for switch_as_x."""
+
+    domain = "switch_as_x"
+    repair = "switch_as_x_unknown_source"
+    events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+        "event_integration_reloaded",
+    }
+
+    async def async_inspect(self) -> None:
+        """Trigger a inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        platforms: list[EntityPlatform] | None
+        if not (platforms := self.hass.data[DATA_ENTITY_PLATFORM].get(self.domain)):
+            return  # Nothing to do, switch_as_x is not loaded
+
+        entity_ids = {
+            entity.entity_id for entity in self.entity_registry.entities.values()
+        }.union(self.hass.states.async_entity_ids())
+
+        for platform in platforms:
+            for entity in platform.entities.values():
+                # pylint: disable-next=protected-access
+                source = entity._switch_entity_id  # noqa: SLF001
+                if source not in entity_ids:
+                    self.async_create_issue(
+                        issue_id=entity.entity_id,
+                        translation_placeholders={
+                            "entity_id": entity.entity_id,
+                            "helper": entity.name,
+                            "source": source,
+                        },
+                    )
+                    LOGGER.debug(
+                        "Spook found unknown source entity %s in %s "
+                        "and created an issue for it",
+                        source,
+                        entity.entity_id,
+                    )
+                else:
+                    self.async_delete_issue(entity.entity_id)

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -60,6 +60,10 @@
     "script_unknown_entity_references": {
       "title": "Unknown entities used in: {script}",
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie."
+    },
+    "switch_as_x_unknown_source": {
+      "title": "Unknown source: {helper}",
+      "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Not your homie."
     }
   }
 }


### PR DESCRIPTION
Adds a new repair handler that detects switch as X helper entities that point to an switch that no longer exists.

![image](https://user-images.githubusercontent.com/195327/232131596-39d67b46-4e22-4d88-98f4-c044b09cbdea.png)
