### PR TITLE
Add homeassistant.add_label_to_area service

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_area.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_area.py
@@ -1,0 +1,46 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import (
+    area_registry as ar,
+    config_validation as cv,
+    label_registry as lr,
+)
+
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant service to add a label to an area."""
+
+    domain = DOMAIN
+    service = "add_label_to_area"
+    schema = {
+        vol.Required("label_id"): vol.All(cv.ensure_list, [cv.string]),
+        vol.Required("area_id"): vol.All(cv.ensure_list, [cv.string]),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        label_registry = lr.async_get(self.hass)
+        for label_id in call.data["label_id"]:
+            if not label_registry.async_get_label(label_id):
+                msg = f"Label {label_id} not found"
+                raise HomeAssistantError(msg)
+
+        area_registry = ar.async_get(self.hass)
+        for area_id in call.data["area_id"]:
+            if area_entry := area_registry.async_get_area(area_id):
+                labels = area_entry.labels.copy()
+                labels.update(call.data["label_id"])
+                area_registry.async_update(area_id, labels=labels)

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -515,6 +515,27 @@ homeassistant_create_label:
             - label: White
               value: white
 
+homeassistant_add_label_to_area:
+  name: Add a label to an area 👻
+  description: >-
+    Adds an label(s) to an area(s). If multiple labels or multiple areas are
+    provided, all combinations will be added.
+  fields:
+    label_id:
+      name: Label ID
+      description: The ID(s) of the label(s) to add the area(s).
+      required: true
+      selector:
+        label:
+          multiple: true
+    area_id:
+      name: Area ID
+      description: The ID(s) of the area(s) to add the label(s) to.
+      required: true
+      selector:
+        area:
+          multiple: true
+
 homeassistant_delete_label:
   name: Delete a label 👻
   description: >-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a service that can assign labels to areas: `homeassistant.add_label_to_area`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
