### PR TITLE
Bump min req Home Assistant 2024.2.0 and HACS 1.34.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,8 @@
 {
   "name": "Spook 👻 Not your homie",
   "render_readme": true,
-  "homeassistant": "2023.12.0",
+  "homeassistant": "2024.2.0",
+  "hacs": "1.34.0",
   "zip_release": true,
   "filename": "spook.zip"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bumps the minimal required Home Assistant version to be 2024.2.0 and HACS 1.34.0.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Home Assistant bump is needed for upcoming detections for Promixity, which has been overhauled in 2024.2.

The HACS bump is to aid/help with getting people bumped to prevent issues with an distribution issue in earlier HACS versions.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

It has not been tested. This is Spook, not your homie.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
