### PR TITLE
Redirect repairs to the first view with unknown entities

### DIFF
--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -68,8 +68,12 @@ class SpookRepair(AbstractSpookRepair):
                 entity_ids=set(extracted_entities.keys()),
                 known_entity_ids=known_entity_ids,
             ):
-                # Get the view path of the first unknown entity
-                first_view_path = extracted_entities[next(iter(unknown_entities))]
+                # Get the view path of the first unknown entity (by view order)
+                first_view_path = next(
+                    path
+                    for entity_id, path in extracted_entities.items()
+                    if entity_id in unknown_entities
+                )
                 title = "Overview"
                 if dashboard.config:
                     title = dashboard.config.get("title", url_path)

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -14,7 +14,11 @@ from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
-from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_filtering import (
+    async_filter_known_entity_ids,
+    async_get_all_entity_ids,
+    split_comma_separated_entity_ids,
+)
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -103,9 +107,10 @@ class SpookRepair(AbstractSpookRepair):
         if isinstance(config, dict) and (views := config.get("views")):
             for view_index, view in enumerate(views):
                 view_path: int | str = view.get("path", view_index)
-                for entity_id in self.__async_extract_entities_from_view(view):
-                    if entity_id not in entities:
-                        entities[entity_id] = view_path
+                for entity_id_raw in self.__async_extract_entities_from_view(view):
+                    for entity_id in split_comma_separated_entity_ids(entity_id_raw):
+                        if entity_id not in entities:
+                            entities[entity_id] = view_path
         return entities
 
     @callback

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -106,7 +106,9 @@ class SpookRepair(AbstractSpookRepair):
         entities: dict[str, int | str] = {}
         if isinstance(config, dict) and (views := config.get("views")):
             for view_index, view in enumerate(views):
-                view_path: int | str = view.get("path", view_index)
+                if not isinstance(view, dict):
+                    continue
+                view_path: int | str = view.get("path") or view_index
                 for entity_id_raw in self.__async_extract_entities_from_view(view):
                     for entity_id in split_comma_separated_entity_ids(entity_id_raw):
                         if entity_id not in entities:

--- a/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
@@ -95,6 +95,27 @@ def test_dashboard_uses_view_index_when_path_is_missing(repair: SpookRepair) -> 
     }
 
 
+def test_dashboard_uses_view_index_when_path_is_empty(repair: SpookRepair) -> None:
+    """An empty view path falls back to its index."""
+    config = {
+        "views": [
+            {
+                "path": "",
+                "cards": [{"type": "entity", "entity": "light.kitchen"}],
+            },
+            "not a view",
+            {
+                "path": None,
+                "cards": [{"type": "entity", "entity": "switch.lamp"}],
+            },
+        ]
+    }
+    assert _extract(repair, config) == {
+        "light.kitchen": 0,
+        "switch.lamp": 2,
+    }
+
+
 def test_dashboard_keeps_first_view_for_duplicate_entity(repair: SpookRepair) -> None:
     """A duplicate entity keeps the first view path by dashboard order."""
     config = {

--- a/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
@@ -31,7 +31,7 @@ def repair_fixture(hass: HomeAssistant) -> SpookRepair:
     return SpookRepair(hass)
 
 
-def _extract(repair: SpookRepair, config: dict[str, Any]) -> set[str]:
+def _extract(repair: SpookRepair, config: dict[str, Any]) -> dict[str, int | str]:
     """Call the name-mangled dashboard-level extractor."""
     return repair._SpookRepair__async_extract_entities(config)  # noqa: SLF001  # type: ignore[attr-defined]
 
@@ -53,20 +53,21 @@ def _extract_element(repair: SpookRepair, config: dict[str, Any]) -> set[str]:
 
 def test_dashboard_with_no_views_returns_empty(repair: SpookRepair) -> None:
     """A dashboard with no ``views`` key yields no entities."""
-    assert _extract(repair, {}) == set()
+    assert _extract(repair, {}) == {}
 
 
 def test_dashboard_non_dict_returns_empty(repair: SpookRepair) -> None:
     """A non-dict config yields no entities."""
-    assert _extract(repair, "not a dict") == set()  # type: ignore[arg-type]
+    assert _extract(repair, "not a dict") == {}  # type: ignore[arg-type]
 
 
 def test_dashboard_full_walk(repair: SpookRepair) -> None:
-    """Views, badges, cards, and sections are all walked."""
+    """Views, badges, cards, and sections are all walked with their view path."""
     config = {
         "views": [
             {
                 "title": "Home",
+                "path": "home",
                 "badges": [{"entity": "sensor.outside_temperature"}],
                 "cards": [{"type": "entity", "entity": "light.kitchen"}],
                 "sections": [{"cards": [{"type": "entity", "entity": "switch.lamp"}]}],
@@ -74,9 +75,57 @@ def test_dashboard_full_walk(repair: SpookRepair) -> None:
         ]
     }
     assert _extract(repair, config) == {
-        "sensor.outside_temperature",
-        "light.kitchen",
-        "switch.lamp",
+        "sensor.outside_temperature": "home",
+        "light.kitchen": "home",
+        "switch.lamp": "home",
+    }
+
+
+def test_dashboard_uses_view_index_when_path_is_missing(repair: SpookRepair) -> None:
+    """A view without a path falls back to its index."""
+    config = {
+        "views": [
+            {"title": "Home", "cards": [{"type": "entity", "entity": "light.kitchen"}]},
+            {"title": "Second", "cards": [{"type": "entity", "entity": "switch.lamp"}]},
+        ]
+    }
+    assert _extract(repair, config) == {
+        "light.kitchen": 0,
+        "switch.lamp": 1,
+    }
+
+
+def test_dashboard_keeps_first_view_for_duplicate_entity(repair: SpookRepair) -> None:
+    """A duplicate entity keeps the first view path by dashboard order."""
+    config = {
+        "views": [
+            {"path": "first", "cards": [{"type": "entity", "entity": "light.kitchen"}]},
+            {
+                "path": "second",
+                "cards": [{"type": "entity", "entity": "light.kitchen"}],
+            },
+        ]
+    }
+    assert _extract(repair, config) == {"light.kitchen": "first"}
+
+
+def test_dashboard_splits_comma_separated_entities_per_view(
+    repair: SpookRepair,
+) -> None:
+    """Comma-separated entity IDs keep the source view path."""
+    config = {
+        "views": [
+            {
+                "path": "home",
+                "cards": [
+                    {"type": "entity", "entity": "light.kitchen, switch.lamp"},
+                ],
+            }
+        ]
+    }
+    assert _extract(repair, config) == {
+        "light.kitchen": "home",
+        "switch.lamp": "home",
     }
 
 


### PR DESCRIPTION
## Description

Redirect repairs to the first view with unknown entities

## Motivation and Context

Previously, the "unknown entity references" repair always linked to view `0` regardless of which view actually contained the missing entity. This made it harder for users to find and fix the issue, especially in dashboards with many views.

Now the repair link points directly to the first view that contains an unknown entity, using the view's path if set or falling back to the view index.

## How has this been tested?

Manual testing with dashboards containing multiple views where unknown entities exist in views other than the first one.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.