### PR TITLE
Add option to listen for config entry changes to trigger repair

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -1,10 +1,7 @@
 """Spook - Not your homie."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from homeassistant.components import automation
-from homeassistant.config_entries import SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntry
 from homeassistant.const import (
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
@@ -12,14 +9,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import valid_entity_id
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
 from ....repairs import AbstractSpookRepair
-
-if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -50,6 +43,7 @@ class SpookRepair(AbstractSpookRepair):
         "event_tod_reloaded",
         "event_utility_meter_reloaded",
     }
+    inspect_config_entry_changed = True
 
     _entity_component: EntityComponent[automation.AutomationEntity]
 
@@ -57,21 +51,6 @@ class SpookRepair(AbstractSpookRepair):
         """Handle the activating a repair."""
         self._entity_component = self.hass.data[DATA_INSTANCES][self.domain]
         await super().async_activate()
-
-        # Listen for config entry changes, this might have an impact
-        # on the available entities (those not in the entity registry)
-        async def _async_update_listener(
-            _hass: HomeAssistant,
-            _entry: ConfigEntry,
-        ) -> None:
-            """Handle options update."""
-            await self.inspect_debouncer.async_call()
-
-        async_dispatcher_connect(
-            self.hass,
-            SIGNAL_CONFIG_ENTRY_CHANGED,
-            _async_update_listener,
-        )
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""

--- a/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
+++ b/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
@@ -2,15 +2,13 @@
 from __future__ import annotations
 
 from homeassistant.components import group
-from homeassistant.config_entries import SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntry
 from homeassistant.const import (
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
     EVENT_COMPONENT_LOADED,
 )
-from homeassistant.core import HomeAssistant, valid_entity_id
+from homeassistant.core import valid_entity_id
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
 from ....const import LOGGER
@@ -41,25 +39,7 @@ class SpookRepair(AbstractSpookRepair):
         "event_tod_reloaded",
         "event_utility_meter_reloaded",
     }
-
-    async def async_activate(self) -> None:
-        """Handle the activating a repair."""
-        await super().async_activate()
-
-        async def _async_update_listener(
-            _hass: HomeAssistant,
-            entry: ConfigEntry,
-        ) -> None:
-            """Handle options update."""
-            if entry.domain != self.domain:
-                return
-            await self.inspect_debouncer.async_call()
-
-        async_dispatcher_connect(
-            self.hass,
-            SIGNAL_CONFIG_ENTRY_CHANGED,
-            _async_update_listener,
-        )
+    inspect_config_entry_changed = group.DOMAIN
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -8,7 +8,6 @@ from homeassistant.components.lovelace.const import (
     EVENT_LOVELACE_UPDATED,
     ConfigNotFound,
 )
-from homeassistant.config_entries import SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntry
 from homeassistant.const import (
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
@@ -16,7 +15,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback, valid_entity_id
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from ....const import LOGGER
 from ....repairs import AbstractSpookRepair
@@ -26,7 +24,6 @@ if TYPE_CHECKING:
         LovelaceStorage,
         LovelaceYAML,
     )
-    from homeassistant.core import HomeAssistant
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -57,6 +54,7 @@ class SpookRepair(AbstractSpookRepair):
         "event_tod_reloaded",
         "event_utility_meter_reloaded",
     }
+    inspect_config_entry_changed = True
 
     _dashboards: dict[str, LovelaceStorage | LovelaceYAML]
 
@@ -64,21 +62,6 @@ class SpookRepair(AbstractSpookRepair):
         """Handle the activating a repair."""
         self._dashboards = self.hass.data["lovelace"]["dashboards"]
         await super().async_activate()
-
-        # Listen for config entry changes, this might have an impact
-        # on the available entities (those not in the entity registry)
-        async def _async_update_listener(
-            _hass: HomeAssistant,
-            _entry: ConfigEntry,
-        ) -> None:
-            """Handle options update."""
-            await self.inspect_debouncer.async_call()
-
-        async_dispatcher_connect(
-            self.hass,
-            SIGNAL_CONFIG_ENTRY_CHANGED,
-            _async_update_listener,
-        )
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -1,10 +1,7 @@
 """Spook - Not your homie."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from homeassistant.components import script
-from homeassistant.config_entries import SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntry
 from homeassistant.const import (
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
@@ -12,14 +9,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import valid_entity_id
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
 from ....repairs import AbstractSpookRepair
-
-if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -49,6 +42,7 @@ class SpookRepair(AbstractSpookRepair):
         "event_tod_reloaded",
         "event_utility_meter_reloaded",
     }
+    inspect_config_entry_changed = True
 
     _entity_component: EntityComponent[script.ScriptEntity]
 
@@ -56,23 +50,6 @@ class SpookRepair(AbstractSpookRepair):
         """Handle the activating a repair."""
         self._entity_component = self.hass.data[DATA_INSTANCES][self.domain]
         await super().async_activate()
-
-        # Listen for config entry changes, this might have an impact
-        # on the available entities (those not in the entity registry)
-        async def _async_update_listener(
-            _hass: HomeAssistant,
-            _entry: ConfigEntry,
-        ) -> None:
-            """Handle options update."""
-            await self.inspect_debouncer.async_call()
-
-        async_dispatcher_connect(
-            self.hass,
-            SIGNAL_CONFIG_ENTRY_CHANGED,
-            _async_update_listener,
-        )
-
-        # Give all integration some time to startup
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""

--- a/custom_components/spook/ectoplasms/switch_as_x/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/switch_as_x/repairs/unknown_source.py
@@ -19,6 +19,7 @@ class SpookRepair(AbstractSpookRepair):
         er.EVENT_ENTITY_REGISTRY_UPDATED,
         "event_integration_reloaded",
     }
+    inspect_config_entry_changed = "switch_as_x"
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, final
 
 from homeassistant.components.homeassistant import SERVICE_HOMEASSISTANT_RESTART
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.config_entries import SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntry
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import (
     area_registry as ar,
@@ -17,6 +18,7 @@ from homeassistant.helpers import (
     issue_registry as ir,
 )
 from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DOMAIN, LOGGER
 
@@ -112,6 +114,7 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
 
     inspect_events: set[str] | None = None
     inspect_debouncer: Debouncer
+    inspect_config_entry_changed: bool | str = False
     _event_subs: set[Callable[[], None]]
 
     def __init__(self, hass: HomeAssistant) -> None:
@@ -152,6 +155,26 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
         for event in self.inspect_events:
             self._event_subs.add(
                 self.hass.bus.async_listen(event, _async_call_inspect_debouncer),
+            )
+
+        if self.inspect_config_entry_changed:
+
+            async def _async_config_entry_changed(
+                _hass: HomeAssistant,
+                entry: ConfigEntry,
+            ) -> None:
+                """Handle options update."""
+                if (
+                    self.inspect_config_entry_changed is not True
+                    and entry.domain != self.inspect_config_entry_changed
+                ):
+                    return
+                await self.inspect_debouncer.async_call()
+
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_CONFIG_ENTRY_CHANGED,
+                _async_config_entry_changed,
             )
 
     async def async_deactivate(self) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some repairs listen for config entry changes. This PR refactors that code a little bit, to remove a bit of de-duplication. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
