### PR TITLE
Fix implicit use of device name in Repairs event

### DIFF
--- a/custom_components/spook/ectoplasms/repairs/event.py
+++ b/custom_components/spook/ectoplasms/repairs/event.py
@@ -48,6 +48,7 @@ class RepairsSpookEventEntity(RepairsSpookEntity, EventEntity):
     """Spook sensor providing repairs information."""
 
     entity_description: RepairsSpookEventEntityDescription
+    _attr_name = None
 
     async def async_added_to_hass(self) -> None:
         """Register for event updates."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fixes

```
Entity event.repair (<class 'custom_components.spook.ectoplasms.repairs.event.RepairsSpookEventEntity'>) is implicitly using device name by not setting its name. Instead, the name should be set to None, please report it to the custom integration author.
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes #312

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Run, confirmed it is gone.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
