### PR TITLE
Add template method: (is_)on

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/templating/is_on.py
+++ b/custom_components/spook/ectoplasms/homeassistant/templating/is_on.py
@@ -1,0 +1,35 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.helpers.template import is_state
+
+from ....templating import AbstractSpookTemplateFunction
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class SpookTemplateFunction(AbstractSpookTemplateFunction):
+    """Spook template function to test if an entity is "on"."""
+
+    name = "is_on"
+    test_name = "on"
+
+    is_filter = True
+    is_global = True
+    is_test = True
+
+    def _function(
+        self,
+        entity_id: str | list[str],
+    ) -> bool:
+        """Check if the current state of an entity is "on"."""
+        if isinstance(entity_id, list):
+            return all(is_state(self.hass, entity, "on") for entity in entity_id)
+        return is_state(self.hass, entity_id, "on")
+
+    def function(self) -> Callable[..., Any]:
+        """Return the python method that runs this template function."""
+        return self._function

--- a/custom_components/spook/ectoplasms/homeassistant/templating/is_on.py
+++ b/custom_components/spook/ectoplasms/homeassistant/templating/is_on.py
@@ -25,10 +25,13 @@ class SpookTemplateFunction(AbstractSpookTemplateFunction):
         self,
         entity_id: str | list[str],
     ) -> bool:
-        """Check if the current state of an entity is "on"."""
+        """Check if the current state of an entity is."""
         if isinstance(entity_id, list):
-            return all(is_state(self.hass, entity, "on") for entity in entity_id)
-        return is_state(self.hass, entity_id, "on")
+            return all(
+                entity_id == "on" or is_state(self.hass, entity, "on")
+                for entity in entity_id
+            )
+        return entity_id == "on" or is_state(self.hass, entity_id, "on")
 
     def function(self) -> Callable[..., Any]:
         """Return the python method that runs this template function."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a template function: `is_on`. Available as test: `on`.

## Motivation and Context

This allows for a cleaner syntax in templates. For example:

```jinja2
{{ is_on("light.kitchen") }}
{{ "light.kitchen" | is_on }}
```

The real gem here is the test usage:

```jinja2
{% if "light.kitchen" is on %}
  Yes the light is on!
{% endif %}
```


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
