### PR TITLE
Remove platinum quality scale markers (they where fake anyways)

### DIFF
--- a/custom_components/spook/integrations/spook_inverse/manifest.json
+++ b/custom_components/spook/integrations/spook_inverse/manifest.json
@@ -7,7 +7,6 @@
   "integration_type": "helper",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/frenck/spook/issues",
-  "quality_scale": "platinum",
   "requirements": [],
   "version": "0.0.0"
 }

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -20,7 +20,6 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/frenck/spook/issues",
-  "quality_scale": "platinum",
   "requirements": [],
   "version": "0.0.0"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes the platinum scale marker, as those currently cause hassfest to fail.
They are fake (as this is really not a platinum level integration) and not used anyways. So nothing changes.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
