### PR TITLE
Add homeassistant.add_alias_to_floor service

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/add_alias_to_floor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/add_alias_to_floor.py
@@ -1,0 +1,40 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, label_registry as lr
+
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant service to add an alias to a floor."""
+
+    domain = DOMAIN
+    service = "add_alias_to_floor"
+    schema = {
+        vol.Required("floor_id"): cv.string,
+        vol.Required("alias"): vol.All(cv.ensure_list, [cv.string]),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        floor_registry = lr.async_get(self.hass)
+        if not (floor := floor_registry.async_get_floor(call.data["floor_id"])):
+            msg = f"Floor {call.data['floor_id']} not found"
+            raise HomeAssistantError(msg)
+
+        aliases = floor.aliases.copy()
+        floor_registry.async_update(
+            call.data["floor_id"],
+            aliases=aliases.union(call.data["alias"]),
+        )

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -335,6 +335,24 @@ homeassistant_create_floor:
       selector:
         object:
 
+homeassistant_add_alias_to_floor:
+  name: Add an alias to a floor 👻
+  description: >-
+    Adds an alias to a floor.
+  fields:
+    floor_id:
+      name: Floor ID
+      description: The ID of the floor to add the alias to.
+      required: true
+      selector:
+        text:
+    alias:
+      name: Alias
+      description: The alias (or list of aliasses) to add to the floor.
+      required: true
+      selector:
+        object:
+
 homeassistant_ignore_all_discovered:
   name: Ignore all currently discovered devices 👻
   description: >-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

SSIA, allows to add an alias to a floor on the fly: `homeassistant.add_alias_to_floor`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
