### PR TITLE
Fix inverse helper device linking (breaks in HA 2026.8) 

### DIFF
--- a/custom_components/spook/integrations/spook_inverse/__init__.py
+++ b/custom_components/spook/integrations/spook_inverse/__init__.py
@@ -77,8 +77,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
     if (
-        config_entry.version == 1
-        and config_entry.minor_version < 2  # noqa: PLR2004
+        config_entry.version == 1 and config_entry.minor_version < 2  # noqa: PLR2004
     ):
         options = {**config_entry.options}
         if source_device_id := async_get_source_entity_device_id(

--- a/custom_components/spook/integrations/spook_inverse/__init__.py
+++ b/custom_components/spook/integrations/spook_inverse/__init__.py
@@ -11,12 +11,14 @@ from homeassistant.helpers.helper_integration import (
     async_remove_helper_config_entry_from_source_device,
 )
 
+from .config_flow import SpookInverseConfigFlowHandler
 from .const import CONF_HIDE_SOURCE
+
+MIGRATION_MINOR_VERSION = SpookInverseConfigFlowHandler.MINOR_VERSION
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
-
 
 @callback
 def async_get_source_entity_device_id(
@@ -73,21 +75,21 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-
     if config_entry.version == 1:
         options = {**config_entry.options}
-        if config_entry.minor_version < 2:
-            # Remove the spook_inverse config entry from the source device
-            if source_device_id := async_get_source_entity_device_id(
+        if config_entry.minor_version < MIGRATION_MINOR_VERSION and (
+            source_device_id := async_get_source_entity_device_id(
                 hass, options[CONF_ENTITY_ID]
-            ):
-                async_remove_helper_config_entry_from_source_device(
-                    hass,
-                    helper_config_entry_id=config_entry.entry_id,
-                    source_device_id=source_device_id,
-                )
+            )
+        ):
+            # Remove the spook_inverse config entry from the source device
+            async_remove_helper_config_entry_from_source_device(
+                hass,
+                helper_config_entry_id=config_entry.entry_id,
+                source_device_id=source_device_id,
+            )
         hass.config_entries.async_update_entry(
-            config_entry, options=options, minor_version=2
+            config_entry, options=options, minor_version=MIGRATION_MINOR_VERSION
         )
 
     return True

--- a/custom_components/spook/integrations/spook_inverse/__init__.py
+++ b/custom_components/spook/integrations/spook_inverse/__init__.py
@@ -76,12 +76,13 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    if config_entry.version == 1:
+    if (
+        config_entry.version == 1
+        and config_entry.minor_version < MIGRATION_MINOR_VERSION
+    ):
         options = {**config_entry.options}
-        if config_entry.minor_version < MIGRATION_MINOR_VERSION and (
-            source_device_id := async_get_source_entity_device_id(
-                hass, options[CONF_ENTITY_ID]
-            )
+        if source_device_id := async_get_source_entity_device_id(
+            hass, options[CONF_ENTITY_ID]
         ):
             # Remove the spook_inverse config entry from the source device
             async_remove_helper_config_entry_from_source_device(

--- a/custom_components/spook/integrations/spook_inverse/__init__.py
+++ b/custom_components/spook/integrations/spook_inverse/__init__.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
+
 @callback
 def async_get_source_entity_device_id(
     hass: HomeAssistant, entity_id: str

--- a/custom_components/spook/integrations/spook_inverse/__init__.py
+++ b/custom_components/spook/integrations/spook_inverse/__init__.py
@@ -11,10 +11,7 @@ from homeassistant.helpers.helper_integration import (
     async_remove_helper_config_entry_from_source_device,
 )
 
-from .config_flow import SpookInverseConfigFlowHandler
 from .const import CONF_HIDE_SOURCE
-
-MIGRATION_MINOR_VERSION = SpookInverseConfigFlowHandler.MINOR_VERSION
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -78,7 +75,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     """Migrate old entry."""
     if (
         config_entry.version == 1
-        and config_entry.minor_version < MIGRATION_MINOR_VERSION
+        and config_entry.minor_version < 2  # noqa: PLR2004
     ):
         options = {**config_entry.options}
         if source_device_id := async_get_source_entity_device_id(
@@ -91,7 +88,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 source_device_id=source_device_id,
             )
         hass.config_entries.async_update_entry(
-            config_entry, options=options, minor_version=MIGRATION_MINOR_VERSION
+            config_entry, options=options, minor_version=2
         )
 
     return True

--- a/custom_components/spook/integrations/spook_inverse/__init__.py
+++ b/custom_components/spook/integrations/spook_inverse/__init__.py
@@ -11,7 +11,10 @@ from homeassistant.helpers.helper_integration import (
     async_remove_helper_config_entry_from_source_device,
 )
 
+from .config_flow import SpookInverseConfigFlowHandler
 from .const import CONF_HIDE_SOURCE
+
+MIGRATION_MINOR_VERSION = SpookInverseConfigFlowHandler.MINOR_VERSION
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -88,7 +91,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 source_device_id=source_device_id,
             )
         hass.config_entries.async_update_entry(
-            config_entry, options=options, minor_version=2
+            config_entry, options=options, minor_version=MIGRATION_MINOR_VERSION
         )
 
     return True

--- a/custom_components/spook/integrations/spook_inverse/__init__.py
+++ b/custom_components/spook/integrations/spook_inverse/__init__.py
@@ -28,7 +28,9 @@ def async_get_source_entity_device_id(
     """Get the entity device id."""
     registry = er.async_get(hass)
 
-    if not (source_entity := registry.async_get(entity_id)):
+    if not (resolved_entity_id := er.async_resolve_entity_id(registry, entity_id)):
+        return None
+    if not (source_entity := registry.async_get(resolved_entity_id)):
         return None
 
     return source_entity.device_id
@@ -80,8 +82,10 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         config_entry.version == 1 and config_entry.minor_version < 2  # noqa: PLR2004
     ):
         options = {**config_entry.options}
-        if source_device_id := async_get_source_entity_device_id(
-            hass, options[CONF_ENTITY_ID]
+        if (source_entity_id := options.get(CONF_ENTITY_ID)) and (
+            source_device_id := async_get_source_entity_device_id(
+                hass, source_entity_id
+            )
         ):
             # Remove the spook_inverse config entry from the source device
             async_remove_helper_config_entry_from_source_device(

--- a/custom_components/spook/integrations/spook_inverse/binary_sensor.py
+++ b/custom_components/spook/integrations/spook_inverse/binary_sensor.py
@@ -26,7 +26,7 @@ async def async_setup_entry(
         er.async_get(hass),
         config_entry.options[CONF_ENTITY_ID],
     )
-    async_add_entities([InverseBinarySensor(config_entry)])
+    async_add_entities([InverseBinarySensor(hass, config_entry)])
 
 
 class InverseBinarySensor(InverseEntity, BinarySensorEntity):

--- a/custom_components/spook/integrations/spook_inverse/config_flow.py
+++ b/custom_components/spook/integrations/spook_inverse/config_flow.py
@@ -102,6 +102,9 @@ OPTIONS_FLOW = {
 class SpookInverseConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle config flow for Spook inverse helper."""
 
+    VERSION = 1
+    MINOR_VERSION = 2
+
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW
 

--- a/custom_components/spook/integrations/spook_inverse/entity.py
+++ b/custom_components/spook/integrations/spook_inverse/entity.py
@@ -45,29 +45,13 @@ class InverseEntity(Entity):  # pylint: disable=too-many-instance-attributes
         self._attr_unique_id = config_entry.entry_id
         self.config_entry = config_entry
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return the device info."""
-        entity_registry = er.async_get(self.hass)
-        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(hass)
+        device_registry = dr.async_get(hass)
         source_entity = entity_registry.async_get(self._entity_id)
-        if (
-            (source_entity is not None)
-            and (source_entity.device_id is not None)
-            and (
-                (
-                    device := device_registry.async_get(
-                        device_id=source_entity.device_id,
-                    )
-                )
-                is not None
-            )
-        ):
-            return DeviceInfo(
-                identifiers=device.identifiers,
-                connections=device.connections,
-            )
-        return None
+        device_id = source_entity.device_id if source_entity else None
+
+        if device_id and (device := device_registry.async_get(device_id)):
+            self.device_entry = device
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""

--- a/custom_components/spook/integrations/spook_inverse/entity.py
+++ b/custom_components/spook/integrations/spook_inverse/entity.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     EventStateChangedData,

--- a/custom_components/spook/integrations/spook_inverse/entity.py
+++ b/custom_components/spook/integrations/spook_inverse/entity.py
@@ -34,6 +34,7 @@ class InverseEntity(Entity):  # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
+        hass: HomeAssistant,
         config_entry: ConfigEntry,
     ) -> None:
         """Initialize an inverse entity."""
@@ -42,6 +43,7 @@ class InverseEntity(Entity):  # pylint: disable=too-many-instance-attributes
         self._attr_name = config_entry.title
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: self._entity_id}
         self._attr_unique_id = config_entry.entry_id
+        self.hass = hass
         self.config_entry = config_entry
 
         entity_registry = er.async_get(self.hass)

--- a/custom_components/spook/integrations/spook_inverse/entity.py
+++ b/custom_components/spook/integrations/spook_inverse/entity.py
@@ -45,8 +45,8 @@ class InverseEntity(Entity):  # pylint: disable=too-many-instance-attributes
         self._attr_unique_id = config_entry.entry_id
         self.config_entry = config_entry
 
-        entity_registry = er.async_get(hass)
-        device_registry = dr.async_get(hass)
+        entity_registry = er.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
         source_entity = entity_registry.async_get(self._entity_id)
         device_id = source_entity.device_id if source_entity else None
 

--- a/custom_components/spook/integrations/spook_inverse/switch.py
+++ b/custom_components/spook/integrations/spook_inverse/switch.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
         er.async_get(hass),
         config_entry.options[CONF_ENTITY_ID],
     )
-    async_add_entities([InverseSwitch(config_entry)])
+    async_add_entities([InverseSwitch(hass, config_entry)])
 
 
 class InverseSwitch(InverseEntity, SwitchEntity):

--- a/tests/integrations/__init__.py
+++ b/tests/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook integrations."""

--- a/tests/integrations/spook_inverse/__init__.py
+++ b/tests/integrations/spook_inverse/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook inverse integration."""

--- a/tests/integrations/spook_inverse/conftest.py
+++ b/tests/integrations/spook_inverse/conftest.py
@@ -1,0 +1,38 @@
+"""Test fixtures for the Spook inverse integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+import custom_components
+from custom_components.spook.integrations import spook_inverse
+from custom_components.spook.integrations.spook_inverse.const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture(autouse=True)
+def link_spook_inverse_sub_integration(hass: HomeAssistant) -> None:
+    """Link the Spook inverse sub-integration into the test config dir."""
+    custom_components_dir = Path(hass.config.config_dir) / "custom_components"
+    custom_components_dir.mkdir(exist_ok=True)
+    if str(custom_components_dir) not in custom_components.__path__:
+        custom_components.__path__.append(str(custom_components_dir))
+
+    link = custom_components_dir / DOMAIN
+    target = Path(spook_inverse.__file__).parent
+    if link.is_symlink():
+        if link.readlink() == target:
+            return
+        link.unlink()
+    elif link.exists():
+        return
+
+    link.symlink_to(
+        target,
+        target_is_directory=True,
+    )

--- a/tests/integrations/spook_inverse/test_init.py
+++ b/tests/integrations/spook_inverse/test_init.py
@@ -1,0 +1,132 @@
+"""Tests for the Spook inverse integration setup helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from custom_components.spook.integrations.spook_inverse import (
+    MIGRATION_MINOR_VERSION,
+    async_get_source_entity_device_id,
+    async_migrate_entry,
+)
+from custom_components.spook.integrations.spook_inverse.const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def test_async_get_source_entity_device_id_resolves_entity_id(
+    hass: HomeAssistant,
+) -> None:
+    """Test source device lookup resolves registered entity IDs."""
+    config_entry = MockConfigEntry(domain="switch", title="Source")
+    config_entry.add_to_hass(hass)
+
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("switch", "source-device")},
+    )
+    er.async_get(hass).async_get_or_create(
+        "switch",
+        "test",
+        "source",
+        suggested_object_id="source",
+        device_id=device.id,
+    )
+
+    assert async_get_source_entity_device_id(hass, "switch.source") == device.id
+
+
+async def test_async_migrate_entry_removes_helper_from_source_device(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test migration removes the helper from the old source device."""
+    source_entry = MockConfigEntry(domain="switch", title="Source")
+    source_entry.add_to_hass(hass)
+
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=source_entry.entry_id,
+        identifiers={("switch", "source-device")},
+    )
+    er.async_get(hass).async_get_or_create(
+        "switch",
+        "test",
+        "source",
+        suggested_object_id="source",
+        device_id=device.id,
+    )
+
+    migrated_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Inverse",
+        options={CONF_ENTITY_ID: "switch.source"},
+        version=1,
+        minor_version=1,
+    )
+    migrated_entry.add_to_hass(hass)
+
+    calls: list[dict[str, Any]] = []
+
+    def remove_helper_from_source_device(
+        hass: HomeAssistant,
+        *,
+        helper_config_entry_id: str,
+        source_device_id: str,
+    ) -> None:
+        """Capture source device cleanup calls."""
+        calls.append(
+            {
+                "hass": hass,
+                "helper_config_entry_id": helper_config_entry_id,
+                "source_device_id": source_device_id,
+            }
+        )
+
+    monkeypatch.setattr(
+        "custom_components.spook.integrations.spook_inverse."
+        "async_remove_helper_config_entry_from_source_device",
+        remove_helper_from_source_device,
+    )
+
+    assert await async_migrate_entry(hass, migrated_entry)
+
+    assert migrated_entry.minor_version == MIGRATION_MINOR_VERSION
+    assert calls == [
+        {
+            "hass": hass,
+            "helper_config_entry_id": migrated_entry.entry_id,
+            "source_device_id": device.id,
+        }
+    ]
+
+
+async def test_async_migrate_entry_handles_missing_source_entity_id(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test migration skips device cleanup when old options lack an entity ID."""
+    migrated_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Inverse",
+        options={},
+        version=1,
+        minor_version=1,
+    )
+    migrated_entry.add_to_hass(hass)
+
+    monkeypatch.setattr(
+        "custom_components.spook.integrations.spook_inverse."
+        "async_remove_helper_config_entry_from_source_device",
+        pytest.fail,
+    )
+
+    assert await async_migrate_entry(hass, migrated_entry)
+
+    assert migrated_entry.minor_version == MIGRATION_MINOR_VERSION

--- a/tests/integrations/spook_inverse/test_init.py
+++ b/tests/integrations/spook_inverse/test_init.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -10,8 +9,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.const import CONF_ENTITY_ID, Platform
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-import custom_components
-from custom_components.spook.integrations import spook_inverse
 from custom_components.spook.integrations.spook_inverse import (
     MIGRATION_MINOR_VERSION,
     async_get_source_entity_device_id,
@@ -23,26 +20,6 @@ from custom_components.spook.integrations.spook_inverse.const import (
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-
-
-def _link_spook_inverse_sub_integration(hass: HomeAssistant) -> None:
-    """Link the Spook inverse sub-integration into the test config dir."""
-    custom_components_dir = Path(hass.config.config_dir) / "custom_components"
-    custom_components_dir.mkdir(exist_ok=True)
-    if str(custom_components_dir) not in custom_components.__path__:
-        custom_components.__path__.append(str(custom_components_dir))
-    link = custom_components_dir / DOMAIN
-    target = Path(spook_inverse.__file__).parent
-    if link.is_symlink():
-        if link.readlink() == target:
-            return
-        link.unlink()
-    elif link.exists():
-        return
-    link.symlink_to(
-        target,
-        target_is_directory=True,
-    )
 
 
 async def test_async_get_source_entity_device_id_resolves_entity_id(
@@ -108,7 +85,6 @@ async def test_async_migrate_entry_removes_helper_from_source_device(
         migrated_entry.entry_id in device_registry.async_get(device.id).config_entries
     )
 
-    _link_spook_inverse_sub_integration(hass)
     assert await hass.config_entries.async_setup(migrated_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -136,7 +112,6 @@ async def test_async_migrate_entry_handles_unresolved_source_entity_id(
     )
     migrated_entry.add_to_hass(hass)
 
-    _link_spook_inverse_sub_integration(hass)
     assert await hass.config_entries.async_setup(migrated_entry.entry_id)
     await hass.async_block_till_done()
 

--- a/tests/integrations/spook_inverse/test_init.py
+++ b/tests/integrations/spook_inverse/test_init.py
@@ -2,23 +2,47 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.const import CONF_ENTITY_ID, Platform
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+import custom_components
+from custom_components.spook.integrations import spook_inverse
 from custom_components.spook.integrations.spook_inverse import (
     MIGRATION_MINOR_VERSION,
     async_get_source_entity_device_id,
-    async_migrate_entry,
 )
-from custom_components.spook.integrations.spook_inverse.const import DOMAIN
+from custom_components.spook.integrations.spook_inverse.const import (
+    CONF_HIDE_SOURCE,
+    DOMAIN,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+
+
+def _link_spook_inverse_sub_integration(hass: HomeAssistant) -> None:
+    """Link the Spook inverse sub-integration into the test config dir."""
+    custom_components_dir = Path(hass.config.config_dir) / "custom_components"
+    custom_components_dir.mkdir(exist_ok=True)
+    if str(custom_components_dir) not in custom_components.__path__:
+        custom_components.__path__.append(str(custom_components_dir))
+    link = custom_components_dir / DOMAIN
+    target = Path(spook_inverse.__file__).parent
+    if link.is_symlink():
+        if link.readlink() == target:
+            return
+        link.unlink()
+    elif link.exists():
+        return
+    link.symlink_to(
+        target,
+        target_is_directory=True,
+    )
 
 
 async def test_async_get_source_entity_device_id_resolves_entity_id(
@@ -45,13 +69,13 @@ async def test_async_get_source_entity_device_id_resolves_entity_id(
 
 async def test_async_migrate_entry_removes_helper_from_source_device(
     hass: HomeAssistant,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test migration removes the helper from the old source device."""
     source_entry = MockConfigEntry(domain="switch", title="Source")
     source_entry.add_to_hass(hass)
 
-    device = dr.async_get(hass).async_get_or_create(
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_or_create(
         config_entry_id=source_entry.entry_id,
         identifiers={("switch", "source-device")},
     )
@@ -66,67 +90,54 @@ async def test_async_migrate_entry_removes_helper_from_source_device(
     migrated_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Inverse",
-        options={CONF_ENTITY_ID: "switch.source"},
+        options={
+            CONF_ENTITY_ID: "switch.source",
+            CONF_HIDE_SOURCE: False,
+            "inverse_type": Platform.SWITCH,
+        },
         version=1,
         minor_version=1,
     )
     migrated_entry.add_to_hass(hass)
 
-    calls: list[dict[str, Any]] = []
-
-    def remove_helper_from_source_device(
-        hass: HomeAssistant,
-        *,
-        helper_config_entry_id: str,
-        source_device_id: str,
-    ) -> None:
-        """Capture source device cleanup calls."""
-        calls.append(
-            {
-                "hass": hass,
-                "helper_config_entry_id": helper_config_entry_id,
-                "source_device_id": source_device_id,
-            }
-        )
-
-    monkeypatch.setattr(
-        "custom_components.spook.integrations.spook_inverse."
-        "async_remove_helper_config_entry_from_source_device",
-        remove_helper_from_source_device,
+    device_registry.async_get_or_create(
+        config_entry_id=migrated_entry.entry_id,
+        identifiers={("switch", "source-device")},
+    )
+    assert (
+        migrated_entry.entry_id in device_registry.async_get(device.id).config_entries
     )
 
-    assert await async_migrate_entry(hass, migrated_entry)
+    _link_spook_inverse_sub_integration(hass)
+    assert await hass.config_entries.async_setup(migrated_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert migrated_entry.minor_version == MIGRATION_MINOR_VERSION
-    assert calls == [
-        {
-            "hass": hass,
-            "helper_config_entry_id": migrated_entry.entry_id,
-            "source_device_id": device.id,
-        }
-    ]
+    assert (
+        migrated_entry.entry_id
+        not in device_registry.async_get(device.id).config_entries
+    )
 
 
-async def test_async_migrate_entry_handles_missing_source_entity_id(
+async def test_async_migrate_entry_handles_unresolved_source_entity_id(
     hass: HomeAssistant,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test migration skips device cleanup when old options lack an entity ID."""
+    """Test migration skips device cleanup when the source entity is unresolved."""
     migrated_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Inverse",
-        options={},
+        options={
+            CONF_ENTITY_ID: "switch.missing",
+            CONF_HIDE_SOURCE: False,
+            "inverse_type": Platform.SWITCH,
+        },
         version=1,
         minor_version=1,
     )
     migrated_entry.add_to_hass(hass)
 
-    monkeypatch.setattr(
-        "custom_components.spook.integrations.spook_inverse."
-        "async_remove_helper_config_entry_from_source_device",
-        pytest.fail,
-    )
-
-    assert await async_migrate_entry(hass, migrated_entry)
+    _link_spook_inverse_sub_integration(hass)
+    assert await hass.config_entries.async_setup(migrated_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert migrated_entry.minor_version == MIGRATION_MINOR_VERSION


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The Inverse helper uses the old method of attaching itself to the device, which will stop working in 2026.8.

Due to the helper method for migration being introduced in 2025.8 I've bumped the HACS min version to that.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is an updated pattern to correctly do this
https://developers.home-assistant.io/blog/2025/07/18/updated-pattern-for-helpers-linking-to-devices/

I've done quite a few of these on other helper, just tidying up any I see as there's no deprecation warning.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Using HA 2026.3.4 I created an inverse switch helper against an existing switch.
I replaced the files for the inverse sub integration and checked the inverse helper config entry was migrated to 1.2.
Checked the inverse switch was still attached to the device.
Created a new inverse helper to check that future switches also worked correctly.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
