### PR TITLE
Reduce repair event debounce cooldown period to 3 seconds

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -133,7 +133,7 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
         self.inspect_debouncer = Debouncer(
             self.hass,
             LOGGER,
-            cooldown=10,
+            cooldown=3,
             immediate=False,
             function=_async_inspect,
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Thanks to a Tweet JLo sent out, I learned that the cooldown period of Spook was rather generous.

This PR reduces it from 10 seconds to 3 seconds.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This will help Spook to respond faster on changes happening on the system. 10 second is quite a bit, and big enough to notice / be annoying.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
