### PR TITLE
Bump min required Home Assistant to 2023.12.0

### DIFF
--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -19,7 +19,7 @@ Getting Spook up and running should not be too hard when you follow this guide. 
 Spook needs a few things to work properly, so let's go over them first.
 
 1. Read, understand, and accept [the license](license) of Spook.
-2. A working {term}`Home Assistant` instance running version **2023.8.0 or newer.**
+2. A working {term}`Home Assistant` instance running version **2023.12.0 or newer.**
 
    :::{note}
    The minimal required version of Home Assistant will change over time. This is not something to worry about. It is only important that you run at least the minimal required version of Home Assistant on the first installation of Spook.

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Spook 👻 Not your homie",
   "render_readme": true,
-  "homeassistant": "2023.8.0",
+  "homeassistant": "2023.12.0",
   "zip_release": true,
   "filename": "spook.zip"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To support error translations and the new `ServiceValidationError`, Spook is bumping the minimal required version of Home Assistant to 2023.12.0

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
