### PR TITLE
Fix for accessing lovelace_data['dashboards'] instead of lovelace_dat…

### DIFF
--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -42,7 +42,7 @@ class SpookRepair(AbstractSpookRepair):
 
     async def async_activate(self) -> None:
         """Handle the activating a repair."""
-        self._dashboards = self.hass.data["lovelace"]["dashboards"]
+        self._dashboards = self.hass.data["lovelace"].dashboards
         await super().async_activate()
 
     async def async_inspect(self) -> None:


### PR DESCRIPTION
…a.dashboards

<!--- Provide a general summary of your changes in the Title above -->

## Description

A fix for https://github.com/frenck/spook/issues/894

## Motivation and Context

Seeing it in logs motivated me :)

## How has this been tested?

"Works on my machine"

## Screenshots (if appropriate):

not appropriate

## Types of changes


- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
