### PR TITLE
Add support for service responses

### DIFF
--- a/custom_components/spook/services.py
+++ b/custom_components/spook/services.py
@@ -9,7 +9,14 @@ from typing import TYPE_CHECKING, Any, final
 
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant, Service, ServiceCall, callback
+from homeassistant.core import (
+    HomeAssistant,
+    Service,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+    callback,
+)
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM
 from homeassistant.helpers.service import (
@@ -66,6 +73,8 @@ class ReplaceExistingService(AbstractSpookServiceBase):
 class AbstractSpookService(AbstractSpookServiceBase):
     """Abstract class to hold a Spook service."""
 
+    supports_response: SupportsResponse = SupportsResponse.NONE
+
     @final
     @callback
     def async_register(self) -> None:
@@ -91,10 +100,11 @@ class AbstractSpookService(AbstractSpookServiceBase):
             service=self.service,
             service_func=self.async_handle_service,
             schema=vol.Schema(self.schema) if self.schema else None,
+            supports_response=self.supports_response,
         )
 
     @abstractmethod
-    async def async_handle_service(self, call: ServiceCall) -> None:
+    async def async_handle_service(self, call: ServiceCall) -> ServiceResponse:
         """Handle the service call."""
         raise NotImplementedError
 
@@ -139,6 +149,7 @@ class AbstractSpookEntityService(AbstractSpookServiceBase):
 
     platform: str
     required_features: list[int] | None = None
+    supports_response: SupportsResponse = SupportsResponse.NONE
 
     @final
     @callback
@@ -170,10 +181,15 @@ class AbstractSpookEntityService(AbstractSpookServiceBase):
             func=self.async_handle_service,
             schema=self.schema,
             required_features=self.required_features,
+            supports_response=self.supports_response,
         )
 
     @abstractmethod
-    async def async_handle_service(self, entity: Entity, call: ServiceCall) -> None:
+    async def async_handle_service(
+        self,
+        entity: Entity,
+        call: ServiceCall,
+    ) -> ServiceResponse:
         """Handle the service call."""
         raise NotImplementedError
 
@@ -182,6 +198,7 @@ class AbstractSpookEntityComponentService(AbstractSpookServiceBase):
     """Abstract class to hold a Spook entity component service."""
 
     required_features: list[int] | None = None
+    supports_response: SupportsResponse = SupportsResponse.NONE
 
     @final
     @callback
@@ -207,10 +224,15 @@ class AbstractSpookEntityComponentService(AbstractSpookServiceBase):
             func=self.async_handle_service,
             schema=self.schema,
             required_features=self.required_features,
+            supports_response=self.supports_response,
         )
 
     @abstractmethod
-    async def async_handle_service(self, entity: Entity, call: ServiceCall) -> None:
+    async def async_handle_service(
+        self,
+        entity: Entity,
+        call: ServiceCall,
+    ) -> ServiceResponse:
         """Handle the service call."""
         raise NotImplementedError
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add support to the framework for handling services that respond with data.

I did notice some weirdness, like: It seems like Home Assistant doesn't support this concept for admin services (likely a miss, but I don't see the use case at this point either).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

So we can add some awesome services.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I didn't.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
