### PR TITLE
Allow template method to be named different for tests and filters

### DIFF
--- a/custom_components/spook/templating.py
+++ b/custom_components/spook/templating.py
@@ -22,6 +22,8 @@ class AbstractSpookTemplateFunction(ABC):
 
     hass: HomeAssistant
     name: str
+    filter_name: str | None = None
+    test_name: str | None = None
 
     requires_hass_object: bool = True
     is_available_in_limited_environment: bool = False
@@ -59,19 +61,19 @@ class AbstractSpookTemplateFunction(ABC):
         if self.is_filter:
             # pylint: disable-next=protected-access
             if is_limited and not self.is_available_in_limited_environment:
-                environment.filters[self.name] = unsupported_in_limited_environment(
-                    self.name
-                )
+                environment.filters[
+                    self.filter_name or self.name
+                ] = unsupported_in_limited_environment(self.name)
             else:
-                environment.filters[self.name] = self.function()
+                environment.filters[self.filter_name or self.name] = self.function()
 
         if self.is_test:
             if is_limited and not self.is_available_in_limited_environment:
-                environment.tests[self.name] = unsupported_in_limited_environment(
-                    self.name
-                )
+                environment.tests[
+                    self.test_name or self.name
+                ] = unsupported_in_limited_environment(self.name)
             else:
-                environment.tests[self.name] = self.function()
+                environment.tests[self.test_name or self.name] = self.function()
 
     @final
     @callback


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow template methods to have slighter different names when used as a filter or test.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
