### PR TITLE
Fix placeholders in Finnish translation

### DIFF
--- a/custom_components/spook/translations/fi.json
+++ b/custom_components/spook/translations/fi.json
@@ -222,99 +222,99 @@
   },
   "issues": {
     "automation_unknown_area_references": {
-      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin alueisiin, jotka ovat Home Assistantille tuntemattomia:\n\n{alueet}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat alueet.\n\nSpook 👻 Kamusi.",
-      "title": "Tuntemattomia alueita käytetty: {automaatio}"
+      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin alueisiin, jotka ovat Home Assistantille tuntemattomia:\n\n{areas}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat alueet.\n\nSpook 👻 Kamusi.",
+      "title": "Tuntemattomia alueita käytetty: {automation}"
     },
     "automation_unknown_device_references": {
-      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin laitteisiin, jotka ovat Home Assistantille tuntemattomia:\n\n{laitteet}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat laitteet.\n\nSpook 👻 Kamusi.",
-      "title": "Tuntemattomia laitteita käytetty: {automaatio}"
+      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin laitteisiin, jotka ovat Home Assistantille tuntemattomia:\n\n{devices}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat laitteet.\n\nSpook 👻 Kamusi.",
+      "title": "Tuntemattomia laitteita käytetty: {automation}"
     },
     "automation_unknown_entity_references": {
-      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin entiteetteihin, jotka ovat Home Assistantille tuntemattomia:\n\n{entiteetit}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat entiteetit.\n\nSpook 👻 Kamusi.",
-      "title": "Tuntemattomia entiteettejä käytetty: {automaatio}"
+      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin entiteetteihin, jotka ovat Home Assistantille tuntemattomia:\n\n{entities}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat entiteetit.\n\nSpook 👻 Kamusi.",
+      "title": "Tuntemattomia entiteettejä käytetty: {automation}"
     },
     "automation_unknown_floor_references": {
-      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin kerroksiin, jotka ovat Home Assistantille tuntemattomia:\n\n{kerrokset}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat kerrokset.\n\nSpook 👻 Kamusi.",
-      "title": "Tuntemattomia kerroksia käytetty: {automaatio}"
+      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin kerroksiin, jotka ovat Home Assistantille tuntemattomia:\n\n{floors}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat kerrokset.\n\nSpook 👻 Kamusi.",
+      "title": "Tuntemattomia kerroksia käytetty: {automation}"
     },
     "automation_unknown_label_references": {
-      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin nimikkeisiin, jotka ovat Home Assistantille tuntemattomia:\n\n{nimikkeet}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat nimikkeet.\n\nSpook 👻 Kamusi.",
-      "title": "Tuntemattomia nimikkeitä käytetty: {automaatio}"
+      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin nimikkeisiin, jotka ovat Home Assistantille tuntemattomia:\n\n{labels}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat nimikkeet.\n\nSpook 👻 Kamusi.",
+      "title": "Tuntemattomia nimikkeitä käytetty: {automation}"
     },
     "automation_unknown_service_references": {
-      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin toimintoihin, jotka ovat Home Assistantille tuntemattomia:\n\n{palvelut}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat toiminnot.\n\nSpook 👻 Kamusi.",
-      "title": "Tuntemattomia toimintoja käytetty: {automaatio}"
+      "description": "Spook on löytänyt kummituksen automaatioistasi 👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavan automaation kanssa:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nTämä automaatio viittaa seuraaviin toimintoihin, jotka ovat Home Assistantille tuntemattomia:\n\n{services}\n\n\n\nKorjataksesi tämän vian  [edit the automation]({edit}) ja poista nämä tuntemattomat toiminnot.\n\nSpook 👻 Kamusi.",
+      "title": "Tuntemattomia toimintoja käytetty: {automation}"
     },
     "group_unknown_members": {
-      "description": "Spook on löytänyt haamuja ryhmistänne 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan ryhmän kanssa:\n\n{ryhmä} (`{entity_id}`)\n\nTässä ryhmässä on jäseniä, joita Home Assistant ei tunne:\n\n{entities}\n\n\n\nKorjaa tämä virhe muokkaamalla ryhmää, poistamalla näiden ei-olemassa olevien entiteettien käyttö ja käynnistämällä Home Assistant uudelleen.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia ryhmänjäseniä: {ryhmä}"
+      "description": "Spook on löytänyt haamuja ryhmistänne 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan ryhmän kanssa:\n\n{group} (`{entity_id}`)\n\nTässä ryhmässä on jäseniä, joita Home Assistant ei tunne:\n\n{entities}\n\n\n\nKorjaa tämä virhe muokkaamalla ryhmää, poistamalla näiden ei-olemassa olevien entiteettien käyttö ja käynnistämällä Home Assistant uudelleen.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia ryhmänjäseniä: {group}"
     },
     "integration_unknown_source": {
-      "description": "Spook on löytänyt haamuja Riemannin sum integraalisista avustajistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan avustajan kanssa:\n\n{auttaja} (`{entity_id}`)\n\nTällä avustajalla on Home Assistantille tuntematon lähdeentiteetti:\n\n`{lähde}`\n\n\n\nKorjaa tämä virhe muokkaamalla apuohjelmaa ja säätämällä lähdekokonaisuutta (tai poistamalla apuohjelma) ja käynnistämällä Home Assistantin uudelleen.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntematon lähde: {apuri}"
+      "description": "Spook on löytänyt haamuja Riemannin sum integraalisista avustajistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan avustajan kanssa:\n\n{helper} (`{entity_id}`)\n\nTällä avustajalla on Home Assistantille tuntematon lähdeentiteetti:\n\n`{source}`\n\n\n\nKorjaa tämä virhe muokkaamalla apuohjelmaa ja säätämällä lähdekokonaisuutta (tai poistamalla apuohjelma) ja käynnistämällä Home Assistantin uudelleen.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntematon lähde: {helper}"
     },
     "lovelace_unknown_entity_references": {
-      "description": "Spook on löytänyt kummituksen kojelaudoistasi👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavaan kojelautaan:\n\n[{dashboard}]({edit})\n\nTämä automaatio viittaa seuraaviin entiteetteihin, jotka ovat Home Assistantille tuntemattomia:\n\n{entiteetit}\n\n\n\nKorjataksesi tämän vian  [edit the dashboard]({edit}) ja poista nämä tuntemattomat entiteetit.\n\nSpook 👻 Kamusi.",
-      "title": "Tuntemattomia entiteettejä käytetty: {kojelauta}"
+      "description": "Spook on löytänyt kummituksen kojelaudoistasi👻\n\nLeijuessaan ympäriinsä, Spook törmäsi seuraavaan kojelautaan:\n\n[{dashboard}]({edit})\n\nTämä automaatio viittaa seuraaviin entiteetteihin, jotka ovat Home Assistantille tuntemattomia:\n\n{entities}\n\n\n\nKorjataksesi tämän vian  [edit the dashboard]({edit}) ja poista nämä tuntemattomat entiteetit.\n\nSpook 👻 Kamusi.",
+      "title": "Tuntemattomia entiteettejä käytetty: {dashboard}"
     },
     "proximity_unknown_ignored_zones": {
-      "description": "Spook on löytänyt haamun läheisyyskokoonpanostasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan läheisyyskonfiguraation kanssa:\n\n{nimi}\n\nTämä kokoonpano jättää huomioimatta vyöhykkeet, joita Home Assistant ei tunne:\n\n{vyöhykkeet}\n\n\n\nKorjaa tämä virhe muokkaamalla kokoonpanoa ja poistamalla tämä/nämä vyöhykkeet.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia sivuutettuja alueita: {nimi}"
+      "description": "Spook on löytänyt haamun läheisyyskokoonpanostasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan läheisyyskonfiguraation kanssa:\n\n{name}\n\nTämä kokoonpano jättää huomioimatta vyöhykkeet, joita Home Assistant ei tunne:\n\n{zones}\n\n\n\nKorjaa tämä virhe muokkaamalla kokoonpanoa ja poistamalla tämä/nämä vyöhykkeet.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia sivuutettuja alueita: {name}"
     },
     "proximity_unknown_tracked_entities": {
-      "description": "Spook on löytänyt haamun läheisyyskokoonpanostasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan läheisyyskonfiguraation kanssa:\n\n{nimi}\n\nTämä kokoonpano seuraa henkilöitä tai laitteiden seurantalaitteita, joita Home Assistant ei tunne:\n\n{entities}\n\n\n\nKorjaa tämä virhe muokkaamalla määritystä ja poistamalla tämä/nämä entiteetit.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia seurattuja entiteettejä: {nimi}"
+      "description": "Spook on löytänyt haamun läheisyyskokoonpanostasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan läheisyyskonfiguraation kanssa:\n\n{name}\n\nTämä kokoonpano seuraa henkilöitä tai laitteiden seurantalaitteita, joita Home Assistant ei tunne:\n\n{entities}\n\n\n\nKorjaa tämä virhe muokkaamalla määritystä ja poistamalla tämä/nämä entiteetit.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia seurattuja entiteettejä: {name}"
     },
     "proximity_unknown_zone": {
-      "description": "Spook on löytänyt haamun läheisyyskokoonpanostasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan läheisyyskonfiguraation kanssa:\n\n{nimi}\n\nTämä kokoonpano perustuu vyöhykkeeseen, jota Home Assistant ei tunne:\n\n`{zone}`\n\n\n\nKorjataksesi tämän virheen, koska et voi muuttaa läheisyysmäärityksen vyöhykettä, ainoa vaihtoehto on poistaa tämä läheisyysintegrointiinstanssi.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntematon alue: {alue}"
+      "description": "Spook on löytänyt haamun läheisyyskokoonpanostasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan läheisyyskonfiguraation kanssa:\n\n{name}\n\nTämä kokoonpano perustuu vyöhykkeeseen, jota Home Assistant ei tunne:\n\n`{zone}`\n\n\n\nKorjataksesi tämän virheen, koska et voi muuttaa läheisyysmäärityksen vyöhykettä, ainoa vaihtoehto on poistaa tämä läheisyysintegrointiinstanssi.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntematon alue: {zone}"
     },
     "scene_unknown_entity_references": {
-      "description": "Spook on löytänyt aaveen kohtauksistasi 👻\n\nKelluessaan ympäriinsä Spook ristesi seuraavan kohtauksen kanssa:\n\n[{kohtaus}]({muokkaa})\n\nTämä kohtaus viittaa seuraaviin entiteeteihin, joita Home Assistant ei tunne:\n\n{entities}\n\n\n\nKorjaa tämä virhe [muokkaa kohtausta]({muokkaa}) ja poista näiden ei-olemassa olevien entiteettien käyttö.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia entiteettejä käytetty: {tilanne}"
+      "description": "Spook on löytänyt aaveen kohtauksistasi 👻\n\nKelluessaan ympäriinsä Spook ristesi seuraavan kohtauksen kanssa:\n\n[{scene}]({edit})\n\nTämä kohtaus viittaa seuraaviin entiteeteihin, joita Home Assistant ei tunne:\n\n{entities}\n\n\n\nKorjaa tämä virhe [muokkaa kohtausta]({edit}) ja poista näiden ei-olemassa olevien entiteettien käyttö.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia entiteettejä käytetty: {scene}"
     },
     "script_unknown_area_references": {
-      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä skripti viittaa seuraaviin alueisiin, joita Home Assistant ei tunne:\n\n{alueet}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({muokkaa}) ja poista näiden ei-olemassa olevien alueiden käyttö.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia alueita käytetty: {skripti}"
+      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä skripti viittaa seuraaviin alueisiin, joita Home Assistant ei tunne:\n\n{areas}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({edit}) ja poista näiden ei-olemassa olevien alueiden käyttö.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia alueita käytetty: {script}"
     },
     "script_unknown_device_references": {
-      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä komentosarja viittaa seuraaviin laitteisiin, joita Home Assistant ei tunne:\n\n{laitteet}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({muokkaa}) ja poista näiden ei-olemassa olevien laitteiden käyttö.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia laitteita käytetty: {skripti}"
+      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä komentosarja viittaa seuraaviin laitteisiin, joita Home Assistant ei tunne:\n\n{devices}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({edit}) ja poista näiden ei-olemassa olevien laitteiden käyttö.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia laitteita käytetty: {script}"
     },
     "script_unknown_entity_references": {
-      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä komentosarja viittaa seuraaviin entiteeteihin, joita Home Assistant ei tunne:\n\n{entities}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({muokkaa}) ja poista näiden ei-olemassa olevien entiteettien käyttö.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia entiteettejä käytetty: {skripti}"
+      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä komentosarja viittaa seuraaviin entiteeteihin, joita Home Assistant ei tunne:\n\n{entities}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({edit}) ja poista näiden ei-olemassa olevien entiteettien käyttö.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia entiteettejä käytetty: {script}"
     },
     "script_unknown_floor_references": {
-      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä skripti viittaa seuraaviin kerroksiin, joita Home Assistant ei tunne:\n\n{lattiat}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({muokkaa}) ja poista näiden ei-olemassa olevien kerrosten käyttö.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia kerroksia käytetty: {skripti}"
+      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä skripti viittaa seuraaviin kerroksiin, joita Home Assistant ei tunne:\n\n{floors}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({edit}) ja poista näiden ei-olemassa olevien kerrosten käyttö.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia kerroksia käytetty: {script}"
     },
     "script_unknown_label_references": {
-      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä komentosarja viittaa seuraaviin nimikkeisiin, joita Home Assistant ei tunne:\n\n{labels}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({muokkaa}) ja poista näiden ei-olemassa olevien tunnisteiden käyttö.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntemattomia nimikkeitä käytetty: {skripti}"
+      "description": "Spook on löytänyt haamun käsikirjoituksistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan käsikirjoituksen kanssa:\n\n[{script}]({edit}) (`{entity_id}`)\n\nTämä komentosarja viittaa seuraaviin nimikkeisiin, joita Home Assistant ei tunne:\n\n{labels}\n\n\n\nKorjaa tämä virhe [muokkaa komentosarjaa]({edit}) ja poista näiden ei-olemassa olevien tunnisteiden käyttö.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntemattomia nimikkeitä käytetty: {script}"
     },
     "switch_as_x_unknown_source": {
-      "description": "Spook on löytänyt haamun Switchistäsi X-auttajina 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan avustajan kanssa:\n\n{auttaja} (`{entity_id}`)\n\nTällä auttajalla on lähdevaihtoyksikkö, jota Home Assistant ei tunne:\n\n`{lähde}`\n\n\n\nKorjaa tämä virhe muokkaamalla apuohjelmaa ja säätämällä lähdekokonaisuutta (tai poistamalla apuohjelma) ja käynnistämällä Home Assistantin uudelleen.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntematon lähde: {apuri}"
+      "description": "Spook on löytänyt haamun Switchistäsi X-auttajina 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan avustajan kanssa:\n\n{helper} (`{entity_id}`)\n\nTällä auttajalla on lähdevaihtoyksikkö, jota Home Assistant ei tunne:\n\n`{source}`\n\n\n\nKorjaa tämä virhe muokkaamalla apuohjelmaa ja säätämällä lähdekokonaisuutta (tai poistamalla apuohjelma) ja käynnistämällä Home Assistantin uudelleen.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntematon lähde: {helper}"
     },
     "utility_meter_unknown_source": {
-      "description": "Spook on löytänyt aaveen sähkömittarin auttajistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan avustajan kanssa:\n\n{auttaja} (`{entity_id}`)\n\nTällä avustajalla on Home Assistantille tuntematon lähdeentiteetti:\n\n`{lähde}`\n\n\n\nKorjaa tämä virhe muokkaamalla apuohjelmaa ja säätämällä lähdekokonaisuutta (tai poistamalla apuohjelma) ja käynnistämällä Home Assistantin uudelleen.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntematon lähde: {apuri}"
+      "description": "Spook on löytänyt aaveen sähkömittarin auttajistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan avustajan kanssa:\n\n{helper} (`{entity_id}`)\n\nTällä avustajalla on Home Assistantille tuntematon lähdeentiteetti:\n\n`{source}`\n\n\n\nKorjaa tämä virhe muokkaamalla apuohjelmaa ja säätämällä lähdekokonaisuutta (tai poistamalla apuohjelma) ja käynnistämällä Home Assistantin uudelleen.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntematon lähde: {helper}"
     },
     "trend_unknown_source": {
-      "description": "Spook on löytänyt aaveen trendiauttajistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan avustajan kanssa:\n\n{auttaja} (`{entity_id}`)\n\nTällä avustajalla on Home Assistantille tuntematon lähdeentiteetti:\n\n`{lähde}`\n\n\n\nKorjaa tämä virhe muokkaamalla apuohjelmaa ja säätämällä lähdekokonaisuutta (tai poistamalla apuohjelma) ja käynnistämällä Home Assistantin uudelleen.\n\nSpook 👻 Sinun kamusi.",
-      "title": "Tuntematon lähde: {apuri}"
+      "description": "Spook on löytänyt aaveen trendiauttajistasi 👻\n\nKelluessaan ympäriinsä Spook ylitti polun seuraavan avustajan kanssa:\n\n{helper} (`{entity_id}`)\n\nTällä avustajalla on Home Assistantille tuntematon lähdeentiteetti:\n\n`{source}`\n\n\n\nKorjaa tämä virhe muokkaamalla apuohjelmaa ja säätämällä lähdekokonaisuutta (tai poistamalla apuohjelma) ja käynnistämällä Home Assistantin uudelleen.\n\nSpook 👻 Sinun kamusi.",
+      "title": "Tuntematon lähde: {helper}"
     },
     "user_issue": {
       "fix_flow": {
         "step": {
           "confirm": {
             "description": "{description}",
-            "title": "{nimike}"
+            "title": "{title}"
           }
         }
       },
-      "title": "{nimike}"
+      "title": "{title}"
     },
     "restart_required": {
       "title": "Uudelleenkäynnistys vaaditaan",


### PR DESCRIPTION
Returned translated placeholders to English.

Fixes the issue #1165.

## Description

Placeholders were incorrectly also translated to Finnish which should not happen.
 
## How has this been tested?

I installed the language file to my system and re-checked logs. No log writings any more.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
