### PR TITLE
Add template method: shuffle

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/templating/__init__.py
+++ b/custom_components/spook/ectoplasms/homeassistant/templating/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Not your homie."""

--- a/custom_components/spook/ectoplasms/homeassistant/templating/shuffle.py
+++ b/custom_components/spook/ectoplasms/homeassistant/templating/shuffle.py
@@ -1,0 +1,35 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from random import Random, shuffle
+from typing import TYPE_CHECKING, Any, Iterable
+
+from ....templating import AbstractSpookTemplateFunction
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class SpookTemplateFunction(AbstractSpookTemplateFunction):
+    """Spook template function to shuffle lists."""
+
+    name = "shuffle"
+
+    requires_hass_object = False
+    is_available_in_limited_environment = True
+    is_filter = True
+    is_global = True
+
+    def shuffle(self, items: Iterable[Any], seed: Any = None) -> Iterable[Any]:
+        """Shuffle a list, either with a seed or without."""
+        items = list(items)
+        if seed:
+            r = Random(seed)
+            r.shuffle(items)
+        else:
+            shuffle(items)
+        return items
+
+    def function(self) -> Callable[..., Any]:
+        """Return the python method that runs this template function."""
+        return self.shuffle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a template method to shuffle lists.

## Motivation and Context

Shuffling lists, is currently way to complex.

See for example: https://community.home-assistant.io/t/get-randrom-value-which-not-duplicate-with-the-value-in-previous-random-list/393887

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

See screenshot down below

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

![CleanShot 2023-12-31 at 18 23 49@2x](https://github.com/frenck/spook/assets/195327/521aea5e-aa7c-4a0f-b0fe-9bd79ce66ddb)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
