### PR TITLE
Fix unknown dashboard entities repair for filtered badges

### DIFF
--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -204,6 +204,16 @@ class SpookRepair(AbstractSpookRepair):
             if (entity_id := config.get("entity")) and isinstance(entity_id, str):
                 return {config["entity"]}
             if (entities := config.get("entities")) and isinstance(entities, list):
+                extracted = []
+                for entity in entities:
+                    if isinstance(entity, str):
+                        extracted.append(entity)
+                    elif (
+                        isinstance(entity, dict)
+                        and "entity" in entity
+                        and isinstance(entity["entity"], str)
+                    ):
+                        extracted.append(entity["entity"])
                 return set(config["entities"])
         return set()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The entities shown in badges of dashboards can be filtered. This wasn't handled by Spook when looking for unknown entity rereferences.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes #318

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Good.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
