### PR TITLE
Fix import location of EntityCategory

### DIFF
--- a/custom_components/spook/ectoplasms/cloud/switch.py
+++ b/custom_components/spook/ectoplasms/cloud/switch.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.cloud import DOMAIN as CLOUD_DOMAIN
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import EntityCategory
 
 from ...entity import SpookEntityDescription
 from .entity import HomeAssistantCloudSpookEntity

--- a/custom_components/spook/ectoplasms/homeassistant/button.py
+++ b/custom_components/spook/ectoplasms/homeassistant/button.py
@@ -14,7 +14,7 @@ from homeassistant.components.homeassistant import (
     SERVICE_HOMEASSISTANT_RESTART,
     SERVICE_RELOAD_ALL,
 )
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import EntityCategory
 
 from ...entity import SpookEntityDescription
 from .entity import HomeAssistantSpookEntity

--- a/custom_components/spook/ectoplasms/homeassistant/sensor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/sensor.py
@@ -26,6 +26,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_HOMEASSISTANT_STARTED,
+    EntityCategory,
     Platform,
 )
 from homeassistant.core import Event, HomeAssistant, callback
@@ -34,7 +35,6 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
-from homeassistant.helpers.entity import EntityCategory
 
 from ...entity import SpookEntityDescription
 from .entity import HomeAssistantSpookEntity

--- a/custom_components/spook/ectoplasms/repairs/button.py
+++ b/custom_components/spook/ectoplasms/repairs/button.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.const import EntityCategory
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.entity import EntityCategory
 
 from ...entity import SpookEntityDescription
 from .entity import RepairsSpookEntity

--- a/custom_components/spook/ectoplasms/repairs/sensor.py
+++ b/custom_components/spook/ectoplasms/repairs/sensor.py
@@ -9,10 +9,9 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EntityCategory
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.entity import EntityCategory
 
 from ...entity import SpookEntityDescription
 from .entity import RepairsSpookEntity


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

SSIA, the thing has moved in Home Assistant. Since Spook now required 2023.8.0, is is save to correct the location.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
