### PR TITLE
Fix incorrect translation key

### DIFF
--- a/custom_components/spook/translations/de.json
+++ b/custom_components/spook/translations/de.json
@@ -11,17 +11,14 @@
   },
   "entity": {
     "button": {
-      "homeassistant_restart": {
-        "name": "Neustart"
-      },
       "homeassistant_reload": {
         "name": "Neu laden"
+      },
+      "homeassistant_restart": {
+        "name": "Neustart"
       }
     },
     "sensor": {
-      "custom_component": {
-        "name": "Custom Integrationen"
-      },
       "homeassistant_air_quality": {
         "name": "Luftqualität"
       },
@@ -51,6 +48,9 @@
       },
       "homeassistant_cover": {
         "name": "Abdeckungen"
+      },
+      "homeassistant_custom_component": {
+        "name": "Custom Integrationen"
       },
       "homeassistant_date": {
         "name": "Daten"

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -11,17 +11,14 @@
   },
   "entity": {
     "button": {
-      "homeassistant_restart": {
-        "name": "Restart"
-      },
       "homeassistant_reload": {
         "name": "Reload"
+      },
+      "homeassistant_restart": {
+        "name": "Restart"
       }
     },
     "sensor": {
-      "custom_component": {
-        "name": "Custom integrations"
-      },
       "homeassistant_air_quality": {
         "name": "Air quality"
       },
@@ -51,6 +48,9 @@
       },
       "homeassistant_cover": {
         "name": "Covers"
+      },
+      "homeassistant_custom_component": {
+        "name": "Custom integrations"
       },
       "homeassistant_date": {
         "name": "Dates"

--- a/custom_components/spook/translations/es.json
+++ b/custom_components/spook/translations/es.json
@@ -11,17 +11,14 @@
   },
   "entity": {
     "button": {
-      "homeassistant_restart": {
-        "name": "Reiniciar"
-      },
       "homeassistant_reload": {
         "name": "Recargar"
+      },
+      "homeassistant_restart": {
+        "name": "Reiniciar"
       }
     },
     "sensor": {
-      "custom_component": {
-        "name": "Integraciones personalizadas"
-      },
       "homeassistant_air_quality": {
         "name": "Calidad del aire"
       },
@@ -51,6 +48,9 @@
       },
       "homeassistant_cover": {
         "name": "Cortinas"
+      },
+      "homeassistant_custom_component": {
+        "name": "Integraciones personalizadas"
       },
       "homeassistant_date": {
         "name": "Fechas"

--- a/custom_components/spook/translations/nl.json
+++ b/custom_components/spook/translations/nl.json
@@ -11,17 +11,14 @@
   },
   "entity": {
     "button": {
-      "homeassistant_restart": {
-        "name": "Herstarten"
-      },
       "homeassistant_reload": {
         "name": "Herladen"
+      },
+      "homeassistant_restart": {
+        "name": "Herstarten"
       }
     },
     "sensor": {
-      "custom_component": {
-        "name": "Custom integraties"
-      },
       "homeassistant_air_quality": {
         "name": "Luchtkwaliteit"
       },
@@ -51,6 +48,9 @@
       },
       "homeassistant_cover": {
         "name": "Bedekkingen"
+      },
+      "homeassistant_custom_component": {
+        "name": "Custom integraties"
       },
       "homeassistant_date": {
         "name": "Datums"


### PR DESCRIPTION
Fixes

```
Logger: homeassistant.helpers.entity
Source: helpers/entity.py:1005
First occurred: 4:23:47 PM (1 occurrences)
Last logged: 4:23:47 PM

Entity sensor.custom_integrations (<class 'custom_components.spook.ectoplasms.homeassistant.sensor.HomeAssistantSpookSensorEntity'>) is implicitly using device name by not setting its name. Instead, the name should be set to None, please report it to the custom integration author.
```