### PR TITLE
Add helper extractor tests

### DIFF
--- a/tests/ectoplasms/__init__.py
+++ b/tests/ectoplasms/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook ectoplasms."""

--- a/tests/ectoplasms/script/__init__.py
+++ b/tests/ectoplasms/script/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for script ectoplasms."""

--- a/tests/ectoplasms/script/repairs/__init__.py
+++ b/tests/ectoplasms/script/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for script ectoplasm repairs."""

--- a/tests/ectoplasms/script/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/script/repairs/test_unknown_entity_references.py
@@ -1,0 +1,97 @@
+"""Tests for script unknown entity reference helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.spook.ectoplasms.script.repairs.unknown_entity_references import (
+    extract_entities_from_trigger_config,
+)
+
+
+def test_trigger_plain_entity_id() -> None:
+    """Test a trigger with a string entity ID is captured."""
+    config = {"platform": "state", "entity_id": "binary_sensor.door"}
+
+    assert extract_entities_from_trigger_config(config) == {"binary_sensor.door"}
+
+
+def test_trigger_entity_id_list() -> None:
+    """Test a trigger with a list of entity IDs captures every string entry."""
+    config = {"platform": "state", "entity_id": ["switch.lamp", "switch.fan", 42]}
+
+    assert extract_entities_from_trigger_config(config) == {"switch.lamp", "switch.fan"}
+
+
+def test_trigger_list_of_triggers_is_walked() -> None:
+    """Test a top-level list of trigger configs is flattened."""
+    config = [
+        {"platform": "state", "entity_id": "light.kitchen"},
+        {"platform": "state", "entity_id": ["switch.a", "switch.b"]},
+    ]
+
+    assert extract_entities_from_trigger_config(config) == {
+        "light.kitchen",
+        "switch.a",
+        "switch.b",
+    }
+
+
+def test_trigger_nested_dict_is_walked() -> None:
+    """Test nested dict values are walked recursively to find entity IDs."""
+    config = {
+        "platform": "state",
+        "entity_id": "light.kitchen",
+        "extra": {"entity_id": "switch.lamp"},
+    }
+
+    assert extract_entities_from_trigger_config(config) == {
+        "light.kitchen",
+        "switch.lamp",
+    }
+
+
+@pytest.mark.parametrize("config", [None, {}, []])
+def test_trigger_empty_inputs_return_empty_set(config: Any) -> None:
+    """Test empty trigger inputs produce an empty set."""
+    assert extract_entities_from_trigger_config(config) == set()
+
+
+@pytest.mark.parametrize("config", ["not a config", 42])
+def test_trigger_non_dict_non_list_returns_empty_set(config: Any) -> None:
+    """Test scalar trigger inputs produce an empty set."""
+    assert extract_entities_from_trigger_config(config) == set()
+
+
+def test_trigger_without_entity_id_field() -> None:
+    """Test a trigger config with no entity ID field yields nothing."""
+    config = {"platform": "time", "at": "08:00:00"}
+
+    assert extract_entities_from_trigger_config(config) == set()
+
+
+def test_trigger_entity_id_with_non_string_in_list() -> None:
+    """Test non-string elements inside an entity ID list are ignored."""
+    config = {"platform": "state", "entity_id": ["light.kitchen", None, 42]}
+
+    assert extract_entities_from_trigger_config(config) == {"light.kitchen"}
+
+
+def test_trigger_blueprint_input_shape() -> None:
+    """Test a blueprint-style nested input dict is walked to find triggers."""
+    config = {
+        "discard_when": {
+            "trigger": [
+                {"platform": "state", "entity_id": "binary_sensor.motion"},
+                {"platform": "state", "entity_id": ["light.a", "light.b"]},
+            ],
+        },
+    }
+
+    assert extract_entities_from_trigger_config(config) == {
+        "binary_sensor.motion",
+        "light.a",
+        "light.b",
+    }

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,141 @@
+"""Tests for Spook utility helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.spook.util import (
+    extract_template_strings_from_config,
+    is_template_string,
+    split_comma_separated_entity_ids,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "{{ states('light.kitchen') }}",
+        "{% if true %}on{% endif %}",
+        "prefix {{ x }} suffix",
+        "{% set x = 1 %}{{ x }}",
+    ],
+)
+def test_is_template_string_recognizes_jinja(value: str) -> None:
+    """Test Jinja delimiters are recognized as templates."""
+    assert is_template_string(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "light.kitchen",
+        "{{ unmatched",
+        "{% unmatched",
+        "{ not jinja }",
+    ],
+)
+def test_is_template_string_rejects_plain_strings(value: str) -> None:
+    """Test plain strings are not recognized as templates."""
+    assert is_template_string(value) is False
+
+
+@pytest.mark.parametrize("value", [None, 42, True, ["{{ x }}"], {"a": "{{ x }}"}])
+def test_is_template_string_rejects_non_strings(value: Any) -> None:
+    """Test non-string values are not recognized as templates."""
+    assert is_template_string(value) is False
+
+
+def test_split_single_entity_id_returns_one_element_list() -> None:
+    """Test a bare entity ID round-trips as a single-item list."""
+    assert split_comma_separated_entity_ids("light.kitchen") == ["light.kitchen"]
+
+
+def test_split_comma_separated_entity_ids() -> None:
+    """Test comma-separated entity IDs are split into separate entries."""
+    assert split_comma_separated_entity_ids("light.kitchen,light.living_room") == [
+        "light.kitchen",
+        "light.living_room",
+    ]
+
+
+def test_split_strips_whitespace_around_entries() -> None:
+    """Test whitespace around comma-separated entries is stripped."""
+    assert split_comma_separated_entity_ids(" light.a ,  light.b , light.c ") == [
+        "light.a",
+        "light.b",
+        "light.c",
+    ]
+
+
+def test_split_drops_empty_entries() -> None:
+    """Test empty entries between commas are dropped."""
+    assert split_comma_separated_entity_ids("light.a,,light.b, ,light.c") == [
+        "light.a",
+        "light.b",
+        "light.c",
+    ]
+
+
+@pytest.mark.parametrize("value", ["", None, 42, ["light.kitchen"]])
+def test_split_empty_or_non_string_returns_empty_list(value: Any) -> None:
+    """Test empty strings and non-string values return an empty list."""
+    assert split_comma_separated_entity_ids(value) == []
+
+
+def test_extract_templates_from_plain_string_config() -> None:
+    """Test a template string at the top level is collected."""
+    assert extract_template_strings_from_config("{{ states('light.kitchen') }}") == [
+        "{{ states('light.kitchen') }}",
+    ]
+
+
+def test_extract_templates_ignores_non_template_strings() -> None:
+    """Test plain strings are not collected as templates."""
+    assert extract_template_strings_from_config("light.kitchen") == []
+
+
+def test_extract_templates_walks_nested_dict_and_list() -> None:
+    """Test template strings in nested dictionaries and lists are collected."""
+    config = {
+        "alias": "Test",
+        "trigger": [
+            {"platform": "template", "value_template": "{{ states('sensor.a') }}"},
+        ],
+        "action": {
+            "service": "notify.notify",
+            "data": {"message": "{{ states('sensor.b') }}"},
+        },
+    }
+
+    assert sorted(extract_template_strings_from_config(config)) == [
+        "{{ states('sensor.a') }}",
+        "{{ states('sensor.b') }}",
+    ]
+
+
+def test_extract_templates_walks_tuples() -> None:
+    """Test tuples are walked like lists."""
+    assert sorted(
+        extract_template_strings_from_config(("{{ a }}", ("nested", "{{ b }}")))
+    ) == ["{{ a }}", "{{ b }}"]
+
+
+@pytest.mark.parametrize("config", [{}, [], None, 42, True])
+def test_extract_templates_from_empty_or_scalar_config(config: Any) -> None:
+    """Test empty containers and non-string scalars yield no templates."""
+    assert extract_template_strings_from_config(config) == []
+
+
+def test_extract_templates_appends_to_caller_supplied_list() -> None:
+    """Test a caller-supplied accumulator is populated in place."""
+    sink = ["{{ preexisting }}"]
+
+    result = extract_template_strings_from_config(
+        {"value": "{{ added }}"}, strings=sink
+    )
+
+    assert result is sink
+    assert sink == ["{{ preexisting }}", "{{ added }}"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add focused tests for existing helper behavior salvaged from #1254:

- utility helpers for template detection, comma-separated entity IDs, and template string extraction
- script unknown entity trigger extraction, including nested and blueprint-style trigger input shapes

No stale scaffold, workflow, dependency, or lockfile changes from #1254 are included.

## Motivation and Context

These tests pin down behavior that is useful before refactoring the unknown-reference repairs and utility helpers. They give the follow-up cleanup work a safer baseline.

## How has this been tested?

- `uv run pytest tests/test_util.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py -q`
- `uv run pytest -q`
- `uv run ruff check tests/test_util.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py tests/ectoplasms/__init__.py tests/ectoplasms/script/__init__.py tests/ectoplasms/script/repairs/__init__.py`
- `uv run ruff format --check tests/test_util.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py tests/ectoplasms/__init__.py tests/ectoplasms/script/__init__.py tests/ectoplasms/script/repairs/__init__.py`
- `uv run pylint tests/test_util.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
