### PR TITLE
Allow setting icon on homeassistant.create_area service

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/create_area.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/create_area.py
@@ -23,6 +23,7 @@ class SpookService(AbstractSpookAdminService):
     schema = {
         vol.Required("name"): cv.string,
         vol.Optional("aliases"): [cv.string],
+        vol.Optional("icon"): cv.icon,
     }
 
     async def async_handle_service(self, call: ServiceCall) -> None:
@@ -31,4 +32,5 @@ class SpookService(AbstractSpookAdminService):
         area_registry.async_create(
             name=call.data["name"],
             aliases=call.data.get("aliases"),
+            icon=call.data.get("icon"),
         )

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -31,6 +31,13 @@ homeassistant_create_area:
       required: true
       selector:
         text:
+    icon:
+      name: Icon
+      description: Icon to use for the floor
+      required: false
+      selector:
+        icon:
+          placeholder: mdi:texture-box
     aliases:
       name: Aliases
       description: >-

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -33,7 +33,7 @@ homeassistant_create_area:
         text:
     icon:
       name: Icon
-      description: Icon to use for the floor
+      description: Icon to use for the area.
       required: false
       selector:
         icon:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Areas now support icons, this adds support for it to the `homeassistant.create_area` service call.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
