### PR TITLE
Don't inspect if automation or scripts aren't loaded yet

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
@@ -19,21 +19,21 @@ class SpookRepair(AbstractSpookRepair):
         ar.EVENT_AREA_REGISTRY_UPDATED,
     }
 
-    _entity_component: EntityComponent[automation.AutomationEntity]
     _issues: set[str] = set()
-
-    async def async_activate(self) -> None:
-        """Handle the activating a repair."""
-        self._entity_component = self.hass.data[DATA_INSTANCES][self.domain]
-
-        await super().async_activate()
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""
+        if self.domain not in self.hass.data[DATA_INSTANCES]:
+            return
+
+        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
+            DATA_INSTANCES
+        ][self.domain]
+
         LOGGER.debug("Spook is inspecting: %s", self.repair)
         areas = set(self.area_registry.areas)
         possible_issue_ids: set[str] = set()
-        for entity in self._entity_component.entities:
+        for entity in entity_component.entities:
             possible_issue_ids.add(entity.entity_id)
             if not isinstance(entity, automation.UnavailableAutomationEntity) and (
                 unknown_areas := {

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -19,20 +19,21 @@ class SpookRepair(AbstractSpookRepair):
         dr.EVENT_DEVICE_REGISTRY_UPDATED,
     }
 
-    _entity_component: EntityComponent[automation.AutomationEntity]
     _issues: set[str] = set()
-
-    async def async_activate(self) -> None:
-        """Handle the activating a repair."""
-        self._entity_component = self.hass.data[DATA_INSTANCES][self.domain]
-        await super().async_activate()
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""
+        if self.domain not in self.hass.data[DATA_INSTANCES]:
+            return
+
+        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
+            DATA_INSTANCES
+        ][self.domain]
+
         LOGGER.debug("Spook is inspecting: %s", self.repair)
         devices = {device.id for device in self.device_registry.devices.values()}
         possible_issue_ids: set[str] = set()
-        for entity in self._entity_component.entities:
+        for entity in entity_component.entities:
             possible_issue_ids.add(entity.entity_id)
             if not isinstance(entity, automation.UnavailableAutomationEntity) and (
                 unknown_devices := {

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -27,16 +27,17 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     inspect_on_reload = True
 
-    _entity_component: EntityComponent[automation.AutomationEntity]
     _issues: set[str] = set()
-
-    async def async_activate(self) -> None:
-        """Handle the activating a repair."""
-        self._entity_component = self.hass.data[DATA_INSTANCES][self.domain]
-        await super().async_activate()
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""
+        if self.domain not in self.hass.data[DATA_INSTANCES]:
+            return
+
+        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
+            DATA_INSTANCES
+        ][self.domain]
+
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
         # Two sources for entities. The entities in the entity registry,
@@ -52,7 +53,7 @@ class SpookRepair(AbstractSpookRepair):
         )
 
         possible_issue_ids: set[str] = set()
-        for entity in self._entity_component.entities:
+        for entity in entity_component.entities:
             possible_issue_ids.add(entity.entity_id)
             # Filter out scenes, groups & device_tracker entities.
             # Those can be created on the fly with services, which we

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
@@ -16,20 +16,21 @@ class SpookRepair(AbstractSpookRepair):
     repair = "script_unknown_area_references"
     inspect_events = {ar.EVENT_AREA_REGISTRY_UPDATED}
 
-    _entity_component: EntityComponent[script.ScriptEntity]
     _issues: set[str] = set()
-
-    async def async_activate(self) -> None:
-        """Handle the activating a repair."""
-        self._entity_component = self.hass.data[DATA_INSTANCES][self.domain]
-        await super().async_activate()
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""
+        if self.domain not in self.hass.data[DATA_INSTANCES]:
+            return
+
+        entity_component: EntityComponent[script.ScriptEntity] = self.hass.data[
+            DATA_INSTANCES
+        ][self.domain]
+
         LOGGER.debug("Spook is inspecting: %s", self.repair)
         areas = set(self.area_registry.areas)
         possible_issue_ids: set[str] = set()
-        for entity in self._entity_component.entities:
+        for entity in entity_component.entities:
             possible_issue_ids.add(entity.entity_id)
             if not isinstance(entity, script.UnavailableScriptEntity) and (
                 unknown_areas := {

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
@@ -16,20 +16,21 @@ class SpookRepair(AbstractSpookRepair):
     repair = "script_unknown_device_references"
     inspect_events = {dr.EVENT_DEVICE_REGISTRY_UPDATED}
 
-    _entity_component: EntityComponent[script.ScriptEntity]
     _issues: set[str] = set()
-
-    async def async_activate(self) -> None:
-        """Handle the activating a repair."""
-        self._entity_component = self.hass.data[DATA_INSTANCES][self.domain]
-        await super().async_activate()
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""
+        if self.domain not in self.hass.data[DATA_INSTANCES]:
+            return
+
+        entity_component: EntityComponent[script.ScriptEntity] = self.hass.data[
+            DATA_INSTANCES
+        ][self.domain]
+
         LOGGER.debug("Spook is inspecting: %s", self.repair)
         devices = {device.id for device in self.device_registry.devices.values()}
         possible_issue_ids: set[str] = set()
-        for entity in self._entity_component.entities:
+        for entity in entity_component.entities:
             possible_issue_ids.add(entity.entity_id)
             if not isinstance(entity, script.UnavailableScriptEntity) and (
                 unknown_devices := {

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -27,16 +27,17 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     inspect_on_reload = True
 
-    _entity_component: EntityComponent[script.ScriptEntity]
     _issues: set[str] = set()
-
-    async def async_activate(self) -> None:
-        """Handle the activating a repair."""
-        self._entity_component = self.hass.data[DATA_INSTANCES][self.domain]
-        await super().async_activate()
 
     async def async_inspect(self) -> None:
         """Trigger a inspection."""
+        if self.domain not in self.hass.data[DATA_INSTANCES]:
+            return
+
+        entity_component: EntityComponent[script.ScriptEntity] = self.hass.data[
+            DATA_INSTANCES
+        ][self.domain]
+
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
         # Two sources for entities. The entities in the entity registry,
@@ -52,7 +53,7 @@ class SpookRepair(AbstractSpookRepair):
         )
 
         possible_issue_ids: set[str] = set()
-        for entity in self._entity_component.entities:
+        for entity in entity_component.entities:
             possible_issue_ids.add(entity.entity_id)
             # Filter out scenes, groups & device_tracker entities.
             # Those can be created on the fly with services, which we


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Don't try to inspect automations or scripts, it the entity component doesn't exist in hass data yet (and thus isn't set up)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes #563

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
