### PR TITLE
Add inspections for unknown service calls in automations

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
@@ -1,0 +1,136 @@
+"""Spook - Not your homie."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components import automation
+from homeassistant.const import (
+    CONF_CHOOSE,
+    CONF_DEFAULT,
+    CONF_ELSE,
+    CONF_ENABLED,
+    CONF_PARALLEL,
+    CONF_SEQUENCE,
+    CONF_SERVICE,
+    CONF_THEN,
+    EVENT_SERVICE_REGISTERED,
+    EVENT_SERVICE_REMOVED,
+)
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair tries to find unknown referenced services in automations."""
+
+    domain = automation.DOMAIN
+    repair = "automation_unknown_service_references"
+    inspect_events = {
+        automation.EVENT_AUTOMATION_RELOADED,
+        EVENT_SERVICE_REGISTERED,
+        EVENT_SERVICE_REMOVED,
+    }
+
+    _issues: set[str] = set()
+
+    async def async_inspect(self) -> None:
+        """Trigger a inspection."""
+        if self.domain not in self.hass.data[DATA_INSTANCES]:
+            return
+
+        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
+            DATA_INSTANCES
+        ][self.domain]
+
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+        known_services = {
+            f"{domain}.{service}"
+            for domain, services in self.hass.services.async_services().items()
+            for service in services
+        }
+
+        possible_issue_ids: set[str] = set()
+        for entity in entity_component.entities:
+            possible_issue_ids.add(entity.entity_id)
+
+            if isinstance(entity, automation.UnavailableAutomationEntity):
+                continue
+
+            called_services: set[str] = set()
+            _async_find_services_in_sequence(
+                called_services, entity.action_script.sequence
+            )
+
+            if unknown_services := {
+                service.lower()
+                for service in called_services - known_services
+                if isinstance(service, str) and service
+            }:
+                self.async_create_issue(
+                    issue_id=entity.entity_id,
+                    translation_placeholders={
+                        "services": "\n".join(
+                            f"- `{service}`" for service in unknown_services
+                        ),
+                        "automation": entity.name,
+                        "edit": f"/config/automation/edit/{entity.unique_id}",
+                        "entity_id": entity.entity_id,
+                    },
+                )
+                self._issues.add(entity.entity_id)
+                LOGGER.debug(
+                    (
+                        "Spook found unknown service calls in %s "
+                        "and created an issue for it; Services: %s",
+                    ),
+                    entity.entity_id,
+                    ", ".join(unknown_services),
+                )
+            else:
+                self.async_delete_issue(entity.entity_id)
+                self._issues.discard(entity.entity_id)
+
+        # Remove issues that no longer exist
+        for issue_id in self._issues - possible_issue_ids:
+            self.async_delete_issue(issue_id)
+            self._issues.discard(issue_id)
+
+
+@callback
+def _async_find_services_in_sequence(  # noqa: C901
+    called_services: set[str],
+    sequence: Sequence[dict[str, Any]],
+) -> None:
+    """Find all services called in a sequence."""
+    for step in sequence:
+        action = cv.determine_script_action(step)
+
+        if action == cv.SCRIPT_ACTION_CALL_SERVICE and step.get(CONF_ENABLED, True):
+            called_services.add(step[CONF_SERVICE])
+
+        if action == cv.SCRIPT_ACTION_CHOOSE:
+            for choice in step[CONF_CHOOSE]:
+                _async_find_services_in_sequence(called_services, choice[CONF_SEQUENCE])
+            if nested_sequence := step.get(CONF_DEFAULT):
+                _async_find_services_in_sequence(called_services, nested_sequence)
+
+        if action == cv.SCRIPT_ACTION_IF:
+            _async_find_services_in_sequence(called_services, step[CONF_THEN])
+            if nested_sequence := step.get(CONF_ELSE):
+                _async_find_services_in_sequence(called_services, nested_sequence)
+
+        if action == cv.SCRIPT_ACTION_PARALLEL:
+            for nested_sequence in step[CONF_PARALLEL]:
+                _async_find_services_in_sequence(
+                    called_services, nested_sequence[CONF_SEQUENCE]
+                )
+
+        if action == cv.SCRIPT_ACTION_REPEAT:
+            _async_find_services_in_sequence(called_services, step[CONF_SEQUENCE])

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -233,6 +233,10 @@
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Not your homie.",
       "title": "Unknown entities used in: {automation}"
     },
+    "automation_unknown_service_references": {
+      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following services, which are unknown to Home Assistant:\n\n{services}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing services.\n\nSpook 👻 Not your homie.",
+      "title": "Unknown services used in: {automation}"
+    },
     "group_unknown_members": {
       "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Not your homie.",
       "title": "Unknown group members in: {group}"

--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -5,7 +5,7 @@ short_title: Automations
 subtitle: The breathing (mechanical) heart of Home Assistant.
 thumbnail: ../images/integrations/automation/example.png
 description: Spook enhances the automation integrations of Home Assistant by raising repairs issues, in case it detects something is wrong with an automation, for example, if it is using non-existing entities.
-date: 2023-08-09T21:29:00+02:00
+date: 2024-02-10T15:58:22+01:00
 ---
 
 ```{image} https://brands.home-assistant.io/automation/logo.png
@@ -100,6 +100,18 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 - {term}`Templates <template>` in automations are not evaluated by Spook. That means that entity IDs used in templates, or targets generated using templates, are not considered by Spook.
 - Comma separated lists of entity IDs are not taken into consideration by Spook. It is advisable to convert these to an actual list in your automations.
   :::
+
+### Unknown referenced services
+
+Automations are inspected for the use of service call actions. If an automation is using a service that does not exist, Spook will raise a repair issue. The repairs issue raised will contain the name of the automation and the service that is referenced but not found.
+
+To resolve the raised issue, you can either remove the reference to the non-existing services. Spook will automatically remove the repair issue once the issue is fixed.
+
+:::{attention} Known limitations
+:class: dropdown
+
+{term}`Templates <template>` in automations are not evaluated by Spook. That means that service call make using templates, are not considered by Spook.
+:::
 
 ## Features requests, ideas, and support
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new inspection to Spook, that can find done service calls in automations and thus able to report on when unknown service calls are made.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Calling non-existing services cause errors and might go undetected. This allows Spook to be proactive and warn before use / run of the actual service.

This inspection will need refactoring in the future, as parts of this one are re-usable (e.g., for scripts).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

By making the worst automations possible.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

![CleanShot 2024-02-10 at 16 03 20@2x](https://github.com/frenck/spook/assets/195327/0e7f31e8-6e37-4e28-b10b-8afcf234a896)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
