### PR TITLE
Extract base classes for unknown-reference repair boilerplate

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import automation
 from homeassistant.helpers import area_registry as ar
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 from ....util import async_filter_known_area_ids, async_get_all_area_ids
 
+if TYPE_CHECKING:
+    from typing import Any
 
-class SpookRepair(AbstractSpookRepair):
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced areas in automations."""
 
     domain = automation.DOMAIN
@@ -22,44 +25,21 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = automation.UnavailableAutomationEntity
+    entity_label = "automation"
+    reference_label = "areas"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_area_ids: set[str]
 
-        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known area IDs for this inspection cycle."""
+        self._known_area_ids = async_get_all_area_ids(self.hass)
 
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        known_area_ids = async_get_all_area_ids(self.hass)
-
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if not isinstance(entity, automation.UnavailableAutomationEntity) and (
-                unknown_areas := async_filter_known_area_ids(
-                    self.hass,
-                    area_ids=entity.referenced_areas,
-                    known_area_ids=known_area_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "areas": "\n".join(f"- `{area}`" for area in unknown_areas),
-                        "automation": entity.name,
-                        "edit": f"/config/automation/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    (
-                        "Spook found unknown areas in %s "
-                        "and created an issue for it; Areas: %s",
-                    ),
-                    entity.entity_id,
-                    ", ".join(unknown_areas),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown area IDs referenced by ``entity``."""
+        return async_filter_known_area_ids(
+            self.hass,
+            area_ids=entity.referenced_areas,
+            known_area_ids=self._known_area_ids,
+        )

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import automation
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 from ....util import async_filter_known_device_ids, async_get_all_device_ids
 
+if TYPE_CHECKING:
+    from typing import Any
 
-class SpookRepair(AbstractSpookRepair):
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced devices in automations."""
 
     domain = automation.DOMAIN
@@ -23,46 +26,21 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = automation.UnavailableAutomationEntity
+    entity_label = "automation"
+    reference_label = "devices"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_device_ids: set[str]
 
-        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known device IDs for this inspection cycle."""
+        self._known_device_ids = async_get_all_device_ids(self.hass)
 
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        known_device_ids = async_get_all_device_ids(self.hass)
-
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if not isinstance(entity, automation.UnavailableAutomationEntity) and (
-                unknown_devices := async_filter_known_device_ids(
-                    self.hass,
-                    device_ids=entity.referenced_devices,
-                    known_device_ids=known_device_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "devices": "\n".join(
-                            f"- `{device}`" for device in unknown_devices
-                        ),
-                        "automation": entity.name,
-                        "edit": f"/config/automation/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    (
-                        "Spook found unknown devices in %s "
-                        "and created an issue for it; Areas: %s",
-                    ),
-                    entity.entity_id,
-                    ", ".join(unknown_devices),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown device IDs referenced by ``entity``."""
+        return async_filter_known_device_ids(
+            self.hass,
+            device_ids=entity.referenced_devices,
+            known_device_ids=self._known_device_ids,
+        )

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -8,10 +8,9 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components import automation
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 from ....util import (
     ENTITY_ID_PATTERN,
     async_extract_entities_from_config,
@@ -259,7 +258,7 @@ async def extract_entities_from_value(hass: HomeAssistant, value: Any) -> set[st
     return entities
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced entity in automations."""
 
     domain = automation.DOMAIN
@@ -271,67 +270,42 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = automation.UnavailableAutomationEntity
+    entity_label = "automation"
+    reference_label = "entities"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_entity_ids: set[str]
 
-        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known entity IDs (including ALL/NONE) for this inspection cycle."""
+        self._known_entity_ids = async_get_all_entity_ids(
+            self.hass, include_all_none=True
+        )
 
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
+    def _should_inspect_entity(self, entity: Any) -> bool:
+        """Skip disabled automations."""
+        return entity.enabled
 
-        known_entity_ids = async_get_all_entity_ids(self.hass, include_all_none=True)
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown entity IDs referenced by ``entity`` (incl. templates)."""
+        all_entities = set(entity.referenced_entities)
 
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-
-            # Skip disabled automations
-            if not entity.enabled:
-                continue
-
-            # Collect entities from multiple sources
-            all_entities = set(entity.referenced_entities)
-
-            # Also extract entities directly from raw configuration if available
-            if hasattr(entity, "raw_config") and entity.raw_config:
-                config_entities = await extract_entities_from_automation_config(
+        # Also extract entities directly from raw configuration if available
+        if hasattr(entity, "raw_config") and entity.raw_config:
+            all_entities.update(
+                await extract_entities_from_automation_config(
                     self.hass, entity.raw_config
                 )
-                all_entities.update(config_entities)
-
-            # Extract entities from Template objects within the automation entity
-            template_entities = await extract_template_entities_from_automation_entity(
-                self.hass, entity
             )
-            all_entities.update(template_entities)
 
-            if not isinstance(entity, automation.UnavailableAutomationEntity) and (
-                unknown_entities := await async_filter_known_entity_ids_with_templates(
-                    self.hass,
-                    entity_ids=all_entities,
-                    known_entity_ids=known_entity_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in unknown_entities
-                        ),
-                        "automation": entity.name,
-                        "edit": f"/config/automation/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    (
-                        "Spook found unknown entities in %s "
-                        "and created an issue for it; Entities: %s",
-                    ),
-                    entity.entity_id,
-                    ", ".join(unknown_entities),
-                )
+        # Extract entities from Template objects within the automation entity
+        all_entities.update(
+            await extract_template_entities_from_automation_entity(self.hass, entity)
+        )
+
+        return await async_filter_known_entity_ids_with_templates(
+            self.hass,
+            entity_ids=all_entities,
+            known_entity_ids=self._known_entity_ids,
+        )

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_floor_references.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import automation
 from homeassistant.helpers import floor_registry as fr
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 from ....util import async_filter_known_floor_ids, async_get_all_floor_ids
 
+if TYPE_CHECKING:
+    from typing import Any
 
-class SpookRepair(AbstractSpookRepair):
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced floors in automations."""
 
     domain = automation.DOMAIN
@@ -21,44 +24,21 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = automation.UnavailableAutomationEntity
+    entity_label = "automation"
+    reference_label = "floors"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_floor_ids: set[str]
 
-        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known floor IDs for this inspection cycle."""
+        self._known_floor_ids = async_get_all_floor_ids(self.hass)
 
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        known_floor_ids = async_get_all_floor_ids(self.hass)
-
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if not isinstance(entity, automation.UnavailableAutomationEntity) and (
-                unknown_floors := async_filter_known_floor_ids(
-                    self.hass,
-                    floor_ids=entity.referenced_floors,
-                    known_floor_ids=known_floor_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "floors": "\n".join(f"- `{floor}`" for floor in unknown_floors),
-                        "automation": entity.name,
-                        "edit": f"/config/automation/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    (
-                        "Spook found unknown floors in %s "
-                        "and created an issue for it; Floors: %s",
-                    ),
-                    entity.entity_id,
-                    ", ".join(unknown_floors),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown floor IDs referenced by ``entity``."""
+        return async_filter_known_floor_ids(
+            self.hass,
+            floor_ids=entity.referenced_floors,
+            known_floor_ids=self._known_floor_ids,
+        )

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_label_references.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import automation
 from homeassistant.helpers import label_registry as lr
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 from ....util import async_filter_known_label_ids, async_get_all_label_ids
 
+if TYPE_CHECKING:
+    from typing import Any
 
-class SpookRepair(AbstractSpookRepair):
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced labels in automations."""
 
     domain = automation.DOMAIN
@@ -21,44 +24,21 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = automation.UnavailableAutomationEntity
+    entity_label = "automation"
+    reference_label = "labels"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_label_ids: set[str]
 
-        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known label IDs for this inspection cycle."""
+        self._known_label_ids = async_get_all_label_ids(self.hass)
 
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        known_label_ids = async_get_all_label_ids(self.hass)
-
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if not isinstance(entity, automation.UnavailableAutomationEntity) and (
-                unknown_labels := async_filter_known_label_ids(
-                    self.hass,
-                    label_ids=entity.referenced_labels,
-                    known_label_ids=known_label_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "labels": "\n".join(f"- `{label}`" for label in unknown_labels),
-                        "automation": entity.name,
-                        "edit": f"/config/automation/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    (
-                        "Spook found unknown labels in %s "
-                        "and created an issue for it; Labels: %s",
-                    ),
-                    entity.entity_id,
-                    ", ".join(unknown_labels),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown label IDs referenced by ``entity``."""
+        return async_filter_known_label_ids(
+            self.hass,
+            label_ids=entity.referenced_labels,
+            known_label_ids=self._known_label_ids,
+        )

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
@@ -2,23 +2,26 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import automation
 from homeassistant.const import (
     EVENT_SERVICE_REGISTERED,
     EVENT_SERVICE_REMOVED,
 )
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 from ....util import (
     async_filter_known_services,
     async_find_services_in_sequence,
     async_get_all_services,
 )
 
+if TYPE_CHECKING:
+    from typing import Any
 
-class SpookRepair(AbstractSpookRepair):
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced services in automations."""
 
     domain = automation.DOMAIN
@@ -31,48 +34,21 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = automation.UnavailableAutomationEntity
+    entity_label = "automation"
+    reference_label = "services"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_services: set[str]
 
-        entity_component: EntityComponent[automation.AutomationEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known services for this inspection cycle."""
+        self._known_services = async_get_all_services(self.hass)
 
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        known_services = async_get_all_services(self.hass)
-
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-
-            if isinstance(entity, automation.UnavailableAutomationEntity):
-                continue
-
-            if unknown_services := async_filter_known_services(
-                self.hass,
-                services=async_find_services_in_sequence(entity.action_script.sequence),
-                known_services=known_services,
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "services": "\n".join(
-                            f"- `{service}`" for service in unknown_services
-                        ),
-                        "automation": entity.name,
-                        "edit": f"/config/automation/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    (
-                        "Spook found unknown action calls in %s "
-                        "and created an issue for it; Actions: %s",
-                    ),
-                    entity.entity_id,
-                    ", ".join(unknown_services),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown services called by ``entity``."""
+        return async_filter_known_services(
+            self.hass,
+            services=async_find_services_in_sequence(entity.action_script.sequence),
+            known_services=self._known_services,
+        )

--- a/custom_components/spook/ectoplasms/integration/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/integration/repairs/unknown_source.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import sensor
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
+from ....repairs import AbstractSpookEntityPlatformUnknownSourceRepair
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityPlatformUnknownSourceRepair):
     """Spook repair tries to find unknown source entites for integration."""
 
     domain = "integration"
@@ -24,39 +26,9 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     inspect_on_reload = "integration"
 
-    automatically_clean_up_issues = True
+    source_platform_domain = sensor.DOMAIN
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        platforms: list[EntityPlatform] | None
-        if not (platforms := self.hass.data[DATA_ENTITY_PLATFORM].get(self.domain)):
-            return  # Nothing to do.
-
-        known_entity_ids = async_get_all_entity_ids(self.hass)
-
-        for platform in platforms:
-            # We only care about the sensor domain
-            if platform.domain != sensor.DOMAIN:
-                continue
-
-            for entity in platform.entities.values():
-                self.possible_issue_ids.add(entity.entity_id)
-                # pylint: disable-next=protected-access
-                source = entity._sensor_source_id  # noqa: SLF001
-                if source not in known_entity_ids:
-                    self.async_create_issue(
-                        issue_id=entity.entity_id,
-                        translation_placeholders={
-                            "entity_id": entity.entity_id,
-                            "helper": entity.name,
-                            "source": source,
-                        },
-                    )
-                    LOGGER.debug(
-                        "Spook found unknown source entity %s in %s "
-                        "and created an issue for it",
-                        source,
-                        entity.entity_id,
-                    )
+    def _get_source_entity_id(self, entity: Any) -> str:
+        """Return the integrating sensor's source entity ID."""
+        # pylint: disable-next=protected-access
+        return entity._sensor_source_id  # noqa: SLF001

--- a/custom_components/spook/ectoplasms/person/services/add_device_tracker.py
+++ b/custom_components/spook/ectoplasms/person/services/add_device_tracker.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code  # Mirrors remove_device_tracker by design.
 """Spook - Your homie."""
 
 from __future__ import annotations

--- a/custom_components/spook/ectoplasms/person/services/remove_device_tracker.py
+++ b/custom_components/spook/ectoplasms/person/services/remove_device_tracker.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code  # Mirrors add_device_tracker by design.
 """Spook - Your homie."""
 
 from __future__ import annotations

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code  # Mirrors unknown_tracked_entities by design.
 """Spook - Your homie."""
 
 from __future__ import annotations

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code  # Mirrors unknown_ignored_zones by design.
 """Spook - Your homie."""
 
 from __future__ import annotations

--- a/custom_components/spook/ectoplasms/switch_as_x/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/switch_as_x/repairs/unknown_source.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
+from ....repairs import AbstractSpookEntityPlatformUnknownSourceRepair
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityPlatformUnknownSourceRepair):
     """Spook repair tries to find unknown source entites for switch_as_x."""
 
     domain = "switch_as_x"
@@ -22,35 +24,7 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_config_entry_changed = "switch_as_x"
 
-    automatically_clean_up_issues = True
-
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        platforms: list[EntityPlatform] | None
-        if not (platforms := self.hass.data[DATA_ENTITY_PLATFORM].get(self.domain)):
-            return  # Nothing to do, switch_as_x is not loaded
-
-        known_entity_ids = async_get_all_entity_ids(self.hass)
-
-        for platform in platforms:
-            for entity in platform.entities.values():
-                self.possible_issue_ids.add(entity.entity_id)
-                # pylint: disable-next=protected-access
-                source = entity._switch_entity_id  # noqa: SLF001
-                if source not in known_entity_ids:
-                    self.async_create_issue(
-                        issue_id=entity.entity_id,
-                        translation_placeholders={
-                            "entity_id": entity.entity_id,
-                            "helper": entity.name,
-                            "source": source,
-                        },
-                    )
-                    LOGGER.debug(
-                        "Spook found unknown source entity %s in %s "
-                        "and created an issue for it",
-                        source,
-                        entity.entity_id,
-                    )
+    def _get_source_entity_id(self, entity: Any) -> str:
+        """Return the wrapped switch's entity ID."""
+        # pylint: disable-next=protected-access
+        return entity._switch_entity_id  # noqa: SLF001

--- a/custom_components/spook/ectoplasms/trend/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/trend/repairs/unknown_source.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import binary_sensor
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
+from ....repairs import AbstractSpookEntityPlatformUnknownSourceRepair
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityPlatformUnknownSourceRepair):
     """Spook repair tries to find unknown source entites for trend sensors."""
 
     domain = "trend"
@@ -23,39 +25,9 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_on_reload = "trend"
 
-    automatically_clean_up_issues = True
+    source_platform_domain = binary_sensor.DOMAIN
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        platforms: list[EntityPlatform] | None
-        if not (platforms := self.hass.data[DATA_ENTITY_PLATFORM].get(self.domain)):
-            return  # Nothing to do.
-
-        known_entity_ids = async_get_all_entity_ids(self.hass)
-
-        for platform in platforms:
-            # We only care about the binary sensor domain
-            if platform.domain != binary_sensor.DOMAIN:
-                continue
-
-            for entity in platform.entities.values():
-                self.possible_issue_ids.add(entity.entity_id)
-                # pylint: disable-next=protected-access
-                source = entity._entity_id  # noqa: SLF001
-                if source not in known_entity_ids:
-                    self.async_create_issue(
-                        issue_id=entity.entity_id,
-                        translation_placeholders={
-                            "entity_id": entity.entity_id,
-                            "helper": entity.name,
-                            "source": source,
-                        },
-                    )
-                    LOGGER.debug(
-                        "Spook found unknown source entity %s in %s "
-                        "and created an issue for it",
-                        source,
-                        entity.entity_id,
-                    )
+    def _get_source_entity_id(self, entity: Any) -> str:
+        """Return the trend sensor's source entity ID."""
+        # pylint: disable-next=protected-access
+        return entity._entity_id  # noqa: SLF001

--- a/custom_components/spook/ectoplasms/utility_meter/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/utility_meter/repairs/unknown_source.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import sensor
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
-from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
+from ....repairs import AbstractSpookEntityPlatformUnknownSourceRepair
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityPlatformUnknownSourceRepair):
     """Spook repair tries to find unknown source entites for utility meters."""
 
     domain = "utility_meter"
@@ -23,39 +25,9 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_on_reload = "utility_meter"
 
-    automatically_clean_up_issues = True
+    source_platform_domain = sensor.DOMAIN
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        platforms: list[EntityPlatform] | None
-        if not (platforms := self.hass.data[DATA_ENTITY_PLATFORM].get(self.domain)):
-            return  # Nothing to do.
-
-        known_entity_ids = async_get_all_entity_ids(self.hass)
-
-        for platform in platforms:
-            # We only care about the sensor domain
-            if platform.domain != sensor.DOMAIN:
-                continue
-
-            for entity in platform.entities.values():
-                self.possible_issue_ids.add(entity.entity_id)
-                # pylint: disable-next=protected-access
-                source = entity._sensor_source_id  # noqa: SLF001
-                if source not in known_entity_ids:
-                    self.async_create_issue(
-                        issue_id=entity.entity_id,
-                        translation_placeholders={
-                            "entity_id": entity.entity_id,
-                            "helper": entity.name,
-                            "source": source,
-                        },
-                    )
-                    LOGGER.debug(
-                        "Spook found unknown source entity %s in %s "
-                        "and created an issue for it",
-                        source,
-                        entity.entity_id,
-                    )
+    def _get_source_entity_id(self, entity: Any) -> str:
+        """Return the utility-meter sensor's source entity ID."""
+        # pylint: disable-next=protected-access
+        return entity._sensor_source_id  # noqa: SLF001

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -25,15 +25,19 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_component import DATA_INSTANCES
+from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM
 from homeassistant.util.async_ import create_eager_task
 
 from .const import DOMAIN, LOGGER
+from .util import async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Mapping
     from types import ModuleType
 
     from homeassistant.data_entry_flow import FlowResult
+    from homeassistant.helpers.entity_platform import EntityPlatform
     from homeassistant.util.event_type import EventType
 
 
@@ -238,6 +242,156 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
         for sub in self._event_subs:
             sub()
         await super().async_deactivate()
+
+
+class AbstractSpookEntityComponentUnknownReferencesRepair(AbstractSpookRepair, ABC):
+    """Base class for repairs that find unknown references in component entities.
+
+    Handles the shared boilerplate for inspecting entities loaded via
+    `EntityComponent` (e.g. automations, scripts): iterating the component's
+    entities, skipping unavailable ones, computing per-entity unknown references
+    via a subclass hook, and creating an issue with the standard translation
+    placeholders (``<reference_label>``, ``<entity_label>``, ``edit``,
+    ``entity_id``).
+    """
+
+    automatically_clean_up_issues = True
+
+    #: Entity class representing an unavailable/broken instance. Entities of
+    #: this type are still tracked in ``possible_issue_ids`` but skipped during
+    #: issue creation.
+    unavailable_entity_class: type
+
+    #: Translation placeholder key holding the entity's display name (e.g.
+    #: ``"automation"`` or ``"script"``).
+    entity_label: str
+
+    #: Translation placeholder key holding the bulleted list of unknown
+    #: references (e.g. ``"areas"``, ``"floors"``, ``"entities"``).
+    reference_label: str
+
+    #: Format string used to build the ``edit`` placeholder. Must contain a
+    #: ``{unique_id}`` field (e.g. ``"/config/automation/edit/{unique_id}"``).
+    edit_url_pattern: str
+
+    async def _async_setup_inspection(self) -> None:
+        """Prepare per-inspection state (called once per inspection cycle).
+
+        Override to cache lookups (e.g. known IDs from a registry) on ``self``
+        for use during per-entity inspection.
+        """
+
+    # pylint: disable-next=unused-argument
+    def _should_inspect_entity(self, entity: Any) -> bool:  # noqa: ARG002
+        """Decide whether the given entity should be inspected.
+
+        Defaults to inspecting every entity. Override (e.g. to skip disabled
+        entities) when needed.
+        """
+        return True
+
+    @abstractmethod
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return the set of unknown referenced IDs for a single entity."""
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        if self.domain not in self.hass.data[DATA_INSTANCES]:
+            return
+
+        entity_component = self.hass.data[DATA_INSTANCES][self.domain]
+
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        await self._async_setup_inspection()
+
+        for entity in entity_component.entities:
+            self.possible_issue_ids.add(entity.entity_id)
+
+            if isinstance(entity, self.unavailable_entity_class):
+                continue
+
+            if not self._should_inspect_entity(entity):
+                continue
+
+            unknown = await self._async_compute_unknown_references(entity)
+            if not unknown:
+                continue
+
+            self.async_create_issue(
+                issue_id=entity.entity_id,
+                translation_placeholders={
+                    self.reference_label: "\n".join(f"- `{item}`" for item in unknown),
+                    self.entity_label: entity.name,
+                    "edit": self.edit_url_pattern.format(unique_id=entity.unique_id),
+                    "entity_id": entity.entity_id,
+                },
+            )
+            LOGGER.debug(
+                "Spook found unknown %s in %s and created an issue for it; %s: %s",
+                self.reference_label,
+                entity.entity_id,
+                self.reference_label.capitalize(),
+                ", ".join(unknown),
+            )
+
+
+class AbstractSpookEntityPlatformUnknownSourceRepair(AbstractSpookRepair, ABC):
+    """Base class for repairs that find unknown source entities on helpers.
+
+    Handles the shared boilerplate for inspecting entities loaded via
+    `EntityPlatform` (e.g. ``switch_as_x``, ``integration``, ``utility_meter``,
+    ``trend``): walking the platforms, optionally filtering by platform domain,
+    pulling each entity's source attribute via a subclass hook, and raising an
+    issue when the source is no longer known to Home Assistant.
+    """
+
+    automatically_clean_up_issues = True
+
+    #: When set, only entities living on platforms whose ``domain`` equals this
+    #: value are inspected. ``None`` (the default) inspects every platform of
+    #: the integration domain.
+    source_platform_domain: str | None = None
+
+    @abstractmethod
+    def _get_source_entity_id(self, entity: Any) -> str:
+        """Return the source entity ID for the given helper entity."""
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        platforms: list[EntityPlatform] | None
+        if not (platforms := self.hass.data[DATA_ENTITY_PLATFORM].get(self.domain)):
+            return  # Nothing to do, integration is not loaded.
+
+        known_entity_ids = async_get_all_entity_ids(self.hass)
+
+        for platform in platforms:
+            if (
+                self.source_platform_domain is not None
+                and platform.domain != self.source_platform_domain
+            ):
+                continue
+
+            for entity in platform.entities.values():
+                self.possible_issue_ids.add(entity.entity_id)
+                source = self._get_source_entity_id(entity)
+                if source not in known_entity_ids:
+                    self.async_create_issue(
+                        issue_id=entity.entity_id,
+                        translation_placeholders={
+                            "entity_id": entity.entity_id,
+                            "helper": entity.name,
+                            "source": source,
+                        },
+                    )
+                    LOGGER.debug(
+                        "Spook found unknown source entity %s in %s "
+                        "and created an issue for it",
+                        source,
+                        entity.entity_id,
+                    )
 
 
 class AbstractSpookSingleShotRepairs(AbstractSpookRepairBase, ABC):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,15 +101,20 @@ combine-as-imports = true
 [tool.pylint."MESSAGES CONTROL"]
 # Reasons disabled:
 # format - handled by ruff
-# duplicate-code - unavoidable
 # used-before-assignment - false positives with TYPE_CHECKING structures
 disable = [
   "abstract-method",
-  "duplicate-code",
   "format",
   "unexpected-keyword-arg",
   "used-before-assignment",
 ]
+
+[tool.pylint.similarities]
+# Trivial header overlap (imports, class skeletons, `inspect_events = {...}`) is
+# inherent to Home Assistant ectoplasms and not worth deduplicating.
+ignore-imports = true
+ignore-signatures = true
+min-similarity-lines = 12
 
 [tool.uv]
 dev-dependencies = [


### PR DESCRIPTION
## What
Pulls the duplicated `async_inspect` boilerplate out of 10 repair modules into two abstract base classes on `repairs.py`, and re-enables pylint's `duplicate-code` check that was disabled because of it.

## Why
Six `ectoplasms/automation/repairs/unknown_*_references.py` files and four `unknown_source.py` files (switch_as_x, integration, utility_meter, trend) were structurally identical — they differed only in the registry queried, the attribute looked up on the entity, and one placeholder key. The shared code blocked `duplicate-code` from being usefully enabled.

## How
Two abstract bases in `custom_components/spook/repairs.py`:

- **`AbstractSpookEntityComponentUnknownReferencesRepair`** walks an `EntityComponent` (`DATA_INSTANCES`). Subclasses provide three hooks:
  - `_async_setup_inspection` — cache known IDs once per inspection cycle.
  - `_should_inspect_entity` — defaults `True`; overridden in `unknown_entity_references` to skip disabled automations.
  - `_async_compute_unknown_references` — per-entity lookup, returns the set of unknown IDs.

  The base owns the unavailable-entity skip, the issue payload (with configurable `entity_label`, `reference_label`, `edit_url_pattern`) and the debug log.

- **`AbstractSpookEntityPlatformUnknownSourceRepair`** walks an `EntityPlatform` (`DATA_ENTITY_PLATFORM`), optionally filtered to a single `source_platform_domain`. Subclasses only implement `_get_source_entity_id` to expose the private source attribute.

Each leaf module is now ~45 lines that read as the 5 attributes that actually differentiate them.

**Side effects:**
- `duplicate-code` is back on the active pylint checks. `min-similarity-lines = 12` and `ignore-imports/ignore-signatures` are set so trivial header overlap (imports, `inspect_events = {...}`) doesn't trigger.
- Four files outside this mission's scope still mirror each other intentionally (the `person/services/{add,remove}_device_tracker.py` pair and the `proximity/repairs/unknown_{ignored_zones,tracked_entities}.py` pair). They carry a one-line `# pylint: disable=duplicate-code` with the reason; deduping them is a separate concern.
- Stats: 10 leaf modules −436 lines, base infra +154 lines, leaf modules −244 net.

## Testing
- `uv run ruff check custom_components/` → clean.
- `uv run ruff format --check custom_components/` → clean.
- `uv run pre-commit run pylint --all-files` → only the pre-existing `async_timeout` `import-error` in `blueprint/services/importer.py` (unrelated, depends on Python <3.13.2; CI installs it transitively). **0 `duplicate-code` warnings** after the refactor; main has the rule disabled altogether.
- All 11 touched modules import cleanly under `uv run python -c "import …"`.

---
### Quality Report

**Changes**: 16 files changed, 357 insertions(+), 436 deletions(-)

**Code scan**: clean

**Tests**: failed (command not found)

**Branch hygiene**: 1 issue(s)
- Branch is not pushed to remote

*Generated by Kōan post-mission quality pipeline*