### PR TITLE
Add unknown entity extractor tests

### DIFF
--- a/tests/ectoplasms/automation/__init__.py
+++ b/tests/ectoplasms/automation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook automation ectoplasm."""

--- a/tests/ectoplasms/automation/repairs/__init__.py
+++ b/tests/ectoplasms/automation/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook automation repairs."""

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -189,8 +189,10 @@ async def test_action_if_then_else_nested(hass: HomeAssistant) -> None:
         "then": [{"service": "light.turn_on", "target": {"entity_id": "light.hall"}}],
         "else": [{"service": "light.turn_off", "target": {"entity_id": "light.hall"}}],
     }
-    result = await extract_entities_from_action_config(hass, config)
-    assert {"binary_sensor.door", "light.hall"} <= result
+    assert await extract_entities_from_action_config(hass, config) == {
+        "binary_sensor.door",
+        "light.hall",
+    }
 
 
 async def test_action_list_of_actions(hass: HomeAssistant) -> None:

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -1,0 +1,250 @@
+"""Golden-path tests for the automation entity-reference extractor.
+
+These tests pin down the observable behavior of the module-level extractors used
+by ``SpookRepair`` in
+``custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py``
+so the upcoming consolidation into a single recursive walker cannot regress them
+silently.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
+    extract_entities_from_action_config,
+    extract_entities_from_automation_config,
+    extract_entities_from_condition_config,
+    extract_entities_from_trigger_config,
+    extract_entities_from_value,
+)
+import pytest
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def test_value_plain_entity_id(hass: HomeAssistant) -> None:
+    """A bare entity ID string is recognized as an entity reference."""
+    assert await extract_entities_from_value(hass, "light.kitchen") == {"light.kitchen"}
+
+
+async def test_value_unknown_domain_is_ignored(hass: HomeAssistant) -> None:
+    """Strings using an unknown domain are not treated as entity IDs."""
+    assert await extract_entities_from_value(hass, "totally_made_up.kitchen") == set()
+
+
+async def test_value_list_of_entity_ids(hass: HomeAssistant) -> None:
+    """A list of entity ID strings yields every valid entry."""
+    result = await extract_entities_from_value(
+        hass, ["light.kitchen", "switch.lamp", "not_a_domain.foo"]
+    )
+    assert result == {"light.kitchen", "switch.lamp"}
+
+
+async def test_value_entity_dict_form(hass: HomeAssistant) -> None:
+    """``{"entity": "..."}`` dicts are unwrapped into their entity ID."""
+    assert await extract_entities_from_value(
+        hass, {"entity": "sensor.temperature"}
+    ) == {"sensor.temperature"}
+
+
+async def test_value_template_extracts_referenced_entity(
+    hass: HomeAssistant,
+) -> None:
+    """Template strings have their referenced entity IDs extracted."""
+    template = "{{ states('light.kitchen') }}"
+    assert await extract_entities_from_value(hass, template) == {"light.kitchen"}
+
+
+async def test_value_non_string_non_collection_returns_empty(
+    hass: HomeAssistant,
+) -> None:
+    """Numbers, booleans, and None yield no entities."""
+    assert await extract_entities_from_value(hass, 42) == set()
+    assert await extract_entities_from_value(hass, None) == set()
+    value = True
+    assert await extract_entities_from_value(hass, value) == set()
+
+
+async def test_trigger_state_entity_id(hass: HomeAssistant) -> None:
+    """A state trigger's ``entity_id`` is captured."""
+    config = {"platform": "state", "entity_id": "binary_sensor.door"}
+    assert await extract_entities_from_trigger_config(hass, config) == {
+        "binary_sensor.door"
+    }
+
+
+async def test_trigger_zone_field(hass: HomeAssistant) -> None:
+    """A zone trigger's ``zone`` field is captured."""
+    config = {
+        "platform": "zone",
+        "entity_id": "person.alice",
+        "zone": "zone.home",
+        "event": "enter",
+    }
+    assert await extract_entities_from_trigger_config(hass, config) == {
+        "person.alice",
+        "zone.home",
+    }
+
+
+async def test_trigger_list_of_triggers(hass: HomeAssistant) -> None:
+    """Lists of triggers are walked recursively."""
+    config = [
+        {"platform": "state", "entity_id": "light.kitchen"},
+        {"platform": "state", "entity_id": ["switch.lamp", "switch.fan"]},
+    ]
+    assert await extract_entities_from_trigger_config(hass, config) == {
+        "light.kitchen",
+        "switch.lamp",
+        "switch.fan",
+    }
+
+
+async def test_trigger_empty_or_none_returns_empty(hass: HomeAssistant) -> None:
+    """Empty inputs produce no entities."""
+    assert await extract_entities_from_trigger_config(hass, None) == set()
+    assert await extract_entities_from_trigger_config(hass, {}) == set()
+    assert await extract_entities_from_trigger_config(hass, []) == set()
+
+
+async def test_condition_state_entity_id(hass: HomeAssistant) -> None:
+    """A state condition's ``entity_id`` is captured."""
+    config = {"condition": "state", "entity_id": "switch.lamp", "state": "on"}
+    assert await extract_entities_from_condition_config(hass, config) == {"switch.lamp"}
+
+
+async def test_condition_zone(hass: HomeAssistant) -> None:
+    """Zone conditions capture both the tracked entity and the zone."""
+    config = {
+        "condition": "zone",
+        "entity_id": "person.alice",
+        "zone": "zone.home",
+    }
+    assert await extract_entities_from_condition_config(hass, config) == {
+        "person.alice",
+        "zone.home",
+    }
+
+
+async def test_condition_nested_and(hass: HomeAssistant) -> None:
+    """An ``and`` condition recurses into its nested condition list."""
+    config = {
+        "condition": "and",
+        "conditions": [
+            {"condition": "state", "entity_id": "light.kitchen", "state": "on"},
+            {"condition": "numeric_state", "entity_id": "sensor.temperature"},
+        ],
+    }
+    assert await extract_entities_from_condition_config(hass, config) == {
+        "light.kitchen",
+        "sensor.temperature",
+    }
+
+
+async def test_action_direct_entity_id(hass: HomeAssistant) -> None:
+    """A direct ``entity_id`` on an action is captured."""
+    config = {"service": "light.turn_on", "entity_id": "light.kitchen"}
+    assert await extract_entities_from_action_config(hass, config) == {"light.kitchen"}
+
+
+async def test_action_target_block(hass: HomeAssistant) -> None:
+    """``target.entity_id`` on an action is captured."""
+    config = {
+        "service": "light.turn_on",
+        "target": {"entity_id": ["light.kitchen", "light.living_room"]},
+    }
+    assert await extract_entities_from_action_config(hass, config) == {
+        "light.kitchen",
+        "light.living_room",
+    }
+
+
+async def test_action_data_dict(hass: HomeAssistant) -> None:
+    """Entities buried inside ``data`` values are captured."""
+    config = {
+        "service": "notify.notify",
+        "data": {"message": "hello", "target": "person.alice"},
+    }
+    assert await extract_entities_from_action_config(hass, config) == {"person.alice"}
+
+
+async def test_action_data_as_template_string(hass: HomeAssistant) -> None:
+    """A template string assigned directly to ``data`` is parsed."""
+    config = {
+        "service": "notify.notify",
+        "data": "{{ states('sensor.temperature') }}",
+    }
+    assert await extract_entities_from_action_config(hass, config) == {
+        "sensor.temperature"
+    }
+
+
+async def test_action_if_then_else_nested(hass: HomeAssistant) -> None:
+    """``if``/``then``/``else`` nested actions are walked."""
+    config = {
+        "if": [{"condition": "state", "entity_id": "binary_sensor.door"}],
+        "then": [{"service": "light.turn_on", "target": {"entity_id": "light.hall"}}],
+        "else": [{"service": "light.turn_off", "target": {"entity_id": "light.hall"}}],
+    }
+    result = await extract_entities_from_action_config(hass, config)
+    assert {"binary_sensor.door", "light.hall"} <= result
+
+
+async def test_action_list_of_actions(hass: HomeAssistant) -> None:
+    """A top-level list of actions is walked."""
+    config = [
+        {"service": "light.turn_on", "target": {"entity_id": "light.a"}},
+        {"service": "switch.turn_on", "entity_id": "switch.b"},
+    ]
+    assert await extract_entities_from_action_config(hass, config) == {
+        "light.a",
+        "switch.b",
+    }
+
+
+async def test_automation_full_config(hass: HomeAssistant) -> None:
+    """A complete automation config yields entities from all three sections."""
+    config = {
+        "alias": "Test",
+        "trigger": [{"platform": "state", "entity_id": "binary_sensor.motion"}],
+        "condition": [
+            {"condition": "state", "entity_id": "input_boolean.guest", "state": "on"}
+        ],
+        "action": [
+            {"service": "light.turn_on", "target": {"entity_id": "light.kitchen"}},
+        ],
+    }
+    assert await extract_entities_from_automation_config(hass, config) == {
+        "binary_sensor.motion",
+        "input_boolean.guest",
+        "light.kitchen",
+    }
+
+
+async def test_automation_non_dict_returns_empty(hass: HomeAssistant) -> None:
+    """A non-dict argument short-circuits to an empty set."""
+    assert await extract_entities_from_automation_config(hass, []) == set()
+    assert await extract_entities_from_automation_config(hass, "not a dict") == set()
+
+
+@pytest.mark.parametrize("section", ["trigger", "condition", "action"])
+async def test_automation_missing_sections(hass: HomeAssistant, section: str) -> None:
+    """Automations missing one of the three sections still extract from the rest."""
+    config = {
+        "trigger": [{"platform": "state", "entity_id": "binary_sensor.t"}],
+        "condition": [
+            {"condition": "state", "entity_id": "binary_sensor.c", "state": "on"}
+        ],
+        "action": [{"service": "light.turn_on", "entity_id": "light.a"}],
+    }
+    config.pop(section)
+    result = await extract_entities_from_automation_config(hass, config)
+    expected = {
+        "trigger": {"binary_sensor.c", "light.a"},
+        "condition": {"binary_sensor.t", "light.a"},
+        "action": {"binary_sensor.t", "binary_sensor.c"},
+    }[section]
+    assert result == expected

--- a/tests/ectoplasms/lovelace/__init__.py
+++ b/tests/ectoplasms/lovelace/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook Lovelace ectoplasm."""

--- a/tests/ectoplasms/lovelace/repairs/__init__.py
+++ b/tests/ectoplasms/lovelace/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook Lovelace repairs."""

--- a/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
@@ -1,0 +1,320 @@
+"""Golden-path tests for the Lovelace entity-reference extractor.
+
+The dashboard walker in
+``custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py``
+is the only place where Spook converts Lovelace YAML into a flat set of entity
+IDs. These tests pin down its current behavior so the upcoming flattening into a
+single recursive walker cannot regress it silently.
+
+The extraction methods are name-mangled private methods on ``SpookRepair``;
+tests call them through the mangled attribute names, which is intentional — the
+mission says "lock down the riskiest logic before any refactor".
+"""
+
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from custom_components.spook.ectoplasms.lovelace.repairs.unknown_entity_references import (
+    SpookRepair,
+)
+import pytest
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture(name="repair")
+def repair_fixture(hass: HomeAssistant) -> SpookRepair:
+    """Return a ``SpookRepair`` instance wired up to the test ``hass``."""
+    return SpookRepair(hass)
+
+
+def _extract(repair: SpookRepair, config: dict[str, Any]) -> set[str]:
+    """Call the name-mangled dashboard-level extractor."""
+    return repair._SpookRepair__async_extract_entities(config)  # noqa: SLF001  # type: ignore[attr-defined]
+
+
+def _extract_card(repair: SpookRepair, config: dict[str, Any]) -> set[str]:
+    """Call the name-mangled card-level extractor."""
+    return repair._SpookRepair__async_extract_entities_from_card(config)  # noqa: SLF001  # type: ignore[attr-defined]
+
+
+def _extract_badge(repair: SpookRepair, config: Any) -> set[str]:
+    """Call the name-mangled badge-level extractor."""
+    return repair._SpookRepair__async_extract_entities_from_badge(config)  # noqa: SLF001  # type: ignore[attr-defined]
+
+
+def _extract_element(repair: SpookRepair, config: dict[str, Any]) -> set[str]:
+    """Call the name-mangled element-level extractor."""
+    return repair._SpookRepair__async_extract_entities_from_element(config)  # noqa: SLF001  # type: ignore[attr-defined]
+
+
+def test_dashboard_with_no_views_returns_empty(repair: SpookRepair) -> None:
+    """A dashboard with no ``views`` key yields no entities."""
+    assert _extract(repair, {}) == set()
+
+
+def test_dashboard_non_dict_returns_empty(repair: SpookRepair) -> None:
+    """A non-dict config yields no entities."""
+    assert _extract(repair, "not a dict") == set()  # type: ignore[arg-type]
+
+
+def test_dashboard_full_walk(repair: SpookRepair) -> None:
+    """Views, badges, cards, and sections are all walked."""
+    config = {
+        "views": [
+            {
+                "title": "Home",
+                "badges": [{"entity": "sensor.outside_temperature"}],
+                "cards": [{"type": "entity", "entity": "light.kitchen"}],
+                "sections": [{"cards": [{"type": "entity", "entity": "switch.lamp"}]}],
+            }
+        ]
+    }
+    assert _extract(repair, config) == {
+        "sensor.outside_temperature",
+        "light.kitchen",
+        "switch.lamp",
+    }
+
+
+def test_card_single_entity_field(repair: SpookRepair) -> None:
+    """A card with a plain ``entity`` field is captured."""
+    assert _extract_card(repair, {"type": "entity", "entity": "light.kitchen"}) == {
+        "light.kitchen"
+    }
+
+
+def test_card_entities_list_mixed_forms(repair: SpookRepair) -> None:
+    """A card's ``entities`` list accepts strings and ``{"entity": ...}`` dicts."""
+    config = {
+        "type": "entities",
+        "entities": [
+            "light.kitchen",
+            {"entity": "switch.lamp"},
+            {"entity": "sensor.temperature", "name": "Temp"},
+        ],
+    }
+    assert _extract_card(repair, config) == {
+        "light.kitchen",
+        "switch.lamp",
+        "sensor.temperature",
+    }
+
+
+def test_card_camera_image(repair: SpookRepair) -> None:
+    """The ``camera_image`` common field is captured."""
+    assert _extract_card(
+        repair, {"type": "picture-entity", "camera_image": "camera.front"}
+    ) == {"camera.front"}
+
+
+def test_card_nested_card_and_cards(repair: SpookRepair) -> None:
+    """``card`` (single) and ``cards`` (list) are both walked."""
+    config = {
+        "type": "conditional",
+        "card": {"type": "entity", "entity": "light.kitchen"},
+        "cards": [
+            {"type": "entity", "entity": "switch.lamp"},
+            {"type": "entity", "entity": "sensor.temperature"},
+        ],
+    }
+    assert _extract_card(repair, config) == {
+        "light.kitchen",
+        "switch.lamp",
+        "sensor.temperature",
+    }
+
+
+def test_card_tap_action_target(repair: SpookRepair) -> None:
+    """A ``tap_action`` with a target entity is captured."""
+    config = {
+        "type": "button",
+        "tap_action": {
+            "action": "call-service",
+            "service": "light.toggle",
+            "target": {"entity_id": "light.kitchen"},
+        },
+    }
+    assert _extract_card(repair, config) == {"light.kitchen"}
+
+
+def test_card_hold_action_service_data(repair: SpookRepair) -> None:
+    """A ``hold_action`` with service_data entities is captured."""
+    config = {
+        "type": "button",
+        "hold_action": {
+            "action": "call-service",
+            "service": "light.turn_on",
+            "service_data": {"entity_id": ["light.kitchen", "light.living_room"]},
+        },
+    }
+    assert _extract_card(repair, config) == {
+        "light.kitchen",
+        "light.living_room",
+    }
+
+
+def test_card_condition_entity(repair: SpookRepair) -> None:
+    """A card's ``condition.entity`` is captured."""
+    config = {
+        "type": "conditional",
+        "condition": {"entity": "input_boolean.guest", "state": "on"},
+        "card": {"type": "entity", "entity": "light.kitchen"},
+    }
+    assert _extract_card(repair, config) == {
+        "input_boolean.guest",
+        "light.kitchen",
+    }
+
+
+def test_card_visibility_conditions(repair: SpookRepair) -> None:
+    """A card's ``visibility`` list of conditions is captured."""
+    config = {
+        "type": "entity",
+        "entity": "light.kitchen",
+        "visibility": [
+            {"condition": "state", "entity": "input_boolean.guest", "state": "on"},
+        ],
+    }
+    assert _extract_card(repair, config) == {
+        "light.kitchen",
+        "input_boolean.guest",
+    }
+
+
+def test_card_header_and_footer(repair: SpookRepair) -> None:
+    """Header and footer common fields are captured."""
+    config = {
+        "type": "entities",
+        "header": {"type": "picture", "camera_image": "camera.front"},
+        "footer": {"type": "graph", "entity": "sensor.power"},
+        "entities": ["light.kitchen"],
+    }
+    assert _extract_card(repair, config) == {
+        "camera.front",
+        "sensor.power",
+        "light.kitchen",
+    }
+
+
+def test_card_picture_elements_walked(repair: SpookRepair) -> None:
+    """``elements`` on a picture-elements card are walked into."""
+    config = {
+        "type": "picture-elements",
+        "elements": [
+            {"type": "state-icon", "entity": "light.kitchen"},
+            {
+                "type": "service-button",
+                "tap_action": {
+                    "action": "call-service",
+                    "service": "switch.toggle",
+                    "target": {"entity_id": "switch.lamp"},
+                },
+            },
+        ],
+    }
+    assert _extract_card(repair, config) == {"light.kitchen", "switch.lamp"}
+
+
+def test_card_mushroom_chips(repair: SpookRepair) -> None:
+    """``chips`` on a mushroom chips card are walked and conditions captured."""
+    config = {
+        "type": "custom:mushroom-chips-card",
+        "chips": [
+            {"type": "entity", "entity": "sensor.temperature"},
+            {
+                "type": "template",
+                "entity": "switch.lamp",
+                "conditions": [
+                    {"entity": "input_boolean.guest"},
+                ],
+            },
+        ],
+    }
+    assert _extract_card(repair, config) == {
+        "sensor.temperature",
+        "switch.lamp",
+        "input_boolean.guest",
+    }
+
+
+def test_card_non_dict_returns_empty(repair: SpookRepair) -> None:
+    """A non-dict card config returns an empty set."""
+    assert _extract_card(repair, "string-card") == set()  # type: ignore[arg-type]
+
+
+def test_badge_string_form(repair: SpookRepair) -> None:
+    """A bare string badge is treated as the entity itself."""
+    assert _extract_badge(repair, "sensor.temperature") == {"sensor.temperature"}
+
+
+def test_badge_entity_dict(repair: SpookRepair) -> None:
+    """A badge with an ``entity`` field is captured."""
+    assert _extract_badge(repair, {"entity": "sensor.temperature"}) == {
+        "sensor.temperature"
+    }
+
+
+def test_badge_entities_list(repair: SpookRepair) -> None:
+    """A badge with an ``entities`` list captures all forms."""
+    config = {
+        "entities": [
+            "sensor.a",
+            {"entity": "sensor.b"},
+        ]
+    }
+    assert _extract_badge(repair, config) == {"sensor.a", "sensor.b"}
+
+
+def test_badge_unknown_shape_returns_empty(repair: SpookRepair) -> None:
+    """An unrecognized badge shape yields an empty set."""
+    assert _extract_badge(repair, {"foo": "bar"}) == set()
+    assert _extract_badge(repair, 42) == set()
+
+
+def test_element_with_nested_elements(repair: SpookRepair) -> None:
+    """``elements`` nested inside an element are walked recursively."""
+    config = {
+        "type": "state-badge",
+        "entity": "sensor.outside",
+        "elements": [
+            {"type": "state-icon", "entity": "light.kitchen"},
+        ],
+    }
+    assert _extract_element(repair, config) == {
+        "sensor.outside",
+        "light.kitchen",
+    }
+
+
+def test_element_with_visibility(repair: SpookRepair) -> None:
+    """An element's ``visibility`` conditions contribute entities."""
+    config = {
+        "type": "state-icon",
+        "entity": "light.kitchen",
+        "visibility": [
+            {"condition": "state", "entity": "input_boolean.guest", "state": "on"},
+        ],
+    }
+    assert _extract_element(repair, config) == {
+        "light.kitchen",
+        "input_boolean.guest",
+    }
+
+
+def test_element_action_target(repair: SpookRepair) -> None:
+    """An element acting as its own action (``service_data``) contributes."""
+    config = {
+        "type": "service-button",
+        "service": "switch.toggle",
+        "service_data": {"entity_id": "switch.lamp"},
+    }
+    assert _extract_element(repair, config) == {"switch.lamp"}
+
+
+def test_element_non_dict_returns_empty(repair: SpookRepair) -> None:
+    """A non-dict element returns an empty set."""
+    assert _extract_element(repair, "not a dict") == set()  # type: ignore[arg-type]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add tests for the automation and Lovelace unknown entity reference extractors.

The automation tests cover the current helper behavior for extracting entity references from values, triggers, conditions, actions, and full automation configs. The Lovelace tests cover the dashboard walker across views, cards, badges, sections, picture elements, actions, visibility, and custom mushroom chips.

## Motivation and Context

This ports the useful remaining test coverage from the old #1254 draft without bringing along the stale scaffold, dependency, workflow, or lockfile changes.

The tests give the unknown entity repair code a better baseline before refactoring the duplicated repair logic.

## How has this been tested?

- `uv run pytest tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py -q`
- `uv run pytest -q`
- `uv run ruff check tests/ectoplasms/automation tests/ectoplasms/lovelace`
- `uv run ruff format --check tests/ectoplasms/automation tests/ectoplasms/lovelace`
- `uv run pylint tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
