### PR TITLE
Fix display of inverse helper

### DIFF
--- a/custom_components/spook/integrations/spook_inverse/translations/en.json
+++ b/custom_components/spook/integrations/spook_inverse/translations/en.json
@@ -47,5 +47,5 @@
       }
     }
   },
-  "title": "Inverse"
+  "title": "Inverse 👻"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spook should always identify itself; however, it did not on the "Add helper" dialog. This PR fixes that.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
