### PR TITLE
fix(recorder): stop blocking the event loop in list_orphaned_database_entities

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/list_orphaned_database_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/list_orphaned_database_entities.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import select
 
 from homeassistant.components.homeassistant import DOMAIN
-from homeassistant.components.recorder import (
-    get_instance,
-)
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.db_schema import StatesMeta
+from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import ServiceResponse, SupportsResponse
 
 from ....services import AbstractSpookService
@@ -25,23 +25,29 @@ class SpookService(AbstractSpookService):
     service = "list_orphaned_database_entities"
     supports_response = SupportsResponse.ONLY
 
+    def _fetch_recorded_entities(self) -> list[str]:
+        """Return all entity IDs known to the recorder database.
+
+        Runs in the recorder's executor thread; the database access here is
+        synchronous and must never touch the event loop.
+        """
+        with session_scope(hass=self.hass, read_only=True) as session:
+            return [
+                entity_id
+                for (entity_id,) in session.execute(select(StatesMeta.entity_id))
+            ]
+
     async def async_handle_service(self, call: ServiceCall) -> ServiceResponse:
         """Handle the service call."""
-        query = text(
-            """
-            SELECT DISTINCT(entity_id) FROM states_meta
-            """
+        recorder = get_instance(self.hass)
+        db_list = await recorder.async_add_executor_job(
+            self._fetch_recorded_entities,
         )
-        db_url = get_instance(self.hass).db_url
-        engine = create_engine(db_url)
-        with engine.connect() as conn:
-            response = conn.execute(query)
-            db_list = [e[0] for e in response]
         states_list = self.hass.states.async_entity_ids()
-        compared_list = set(db_list).difference(states_list)
+        orphaned = set(db_list).difference(states_list)
         if call.return_response:
             return {
-                "count": len(compared_list),
-                "entities": list(compared_list),
+                "count": len(orphaned),
+                "entities": sorted(orphaned),
             }
         return None


### PR DESCRIPTION
## What
Rewrite the `homeassistant.list_orphaned_database_entities` service so it no longer blocks Home Assistant's event loop and no longer leaks database connections.

## Why
Mission was "review database schema". Spook has no schema of its own, but it touches Home Assistant's **recorder** schema in two places. The orphaned-entities service had a real correctness/stability bug:

- `create_engine(db_url)` + `conn.execute(...)` ran **synchronously on the event loop** — a blocking-I/O violation that stalls all of Home Assistant while the query runs.
- A fresh engine (own connection pool) was created on **every call and never disposed** → connection/pool leak.
- Opening a second engine against the recorder's SQLite file while the recorder writes can raise `database is locked`.
- Raw SQL against `states_meta` bypasses the recorder abstraction and is fragile across schema revisions.

## How
- Query runs in the **recorder executor** via `get_instance(hass).async_add_executor_job`, off the event loop.
- Uses the recorder's managed `session_scope(read_only=True)` instead of a hand-rolled engine — no leak, no second connection.
- Queries the `StatesMeta` ORM model instead of raw `text()` SQL. `DISTINCT` dropped (entity_id is already unique in `states_meta`).
- Output sorted for deterministic responses.

Orphaned-detection logic unchanged: entities in the recorder DB but absent from the live state machine.

## Testing
No Python/Home Assistant toolchain or test suite exists in this environment, so this was **not executed locally**. The change uses only stable public recorder APIs already used across HA core (`get_instance`, `session_scope`, `StatesMeta`, `async_add_executor_job`); `recorder` is already declared in `manifest.json`. Recommend running the integration CI / a live HA instance to confirm.

## Other review findings (not changed)
- `recorder/import_statistics.py`: uses official `async_import_statistics` / `async_add_external_statistics` — correct. Minor: no explicit check that external `statistic_id` is `domain:id` formatted; HA raises downstream, low severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)