### PR TITLE
Add template method: fnmatch_filter

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/templating/fnmatch_filter.py
+++ b/custom_components/spook/ectoplasms/homeassistant/templating/fnmatch_filter.py
@@ -1,0 +1,40 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+import fnmatch
+from typing import TYPE_CHECKING, Any, Iterable
+
+from ....templating import AbstractSpookTemplateFunction
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class SpookTemplateFunction(AbstractSpookTemplateFunction):
+    """Spook template function to filter using fnmatch."""
+
+    name = "fnmatch_filter"
+
+    requires_hass_object = False
+    is_available_in_limited_environment = True
+    is_filter = True
+    is_global = True
+
+    def _function(
+        self,
+        value: Iterable[str],
+        pattern: str,
+        case_sensitive: bool = False,  # noqa: FBT001, FBT002
+    ) -> bool | list[str]:
+        """Unix file pattern matching a string or list."""
+        if isinstance(value, Iterable) and not isinstance(value, str):
+            if case_sensitive:
+                return [x for x in value if fnmatch.fnmatchcase(x, pattern)]
+            return fnmatch.filter(value, pattern)
+
+        msg = f"fnmatch() argument must be a list, not {type(value)}"
+        raise TypeError(msg)
+
+    def function(self) -> Callable[..., Any]:
+        """Return the python method that runs this template function."""
+        return self._function


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the `fnmatch_filter` template method, allowing to use Unix filename pattern matching to filter a list of strings.

## Motivation and Context

This provides an easier way/alternative to the regex versions that Home Assistant core has.

One could, for example:

```
# Returns: ['test', 'test2']
{{ fnmatch_filter(["test", "test2", "no-test", "no-pain", "no-glory"], "t*") }}

# Returns: ['no-test', 'no-pain', 'no-glory']
{{ fnmatch_filter(["test", "test2", "no-test", "no-pain", "no-glory"], "no-*") }}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
