### PR TITLE
Fix zone services not working with YAML home zone

### DIFF
--- a/custom_components/spook/ectoplasms/zone/services/create.py
+++ b/custom_components/spook/ectoplasms/zone/services/create.py
@@ -20,5 +20,15 @@ class SpookService(AbstractSpookAdminService):
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
-        collection: ZoneStorageCollection = self.hass.data[DOMAIN]
+        collection: ZoneStorageCollection
+        if DOMAIN in self.hass.data:
+            collection = self.hass.data[DOMAIN]
+        else:
+            # Home zone is set in YAML, as a result Home Assistant doesn't
+            # set the storage collection into hass data.
+            # Major hack to get around this. 👻
+            collection = self.hass.data["websocket_api"]["zone/list"][
+                0
+            ].__self__.storage_collection
+
         await collection.async_create_item(call.data.copy())

--- a/custom_components/spook/ectoplasms/zone/services/delete.py
+++ b/custom_components/spook/ectoplasms/zone/services/delete.py
@@ -30,7 +30,18 @@ class SpookService(AbstractSpookAdminService):
         entity_component: [EntityComponent[Zone]] = self.hass.data[DATA_INSTANCES][
             DOMAIN
         ]
-        collection: ZoneStorageCollection = self.hass.data[DOMAIN]
+
+        collection: ZoneStorageCollection
+        if DOMAIN in self.hass.data:
+            collection = self.hass.data[DOMAIN]
+        else:
+            # Home zone is set in YAML, as a result Home Assistant doesn't
+            # set the storage collection into hass data.
+            # Major hack to get around this. 👻
+            collection = self.hass.data["websocket_api"]["zone/list"][
+                0
+            ].__self__.storage_collection
+
         for entity_id in call.data["entity_id"]:
             if not (entity := entity_component.get_entity(entity_id)):
                 message = f"Could not find entity_id: {entity_id}"

--- a/custom_components/spook/ectoplasms/zone/services/update.py
+++ b/custom_components/spook/ectoplasms/zone/services/update.py
@@ -35,7 +35,18 @@ class SpookService(AbstractSpookAdminService):
         entity_component: [EntityComponent[Zone]] = self.hass.data[DATA_INSTANCES][
             DOMAIN
         ]
-        collection: ZoneStorageCollection = self.hass.data[DOMAIN]
+
+        collection: ZoneStorageCollection
+        if DOMAIN in self.hass.data:
+            collection = self.hass.data[DOMAIN]
+        else:
+            # Home zone is set in YAML, as a result Home Assistant doesn't
+            # set the storage collection into hass data.
+            # Major hack to get around this. 👻
+            collection = self.hass.data["websocket_api"]["zone/list"][
+                0
+            ].__self__.storage_collection
+
         if not (entity := entity_component.get_entity(call.data["entity_id"])):
             message = f"Could not find entity_id: {call.data['entity_id']}"
             raise HomeAssistantError(message)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a workaround to get to the Zone storage collection.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Home Assistant doesn't set the Zone storage collection into the hass.data when the Home zone is defined/overriden in YAML. Causing Spook his zone services to fail.

This PR adds a workaround by grabbing the collection from the WebSocket API handlers. (Super dirty).

fixes #311 


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Defined the Home zone in YAML and restarted HA. 
Confirmed the services now work, but don't work without the PR applied.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

-

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
