### PR TITLE
Add Home Assistant restart safe_mode support

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/restart.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/restart.py
@@ -27,6 +27,7 @@ class SpookService(AbstractSpookAdminService, ReplaceExistingService):
     domain = DOMAIN
     service = "restart"
     schema = {
+        vol.Optional("safe_mode", default=False): cv.boolean,
         vol.Optional("force", default=False): cv.boolean,
     }
 

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -330,6 +330,14 @@ homeassistant_restart:
   name: Restart 👻
   description: Restart the Home Assistant service.
   fields:
+    safe_mode:
+      name: Safe mode
+      description: >-
+        If the restart should be done in safe mode. This will disable all
+        custom integrations and frontend modules.
+      required: false
+      selector:
+        boolean:
     force:
       name: Force restart
       description: >-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds support for restarting Home Assistant in safe mode. This is added in Home Assistant 2023.11, and because of this addition, the restart service currently breaks when using Spook.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix it!

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Good!

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Shot the screen, now has a bullet hole.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
