### PR TITLE
Add Scorecard and dependency review

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,5 +1,47 @@
 # Security policy
 
-The security policy of Spook is fully documented here:
+Spook takes security issues seriously. The full policy is documented at
+[spook.boo/security](https://spook.boo/security).
 
-https://spook.boo/security
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities through GitHub's private vulnerability
+reporting flow:
+
+<https://github.com/frenck/spook/security/advisories/new>
+
+Do not publish vulnerability details before there has been time to investigate
+and release a fix.
+
+## Supported versions
+
+Spook follows the Home Assistant custom integration model. Security fixes are
+made for the latest released version only.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release | Yes |
+| Older releases | No |
+
+## Disclosure timeline
+
+We aim to acknowledge valid reports within 7 days. Please allow at least 90 days
+for investigation, mitigation, release, and coordinated disclosure unless there
+is active exploitation or another clear reason to adjust that timeline.
+
+## Out of scope
+
+The following reports are generally out of scope for Spook itself:
+
+- Issues in unsupported Spook versions.
+- Issues that only affect unsupported Home Assistant or Python versions.
+- Vulnerabilities in third-party dependencies, unless Spook uses them in a way
+  that creates a Spook-specific security issue.
+- Theoretical attacks without a practical proof of exploitability.
+
+## More details
+
+The project documentation contains the full policy, including severity scoring,
+CVE handling, and bounty expectations:
+
+<https://spook.boo/security>

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,47 +1,77 @@
 # Security policy
 
-Spook takes security issues seriously. The full policy is documented at
-[spook.boo/security](https://spook.boo/security).
+The full security policy of Spook is documented at
+[spook.boo/security](https://spook.boo/security). This file mirrors the same
+policy for GitHub's security policy detection.
 
-## Reporting a vulnerability
+So, you have found a security vulnerability in Spook? Please, be sure to
+**responsibly** disclose it to us by
+[reporting a vulnerability using GitHub's Security Advisory](https://github.com/frenck/spook/security/advisories/new).
 
-Please report suspected vulnerabilities through GitHub's private vulnerability
-reporting flow:
+**DO NOT MAKE A PUBLIC ISSUE FOR SECURITY VULNERABILITIES!**
 
-<https://github.com/frenck/spook/security/advisories/new>
+For the sake of the security of our users, please do not make vulnerabilities
+public without notifying us and giving us at least 90 days to release a fixed
+version. We will do our best to respond to your report within 7 days and also to
+keep you informed of the progress of our efforts to resolve the issue, but
+understand that Spook, like many Open Source projects, is primarily a volunteer
+project with no full-time resources. We may not be able to respond as quickly as
+you would like due to other responsibilities.
 
-Do not publish vulnerability details before there has been time to investigate
-and release a fix.
+If you are going to write about Spook's security, please get in touch, so we can
+ensure that all claims are correct.
 
 ## Supported versions
 
-Spook follows the Home Assistant custom integration model. Security fixes are
-made for the latest released version only.
+We only accept reports against the latest stable and official version of Spook or
+any versions beyond that currently in development. The latest version can be
+found [here](https://github.com/frenck/spook/releases/latest).
 
-| Version | Supported |
-| ------- | --------- |
-| Latest release | Yes |
-| Older releases | No |
+We do not accept reports against forks of Spook.
 
-## Disclosure timeline
+## Non-qualifying vulnerabilities
 
-We aim to acknowledge valid reports within 7 days. Please allow at least 90 days
-for investigation, mitigation, release, and coordinated disclosure unless there
-is active exploitation or another clear reason to adjust that timeline.
+We will not accept reports of vulnerabilities of the following types:
 
-## Out of scope
+- Reports from automated tools or scanners.
+- Theoretical attacks without proof of exploitability.
+- Attacks that are the result of a third-party application or library (these
+  should instead be reported to the library maintainers).
+- Social engineering.
+- Attacks involving physical access to a user's device, or involving a device or
+  network that's already seriously compromised (like, man-in-the-middle).
+- Attacks that require the user to install a malicious other Home Assistant
+  integration or add-on.
+- Attacks that the user can only perform on themselves.
 
-The following reports are generally out of scope for Spook itself:
+## Severity scoring
 
-- Issues in unsupported Spook versions.
-- Issues that only affect unsupported Home Assistant or Python versions.
-- Vulnerabilities in third-party dependencies, unless Spook uses them in a way
-  that creates a Spook-specific security issue.
-- Theoretical attacks without a practical proof of exploitability.
+If you are familiar with
+[CVSS3.1](https://www.first.org/cvss/v3.1/specification-document), please provide
+the vulnerability score in your report in the shape of a vector string. There's a
+calculator [here](https://www.first.org/cvss/calculator/3.1). If you are unsure
+how or unable to score a vulnerability, state that in your report, and we will
+look into it.
 
-## More details
+If you intend to provide a score, please familiarize yourself with CVSS first (we
+strongly recommend reading the
+[Specification](https://www.first.org/cvss/v3.1/specification-document) and
+[Scoring Guide](https://www.first.org/cvss/v3.1/user-guide#Scoring-Guide)), as
+we will not accept reports that use it incorrectly.
 
-The project documentation contains the full policy, including severity scoring,
-CVE handling, and bounty expectations:
+## Public disclosure & CVE assignment
 
-<https://spook.boo/security>
+We will publish GitHub Security Advisories and through those, will also request
+CVEs, for valid vulnerabilities that meet the following criteria:
+
+- The vulnerability is in Spook itself, not a third-party library.
+- The vulnerability is not already known to us.
+- The vulnerability is not already known to the public.
+- CVEs will only be requested for vulnerabilities with a severity of Medium or
+  higher.
+
+## Bounties
+
+As a crowd-funded community project, Spook cannot offer bounties for security
+vulnerabilities. However, if so desired, we will credit the discoverer of a
+vulnerability in our release notes.

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,28 @@
+---
+name: Dependency review
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    paths:
+      - "uv.lock"
+      - "pyproject.toml"
+      - ".github/workflows/dependency-review.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🚀 Review dependency changes
+        uses: actions/dependency-review-action@56339e523c0409420f6c2c9a2f4292bbb3c07dd3 # v4.8.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,38 @@
+---
+name: Scorecard
+
+# yamllint disable-line rule:truthy
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "30 1 * * 0"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
+
+jobs:
+  scorecard:
+    name: Scorecard
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🚀 Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: ⬆️ Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License][license-shield]](LICENSE.md)
 ![Project Maintenance][maintenance-shield]
 [![Coverage][codecov-shield]][codecov]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard]
 
 ![Spook - Your homie](https://raw.githubusercontent.com/frenck/spook/main/logos/logo_wordmark_catchphrase_2048x512.png)
 
@@ -81,3 +82,5 @@ SOFTWARE.
 [releases-shield]: https://img.shields.io/github/release/frenck/spook.svg
 [releases]: https://github.com/frenck/spook/releases
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
+[scorecard-shield]: https://api.scorecard.dev/projects/github.com/frenck/spook/badge
+[scorecard]: https://scorecard.dev/viewer/?uri=github.com/frenck/spook


### PR DESCRIPTION
Add OpenSSF Scorecard and dependency review workflows, and expand the repository security policy so automated checks and humans get the same useful basics.

The SECURITY.md file now includes the reporting link, supported version policy, disclosure timeline, and scope boundaries while keeping the full documentation linked.

Checks run locally:
- uv run pre-commit run check-yaml --all-files
- python -m json.tool .github/renovate.json