### PR TITLE
Add button entities for ignoring / unignoring repairs

### DIFF
--- a/custom_components/spook/ectoplasms/repairs/button.py
+++ b/custom_components/spook/ectoplasms/repairs/button.py
@@ -1,0 +1,78 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.entity import EntityCategory
+
+from ...entity import SpookEntityDescription
+from .entity import RepairsSpookEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+@dataclass
+class RepairsSpookButtonEntityDescriptionMixin:
+    """Mixin values for Repairs related buttons."""
+
+    ignore: bool
+
+
+@dataclass
+class RepairsSpookButtonEntityDescription(
+    SpookEntityDescription,
+    ButtonEntityDescription,
+    RepairsSpookButtonEntityDescriptionMixin,
+):
+    """Class describing Spook Repairs button entities."""
+
+
+BUTTONS: tuple[RepairsSpookButtonEntityDescription, ...] = (
+    RepairsSpookButtonEntityDescription(
+        key="ignore_all",
+        translation_key="repairs_ignore_all",
+        entity_id="button.ignore_all_issues",
+        icon="mdi:checkbox-outline",
+        entity_category=EntityCategory.CONFIG,
+        ignore=True,
+    ),
+    RepairsSpookButtonEntityDescription(
+        key="unignore_all",
+        translation_key="repairs_unignore_all",
+        entity_id="button.unignore_all_issues",
+        icon="mdi:checkbox-blank-outline",
+        entity_category=EntityCategory.CONFIG,
+        ignore=False,
+    ),
+)
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    _entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Spook sensor."""
+    async_add_entities(RepairsSpookButtonEntity(description) for description in BUTTONS)
+
+
+class RepairsSpookButtonEntity(RepairsSpookEntity, ButtonEntity):
+    """Spook button providig Repairs actions."""
+
+    entity_description: RepairsSpookButtonEntityDescription
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        issue_registry = ir.async_get(self.hass)
+        for domain, issue_id in issue_registry.issues:
+            issue_registry.async_ignore(
+                domain,
+                issue_id,
+                ignore=self.entity_description.ignore,
+            )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -16,6 +16,12 @@
       },
       "homeassistant_restart": {
         "name": "Restart"
+      },
+      "repairs_ignore_all": {
+        "name": "Ignore all"
+      },
+      "repairs_unignore_all": {
+        "name": "Unignore all"
       }
     },
     "event": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds buttons for (un)ignoring all repair issues

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

See recording below.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

![CleanShot 2023-08-11 at 10 10 17](https://github.com/frenck/spook/assets/195327/b18a4c81-8a41-4ac5-961e-6f6768ec1953)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
