### PR TITLE
Correct placeholder names in Czech translation

### DIFF
--- a/custom_components/spook/translations/cs.json
+++ b/custom_components/spook/translations/cs.json
@@ -242,8 +242,8 @@
       "title": "Neznámé štítky použité v: {automation}"
     },
     "automation_unknown_service_references": {
-      "description": "Spook našel ducha ve tvých automatizacích 👻\n\nZatímco poletoval kolem, Spook narazil na následující automatizaci:\n\n[{automatizace}]({upravit}) (`{entity_id}`)\n\nTato automatizace odkazuje na následující služby, které Home Assistant nezná:\n\n\n{služby}\n\n\nAbys opravil tuto chybu, [uprav automatizaci]({upravit})  a zamez použití těchto neexistujících služeb.\n\nSpook  👻 Your homie.",
-      "title": "Neznámá činnost použitá v: {automatizaci}"
+      "description": "Spook našel ducha ve tvých automatizacích 👻\n\nZatímco poletoval kolem, Spook narazil na následující automatizaci:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTato automatizace odkazuje na následující služby, které Home Assistant nezná:\n\n\n{services}\n\n\nAbys opravil tuto chybu, [uprav automatizaci]({edit})  a zamez použití těchto neexistujících služeb.\n\nSpook  👻 Your homie.",
+      "title": "Neznámá činnost použitá v: {automation}"
     },
     "group_unknown_members": {
       "description": "Spook našel ducha ve tvých skupinách👻\n\nZatímco poletoval kolem, Spook narazil na následující automatizaci:\n\n{group} (`{entity_id}`)\n\nTato skupina má členy, které Home Assistant nezná:\n\n\n{entities}\n\n\nAbys opravil tuto chybu, uprav skupinu - odstraň tyto neexistující členy a restartuj Home Assistant.\n\nSpook  👻 Your homie.",


### PR DESCRIPTION
## Fix Czech translation placeholder validation errors

## Description

Fixed placeholder names in the Czech translation file (`cs.json`) for the `automation_unknown_service_references` issue. The placeholder variable names were incorrectly translated to Czech (`{automatizace}`, `{upravit}`, `{služby}`, `{automatizaci}`) instead of remaining in English (`{automation}`, `{edit}`, `{services}`), which caused translation validation failures.

## Motivation and Context

This change fixes translation validation errors that were occurring during the build process:

```
Validation of translation placeholders for localized (cs) string component.spook.issues.automation_unknown_service_references.description failed: ({'automatizace', 'služby', 'entity_id', 'upravit'} != {'edit', 'automation', 'entity_id', 'services'})
Validation of translation placeholders for localized (cs) string component.spook.issues.automation_unknown_service_references.title failed: ({'automatizaci'} != {'automation'})
```

## How has this been tested?

The translation validation was run after the fix, confirming that the placeholder names now match the expected English keys and no validation errors are raised for the Czech translation file.

## Screenshots (if appropriate):

N/A - This is a translation file fix with no visual changes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

