### PR TITLE
Fix parsing of used services when encountering a repeat action

### DIFF
--- a/custom_components/spook/util.py
+++ b/custom_components/spook/util.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     CONF_ELSE,
     CONF_ENABLED,
     CONF_PARALLEL,
+    CONF_REPEAT,
     CONF_SEQUENCE,
     CONF_SERVICE,
     CONF_THEN,
@@ -278,6 +279,8 @@ def async_find_services_in_sequence(  # noqa: C901
                 )
 
         if action == cv.SCRIPT_ACTION_REPEAT:
-            called_services |= async_find_services_in_sequence(step[CONF_SEQUENCE])
+            called_services |= async_find_services_in_sequence(
+                step[CONF_REPEAT][CONF_SEQUENCE]
+            )
 
     return called_services


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug reported by @Mariusthvdb on the Home Assistant Community forums.

```
Unexpected exception from <function AbstractSpookRepair.async_activate.<locals>._async_inspect at 0x7fcc85ea3560>
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/debounce.py", line 114, in _handle_timer_finish
    await task
  File "/config/custom_components/spook/repairs.py", line 134, in _async_inspect
    await self.async_inspect()
  File "/config/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py", line 67, in async_inspect
    _async_find_services_in_sequence(
  File "/config/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py", line 136, in _async_find_services_in_sequence
    _async_find_services_in_sequence(called_services, step[CONF_SEQUENCE])
                                                      ~~~~^^^^^^^^^^^^^^^
KeyError: 'sequence'
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
