### PR TITLE
Don't use LOGGER.error for debug logging during scene entities check

### DIFF
--- a/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
@@ -37,7 +37,6 @@ class SpookRepair(AbstractSpookRepair):
         ].entities.values()
 
         for entity in scenes:
-            LOGGER.debug("Inspecting scene: %s", entity.entity_id)
             if unknown_entities := {
                 entity_id
                 for entity_id in entity.scene_config.states

--- a/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
@@ -37,7 +37,7 @@ class SpookRepair(AbstractSpookRepair):
         ].entities.values()
 
         for entity in scenes:
-            LOGGER.error("Scene: %s", entity.entity_id)
+            LOGGER.debug("Inspecting scene: %s", entity.entity_id)
             if unknown_entities := {
                 entity_id
                 for entity_id in entity.scene_config.states


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Change a LOGGER.error statement that's not used to log an error to a more approproate debug statement.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I new errors in my HA log after installing spook, and after I'd fixed all the repairs. Since the error's title was just `Scene: scene.one_of_my_scenes`, repeated multiple times for each scene, I checked the code and noticed that every time a scene's entities are scanned for missing entities (e.g. when saving a scene), the scene's id is logged as error. This PR changes the message's log level to debug.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

1. changed the file locally
2. deleted the corresponding pycache file
3. restarted HomeAssistant
4. changed a scene, to see if the log's gone
5. error is no longer logged!
6. reverted the change locally, then repeated 2.-4. to check that the error comes back, which it does

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

![grafik](https://github.com/frenck/spook/assets/6765536/e2afaa0d-2e68-423a-9a0f-97a05bc7c2fb)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
