### PR TITLE
Add services to add/remove device trackers from persons

### DIFF
--- a/custom_components/spook/ectoplasms/person/__init__.py
+++ b/custom_components/spook/ectoplasms/person/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Not your homie."""

--- a/custom_components/spook/ectoplasms/person/services/__init__.py
+++ b/custom_components/spook/ectoplasms/person/services/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Not your homie."""

--- a/custom_components/spook/ectoplasms/person/services/add_device_tracker.py
+++ b/custom_components/spook/ectoplasms/person/services/add_device_tracker.py
@@ -1,0 +1,55 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.person import DOMAIN, Person, PersonStorageCollection
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+    from homeassistant.helpers.entity_component import EntityComponent
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant service to add a device tracker to a person."""
+
+    domain = DOMAIN
+    service = "add_device_tracker"
+    schema = {
+        vol.Required("entity_id"): cv.entity_domain(DOMAIN),
+        vol.Required("device_tracker"): vol.All(
+            cv.ensure_list,
+            [cv.entity_domain("device_tracker")],
+        ),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        collection: PersonStorageCollection
+        entity_component: EntityComponent[Person]
+        _, collection, entity_component = self.hass.data[DOMAIN]
+
+        if not (entity := entity_component.get_entity(call.data["entity_id"])):
+            message = f"Could not find entity_id: {call.data['entity_id']}"
+            raise HomeAssistantError(message)
+
+        # pylint: disable-next=protected-access
+        if not entity.editable or "id" not in entity._config:  # noqa: SLF001
+            message = f"This person is not editable: {call.data['entity_id']}"
+            raise HomeAssistantError(message)
+
+        await collection.async_update_item(
+            # pylint: disable-next=protected-access
+            entity._config["id"],  # noqa: SLF001
+            {
+                "device_trackers": list(
+                    set(entity.device_trackers + call.data["device_tracker"]),
+                ),
+            },
+        )

--- a/custom_components/spook/ectoplasms/person/services/remove_device_tracker.py
+++ b/custom_components/spook/ectoplasms/person/services/remove_device_tracker.py
@@ -1,0 +1,55 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.person import DOMAIN, Person, PersonStorageCollection
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+    from homeassistant.helpers.entity_component import EntityComponent
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant service to remove a device tracker from a person."""
+
+    domain = DOMAIN
+    service = "remove_device_tracker"
+    schema = {
+        vol.Required("entity_id"): cv.entity_domain(DOMAIN),
+        vol.Required("device_tracker"): vol.All(
+            cv.ensure_list,
+            [cv.entity_domain("device_tracker")],
+        ),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        collection: PersonStorageCollection
+        entity_component: EntityComponent[Person]
+        _, collection, entity_component = self.hass.data[DOMAIN]
+
+        if not (entity := entity_component.get_entity(call.data["entity_id"])):
+            message = f"Could not find entity_id: {call.data['entity_id']}"
+            raise HomeAssistantError(message)
+
+        # pylint: disable-next=protected-access
+        if not entity.editable or "id" not in entity._config:  # noqa: SLF001
+            message = f"This person is not editable: {call.data['entity_id']}"
+            raise HomeAssistantError(message)
+
+        await collection.async_update_item(
+            # pylint: disable-next=protected-access
+            entity._config["id"],  # noqa: SLF001
+            {
+                "device_trackers": list(
+                    entity.device_trackers - call.data["device_tracker"],
+                ),
+            },
+        )

--- a/custom_components/spook/ectoplasms/person/services/remove_device_tracker.py
+++ b/custom_components/spook/ectoplasms/person/services/remove_device_tracker.py
@@ -49,7 +49,7 @@ class SpookService(AbstractSpookAdminService):
             entity._config["id"],  # noqa: SLF001
             {
                 "device_trackers": list(
-                    entity.device_trackers - call.data["device_tracker"],
+                    set(entity.device_trackers) - set(call.data["device_tracker"]),
                 ),
             },
         )

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -10,6 +10,7 @@
     "input_select",
     "lovelace",
     "number",
+    "person",
     "recorder",
     "repairs",
     "select",

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -559,7 +559,6 @@ person_add_device_tracker:
       required: true
       selector:
         entity:
-          multiple: true
           filter:
             - domain: person
     device_tracker:
@@ -585,7 +584,6 @@ person_remove_device_tracker:
       required: true
       selector:
         entity:
-          multiple: true
           filter:
             - domain: person
     device_tracker:

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -547,6 +547,58 @@ input_number_min:
     entity:
       domain: input_number
 
+person_add_device_tracker:
+  name: Add a device tracker 👻
+  description: >-
+    Add a device tracker to a person.
+  fields:
+    entity_id:
+      name: Person
+      description: >-
+        The person entity ID to add the device tracker to.
+      required: true
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: person
+    device_tracker:
+      name: Device tracker
+      description: >-
+        The device tracker entity ID to add to the person.
+      required: true
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: device_tracker
+
+person_remove_device_tracker:
+  name: Remove a device tracker 👻
+  description: >-
+    Remove a device tracker from a person.
+  fields:
+    entity_id:
+      name: Person
+      description: >-
+        The person entity ID to remove the device tracker from.
+      required: true
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: person
+    device_tracker:
+      name: Device tracker
+      description: >-
+        The device tracker entity ID to remove from the person.
+      required: true
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: device_tracker
+
 repairs_create:
   name: Create issue 👻
   description: >-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds services to modify persons in Home Assistant, allowing to add/remove devices trackers from them on the fly.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As requested in: https://github.com/frenck/spook/discussions/325

It would, for example, allow temporarily attaching a device tracker (for example, a car tracker) to a person while they are traveling.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Using the dev tools


## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

![image](https://github.com/frenck/spook/assets/195327/72ce625e-1da9-413a-9c63-f97619c67a5c)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
