### PR TITLE
Fixed typo in automation integration documentation

### DIFF
--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -57,7 +57,7 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 :::{attention} Known limitations
 :class: dropdown
 
-{term}`Templates <template>` in automations are not evaluated by Spook. That means that service calls that target areas dynamically using a template, are considered by Spook.
+{term}`Templates <template>` in automations are not evaluated by Spook. That means that service calls that target areas dynamically using a template, are not considered by Spook.
 :::
 
 ### Unknown referenced devices

--- a/documentation/integrations/script.md
+++ b/documentation/integrations/script.md
@@ -56,7 +56,7 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 :::{attention} Known limitations
 :class: dropdown
 
-{term}`Templates <template>` in scripts are not evaluated by Spook. That means that service calls that target areas dynamically using a template, are considered by Spook.
+{term}`Templates <template>` in scripts are not evaluated by Spook. That means that service calls that target areas dynamically using a template, are not considered by Spook.
 :::
 
 ### Unknown referenced devices


### PR DESCRIPTION

## Description

Added the word "not" to limitation

## Motivation and Context

Documentation had a typo
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Looked at the markdown on GitHub
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
