### PR TITLE
Fix decimal math inaccuracy in increment/decrement services

### DIFF
--- a/custom_components/spook/ectoplasms/input_number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/input_number/services/decrement.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 import math
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 

--- a/custom_components/spook/ectoplasms/input_number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/input_number/services/decrement.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import math
 
 import voluptuous as vol
 
@@ -33,9 +34,8 @@ class SpookService(
     ) -> None:
         """Handle the service call."""
         # pylint: disable=protected-access
-        if (
-            amount := call.data.get("amount", entity._step)  # noqa: SLF001
-        ) % entity._step != 0:  # noqa: SLF001
+        amount = call.data.get("amount", entity._step)  # noqa: SLF001
+        if not math.isclose(amount % entity._step, 0, abs_tol=1e-9):  # noqa: SLF001
             msg = (
                 f"Amount {amount} not valid for {entity.entity_id}, "
                 f"it needs to be a multiple of {entity._step}",  # noqa: SLF001

--- a/custom_components/spook/ectoplasms/input_number/services/increment.py
+++ b/custom_components/spook/ectoplasms/input_number/services/increment.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 import math
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 

--- a/custom_components/spook/ectoplasms/input_number/services/increment.py
+++ b/custom_components/spook/ectoplasms/input_number/services/increment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import math
 
 import voluptuous as vol
 
@@ -33,9 +34,8 @@ class SpookService(
     ) -> None:
         """Handle the service call."""
         # pylint: disable=protected-access
-        if (
-            amount := call.data.get("amount", entity._step)  # noqa: SLF001
-        ) % entity._step != 0:  # noqa: SLF001
+        amount = call.data.get("amount", entity._step)  # noqa: SLF001
+        if not math.isclose(amount % entity._step, 0, abs_tol=1e-9):  # noqa: SLF001
             msg = (
                 f"Amount {amount} not valid for {entity.entity_id}, "
                 f"it needs to be a multiple of {entity._step}",  # noqa: SLF001

--- a/custom_components/spook/ectoplasms/number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/number/services/decrement.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 import math
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 

--- a/custom_components/spook/ectoplasms/number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/number/services/decrement.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import math
 
 import voluptuous as vol
 
@@ -27,7 +28,8 @@ class SpookService(AbstractSpookEntityComponentService[NumberEntity]):
         call: ServiceCall,
     ) -> None:
         """Handle the service call."""
-        if (amount := call.data.get("amount", entity.step or 1)) % entity.step != 0:
+        amount = call.data.get("amount", entity.step or 1)
+        if not math.isclose(amount % entity.step, 0, abs_tol=1e-9):
             msg = (
                 f"Amount {amount} not valid for {entity.entity_id}, "
                 f"it needs to be a multiple of {entity.step}",

--- a/custom_components/spook/ectoplasms/number/services/increment.py
+++ b/custom_components/spook/ectoplasms/number/services/increment.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 import math
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 

--- a/custom_components/spook/ectoplasms/number/services/increment.py
+++ b/custom_components/spook/ectoplasms/number/services/increment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import math
 
 import voluptuous as vol
 
@@ -27,7 +28,8 @@ class SpookService(AbstractSpookEntityComponentService[NumberEntity]):
         call: ServiceCall,
     ) -> None:
         """Handle the service call."""
-        if (amount := call.data.get("amount", entity.step or 1)) % entity.step != 0:
+        amount = call.data.get("amount", entity.step or 1)
+        if not math.isclose(amount % entity.step, 0, abs_tol=1e-9):
             msg = (
                 f"Amount {amount} not valid for {entity.entity_id}, "
                 f"it needs to be a multiple of {entity.step}",


### PR DESCRIPTION
Updates increment and decrement services in Spook to handle floating-point arithmetic inaccuracies.

- Replaces the strict equality check for step multiples with a tolerance-based check using `math.isclose` in `custom_components/spook/ectoplasms/number/services/decrement.py` and `increment.py`. This change addresses the issue of floating-point arithmetic inaccuracies when checking if an amount is a multiple of the step value.
- Applies the same tolerance-based check for step multiples in `custom_components/spook/ectoplasms/input_number/services/decrement.py` and `increment.py`, ensuring consistency across different types of number entities within Spook.

fixes #744


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/frenck/spook?shareId=d62737e9-6aa2-4895-9dac-ce9fab05ce2f).