### PR TITLE
Fix detecting service calls that use old-style service_template

### DIFF
--- a/custom_components/spook/util.py
+++ b/custom_components/spook/util.py
@@ -256,7 +256,11 @@ def async_find_services_in_sequence(  # noqa: C901
     for step in sequence:
         action = cv.determine_script_action(step)
 
-        if action == cv.SCRIPT_ACTION_CALL_SERVICE and step.get(CONF_ENABLED, True):
+        if (
+            action == cv.SCRIPT_ACTION_CALL_SERVICE
+            and CONF_SERVICE in step
+            and step.get(CONF_ENABLED, True)
+        ):
             called_services.add(step[CONF_SERVICE])
 
         if action == cv.SCRIPT_ACTION_CHOOSE:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Back in the Home Assistant days, services could be called in different ways. Using the `service` key and using the `service_template` key. The latter supported templates, the first didn't in the past (but now does).

`service_template` isn't used anymore (but Home Assistant is still backwards compatible).

This PR makes sure Spook has the same backward-compatibility.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes #615 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
