### PR TITLE
Add support for sub-integrations

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.core import (
 from .const import LOGGER, PLATFORMS
 from .repairs import SpookRepairManager
 from .services import SpookServiceManager
-from .util import link_sub_integrations
+from .util import link_sub_integrations, unlink_sub_integrations
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -81,4 +81,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_remove_entry(hass: HomeAssistant, _: ConfigEntry) -> None:
     """Remove a config entry."""
-    await hass.async_add_executor_job(link_sub_integrations, hass)
+    await hass.async_add_executor_job(unlink_sub_integrations, hass)

--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
         # User asked to restart Home Assistant in the config flow.
-        if hass.data[DOMAIN] == "Boo!":
+        if hass.data.get(DOMAIN) == "Boo!":
             _restart()
             return False
 

--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.core import (
     CoreState,
     callback,
 )
+from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .repairs import SpookRepairManager
@@ -55,7 +56,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _restart)
             return False
 
-        # TODO: Raise repair issue instead
+        LOGGER.info(
+            "Home Assistant needs to be restarted in for Spook to complete setting up",
+        )
+        ir.async_create_issue(
+            hass=hass,
+            domain=DOMAIN,
+            issue_id="restart_required",
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="restart_required",
+        )
 
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/spook/config_flow.py
+++ b/custom_components/spook/config_flow.py
@@ -45,13 +45,13 @@ class UptimeConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_restart_later(
-        self, _: dict[str, Any] | None = None
+        self, _: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Handle restart later case."""
         return self.async_create_entry(title="Not your homie", data={})
 
     async def async_step_restart_now(
-        self, _: dict[str, Any] | None = None
+        self, _: dict[str, Any] | None = None,
     ) -> FlowResult:
         """Handle restart now case.
 

--- a/custom_components/spook/config_flow.py
+++ b/custom_components/spook/config_flow.py
@@ -27,6 +27,35 @@ class UptimeConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="already_spooked")
 
         if user_input is not None:
-            return self.async_create_entry(title="Not your homie", data={})
+            return await self.async_step_choice_restart()
 
         return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+
+    async def async_step_choice_restart(
+        self,
+        _: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Handle the user's choice.
+
+        Allows the user to choose to restart now or later.
+        """
+        return self.async_show_menu(
+            step_id="choice_restart",
+            menu_options=["restart_now", "restart_later"],
+        )
+
+    async def async_step_restart_later(
+        self, _: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle restart later case."""
+        return self.async_create_entry(title="Not your homie", data={})
+
+    async def async_step_restart_now(
+        self, _: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle restart now case.
+
+        Sets a flag, so the integraton setup knows it can go ahead and restart.
+        """
+        self.hass.data[DOMAIN] = "Boo!"
+        return await self.async_step_restart_later()

--- a/custom_components/spook/integrations/__init__.py
+++ b/custom_components/spook/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Not your homie."""

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -271,6 +271,17 @@
         }
       },
       "title": "{title}"
+    },
+    "restart_required": {
+      "title": "Restart required",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Restart required",
+            "description": "In order for Spook 👻 to finish setting up, Home Assistant needs to be restarted.\n\nSelect submit to restart Home Assistant now."
+          }
+        }
+      }
     }
   }
 }

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -6,6 +6,13 @@
     "step": {
       "user": {
         "description": "Did you read the readme? Did you read the license? Are you really sure?"
+      },
+      "choice_restart": {
+        "description": "In order for Spook to finish setting up, Home Assistant needs to be restarted.\n\nDo you want to restart Home Assistant now?",
+        "menu_options": {
+          "restart_now": "Restart now",
+          "restart_later": "Restart later"
+        }
       }
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds support for shipping integrations from within Spook itself.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Spook has much to offer and could be offering much more. However, the concept of integration in Home Assistant is limited to a single integration at a time.

Trying to break that barrier with Spook, by having Spook smuggle multiple integrations inside itself like a little trojan horse.

The goal is to be able to provide additional other integrations, like, for example, new helpers.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

It hasn't yet, this is building the foundation.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
