### PR TITLE
Repairs: Ignore invalid entity IDs in all cases

### DIFF
--- a/custom_components/spook/repairs/automation_unknown_entity_references.py
+++ b/custom_components/spook/repairs/automation_unknown_entity_references.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     ENTITY_MATCH_NONE,
     EVENT_COMPONENT_LOADED,
 )
+from homeassistant.core import valid_entity_id
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
@@ -106,6 +107,7 @@ class SpookRepair(AbstractSpookRepair):
                         ),
                     )
                     and entity_id not in entity_ids
+                    and valid_entity_id(entity_id)
                 )
             }:
                 self.async_create_issue(

--- a/custom_components/spook/repairs/group_unknown_members.py
+++ b/custom_components/spook/repairs/group_unknown_members.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     ENTITY_MATCH_NONE,
     EVENT_COMPONENT_LOADED,
 )
+from homeassistant.core import valid_entity_id
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
@@ -83,6 +84,7 @@ class SpookRepair(AbstractSpookRepair):
                             ("device_tracker.", "group.", "scene."),
                         )
                         and entity_id not in entity_ids
+                        and valid_entity_id(entity_id)
                     )
                 }:
                     self.async_create_issue(

--- a/custom_components/spook/repairs/lovelace_unknown_entity_references.py
+++ b/custom_components/spook/repairs/lovelace_unknown_entity_references.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     ENTITY_MATCH_NONE,
     EVENT_COMPONENT_LOADED,
 )
-from homeassistant.core import callback
+from homeassistant.core import callback, valid_entity_id
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -117,6 +117,7 @@ class SpookRepair(AbstractSpookRepair):
                         ),
                     )
                     and entity_id not in entity_ids
+                    and valid_entity_id(entity_id)
                 )
             }:
                 title = "Overview"

--- a/custom_components/spook/repairs/script_unknown_entity_references.py
+++ b/custom_components/spook/repairs/script_unknown_entity_references.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     ENTITY_MATCH_NONE,
     EVENT_COMPONENT_LOADED,
 )
+from homeassistant.core import valid_entity_id
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
@@ -107,6 +108,7 @@ class SpookRepair(AbstractSpookRepair):
                         ),
                     )
                     and entity_id not in entity_ids
+                    and valid_entity_id(entity_id)
                 )
             }:
                 self.async_create_issue(


### PR DESCRIPTION
All repairs handling entity IDs now ignore entity IDs that have an invalid format.

This is suboptimal IMHO, but there are quite a bunch of "custom" weird use cases out there, I'm not going to support; as an example: Custom template format of a custom button card. Just ignore it.

fixes #71

