### PR TITLE
Add event entity for Home Assistant Repairs

### DIFF
--- a/custom_components/spook/const.py
+++ b/custom_components/spook/const.py
@@ -10,6 +10,7 @@ LOGGER = logging.getLogger(__package__)
 PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.EVENT,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,

--- a/custom_components/spook/ectoplasms/repairs/event.py
+++ b/custom_components/spook/ectoplasms/repairs/event.py
@@ -1,0 +1,65 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.components.event import EventEntity, EventEntityDescription
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.issue_registry import EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED
+
+from ...entity import SpookEntityDescription
+from .entity import RepairsSpookEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+@dataclass
+class RepairsSpookEventEntityDescription(
+    SpookEntityDescription,
+    EventEntityDescription,
+):
+    """Class describing Spook Repairs event entities."""
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    _entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Spook event."""
+    async_add_entities(
+        [
+            RepairsSpookEventEntity(
+                RepairsSpookEventEntityDescription(
+                    key="event",
+                    translation_key="repairs_event",
+                    entity_id="event.repair",
+                    event_types=["create", "remove", "update"],
+                ),
+            ),
+        ],
+    )
+
+
+class RepairsSpookEventEntity(RepairsSpookEntity, EventEntity):
+    """Spook sensor providing repairs information."""
+
+    entity_description: RepairsSpookEventEntityDescription
+
+    async def async_added_to_hass(self) -> None:
+        """Register for event updates."""
+
+        @callback
+        def _fire(event: Event) -> None:
+            """Update state."""
+            data = event.data.copy()
+            event_type = data.pop("action")
+            self._trigger_event(event_type, data)
+            self.async_schedule_update_ha_state()
+
+        self.async_on_remove(
+            self.hass.bus.async_listen(EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED, _fire),
+        )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -18,6 +18,25 @@
         "name": "Restart"
       }
     },
+    "event": {
+      "repairs_event": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "create": "Issue created",
+              "remove": "Issue removed",
+              "update": "Issue updated"
+            }
+          },
+          "domain": {
+            "name": "Issue issuer"
+          },
+          "issue_id": {
+            "name": "Issue ID"
+          }
+        }
+      }
+    },
     "sensor": {
       "homeassistant_air_quality": {
         "name": "Air quality"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds an event entity for Home Assistant Repairs

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This entity allows you to monitor if new repairs are raised (or existing ones changed/removed).
It can help create notifications.

The attributes contain the integration that issued the issue and the issue ID.

The plan is to create a service to query the issue registry to get the details on it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

![CleanShot 2023-08-10 at 23 47 39](https://github.com/frenck/spook/assets/195327/c05f9ab2-6647-4d3d-b8f0-43b40a0716d7)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
