### PR TITLE
Add util to forward platform entry setup to ectoplasm, add other future platforms

### DIFF
--- a/custom_components/spook/binary_sensor.py
+++ b/custom_components/spook/binary_sensor.py
@@ -18,10 +18,10 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Spook sensors."""
+    """Set up Spook binary sensors."""
     await async_forward_platform_entry_setups_to_ectoplasm(
         hass,
         entry,
         async_add_entities,
-        Platform.SENSOR,
+        Platform.BINARY_SENSOR,
     )

--- a/custom_components/spook/button.py
+++ b/custom_components/spook/button.py
@@ -1,11 +1,11 @@
 """Spook - Not your homie."""
 from __future__ import annotations
 
-import importlib
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .const import LOGGER
+from homeassistant.const import Platform
+
+from .util import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -19,14 +19,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Spook buttons."""
-    LOGGER.debug("Setting up Spook ectoplasm buttons")
-
-    for module_file in Path(__file__).parent.rglob("ectoplasms/*/button.py"):
-        module_path = str(module_file.relative_to(Path(__file__).parent))[:-3].replace(
-            "/",
-            ".",
-        )
-        LOGGER.debug("Loading Spook button from ectoplasm: %s", module_path)
-        module = importlib.import_module(f".{module_path}", __package__)
-        LOGGER.debug("Setting up Spook ectoplasm button: %s", module_path)
-        await module.async_setup_entry(hass, entry, async_add_entities)
+    await async_forward_platform_entry_setups_to_ectoplasm(
+        hass,
+        entry,
+        async_add_entities,
+        Platform.BUTTON,
+    )

--- a/custom_components/spook/const.py
+++ b/custom_components/spook/const.py
@@ -8,7 +8,11 @@ DOMAIN: Final = "spook"
 LOGGER = logging.getLogger(__package__)
 
 PLATFORMS: Final = [
+    Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TIME,
 ]

--- a/custom_components/spook/number.py
+++ b/custom_components/spook/number.py
@@ -18,10 +18,10 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Spook sensors."""
+    """Set up Spook numbers."""
     await async_forward_platform_entry_setups_to_ectoplasm(
         hass,
         entry,
         async_add_entities,
-        Platform.SENSOR,
+        Platform.NUMBER,
     )

--- a/custom_components/spook/select.py
+++ b/custom_components/spook/select.py
@@ -18,10 +18,10 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Spook sensors."""
+    """Set up Spook selects."""
     await async_forward_platform_entry_setups_to_ectoplasm(
         hass,
         entry,
         async_add_entities,
-        Platform.SENSOR,
+        Platform.SELECT,
     )

--- a/custom_components/spook/switch.py
+++ b/custom_components/spook/switch.py
@@ -1,11 +1,11 @@
 """Spook - Not your homie."""
 from __future__ import annotations
 
-import importlib
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .const import LOGGER
+from homeassistant.const import Platform
+
+from .util import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -19,14 +19,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Spook switches."""
-    LOGGER.debug("Setting up Spook ectoplasm switches")
-
-    for module_file in Path(__file__).parent.rglob("ectoplasms/*/switch.py"):
-        module_path = str(module_file.relative_to(Path(__file__).parent))[:-3].replace(
-            "/",
-            ".",
-        )
-        LOGGER.debug("Loading Spook switch from ectoplasm: %s", module_path)
-        module = importlib.import_module(f".{module_path}", __package__)
-        LOGGER.debug("Setting up Spook ectoplasm switch: %s", module_path)
-        await module.async_setup_entry(hass, entry, async_add_entities)
+    await async_forward_platform_entry_setups_to_ectoplasm(
+        hass,
+        entry,
+        async_add_entities,
+        Platform.SWITCH,
+    )

--- a/custom_components/spook/time.py
+++ b/custom_components/spook/time.py
@@ -18,10 +18,10 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Spook sensors."""
+    """Set up Spook times."""
     await async_forward_platform_entry_setups_to_ectoplasm(
         hass,
         entry,
         async_add_entities,
-        Platform.SENSOR,
+        Platform.TIME,
     )

--- a/custom_components/spook/util.py
+++ b/custom_components/spook/util.py
@@ -1,0 +1,34 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .const import LOGGER
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.const import Platform
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_forward_platform_entry_setups_to_ectoplasm(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    platform: Platform,
+) -> None:
+    """Set up Spook ectoplasm platform."""
+    LOGGER.debug("Setting up Spook ectoplasm platform: %s", platform)
+
+    for module_file in Path(__file__).parent.rglob(f"ectoplasms/*/{platform}.py"):
+        module_path = str(module_file.relative_to(Path(__file__).parent))[:-3].replace(
+            "/",
+            ".",
+        )
+        LOGGER.debug("Loading Spook %s from ectoplasm: %s", platform, module_path)
+        module = importlib.import_module(f".{module_path}", __package__)
+        LOGGER.debug("Setting up Spook ectoplasm %s: %s", platform, module_path)
+        await module.async_setup_entry(hass, entry, async_add_entities)


### PR DESCRIPTION
Extract some duplicated logic from platforms, and adds basics for numbers, selects, binary sensors and time entities (added in future PRs).