### PR TITLE
Extend Home Assistant restart service with an force option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ or to be supported, or well, for starters, to be a good idea.
   - [Service: Remove repair issue](#service-remove-repair-issue)
   - [Service: Ignore all repair issues](#service-ignore-all-repair-issues)
   - [Service: Unignore all repair issues](#service-unignore-all-repair-issues)
+  - [Service: Restart Home Assistant (with force option)](#service-restart-home-assistant-with-force-option)
   - [Service: Boo! 👻](#service-boo-)
   - [Service: Random fail](#service-random-fail)
 - [Entity services](#entity-services)
@@ -382,6 +383,13 @@ Call it using: [`repairs.ignore_all`](https://my.home-assistant.io/redirect/deve
 Call it using: [`repairs.unignore_all`](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.unignore_all)
 
 > Will unignore all issues marked ignored, and shows them all again. _#faceit_
+
+## Service: Restart Home Assistant (with force option)
+
+Call it using: [`homeassistant.restart`](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.restart)
+
+> Extends the existing restart service with an "force" option. Because forcing
+> is always a good idea. _#hammer_
 
 ## Service: Boo! 👻
 

--- a/custom_components/spook/ectoplasms/homeassistant/services/restart.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/restart.py
@@ -1,0 +1,47 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.const import RESTART_EXIT_CODE
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+
+from ....const import LOGGER
+from ....services import AbstractSpookAdminService, ReplaceExistingService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookAdminService, ReplaceExistingService):
+    """Home Assistant service to restart Home Assistant.
+
+    It overrides the built-in restart service to add a force option.
+    """
+
+    domain = DOMAIN
+    service = "restart"
+    schema = {
+        vol.Optional("force", default=False): cv.boolean,
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        if call.data["force"]:
+            LOGGER.warning("!! Forcing an Home Assistant restart !!")
+            self.hass.data["homeassistant_stop"] = asyncio.create_task(
+                self.hass.async_stop(RESTART_EXIT_CODE),
+            )
+            return
+
+        if not self.overriden_service:
+            msg = "Spook encountered an error while restarting Home Assistant."
+            raise HomeAssistantError(
+                msg,
+            )
+
+        self.hass.async_run_hass_job(self.overriden_service.job, call)

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -326,6 +326,20 @@ homeassistant_delete_all_orphaned_entities:
     integration is offline or not working since Home Assistant started. Calling
     this service will delete those entities as well.
 
+homeassistant_restart:
+  name: Restart 👻
+  description: Restart the Home Assistant service.
+  fields:
+    force:
+      name: Force restart
+      description: >-
+        Force the restart. WARNING! This will not gracefully shutdown Home
+        Assistant, it will skip configuration checks and ignore running database
+        migrations. Only use this if you know what you are doing.
+      required: false
+      selector:
+        boolean:
+
 recorder_import_statistics:
   name: Import statistics 👻
   description: >-


### PR DESCRIPTION
As requested here: <https://github.com/frenck/spook/discussions/6>

![image](https://github.com/frenck/spook/assets/195327/4a93b7a1-a837-473a-a112-ca08fb34ae9b)
