### PR TITLE
Make cloud switch entity `_update_state` function a coro

### DIFF
--- a/custom_components/spook/ectoplasms/cloud/switch.py
+++ b/custom_components/spook/ectoplasms/cloud/switch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.cloud import DOMAIN as CLOUD_DOMAIN
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 
 from ...entity import SpookEntityDescription
 from .entity import HomeAssistantCloudSpookEntity
@@ -119,8 +119,7 @@ class HomeAssistantCloudSpookSwitchEntity(HomeAssistantCloudSpookEntity, SwitchE
     async def async_added_to_hass(self) -> None:
         """Register for switch updates."""
 
-        @callback
-        def _update_state(_: Any) -> None:
+        async def _update_state(_: Any) -> None:
             """Update state."""
             self.async_schedule_update_ha_state()
 

--- a/custom_components/spook/ectoplasms/cloud/switch.py
+++ b/custom_components/spook/ectoplasms/cloud/switch.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.cloud import DOMAIN as CLOUD_DOMAIN
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
 
 from ...entity import SpookEntityDescription
 from .entity import HomeAssistantCloudSpookEntity
@@ -18,6 +17,7 @@ if TYPE_CHECKING:
     from hass_nabucasa import Cloud
 
     from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 


### PR DESCRIPTION
## Description

Make the `_update_state`  function of the cloud switch entities a coro.

## Motivation and Context

The `async_listen_updates` of the cloud client requires the function to be a coro, as the function uses the `async_create_catching_coro` logging helper of core, which (in some nested functions) always awaits.

## How has this been tested?

This appeared while beta testing https://github.com/home-assistant/core/issues/111797.
I applied this change on my prod system and the log went away.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
