### PR TITLE
Raise repairs for unknown entity references in scenes

### DIFF
--- a/custom_components/spook/ectoplasms/scene/__init__.py
+++ b/custom_components/spook/ectoplasms/scene/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Not your homie."""

--- a/custom_components/spook/ectoplasms/scene/repairs/__init__.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Not your homie."""

--- a/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
@@ -1,0 +1,64 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from homeassistant.components.homeassistant import scene
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.core import valid_entity_id
+from homeassistant.helpers import entity_registry as er
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair tries to find unknown entities in scenes."""
+
+    domain = "scene"
+    repair = "scene_unknown_entity_references"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+        scene.EVENT_SCENE_RELOADED,
+        "event_group_reloaded",
+        "event_integration_reloaded",
+        "event_mqtt_reloaded",
+    }
+
+    async def async_inspect(self) -> None:
+        """Trigger a inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        entity_ids = {
+            entity.entity_id for entity in self.entity_registry.entities.values()
+        }.union(self.hass.states.async_entity_ids())
+
+        scenes: list[scene.HomeAssistantScene] = self.hass.data[
+            "homeassistant_scene"
+        ].entities.values()
+
+        for entity in scenes:
+            LOGGER.error("Scene: %s", entity.entity_id)
+            if unknown_entities := {
+                entity_id
+                for entity_id in entity.scene_config.states
+                if (entity_id not in entity_ids and valid_entity_id(entity_id))
+            }:
+                self.async_create_issue(
+                    issue_id=entity.entity_id,
+                    translation_placeholders={
+                        "entities": "\n".join(
+                            f"- `{entity_id}`" for entity_id in unknown_entities
+                        ),
+                        "scene": entity.name,
+                        "entity_id": entity.entity_id,
+                        "edit": f"/config/scene/edit/{entity.unique_id}",
+                    },
+                )
+                LOGGER.debug(
+                    "Spook found unknown entities references in %s "
+                    "and created an issue for it; Entities: %s",
+                    entity.entity_id,
+                    ", ".join(unknown_entities),
+                )
+            else:
+                self.async_delete_issue(entity.entity_id)

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -245,6 +245,10 @@
       "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n[{dashboard}]({edit})\n\nThis dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie.",
       "title": "Unknown entities used in: {dashboard}"
     },
+    "scene_unknown_entity_references": {
+      "description": "Spook has found a ghost in your scenes 👻\n\nWhile floating around, Spook crossed path with the following scene:\n\n[{scene}]({edit})\n\nThis scene references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the scene]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown entities used in: {scene}"
+    },
     "script_unknown_area_references": {
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Not your homie.",
       "title": "Unknown areas used in: {script}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add logic to raise repairs for scenes that have unknown entity references.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Referencing non-existing entities in scene, may cause your scene not to work as expected.
These issues are hard to pinpoint, Spook helps with this one.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

![CleanShot 2023-09-23 at 12 39 24](https://github.com/frenck/spook/assets/195327/ed1f43c3-02f9-44d2-abae-91d064d2c5b4)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
