### PR TITLE
Fix schema for recorder.import_statistics

### DIFF
--- a/custom_components/spook/ectoplasms/recorder/services/import_statistics.py
+++ b/custom_components/spook/ectoplasms/recorder/services/import_statistics.py
@@ -21,10 +21,10 @@ class SpookService(AbstractSpookAdminService):
     schema = {
         vol.Required("has_mean"): bool,
         vol.Required("has_sum"): bool,
-        vol.Optional("name", default=None): str,
+        vol.Optional("name", default=None): vol.Any(None, str),
         vol.Required("source"): str,
         vol.Required("statistic_id"): str,
-        vol.Optional("unit_of_measurement", default=None): str,
+        vol.Optional("unit_of_measurement", default=None): vol.Any(None, str),
         vol.Required("stats"): [
             {
                 vol.Required("start"): cv.datetime,


### PR DESCRIPTION
SSIA, name & unit of measurement should accept `None` in the validation (as it is their default as well).