### PR TITLE
Fix minimal Home Assistant version in docs

### DIFF
--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -19,7 +19,7 @@ Getting Spook up and running should not be too hard when you follow this guide. 
 Spook needs a few things to work properly, so let's go over them first.
 
 1. Read, understand, and accept [the license](license) of Spook.
-2. A working {term}`Home Assistant` instance running version **2023.7.0 or newer.**
+2. A working {term}`Home Assistant` instance running version **2023.8.0 or newer.**
 
    :::{note}
    The minimal required version of Home Assistant will change over time. This is not something to worry about. It is only important that you run at least the minimal required version of Home Assistant on the first installation of Spook.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The documentation listed 2023.7.0 as the minimal version; however, this is actually 2023.8.0.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
