### PR TITLE
Find unknown entities in heading badge

### DIFF
--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -217,6 +217,13 @@ class SpookRepair(AbstractSpookRepair):
             for chip in chips:
                 entities.update(self.__async_extract_entities_from_mushroom_chip(chip))
 
+        # Heading card
+        if badges := config.get("badges"):
+            for badge in badges:
+                if isinstance(badge, dict):
+                    entities.update(self.__async_extract_common(badge))
+                    entities.update(self.__async_extract_entities_from_actions(badge))
+
         visibility = config.get("visibility")
         if isinstance(visibility, list):
             for condition in visibility:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for detecting unknown entity references in heading card badges.

## Motivation and Context

The heading card supports a `badges` array where each badge can reference an entity and have tap/hold/double-tap actions. Previously, these entity references were not being detected by the "unknown entity references" repair.

Example heading card configuration:

```yaml
type: heading
heading: "Living Room"
badges:
  - type: entity
    entity: sensor.temperature
    tap_action:
      action: more-info
      entity: sensor.temperature
```
## How has this been tested?

Manual testing with a dashboard containing heading cards with badges that reference non-existent entities.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.