### PR TITLE
Add entity name translations to all entities

### DIFF
--- a/custom_components/spook/ectoplasms/cloud/switch.py
+++ b/custom_components/spook/ectoplasms/cloud/switch.py
@@ -58,8 +58,8 @@ SWITCHES: tuple[HomeAssistantCloudSpookSwitchEntityDescription, ...] = (
     ),
     HomeAssistantCloudSpookSwitchEntityDescription(
         key="alexa_report_state",
+        translation_key="cloud_alexa_report_state",
         entity_id="switch.cloud_alexa_report_state",
-        name="Alexa state reporting",
         icon="mdi:account-voice",
         entity_category=EntityCategory.CONFIG,
         is_on_fn=lambda cloud: cloud.client.prefs.alexa_report_state,
@@ -80,8 +80,8 @@ SWITCHES: tuple[HomeAssistantCloudSpookSwitchEntityDescription, ...] = (
     ),
     HomeAssistantCloudSpookSwitchEntityDescription(
         key="google_report_state",
+        translation_key="cloud_google_report_state",
         entity_id="switch.cloud_google_report_state",
-        name="Google Assistant state reporting",
         icon="mdi:google-assistant",
         entity_category=EntityCategory.CONFIG,
         is_on_fn=lambda cloud: cloud.client.prefs.google_report_state,
@@ -91,8 +91,8 @@ SWITCHES: tuple[HomeAssistantCloudSpookSwitchEntityDescription, ...] = (
     ),
     HomeAssistantCloudSpookSwitchEntityDescription(
         key="remote",
+        translation_key="cloud_remote",
         entity_id="switch.cloud_remote",
-        name="Remote",
         icon="mdi:remote-desktop",
         entity_category=EntityCategory.CONFIG,
         is_on_fn=lambda cloud: cloud.client.prefs.remote_enabled,

--- a/custom_components/spook/ectoplasms/homeassistant/sensor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/sensor.py
@@ -70,8 +70,8 @@ class HomeAssistantSpookSensorEntityDescription(
 SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.AIR_QUALITY,
+        translation_key="homeassistant_air_quality",
         entity_id="sensor.air_quality",
-        name="Air Quality",
         icon="mdi:air-filter",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -80,8 +80,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.ALARM_CONTROL_PANEL,
+        translation_key="homeassistant_alarm_control_panel",
         entity_id="sensor.alarm_control_panels",
-        name="Alarm control panels",
         icon="mdi:alarm-panel",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -92,8 +92,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key="area",
+        translation_key="homeassistant_area",
         entity_id="sensor.areas",
-        name="Areas",
         icon="mdi:texture-box",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -102,8 +102,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=automation.DOMAIN,
+        translation_key="homeassistant_automation",
         entity_id="sensor.automations",
-        name="Automations",
         icon="mdi:robot",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -112,8 +112,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.BINARY_SENSOR,
+        translation_key="homeassistant_binary_sensor",
         entity_id="sensor.binary_sensors",
-        name="Binary sensors",
         icon="mdi:numeric-10",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -122,8 +122,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.BUTTON,
+        translation_key="homeassistant_button",
         entity_id="sensor.buttons",
-        name="Buttons",
         icon="mdi:gesture-tap",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -132,8 +132,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.CALENDAR,
+        translation_key="homeassistant_calendar",
         entity_id="sensor.calendars",
-        name="Calendars",
         icon="mdi:calendar",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -142,8 +142,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.CAMERA,
+        translation_key="homeassistant_camera",
         entity_id="sensor.cameras",
-        name="Cameras",
         icon="mdi:cctv",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -152,8 +152,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.CLIMATE,
+        translation_key="homeassistant_climate",
         entity_id="sensor.climate",
-        name="Climate",
         icon="mdi:thermostat",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -162,8 +162,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.COVER,
+        translation_key="homeassistant_cover",
         entity_id="sensor.covers",
-        name="Covers",
         icon="mdi:blinds",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -172,8 +172,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.DATE,
+        translation_key="homeassistant_date",
         entity_id="sensor.dates",
-        name="Dates",
         icon="mdi:calendar-month-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -182,8 +182,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.DATETIME,
+        translation_key="homeassistant_datetime",
         entity_id="sensor.datetimes",
-        name="Date/Times",
         icon="mdi:calendar-clock",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -192,8 +192,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key="device",
+        translation_key="homeassistant_device",
         entity_id="sensor.devices",
-        name="Devices",
         icon="mdi:cellphone",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -202,8 +202,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.DEVICE_TRACKER,
+        translation_key="homeassistant_device_tracker",
         entity_id="sensor.device_trackers",
-        name="Device trackers",
         icon="mdi:cellphone-marker",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -214,8 +214,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key="entities",
+        translation_key="homeassistant_entities",
         entity_id="sensor.entities",
-        name="Entities",
         icon="mdi:counter",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -224,8 +224,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.FAN,
+        translation_key="homeassistant_fan",
         entity_id="sensor.fans",
-        name="Fans",
         icon="mdi:fan",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -234,8 +234,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.HUMIDIFIER,
+        translation_key="homeassistant_humidifier",
         entity_id="sensor.humidifiers",
-        name="Humidifiers",
         icon="mdi:air-humidifier",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -244,8 +244,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key="integration",
+        translation_key="homeassistant_integration",
         entity_id="sensor.integrations",
-        name="Integrations",
         icon="mdi:package-variant-closed",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -254,8 +254,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key="custom_component",
+        translation_key="homeassistant_custom_component",
         entity_id="sensor.custom_integrations",
-        name="Custom integrations",
         icon="mdi:package-variant-closed",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -264,8 +264,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=input_boolean.DOMAIN,
+        translation_key="homeassistant_input_boolean",
         entity_id="sensor.input_booleans",
-        name="Input booleans",
         icon="mdi:toggle-switch-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -274,8 +274,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=input_button.DOMAIN,
+        translation_key="homeassistant_input_button",
         entity_id="sensor.input_buttons",
-        name="Input buttons",
         icon="mdi:gesture-tap-button",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -284,8 +284,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=input_datetime.DOMAIN,
+        translation_key="homeassistant_input_datetime",
         entity_id="sensor.input_datetimes",
-        name="Input date/times",
         icon="mdi:clock",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -294,8 +294,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=input_number.DOMAIN,
+        translation_key="homeassistant_input_number",
         entity_id="sensor.input_numbers",
-        name="Input numbers",
         icon="mdi:ray-vertex",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -304,8 +304,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=input_select.DOMAIN,
+        translation_key="homeassistant_input_select",
         entity_id="sensor.input_selects",
-        name="Input selects",
         icon="mdi:form-dropdown",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -314,8 +314,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=input_text.DOMAIN,
+        translation_key="homeassistant_input_text",
         entity_id="sensor.input_texts",
-        name="Input texts",
         icon="mdi:form-textbox",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -324,8 +324,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.LIGHT,
+        translation_key="homeassistant_light",
         entity_id="sensor.lights",
-        name="Lights",
         icon="mdi:lightbulb",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -334,8 +334,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.LOCK,
+        translation_key="homeassistant_lock",
         entity_id="sensor.locks",
-        name="Locks",
         icon="mdi:lock",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -344,8 +344,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.MEDIA_PLAYER,
+        translation_key="homeassistant_media_player",
         entity_id="sensor.media_players",
-        name="Media players",
         icon="mdi:record-player",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -354,8 +354,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.NUMBER,
+        translation_key="homeassistant_number",
         entity_id="sensor.numbers",
-        name="Numbers",
         icon="mdi:ray-vertex",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -364,8 +364,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=person.DOMAIN,
+        translation_key="homeassistant_person",
         entity_id="sensor.persons",
-        name="Persons",
         icon="mdi:account-group",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -374,8 +374,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.REMOTE,
+        translation_key="homeassistant_remote",
         entity_id="sensor.remotes",
-        name="Remotes",
         icon="mdi:remote",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -384,8 +384,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.SCENE,
+        translation_key="homeassistant_scene",
         entity_id="sensor.scenes",
-        name="Scenes",
         icon="mdi:palette",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -394,8 +394,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=script.DOMAIN,
+        translation_key="homeassistant_script",
         entity_id="sensor.scripts",
-        name="Scripts",
         icon="mdi:script-text",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -404,8 +404,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.SELECT,
+        translation_key="homeassistant_select",
         entity_id="sensor.selects",
-        name="Selects",
         icon="mdi:format-list-bulleted",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -414,8 +414,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.SENSOR,
+        translation_key="homeassistant_sensor",
         entity_id="sensor.sensors",
-        name="Sensors",
         icon="mdi:eye",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -424,8 +424,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.SIREN,
+        translation_key="homeassistant_siren",
         entity_id="sensor.sirens",
-        name="Sirens",
         icon="mdi:bullhorn",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -434,8 +434,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=sun.DOMAIN,
+        translation_key="homeassistant_sun",
         entity_id="sensor.suns",
-        name="Suns",
         icon="mdi:emoticon-cool",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -444,8 +444,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.STT,
+        translation_key="homeassistant_stt",
         entity_id="sensor.stt",
-        name="Speech-to-text",
         icon="mdi:microphone-message",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -454,8 +454,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.SWITCH,
+        translation_key="homeassistant_switch",
         entity_id="sensor.switches",
-        name="Switches",
         icon="mdi:toggle-switch",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -464,8 +464,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.TEXT,
+        translation_key="homeassistant_text",
         entity_id="sensor.texts",
-        name="Texts",
         icon="mdi:form-textbox",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -474,8 +474,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.TIME,
+        translation_key="homeassistant_time",
         entity_id="sensor.times",
-        name="Times",
         icon="mdi:clock-time-eight-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -484,8 +484,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.TTS,
+        translation_key="homeassistant_tts",
         entity_id="sensor.tts",
-        name="Text-to-speech",
         icon="mdi:speaker-message",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -494,8 +494,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.VACUUM,
+        translation_key="homeassistant_vacuum",
         entity_id="sensor.vacuums",
-        name="Vacuums",
         icon="mdi:vacuum",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -504,8 +504,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.UPDATE,
+        translation_key="homeassistant_update",
         entity_id="sensor.update",
-        name="Update",
         icon="mdi:cellphone-arrow-down",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -514,8 +514,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.WATER_HEATER,
+        translation_key="homeassistant_water_heater",
         entity_id="sensor.water_heaters",
-        name="Water heaters",
         icon="mdi:water-boiler",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -524,8 +524,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.WEATHER,
+        translation_key="homeassistant_weather",
         entity_id="sensor.weather",
-        name="Weather",
         icon="mdi:weather-cloudy",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
@@ -534,8 +534,8 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=zone.DOMAIN,
+        translation_key="homeassistant_zone",
         entity_id="sensor.zones",
-        name="Zones",
         icon="mdi:selection-marker",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,

--- a/custom_components/spook/translations/de.json
+++ b/custom_components/spook/translations/de.json
@@ -9,42 +9,198 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "custom_component": {
+        "name": "Custom Integrationen"
+      },
+      "homeassistant_air_quality": {
+        "name": "Luftqualität"
+      },
+      "homeassistant_alarm_control_panel": {
+        "name": "Alarmbedienfelder"
+      },
+      "homeassistant_area": {
+        "name": "Bereiche"
+      },
+      "homeassistant_automation": {
+        "name": "Automatisierungen"
+      },
+      "homeassistant_binary_sensor": {
+        "name": "Binäre Sensoren"
+      },
+      "homeassistant_button": {
+        "name": "Tasten"
+      },
+      "homeassistant_calendar": {
+        "name": "Kalender"
+      },
+      "homeassistant_camera": {
+        "name": "Kameras"
+      },
+      "homeassistant_climate": {
+        "name": "Klima"
+      },
+      "homeassistant_cover": {
+        "name": "Abdeckungen"
+      },
+      "homeassistant_date": {
+        "name": "Daten"
+      },
+      "homeassistant_datetime": {
+        "name": "Datum/Zeit"
+      },
+      "homeassistant_device": {
+        "name": "Geräte"
+      },
+      "homeassistant_device_tracker": {
+        "name": "Geräte-Tracker"
+      },
+      "homeassistant_entities": {
+        "name": "Entitäten"
+      },
+      "homeassistant_fan": {
+        "name": "Ventilatoren"
+      },
+      "homeassistant_humidifier": {
+        "name": "Luftbefeuchter"
+      },
+      "homeassistant_input_boolean": {
+        "name": "Eingabe-Booleans"
+      },
+      "homeassistant_input_button": {
+        "name": "Eingabe-Tasten"
+      },
+      "homeassistant_input_datetime": {
+        "name": "Eingabe-Datum/Zeit"
+      },
+      "homeassistant_input_number": {
+        "name": "Eingabe-Nummern"
+      },
+      "homeassistant_input_select": {
+        "name": "Eingabe-Auswahlen"
+      },
+      "homeassistant_input_text": {
+        "name": "Eingabe-Texte"
+      },
+      "homeassistant_integration": {
+        "name": "Integrationen"
+      },
+      "homeassistant_light": {
+        "name": "Lichter"
+      },
+      "homeassistant_lock": {
+        "name": "Schlösser"
+      },
+      "homeassistant_media_player": {
+        "name": "Mediaplayer"
+      },
+      "homeassistant_number": {
+        "name": "Nummern"
+      },
+      "homeassistant_person": {
+        "name": "Personen"
+      },
+      "homeassistant_remote": {
+        "name": "Fernbedienung"
+      },
+      "homeassistant_scene": {
+        "name": "Szenen"
+      },
+      "homeassistant_script": {
+        "name": "Skripte"
+      },
+      "homeassistant_select": {
+        "name": "Auswahlen"
+      },
+      "homeassistant_sensor": {
+        "name": "Sensoren"
+      },
+      "homeassistant_siren": {
+        "name": "Sirenen"
+      },
+      "homeassistant_stt": {
+        "name": "Sprache-zu-Text"
+      },
+      "homeassistant_sun": {
+        "name": "Sonnen"
+      },
+      "homeassistant_switch": {
+        "name": "Schalter"
+      },
+      "homeassistant_text": {
+        "name": "Texte"
+      },
+      "homeassistant_time": {
+        "name": "Zeiten"
+      },
+      "homeassistant_tts": {
+        "name": "Text-zu-Sprache"
+      },
+      "homeassistant_update": {
+        "name": "Aktualisierung"
+      },
+      "homeassistant_vacuum": {
+        "name": "Staubsauger"
+      },
+      "homeassistant_water_heater": {
+        "name": "Wasserheizungen"
+      },
+      "homeassistant_weather": {
+        "name": "Wetter"
+      },
+      "homeassistant_zone": {
+        "name": "Zonen"
+      }
+    },
+    "switch": {
+      "cloud_alexa_report_state": {
+        "name": "Alexa-Zustandsbericht"
+      },
+      "cloud_google_report_state": {
+        "name": "Google Assistant-Zustandsbericht"
+      },
+      "cloud_remote": {
+        "name": "Fernbedienung"
+      }
+    }
+  },
   "issues": {
     "automation_unknown_area_references": {
-      "title": "Unbekannte Bereiche verwendet in: {automation}",
-      "description": "Spook hat einen Geist in deinen Automatisierungen gefunden 👻\n\nBeim Herumschweben begegnete Spook der folgenden Automatisierung:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDiese Automatisierung bezieht sich auf die folgenden Bereiche, die Home Assistant unbekannt sind:\n\n{areas}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite die Automatisierung]({edit}) und entferne die Verwendung dieser nicht existierenden Bereiche.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinen Automatisierungen gefunden 👻\n\nBeim Herumschweben begegnete Spook der folgenden Automatisierung:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDiese Automatisierung bezieht sich auf die folgenden Bereiche, die Home Assistant unbekannt sind:\n\n{areas}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite die Automatisierung]({edit}) und entferne die Verwendung dieser nicht existierenden Bereiche.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Bereiche verwendet in: {automation}"
     },
     "automation_unknown_device_references": {
-      "title": "Unbekannte Geräte verwendet in: {automation}",
-      "description": "Spook hat einen Geist in deinen Automatisierungen gefunden 👻\n\nBeim Herumschweben begegnete Spook der folgenden Automatisierung:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDiese Automatisierung bezieht sich auf die folgenden Geräte, die Home Assistant unbekannt sind:\n\n{devices}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite die Automatisierung]({edit}) und entferne die Verwendung dieser nicht existierenden Geräte.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinen Automatisierungen gefunden 👻\n\nBeim Herumschweben begegnete Spook der folgenden Automatisierung:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDiese Automatisierung bezieht sich auf die folgenden Geräte, die Home Assistant unbekannt sind:\n\n{devices}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite die Automatisierung]({edit}) und entferne die Verwendung dieser nicht existierenden Geräte.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Geräte verwendet in: {automation}"
     },
     "automation_unknown_entity_references": {
-      "title": "Unbekannte Entitäten verwendet in: {automation}",
-      "description": "Spook hat einen Geist in deinen Automatisierungen gefunden 👻\n\nBeim Herumschweben begegnete Spook der folgenden Automatisierung:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDiese Automatisierung bezieht sich auf die folgenden Entitäten, die Home Assistant unbekannt sind:\n\n{entities}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite die Automatisierung]({edit}) und entferne die Verwendung dieser nicht existierenden Entitäten.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinen Automatisierungen gefunden 👻\n\nBeim Herumschweben begegnete Spook der folgenden Automatisierung:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDiese Automatisierung bezieht sich auf die folgenden Entitäten, die Home Assistant unbekannt sind:\n\n{entities}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite die Automatisierung]({edit}) und entferne die Verwendung dieser nicht existierenden Entitäten.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Entitäten verwendet in: {automation}"
     },
     "group_unknown_members": {
-      "title": "Unbekannte Gruppenmitglieder in: {group}",
-      "description": "Spook hat einen Geist in deinen Gruppen gefunden 👻\n\nBeim Herumschweben begegnete Spook der folgenden Gruppe:\n\n{group} (`{entity_id}`)\n\nDiese Gruppe hat Mitglieder, die Home Assistant unbekannt sind:\n\n{entities}\n\n\n\nUm diesen Fehler zu beheben, bearbeite die Gruppe, entferne die Verwendung dieser nicht existierenden Entitäten und starte Home Assistant neu.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinen Gruppen gefunden 👻\n\nBeim Herumschweben begegnete Spook der folgenden Gruppe:\n\n{group} (`{entity_id}`)\n\nDiese Gruppe hat Mitglieder, die Home Assistant unbekannt sind:\n\n{entities}\n\n\n\nUm diesen Fehler zu beheben, bearbeite die Gruppe, entferne die Verwendung dieser nicht existierenden Entitäten und starte Home Assistant neu.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Gruppenmitglieder in: {group}"
     },
     "integration_unknown_source": {
-      "title": "Unbekannte Quelle: {helper}",
-      "description": "Spook hat einen Geist in deinem Helfer Riemann Summenintegralsensor gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Helfer:\n\n{helper} (`{entity_id}`)\n\nDieser Helfer hat eine Quell-Entität, die Home Assistant unbekannt ist:\n\n`{source}`\n\n\n\nUm diesen Fehler zu beheben, bearbeite den Helfer und passe die Quell-Entität an (oder entferne den Helfer) und starte Home Assistant neu.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinem Helfer Riemann Summenintegralsensor gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Helfer:\n\n{helper} (`{entity_id}`)\n\nDieser Helfer hat eine Quell-Entität, die Home Assistant unbekannt ist:\n\n`{source}`\n\n\n\nUm diesen Fehler zu beheben, bearbeite den Helfer und passe die Quell-Entität an (oder entferne den Helfer) und starte Home Assistant neu.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Quelle: {helper}"
     },
     "lovelace_unknown_entity_references": {
-      "title": "Unbekannte Entitäten verwendet in: {dashboard}",
-      "description": "Spook hat einen Geist in deinen Dashboards gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Dashboard:\n\n[{dashboard}]({edit})\n\nDieses Dashboard verweist auf die folgenden Entitäten, die Home Assistant unbekannt sind:\n\n{entities}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite das Dashboard]({edit}) und entferne die Verwendung dieser nicht existierenden Entitäten.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinen Dashboards gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Dashboard:\n\n[{dashboard}]({edit})\n\nDieses Dashboard verweist auf die folgenden Entitäten, die Home Assistant unbekannt sind:\n\n{entities}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite das Dashboard]({edit}) und entferne die Verwendung dieser nicht existierenden Entitäten.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Entitäten verwendet in: {dashboard}"
     },
     "script_unknown_area_references": {
-      "title": "Unbekannte Bereiche verwendet in: {script}",
-      "description": "Spook hat einen Geist in deinen Skripten gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Skript:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDieses Skript bezieht sich auf die folgenden Bereiche, die Home Assistant unbekannt sind:\n\n{areas}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite das Skript]({edit}) und entferne die Verwendung dieser nicht existierenden Bereiche.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinen Skripten gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Skript:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDieses Skript bezieht sich auf die folgenden Bereiche, die Home Assistant unbekannt sind:\n\n{areas}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite das Skript]({edit}) und entferne die Verwendung dieser nicht existierenden Bereiche.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Bereiche verwendet in: {script}"
     },
     "script_unknown_device_references": {
-      "title": "Unbekannte Geräte verwendet in: {script}",
-      "description": "Spook hat einen Geist in deinen Skripten gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Skript:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDieses Skript bezieht sich auf die folgenden Geräte, die Home Assistant unbekannt sind:\n\n{devices}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite das Skript]({edit}) und entferne die Verwendung dieser nicht existierenden Geräte.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinen Skripten gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Skript:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDieses Skript bezieht sich auf die folgenden Geräte, die Home Assistant unbekannt sind:\n\n{devices}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite das Skript]({edit}) und entferne die Verwendung dieser nicht existierenden Geräte.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Geräte verwendet in: {script}"
     },
     "script_unknown_entity_references": {
-      "title": "Unbekannte Entitäten verwendet in: {script}",
-      "description": "Spook hat einen Geist in deinen Skripten gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Skript:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDieses Skript bezieht sich auf die folgenden Entitäten, die Home Assistant unbekannt sind:\n\n{entities}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite das Skript]({edit}) und entferne die Verwendung dieser nicht existierenden Entitäten.\n\nSpook 👻 Nicht dein Kumpel."
+      "description": "Spook hat einen Geist in deinen Skripten gefunden 👻\n\nBeim Herumschweben begegnete Spook dem folgenden Skript:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDieses Skript bezieht sich auf die folgenden Entitäten, die Home Assistant unbekannt sind:\n\n{entities}\n\n\n\nUm diesen Fehler zu beheben, [bearbeite das Skript]({edit}) und entferne die Verwendung dieser nicht existierenden Entitäten.\n\nSpook 👻 Nicht dein Kumpel.",
+      "title": "Unbekannte Entitäten verwendet in: {script}"
     }
   }
 }

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -9,57 +9,213 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "custom_component": {
+        "name": "Custom integrations"
+      },
+      "homeassistant_air_quality": {
+        "name": "Air quality"
+      },
+      "homeassistant_alarm_control_panel": {
+        "name": "Alarm control panels"
+      },
+      "homeassistant_area": {
+        "name": "Areas"
+      },
+      "homeassistant_automation": {
+        "name": "Automations"
+      },
+      "homeassistant_binary_sensor": {
+        "name": "Binary sensors"
+      },
+      "homeassistant_button": {
+        "name": "Buttons"
+      },
+      "homeassistant_calendar": {
+        "name": "Calendars"
+      },
+      "homeassistant_camera": {
+        "name": "Cameras"
+      },
+      "homeassistant_climate": {
+        "name": "Climate"
+      },
+      "homeassistant_cover": {
+        "name": "Covers"
+      },
+      "homeassistant_date": {
+        "name": "Dates"
+      },
+      "homeassistant_datetime": {
+        "name": "Date/times"
+      },
+      "homeassistant_device": {
+        "name": "Devices"
+      },
+      "homeassistant_device_tracker": {
+        "name": "Device trackers"
+      },
+      "homeassistant_entities": {
+        "name": "Entities"
+      },
+      "homeassistant_fan": {
+        "name": "Fans"
+      },
+      "homeassistant_humidifier": {
+        "name": "Humidifiers"
+      },
+      "homeassistant_input_boolean": {
+        "name": "Input booleans"
+      },
+      "homeassistant_input_button": {
+        "name": "Input buttons"
+      },
+      "homeassistant_input_datetime": {
+        "name": "Input date/times"
+      },
+      "homeassistant_input_number": {
+        "name": "Input numbers"
+      },
+      "homeassistant_input_select": {
+        "name": "Input selects"
+      },
+      "homeassistant_input_text": {
+        "name": "Input texts"
+      },
+      "homeassistant_integration": {
+        "name": "Integrations"
+      },
+      "homeassistant_light": {
+        "name": "Lights"
+      },
+      "homeassistant_lock": {
+        "name": "Locks"
+      },
+      "homeassistant_media_player": {
+        "name": "Media players"
+      },
+      "homeassistant_number": {
+        "name": "Numbers"
+      },
+      "homeassistant_person": {
+        "name": "Persons"
+      },
+      "homeassistant_remote": {
+        "name": "Remotes"
+      },
+      "homeassistant_scene": {
+        "name": "Scenes"
+      },
+      "homeassistant_script": {
+        "name": "Scripts"
+      },
+      "homeassistant_select": {
+        "name": "Selects"
+      },
+      "homeassistant_sensor": {
+        "name": "Sensors"
+      },
+      "homeassistant_siren": {
+        "name": "Sirens"
+      },
+      "homeassistant_stt": {
+        "name": "Speech-to-text"
+      },
+      "homeassistant_sun": {
+        "name": "Suns"
+      },
+      "homeassistant_switch": {
+        "name": "Switches"
+      },
+      "homeassistant_text": {
+        "name": "Texts"
+      },
+      "homeassistant_time": {
+        "name": "Times"
+      },
+      "homeassistant_tts": {
+        "name": "Text-to-speech"
+      },
+      "homeassistant_update": {
+        "name": "Update"
+      },
+      "homeassistant_vacuum": {
+        "name": "Vacuums"
+      },
+      "homeassistant_water_heater": {
+        "name": "Water heaters"
+      },
+      "homeassistant_weather": {
+        "name": "Weather"
+      },
+      "homeassistant_zone": {
+        "name": "Zones"
+      }
+    },
+    "switch": {
+      "cloud_alexa_report_state": {
+        "name": "Alexa state reporting"
+      },
+      "cloud_google_report_state": {
+        "name": "Google Assistant state reporting"
+      },
+      "cloud_remote": {
+        "name": "Remote"
+      }
+    }
+  },
   "issues": {
+    "automation_unknown_area_references": {
+      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown areas used in: {automation}"
+    },
+    "automation_unknown_device_references": {
+      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown devices used in: {automation}"
+    },
+    "automation_unknown_entity_references": {
+      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown entities used in: {automation}"
+    },
+    "group_unknown_members": {
+      "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown group members in: {group}"
+    },
+    "integration_unknown_source": {
+      "description": "Spook has found a ghost in your Riemann sum integral helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown source: {helper}"
+    },
+    "lovelace_unknown_entity_references": {
+      "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n[{dashboard}]({edit})\n\nThis dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown entities used in: {dashboard}"
+    },
+    "script_unknown_area_references": {
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown areas used in: {script}"
+    },
+    "script_unknown_device_references": {
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown devices used in: {script}"
+    },
+    "script_unknown_entity_references": {
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown entities used in: {script}"
+    },
+    "switch_as_x_unknown_source": {
+      "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown source: {helper}"
+    },
     "user_issue": {
-      "title": "{title}",
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "{title}",
-            "description": "{description}"
+            "description": "{description}",
+            "title": "{title}"
           }
         }
-      }
-    },
-    "automation_unknown_area_references": {
-      "title": "Unknown areas used in: {automation}",
-      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Not your homie."
-    },
-    "automation_unknown_device_references": {
-      "title": "Unknown devices used in: {automation}",
-      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Not your homie."
-    },
-    "automation_unknown_entity_references": {
-      "title": "Unknown entities used in: {automation}",
-      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie."
-    },
-    "group_unknown_members": {
-      "title": "Unknown group members in: {group}",
-      "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Not your homie."
-    },
-    "integration_unknown_source": {
-      "title": "Unknown source: {helper}",
-      "description": "Spook has found a ghost in your Riemann sum integral helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Not your homie."
-    },
-    "lovelace_unknown_entity_references": {
-      "title": "Unknown entities used in: {dashboard}",
-      "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n[{dashboard}]({edit})\n\nThis dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie."
-    },
-    "script_unknown_area_references": {
-      "title": "Unknown areas used in: {script}",
-      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Not your homie."
-    },
-    "script_unknown_device_references": {
-      "title": "Unknown devices used in: {script}",
-      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Not your homie."
-    },
-    "script_unknown_entity_references": {
-      "title": "Unknown entities used in: {script}",
-      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie."
-    },
-    "switch_as_x_unknown_source": {
-      "title": "Unknown source: {helper}",
-      "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Not your homie."
+      },
+      "title": "{title}"
     }
   }
 }

--- a/custom_components/spook/translations/nl.json
+++ b/custom_components/spook/translations/nl.json
@@ -9,46 +9,202 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "custom_component": {
+        "name": "Custom integraties"
+      },
+      "homeassistant_air_quality": {
+        "name": "Luchtkwaliteit"
+      },
+      "homeassistant_alarm_control_panel": {
+        "name": "Alarm bedieningspanelen"
+      },
+      "homeassistant_area": {
+        "name": "Ruimtes"
+      },
+      "homeassistant_automation": {
+        "name": "Automatiseringen"
+      },
+      "homeassistant_binary_sensor": {
+        "name": "Binaire sensoren"
+      },
+      "homeassistant_button": {
+        "name": "Knoppen"
+      },
+      "homeassistant_calendar": {
+        "name": "Kalenders"
+      },
+      "homeassistant_camera": {
+        "name": "Camera's"
+      },
+      "homeassistant_climate": {
+        "name": "Klimaat"
+      },
+      "homeassistant_cover": {
+        "name": "Bedekkingen"
+      },
+      "homeassistant_date": {
+        "name": "Datums"
+      },
+      "homeassistant_datetime": {
+        "name": "Datum/tijden"
+      },
+      "homeassistant_device": {
+        "name": "Apparaten"
+      },
+      "homeassistant_device_tracker": {
+        "name": "Locatie trackers"
+      },
+      "homeassistant_entities": {
+        "name": "Entiteiten"
+      },
+      "homeassistant_fan": {
+        "name": "Ventilatoren"
+      },
+      "homeassistant_humidifier": {
+        "name": "Luchtbevochtigers"
+      },
+      "homeassistant_input_boolean": {
+        "name": "Invoer booleans"
+      },
+      "homeassistant_input_button": {
+        "name": "Invoer knoppen"
+      },
+      "homeassistant_input_datetime": {
+        "name": "Invoer datum/tijden"
+      },
+      "homeassistant_input_number": {
+        "name": "Invoer getallen"
+      },
+      "homeassistant_input_select": {
+        "name": "Invoer selecties"
+      },
+      "homeassistant_input_text": {
+        "name": "Invoer teksten"
+      },
+      "homeassistant_integration": {
+        "name": "Integraties"
+      },
+      "homeassistant_light": {
+        "name": "Lichten"
+      },
+      "homeassistant_lock": {
+        "name": "Sloten"
+      },
+      "homeassistant_media_player": {
+        "name": "Media spelers"
+      },
+      "homeassistant_number": {
+        "name": "Getallen"
+      },
+      "homeassistant_person": {
+        "name": "Personen"
+      },
+      "homeassistant_remote": {
+        "name": "Afstandsbedieningen"
+      },
+      "homeassistant_scene": {
+        "name": "Scènes"
+      },
+      "homeassistant_script": {
+        "name": "Scripts"
+      },
+      "homeassistant_select": {
+        "name": "Selecties"
+      },
+      "homeassistant_sensor": {
+        "name": "Sensoren"
+      },
+      "homeassistant_siren": {
+        "name": "Sirenes"
+      },
+      "homeassistant_stt": {
+        "name": "Spraak-naar-tekst"
+      },
+      "homeassistant_sun": {
+        "name": "Zonnen"
+      },
+      "homeassistant_switch": {
+        "name": "Schakelaars"
+      },
+      "homeassistant_text": {
+        "name": "Teksten"
+      },
+      "homeassistant_time": {
+        "name": "Tijden"
+      },
+      "homeassistant_tts": {
+        "name": "Tekst-naar-spraak"
+      },
+      "homeassistant_update": {
+        "name": "Update"
+      },
+      "homeassistant_vacuum": {
+        "name": "Stofzuigers"
+      },
+      "homeassistant_water_heater": {
+        "name": "Boilers"
+      },
+      "homeassistant_weather": {
+        "name": "Weer"
+      },
+      "homeassistant_zone": {
+        "name": "Zones"
+      }
+    },
+    "switch": {
+      "cloud_alexa_report_state": {
+        "name": "Alexa-status rapportage"
+      },
+      "cloud_google_report_state": {
+        "name": "Google Assistent-status rapportage"
+      },
+      "cloud_remote": {
+        "name": "Afstandsbediening"
+      }
+    }
+  },
   "issues": {
     "automation_unknown_area_references": {
-      "title": "Onbekende ruimtes gebruikt in: {automation}",
-      "description": "Spook heeft een geest gevonden in jouw automatiseringen 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende automatisering tegen:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDeze automatisering verwijst naar de volgende ruimtes, die onbekend zijn voor Home Assistant:\n\n{areas}\n\n\n\nOm deze fout op te lossen, [bewerk de automatisering]({edit}) en verwijder het gebruik van deze niet-bestaande ruimtes.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw automatiseringen 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende automatisering tegen:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDeze automatisering verwijst naar de volgende ruimtes, die onbekend zijn voor Home Assistant:\n\n{areas}\n\n\n\nOm deze fout op te lossen, [bewerk de automatisering]({edit}) en verwijder het gebruik van deze niet-bestaande ruimtes.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende ruimtes gebruikt in: {automation}"
     },
     "automation_unknown_device_references": {
-      "title": "Onbekende apparaten gebruikt in: {automation}",
-      "description": "Spook heeft een geest gevonden in jouw automatiseringen 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende automatisering tegen:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDeze automatisering verwijst naar de volgende apparaten, die onbekend zijn voor Home Assistant:\n\n{devices}\n\n\n\nOm deze fout op te lossen, [bewerk de automatisering]({edit}) en verwijder het gebruik van deze niet-bestaande apparaten.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw automatiseringen 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende automatisering tegen:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDeze automatisering verwijst naar de volgende apparaten, die onbekend zijn voor Home Assistant:\n\n{devices}\n\n\n\nOm deze fout op te lossen, [bewerk de automatisering]({edit}) en verwijder het gebruik van deze niet-bestaande apparaten.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende apparaten gebruikt in: {automation}"
     },
     "automation_unknown_entity_references": {
-      "title": "Onbekende entiteiten gebruikt in: {automation}",
-      "description": "Spook heeft een geest gevonden in jouw automatiseringen 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende automatisering tegen:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDeze automatisering verwijst naar de volgende entiteiten, die onbekend zijn voor Home Assistant:\n\n{entities}\n\n\n\nOm deze fout op te lossen, [bewerk de automatisering]({edit}) en verwijder het gebruik van deze niet-bestaande entiteiten.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw automatiseringen 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende automatisering tegen:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDeze automatisering verwijst naar de volgende entiteiten, die onbekend zijn voor Home Assistant:\n\n{entities}\n\n\n\nOm deze fout op te lossen, [bewerk de automatisering]({edit}) en verwijder het gebruik van deze niet-bestaande entiteiten.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende entiteiten gebruikt in: {automation}"
     },
     "group_unknown_members": {
-      "title": "Onbekende groep leden in: {group}",
-      "description": "Spook heeft een geest gevonden in jouw groepen 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende groep tegen:\n\n{group} (`{entity_id}`)\n\nDeze groep heeft leden, die onbekend zijn voor Home Assistant:\n\n{entities}\n\n\n\nOm deze fout op te lossen, bewerk de groep, verwijder het gebruik van deze niet-bestaande entiteiten en start Home Assistant opnieuw.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw groepen 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende groep tegen:\n\n{group} (`{entity_id}`)\n\nDeze groep heeft leden, die onbekend zijn voor Home Assistant:\n\n{entities}\n\n\n\nOm deze fout op te lossen, bewerk de groep, verwijder het gebruik van deze niet-bestaande entiteiten en start Home Assistant opnieuw.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende groep leden in: {group}"
     },
     "integration_unknown_source": {
-      "title": "Onbekende bron: {helper}",
-      "description": "Spook heeft een geest gevonden in jouw Riemann som integrale sensoren 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende sensor tegen:\n\n{helper} (`{entity_id}`)\n\nDeze sensor heeft een bron entiteit die onbekend is voor Home Assistant:\n\n`{source}`\n\n\n\nOm deze fout op te lossen, bewerk de sensor en pas de bron entiteit aan (of verwijder de sensor) en start Home Assistant opnieuw.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw Riemann som integrale sensoren 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende sensor tegen:\n\n{helper} (`{entity_id}`)\n\nDeze sensor heeft een bron entiteit die onbekend is voor Home Assistant:\n\n`{source}`\n\n\n\nOm deze fout op te lossen, bewerk de sensor en pas de bron entiteit aan (of verwijder de sensor) en start Home Assistant opnieuw.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende bron: {helper}"
     },
     "lovelace_unknown_entity_references": {
-      "title": "Onbekende entiteiten gebruikt in: {dashboard}",
-      "description": "Spook heeft een geest gevonden in jouw dashboards 👻\n\nTerwijl hij rond zweefde, kwam Spook het volgende dashboard tegen:\n\n[{dashboard}]({edit})\n\nDit dashboard verwijst naar de volgende entiteiten, die onbekend zijn voor Home Assistant:\n\n{entities}\n\n\n\nOm deze fout op te lossen, [bewerk het dashboard]({edit}) en verwijder het gebruik van deze niet-bestaande entiteiten.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw dashboards 👻\n\nTerwijl hij rond zweefde, kwam Spook het volgende dashboard tegen:\n\n[{dashboard}]({edit})\n\nDit dashboard verwijst naar de volgende entiteiten, die onbekend zijn voor Home Assistant:\n\n{entities}\n\n\n\nOm deze fout op te lossen, [bewerk het dashboard]({edit}) en verwijder het gebruik van deze niet-bestaande entiteiten.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende entiteiten gebruikt in: {dashboard}"
     },
     "script_unknown_area_references": {
-      "title": "Onbekende ruimtes gebruikt in: {script}",
-      "description": "Spook heeft een geest gevonden in jouw scripts 👻\n\nTerwijl hij rond zweefde, kwam Spook het volgende script tegen:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDit script verwijst naar de volgende ruimtes, die onbekend zijn voor Home Assistant:\n\n{areas}\n\n\n\nOm deze fout op te lossen, [bewerk het script]({edit}) en verwijder het gebruik van deze niet-bestaande ruimtes.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw scripts 👻\n\nTerwijl hij rond zweefde, kwam Spook het volgende script tegen:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDit script verwijst naar de volgende ruimtes, die onbekend zijn voor Home Assistant:\n\n{areas}\n\n\n\nOm deze fout op te lossen, [bewerk het script]({edit}) en verwijder het gebruik van deze niet-bestaande ruimtes.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende ruimtes gebruikt in: {script}"
     },
     "script_unknown_device_references": {
-      "title": "Onbekende apparaten gebruikt in: {script}",
-      "description": "Spook heeft een geest gevonden in jouw scripts 👻\n\nTerwijl hij rond zweefde, kwam Spook het volgende script tegen:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDit script verwijst naar de volgende apparaten, die onbekend zijn voor Home Assistant:\n\n{devices}\n\n\n\nOm deze fout op te lossen, [bewerk het script]({edit}) en verwijder het gebruik van deze niet-bestaande apparaten.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw scripts 👻\n\nTerwijl hij rond zweefde, kwam Spook het volgende script tegen:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDit script verwijst naar de volgende apparaten, die onbekend zijn voor Home Assistant:\n\n{devices}\n\n\n\nOm deze fout op te lossen, [bewerk het script]({edit}) en verwijder het gebruik van deze niet-bestaande apparaten.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende apparaten gebruikt in: {script}"
     },
     "script_unknown_entity_references": {
-      "title": "Onbekende entiteiten gebruikt in: {script}",
-      "description": "Spook heeft een geest gevonden in jouw scripts 👻\n\nTerwijl hij rond zweefde, kwam Spook het volgende script tegen:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDit script verwijst naar de volgende entiteiten, die onbekend zijn voor Home Assistant:\n\n{entities}\n\n\n\nOm deze fout op te lossen, [bewerk het script]({edit}) en verwijder het gebruik van deze niet-bestaande entiteiten.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw scripts 👻\n\nTerwijl hij rond zweefde, kwam Spook het volgende script tegen:\n\n[{script}]({edit}) (`{entity_id}`)\n\nDit script verwijst naar de volgende entiteiten, die onbekend zijn voor Home Assistant:\n\n{entities}\n\n\n\nOm deze fout op te lossen, [bewerk het script]({edit}) en verwijder het gebruik van deze niet-bestaande entiteiten.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende entiteiten gebruikt in: {script}"
     },
     "switch_as_x_unknown_source": {
-      "title": "Onbekende bron: {helper}",
-      "description": "Spook heeft een geest gevonden in jouw Schakelaar als X helpers 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende helper tegen:\n\n{helper} (`{entity_id}`)\n\nDeze helper heeft een bron schakelaar entiteit die onbekend is voor Home Assistant:\n\n`{source}`\n\n\n\nOm deze fout op te lossen, bewerk de helper en pas de bron schakelaar entiteit aan (of verwijder de helper) en start Home Assistant opnieuw.\n\nSpook 👻 Niet je maatje."
+      "description": "Spook heeft een geest gevonden in jouw Schakelaar als X helpers 👻\n\nTerwijl hij rond zweefde, kwam Spook de volgende helper tegen:\n\n{helper} (`{entity_id}`)\n\nDeze helper heeft een bron schakelaar entiteit die onbekend is voor Home Assistant:\n\n`{source}`\n\n\n\nOm deze fout op te lossen, bewerk de helper en pas de bron schakelaar entiteit aan (of verwijder de helper) en start Home Assistant opnieuw.\n\nSpook 👻 Niet je maatje.",
+      "title": "Onbekende bron: {helper}"
     }
   }
 }


### PR DESCRIPTION
Add entity name translations to all entities.
Includes the translations for `en`, `nl` and `de`.