### PR TITLE
Fix crash on unavailable automations & scripts

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
@@ -32,11 +32,13 @@ class SpookRepair(AbstractSpookRepair):
         LOGGER.debug("Spook is inspecting: %s", self.repair)
         areas = set(self.area_registry.areas)
         for entity in self._entity_component.entities:
-            if unknown_areas := {
-                area
-                for area in entity.referenced_areas - areas
-                if isinstance(area, str)
-            }:
+            if not isinstance(entity, automation.UnavailableAutomationEntity) and (
+                unknown_areas := {
+                    area
+                    for area in entity.referenced_areas - areas
+                    if isinstance(area, str)
+                }
+            ):
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -31,11 +31,13 @@ class SpookRepair(AbstractSpookRepair):
         LOGGER.debug("Spook is inspecting: %s", self.repair)
         devices = {device.id for device in self.device_registry.devices.values()}
         for entity in self._entity_component.entities:
-            if unknown_devices := {
-                device
-                for device in entity.referenced_devices - devices
-                if isinstance(device, str)
-            }:
+            if not isinstance(entity, automation.UnavailableAutomationEntity) and (
+                unknown_devices := {
+                    device
+                    for device in entity.referenced_devices - devices
+                    if isinstance(device, str)
+                }
+            ):
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -93,23 +93,25 @@ class SpookRepair(AbstractSpookRepair):
             # Filter out scenes, groups & device_tracker entities.
             # Those can be created on the fly with services, which we
             # currently cannot detect yet. Let's prevent some false positives.
-            if unknown_entities := {
-                entity_id
-                for entity_id in entity.referenced_entities
-                if (
-                    isinstance(entity_id, str)
-                    and not entity_id.startswith(
-                        (
-                            "device_tracker.",
-                            "group.",
-                            "persistent_notification.",
-                            "scene.",
-                        ),
+            if not isinstance(entity, automation.UnavailableAutomationEntity) and (
+                unknown_entities := {
+                    entity_id
+                    for entity_id in entity.referenced_entities
+                    if (
+                        isinstance(entity_id, str)
+                        and not entity_id.startswith(
+                            (
+                                "device_tracker.",
+                                "group.",
+                                "persistent_notification.",
+                                "scene.",
+                            ),
+                        )
+                        and entity_id not in entity_ids
+                        and valid_entity_id(entity_id)
                     )
-                    and entity_id not in entity_ids
-                    and valid_entity_id(entity_id)
-                )
-            }:
+                }
+            ):
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
@@ -28,11 +28,13 @@ class SpookRepair(AbstractSpookRepair):
         LOGGER.debug("Spook is inspecting: %s", self.repair)
         areas = set(self.area_registry.areas)
         for entity in self._entity_component.entities:
-            if unknown_areas := {
-                area
-                for area in entity.script.referenced_areas - areas
-                if isinstance(area, str)
-            }:
+            if not isinstance(entity, script.UnavailableScriptEntity) and (
+                unknown_areas := {
+                    area
+                    for area in entity.script.referenced_areas - areas
+                    if isinstance(area, str)
+                }
+            ):
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
@@ -28,11 +28,13 @@ class SpookRepair(AbstractSpookRepair):
         LOGGER.debug("Spook is inspecting: %s", self.repair)
         devices = {device.id for device in self.device_registry.devices.values()}
         for entity in self._entity_component.entities:
-            if unknown_devices := {
-                device
-                for device in entity.script.referenced_devices - devices
-                if isinstance(device, str)
-            }:
+            if not isinstance(entity, script.UnavailableScriptEntity) and (
+                unknown_devices := {
+                    device
+                    for device in entity.script.referenced_devices - devices
+                    if isinstance(device, str)
+                }
+            ):
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -94,23 +94,25 @@ class SpookRepair(AbstractSpookRepair):
             # Filter out scenes, groups & device_tracker entities.
             # Those can be created on the fly with services, which we
             # currently cannot detect yet. Let's prevent some false positives.
-            if unknown_entities := {
-                entity_id
-                for entity_id in entity.script.referenced_entities
-                if (
-                    isinstance(entity_id, str)
-                    and not entity_id.startswith(
-                        (
-                            "device_tracker.",
-                            "group.",
-                            "persistent_notification.",
-                            "scene.",
-                        ),
+            if not isinstance(entity, script.UnavailableScriptEntity) and (
+                unknown_entities := {
+                    entity_id
+                    for entity_id in entity.script.referenced_entities
+                    if (
+                        isinstance(entity_id, str)
+                        and not entity_id.startswith(
+                            (
+                                "device_tracker.",
+                                "group.",
+                                "persistent_notification.",
+                                "scene.",
+                            ),
+                        )
+                        and entity_id not in entity_ids
+                        and valid_entity_id(entity_id)
                     )
-                    and entity_id not in entity_ids
-                    and valid_entity_id(entity_id)
-                )
-            }:
+                }
+            ):
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When an automation or script has an parsing error, and entity stub object is used to fill in the gap. Being `UnavailableScriptEntity` and `UnavailableAutomationEntity`.

These can be skipped for determining unknown entities/devices/areas, as they are not valid YAML/not loaded.

Fixes #476

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Good

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
