### PR TITLE
Add template method: fnmatch

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/templating/fnmatch.py
+++ b/custom_components/spook/ectoplasms/homeassistant/templating/fnmatch.py
@@ -1,0 +1,46 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+import fnmatch
+from typing import TYPE_CHECKING, Any, Iterable
+
+from ....templating import AbstractSpookTemplateFunction
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class SpookTemplateFunction(AbstractSpookTemplateFunction):
+    """Spook template function fnmatch."""
+
+    name = "fnmatch"
+
+    requires_hass_object = False
+    is_available_in_limited_environment = True
+    is_filter = True
+    is_global = True
+    is_test = True
+
+    def _function(
+        self,
+        value: str | Iterable[str],
+        pattern: str,
+        case_sensitive: bool = False,  # noqa: FBT001, FBT002
+    ) -> bool | list[str]:
+        """Unix file pattern matching a string or list."""
+        if isinstance(value, str):
+            if case_sensitive:
+                return fnmatch.fnmatchcase(value, pattern)
+            return fnmatch.fnmatch(value, pattern)
+
+        if isinstance(value, Iterable):
+            if case_sensitive:
+                return any(x for x in value if fnmatch.fnmatchcase(x, pattern))
+            return bool(fnmatch.filter(value, pattern))
+
+        msg = f"fnmatch() argument must be a string or a list, not {type(value)}"
+        raise TypeError(msg)
+
+    def function(self) -> Callable[..., Any]:
+        """Return the python method that runs this template function."""
+        return self._function


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the `fnmatch` template method, allowing to use Unix filename pattern matching on strings or lists of strings. 

## Motivation and Context

This provides an easier way/alternative to the regex versions that Home Assistant core has.

On could, for example:

```
{{ fnmatch("test", "t*") }}  # True
{{ fnmatch("notest", "t*") }}  # False
{{ fnmatch(["test", "test2"], "t*") }}  # True
{{ fnmatch(["test", "test2", "no-test"], "t*") }}  # False
```


## How has this been tested?

With the examples above.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
