### PR TITLE
Add possibility to extend the Home Assistant template engine

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import issue_registry as ir
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .repairs import SpookRepairManager
 from .services import SpookServiceManager
+from .templating import SpookTemplateFunctionManager
 from .util import (
     async_ensure_template_environments_exists,
     async_forward_setup_entry,
@@ -78,6 +79,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Forward async_setup_entry to ectoplasms
     await async_forward_setup_entry(hass, entry)
+
+    # Set up templating
+    templating = SpookTemplateFunctionManager(hass)
+    await templating.async_setup()
+    entry.async_on_unload(templating.async_on_unload)
 
     # Set up services
     services = SpookServiceManager(hass)

--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -17,6 +17,7 @@ from .const import DOMAIN, LOGGER, PLATFORMS
 from .repairs import SpookRepairManager
 from .services import SpookServiceManager
 from .util import (
+    async_ensure_template_environments_exists,
     async_forward_setup_entry,
     link_sub_integrations,
     unlink_sub_integrations,
@@ -71,6 +72,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             severity=ir.IssueSeverity.WARNING,
             translation_key="restart_required",
         )
+
+    # Ensure template environments exists
+    async_ensure_template_environments_exists(hass)
 
     # Forward async_setup_entry to ectoplasms
     await async_forward_setup_entry(hass, entry)

--- a/custom_components/spook/templating.py
+++ b/custom_components/spook/templating.py
@@ -1,0 +1,169 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn, final
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.template import TemplateEnvironment
+
+from .const import LOGGER
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class AbstractSpookTemplateFunction(ABC):
+    """Abstract base class to hold a Spook template function."""
+
+    hass: HomeAssistant
+    name: str
+
+    requires_hass_object: bool = True
+    is_available_in_limited_environment: bool = False
+    is_filter: bool = False
+    is_global: bool = False
+    is_test: bool = False
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the template function."""
+        self.hass = hass
+
+    @abstractmethod
+    def function(self) -> Callable[..., Any]:
+        """Return the python method that runs this template function."""
+        raise NotImplementedError
+
+    @final
+    @callback
+    def async_register(
+        self, environment: TemplateEnvironment, *, is_limited: bool = False
+    ) -> None:
+        """Register the template method."""
+        if environment.hass is None and self.requires_hass_object:
+            return
+
+        if self.is_global:
+            # pylint: disable-next=protected-access
+            if is_limited and not self.is_available_in_limited_environment:
+                environment.globals[self.name] = unsupported_in_limited_environment(
+                    self.name
+                )
+            else:
+                environment.globals[self.name] = self.function()
+
+        if self.is_filter:
+            # pylint: disable-next=protected-access
+            if is_limited and not self.is_available_in_limited_environment:
+                environment.filters[self.name] = unsupported_in_limited_environment(
+                    self.name
+                )
+            else:
+                environment.filters[self.name] = self.function()
+
+        if self.is_test:
+            if is_limited and not self.is_available_in_limited_environment:
+                environment.tests[self.name] = unsupported_in_limited_environment(
+                    self.name
+                )
+            else:
+                environment.tests[self.name] = self.function()
+
+    @final
+    @callback
+    def async_unregister(self, environment: TemplateEnvironment) -> None:
+        """Unregister the template method."""
+        environment.globals.pop(self.name, None)
+        environment.filters.pop(self.name, None)
+        environment.tests.pop(self.name, None)
+
+
+def unsupported_in_limited_environment(name: str) -> Callable[[], NoReturn]:
+    """Return a function that raises TemplateError when called."""
+
+    def warn_unsupported(*_: Any, **__: Any) -> NoReturn:
+        msg = f"Use of '{name}' is not supported in limited templates"
+        raise TemplateError(msg)
+
+    return warn_unsupported
+
+
+@dataclass
+class SpookTemplateFunctionManager:
+    """Class to manage Spook template functions."""
+
+    hass: HomeAssistant
+
+    _functions: set[AbstractSpookTemplateFunction] = field(default_factory=set)
+    _service_schemas: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Post initialization."""
+        LOGGER.debug("Spook template function manager initialized")
+
+    async def async_setup(self) -> None:
+        """Set up the Spook services."""
+        LOGGER.debug("Setting up Spook template functions")
+
+        # Load template functions
+        for module_file in Path(__file__).parent.rglob("ectoplasms/*/templating/*.py"):
+            if module_file.name == "__init__.py":
+                continue
+            module_path = str(module_file.relative_to(Path(__file__).parent))[
+                :-3
+            ].replace("/", ".")
+            module = importlib.import_module(f".{module_path}", __package__)
+            function = module.SpookTemplateFunction(self.hass)
+
+            LOGGER.debug(
+                "Registering Spook template function: %s",
+                function.name,
+            )
+
+            function.async_register(self.hass.data["template.environment"])
+            function.async_register(self.hass.data["template.environment_strict"])
+            function.async_register(
+                self.hass.data["template.environment_limited"], is_limited=True
+            )
+            self._functions.add(function)
+
+        # Patch TemplateEnvironment for new instances
+        functions = self._functions
+
+        def template_environment_init(
+            self: TemplateEnvironment,
+            hass: HomeAssistant | None,
+            limited: bool | None = False,  # noqa: FBT002
+            strict: bool | None = False,  # noqa: FBT002
+            log_fn: Callable[[int, str], None] | None = None,
+        ) -> None:
+            self.original_init_before_spook(hass, limited, strict, log_fn)
+            # Register the Spook template functions
+            for function in functions:
+                function.async_register(self)
+
+        # Keep a reference to the original __init__ method, so we can restore on unload
+        TemplateEnvironment.original_init_before_spook = TemplateEnvironment.__init__
+        TemplateEnvironment.__init__ = template_environment_init
+
+    @callback
+    def async_on_unload(self) -> None:
+        """Tear down the Spook template functions."""
+        LOGGER.debug("Tearing down Spook template functions")
+        for function in self._functions:
+            LOGGER.debug(
+                "Unregistering Spook template function: %s",
+                function.name,
+            )
+            function.async_unregister(self.hass.data["template.environment"])
+            function.async_unregister(self.hass.data["template.environment_strict"])
+            function.async_unregister(self.hass.data["template.environment_limited"])
+            self._functions.discard(function)
+
+        # Restore the original TemplateEnvironment.__init__ method
+        TemplateEnvironment.__init__ = TemplateEnvironment.original_init_before_spook
+        del TemplateEnvironment.original_init_before_spook

--- a/custom_components/spook/templating.py
+++ b/custom_components/spook/templating.py
@@ -144,7 +144,7 @@ class SpookTemplateFunctionManager:
             self.original_init_before_spook(hass, limited, strict, log_fn)
             # Register the Spook template functions
             for function in functions:
-                function.async_register(self)
+                function.async_register(self, is_limited=limited)
 
         # Keep a reference to the original __init__ method, so we can restore on unload
         TemplateEnvironment.original_init_before_spook = TemplateEnvironment.__init__

--- a/custom_components/spook/util.py
+++ b/custom_components/spook/util.py
@@ -5,6 +5,9 @@ import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from homeassistant.core import callback
+from homeassistant.helpers.template import Template
+
 from .const import DOMAIN, LOGGER
 
 if TYPE_CHECKING:
@@ -82,3 +85,31 @@ def unlink_sub_integrations(hass: HomeAssistant) -> bool:
         dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
         if dest.exists():
             dest.unlink()
+
+
+@callback
+def async_ensure_template_environments_exists(hass: HomeAssistant) -> None:
+    """Ensure default template environments exist.
+
+    Spook wants to patch the template environment to allow for custom filters.
+    To make this easier, we need to ensure the default template environments
+    exist before we patch them.
+    """
+    if "template.environment" not in hass.data:
+        template = Template(hass, '{{ "OMG Puppies!" }}')
+        # pylint: disable-next=protected-access
+        assert template._env  # noqa: SLF001, S101
+
+    if "template.environment_limited" not in hass.data:
+        template = Template(hass, '{{ "OMG Puppies!" }}')
+        # pylint: disable-next=protected-access
+        template._limited = True  # noqa: SLF001
+        # pylint: disable-next=protected-access
+        assert template._env  # noqa: SLF001, S101
+
+    if "template.environment_strict" not in hass.data:
+        template = Template(hass, '{{ "OMG Puppies!" }}')
+        # pylint: disable-next=protected-access
+        template._strict = True  # noqa: SLF001
+        # pylint: disable-next=protected-access
+        assert template._env  # noqa: SLF001, S101

--- a/custom_components/spook/util.py
+++ b/custom_components/spook/util.py
@@ -96,19 +96,19 @@ def async_ensure_template_environments_exists(hass: HomeAssistant) -> None:
     exist before we patch them.
     """
     if "template.environment" not in hass.data:
-        template = Template(hass, '{{ "OMG Puppies!" }}')
+        template = Template("OMG Puppies!", hass)
         # pylint: disable-next=protected-access
         assert template._env  # noqa: SLF001, S101
 
     if "template.environment_limited" not in hass.data:
-        template = Template(hass, '{{ "OMG Puppies!" }}')
+        template = Template("OMG Puppies!", hass)
         # pylint: disable-next=protected-access
         template._limited = True  # noqa: SLF001
         # pylint: disable-next=protected-access
         assert template._env  # noqa: SLF001, S101
 
     if "template.environment_strict" not in hass.data:
-        template = Template(hass, '{{ "OMG Puppies!" }}')
+        template = Template("OMG Puppies!", hass)
         # pylint: disable-next=protected-access
         template._strict = True  # noqa: SLF001
         # pylint: disable-next=protected-access


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for extending the Home Assistant template engine.

## Motivation and Context

It would be cool if Spook could extend the Home Assistant template engine with custom functions/tests.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

![image](https://github.com/frenck/spook/assets/195327/1ad21b9b-0225-4e9e-9c1c-27025de76aa0)

`fnmatch` is not an existing template method in Home Assistant, but injected by Spook.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
