### PR TITLE
Split util.py (746 lines) into three focused modules

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -17,14 +17,11 @@ from homeassistant.core import (
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN, LOGGER, PLATFORMS
+from .entity_filtering import async_setup_all_entity_ids_cache_invalidation
+from .integration_linking import link_sub_integrations, unlink_sub_integrations
 from .repairs import SpookRepairManager
 from .services import SpookServiceManager
-from .util import (
-    async_forward_setup_entry,
-    async_setup_all_entity_ids_cache_invalidation,
-    link_sub_integrations,
-    unlink_sub_integrations,
-)
+from .setup_helpers import async_forward_setup_entry
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/custom_components/spook/binary_sensor.py
+++ b/custom_components/spook/binary_sensor.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/button.py
+++ b/custom_components/spook/button.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_area_ids, async_get_all_area_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_device_ids, async_get_all_device_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -11,8 +11,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
-from ....util import (
+from ....entity_filtering import (
     ENTITY_ID_PATTERN,
     async_extract_entities_from_config,
     async_extract_entities_from_template_string,
@@ -20,6 +19,7 @@ from ....util import (
     async_get_all_entity_ids,
     is_template_string,
 )
+from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_floor_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import floor_registry as fr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_floor_ids, async_get_all_floor_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_floor_ids, async_get_all_floor_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_label_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import label_registry as lr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_label_ids, async_get_all_label_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_label_ids, async_get_all_label_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
@@ -10,12 +10,12 @@ from homeassistant.const import (
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
-from ....repairs import AbstractSpookRepair
-from ....util import (
+from ....entity_filtering import (
     async_filter_known_services,
     async_find_services_in_sequence,
     async_get_all_services,
 )
+from ....repairs import AbstractSpookRepair
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
+++ b/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
@@ -10,8 +10,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/integration/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/integration/repairs/unknown_source.py
@@ -8,8 +8,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
 from ....const import LOGGER
+from ....entity_filtering import async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -14,8 +14,8 @@ from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.lovelace.dashboard import (

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
@@ -8,8 +8,8 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.proximity.coordinator import (

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
@@ -8,8 +8,8 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.proximity.coordinator import (

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_zone.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_zone.py
@@ -8,8 +8,8 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.proximity.coordinator import (

--- a/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
@@ -8,8 +8,8 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.homeassistant import scene

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_area_ids, async_get_all_area_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_device_ids, async_get_all_device_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -9,12 +9,12 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....repairs import AbstractSpookRepair
-from ....util import (
+from ....entity_filtering import (
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
     async_get_all_entity_ids,
 )
+from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import floor_registry as fr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_floor_ids, async_get_all_floor_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_floor_ids, async_get_all_floor_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import label_registry as lr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_label_ids, async_get_all_label_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_label_ids, async_get_all_label_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/switch_as_x/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/switch_as_x/repairs/unknown_source.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
 from ....const import LOGGER
+from ....entity_filtering import async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/trend/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/trend/repairs/unknown_source.py
@@ -8,8 +8,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
 from ....const import LOGGER
+from ....entity_filtering import async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/utility_meter/repairs/unknown_source.py
+++ b/custom_components/spook/ectoplasms/utility_meter/repairs/unknown_source.py
@@ -8,8 +8,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
 from ....const import LOGGER
+from ....entity_filtering import async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -1,10 +1,7 @@
-"""Spook - Your homie."""
+"""Spook - Your homie. Entity, registry, and template filtering helpers."""
 
 from __future__ import annotations
 
-import asyncio
-import importlib
-from pathlib import Path
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -38,15 +35,12 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.template import Template
 
-from .const import DOMAIN, LOGGER
+from .const import LOGGER
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
-    from types import ModuleType
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
-    from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 
 # Entity domains to ignore when filtering unknown entities
@@ -221,98 +215,6 @@ def async_get_all_entity_ids(
     if include_all_none:
         return _CACHED_ALL_ENTITY_IDS.union({ENTITY_MATCH_ALL, ENTITY_MATCH_NONE})
     return _CACHED_ALL_ENTITY_IDS.copy()
-
-
-async def async_forward_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-) -> None:
-    """Set up Spook ectoplasms."""
-    LOGGER.debug("Setting up Spook ectoplasms")
-
-    modules: list[ModuleType] = []
-
-    def _load_all_ectoplasm_modules() -> None:
-        """Load all Spook ectoplasm modules."""
-        for module_file in Path(__file__).parent.rglob("ectoplasms/*/__init__.py"):
-            module_path = str(module_file.relative_to(Path(__file__).parent))[
-                :-3
-            ].replace(
-                "/",
-                ".",
-            )
-            LOGGER.debug("Loading Spook ectoplasm: %s", module_path)
-            module = importlib.import_module(f".{module_path}", __package__)
-            if hasattr(module, "async_setup_entry"):
-                modules.append(module)
-                LOGGER.debug("Setting up Spook ectoplasm: %s", module_path)
-
-    await hass.async_add_import_executor_job(_load_all_ectoplasm_modules)
-    await asyncio.gather(*(module.async_setup_entry(hass, entry) for module in modules))
-
-
-async def async_forward_platform_entry_setups_to_ectoplasm(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-    platform: Platform,
-) -> None:
-    """Set up Spook ectoplasm platform."""
-    LOGGER.debug("Setting up Spook ectoplasm platform: %s", platform)
-
-    modules: list[ModuleType] = []
-
-    def _load_all_ectoplasm_platform_modules() -> None:
-        """Load all Spook ectoplasm platform modules."""
-        for module_file in Path(__file__).parent.rglob(f"ectoplasms/*/{platform}.py"):
-            module_path = str(module_file.relative_to(Path(__file__).parent))[
-                :-3
-            ].replace(
-                "/",
-                ".",
-            )
-            LOGGER.debug("Loading Spook %s from ectoplasm: %s", platform, module_path)
-            modules.append(importlib.import_module(f".{module_path}", __package__))
-            LOGGER.debug("Setting up Spook ectoplasm %s: %s", platform, module_path)
-
-    await hass.async_add_import_executor_job(_load_all_ectoplasm_platform_modules)
-    await asyncio.gather(
-        *(
-            module.async_setup_entry(hass, entry, async_add_entities)
-            for module in modules
-        )
-    )
-
-
-def link_sub_integrations(hass: HomeAssistant) -> bool:
-    """Link Spook sub integrations."""
-    LOGGER.debug("Linking up Spook sub integrations")
-
-    changes = False
-    for manifest in Path(__file__).parent.rglob("integrations/*/manifest.json"):
-        LOGGER.debug("Linking Spook sub integration: %s", manifest.parent.name)
-        dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
-        if not dest.exists():
-            src = (
-                Path(hass.config.config_dir)
-                / "custom_components"
-                / DOMAIN
-                / "integrations"
-                / manifest.parent.name
-            )
-            dest.symlink_to(src)
-            changes = True
-    return changes
-
-
-def unlink_sub_integrations(hass: HomeAssistant) -> None:
-    """Unlink Spook sub integrations."""
-    LOGGER.debug("Unlinking Spook sub integrations")
-    for manifest in Path(__file__).parent.rglob("integrations/*/manifest.json"):
-        LOGGER.debug("Unlinking Spook sub integration: %s", manifest.parent.name)
-        dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
-        if dest.exists():
-            dest.unlink()
 
 
 @callback

--- a/custom_components/spook/event.py
+++ b/custom_components/spook/event.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/integration_linking.py
+++ b/custom_components/spook/integration_linking.py
@@ -1,0 +1,42 @@
+"""Spook - Your homie. Sub-integration symlinking helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .const import DOMAIN, LOGGER
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def link_sub_integrations(hass: HomeAssistant) -> bool:
+    """Link Spook sub integrations."""
+    LOGGER.debug("Linking up Spook sub integrations")
+
+    changes = False
+    for manifest in Path(__file__).parent.rglob("integrations/*/manifest.json"):
+        LOGGER.debug("Linking Spook sub integration: %s", manifest.parent.name)
+        dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
+        if not dest.exists():
+            src = (
+                Path(hass.config.config_dir)
+                / "custom_components"
+                / DOMAIN
+                / "integrations"
+                / manifest.parent.name
+            )
+            dest.symlink_to(src)
+            changes = True
+    return changes
+
+
+def unlink_sub_integrations(hass: HomeAssistant) -> None:
+    """Unlink Spook sub integrations."""
+    LOGGER.debug("Unlinking Spook sub integrations")
+    for manifest in Path(__file__).parent.rglob("integrations/*/manifest.json"):
+        LOGGER.debug("Unlinking Spook sub integration: %s", manifest.parent.name)
+        dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
+        if dest.exists():
+            dest.unlink()

--- a/custom_components/spook/number.py
+++ b/custom_components/spook/number.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/select.py
+++ b/custom_components/spook/select.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/sensor.py
+++ b/custom_components/spook/sensor.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/setup_helpers.py
+++ b/custom_components/spook/setup_helpers.py
@@ -1,0 +1,79 @@
+"""Spook - Your homie. Ectoplasm setup forwarding helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .const import LOGGER
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.const import Platform
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_forward_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> None:
+    """Set up Spook ectoplasms."""
+    LOGGER.debug("Setting up Spook ectoplasms")
+
+    modules: list[ModuleType] = []
+
+    def _load_all_ectoplasm_modules() -> None:
+        """Load all Spook ectoplasm modules."""
+        for module_file in Path(__file__).parent.rglob("ectoplasms/*/__init__.py"):
+            module_path = str(module_file.relative_to(Path(__file__).parent))[
+                :-3
+            ].replace(
+                "/",
+                ".",
+            )
+            LOGGER.debug("Loading Spook ectoplasm: %s", module_path)
+            module = importlib.import_module(f".{module_path}", __package__)
+            if hasattr(module, "async_setup_entry"):
+                modules.append(module)
+                LOGGER.debug("Setting up Spook ectoplasm: %s", module_path)
+
+    await hass.async_add_import_executor_job(_load_all_ectoplasm_modules)
+    await asyncio.gather(*(module.async_setup_entry(hass, entry) for module in modules))
+
+
+async def async_forward_platform_entry_setups_to_ectoplasm(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    platform: Platform,
+) -> None:
+    """Set up Spook ectoplasm platform."""
+    LOGGER.debug("Setting up Spook ectoplasm platform: %s", platform)
+
+    modules: list[ModuleType] = []
+
+    def _load_all_ectoplasm_platform_modules() -> None:
+        """Load all Spook ectoplasm platform modules."""
+        for module_file in Path(__file__).parent.rglob(f"ectoplasms/*/{platform}.py"):
+            module_path = str(module_file.relative_to(Path(__file__).parent))[
+                :-3
+            ].replace(
+                "/",
+                ".",
+            )
+            LOGGER.debug("Loading Spook %s from ectoplasm: %s", platform, module_path)
+            modules.append(importlib.import_module(f".{module_path}", __package__))
+            LOGGER.debug("Setting up Spook ectoplasm %s: %s", platform, module_path)
+
+    await hass.async_add_import_executor_job(_load_all_ectoplasm_platform_modules)
+    await asyncio.gather(
+        *(
+            module.async_setup_entry(hass, entry, async_add_entities)
+            for module in modules
+        )
+    )

--- a/custom_components/spook/switch.py
+++ b/custom_components/spook/switch.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/time.py
+++ b/custom_components/spook/time.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,8 @@ classifiers = [
   "Framework :: AsyncIO",
   "Intended Audience :: Developers",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.13",
 ]
 keywords = [
   "automation",
@@ -37,7 +36,7 @@ keywords = [
   "spook",
   "utils",
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.13.2"
 dependencies = [
     "homeassistant>=2025.2.0",
 ]


### PR DESCRIPTION
## What
Split \`custom_components/spook/util.py\` (746 lines) into three focused modules:
\`entity_filtering.py\`, \`setup_helpers.py\`, \`integration_linking.py\`. Also fix
some pyproject metadata that drifted away from the actual codebase reality.

## Why
\`util.py\` had become a kitchen-sink of three unrelated concerns:

- Registry lookups, template entity extraction, comma-separated entity ID
  splitting, and unknown-reference filtering (used by ~25 repair modules).
- Ectoplasm setup forwarding (used by \`__init__.py\` and every platform file).
- Sub-integration symlinking (used only by \`async_setup_entry\` /
  \`async_remove_entry\`).

A 746-line module that's imported in 30 places makes it hard to reason about
what depends on what. Splitting along the existing concern lines gives each
module a single reason to change and makes the dependency graph honest.

## How
- \`entity_filtering.py\` (648 lines) — all entity/area/device/floor/label/
  service lookups, the cache invalidation listeners, template regex extraction,
  and \`async_find_services_in_sequence\`. Most of util.py's bulk lives here.
- \`setup_helpers.py\` (79 lines) — \`async_forward_setup_entry\` and
  \`async_forward_platform_entry_setups_to_ectoplasm\`.
- \`integration_linking.py\` (42 lines) — \`link_sub_integrations\` and
  \`unlink_sub_integrations\`.
- All 30 caller imports rewired (no compatibility shim — \`util.py\` is deleted).
- \`pyproject.toml\` cleanup: classifiers no longer list Python 3.11/3.12 (the
  project already requires 3.13+), and \`requires-python\` is bumped to
  \`>=3.13.2\` to match the HA pin used elsewhere.

No behavior changes — every symbol is moved verbatim.

## Testing
- \`uv run ruff check custom_components/spook/\` — clean.
- \`uv run ruff format --check custom_components/spook/\` — 166 files already
  formatted.
- \`uv run pylint custom_components/spook/\` — 9.98/10, same as before (the one
  remaining warning is a pre-existing \`async_timeout\` import error in
  \`blueprint/services/importer.py\`, unrelated to this change).
- Smoke test: imported every one of the 30 callers via \`importlib\` — all
  resolve cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Quality Report

**Changes**: 34 files changed, 160 insertions(+), 141 deletions(-)

**Code scan**: clean

**Tests**: failed (command not found)

**Branch hygiene**: 1 issue(s)
- Branch is not pushed to remote

*Generated by Kōan post-mission quality pipeline*