### PR TITLE
Split util helpers into focused modules

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -17,14 +17,11 @@ from homeassistant.core import (
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN, LOGGER, PLATFORMS
+from .entity_filtering import async_setup_all_entity_ids_cache_invalidation
+from .integration_linking import link_sub_integrations, unlink_sub_integrations
 from .repairs import SpookRepairManager
 from .services import SpookServiceManager
-from .util import (
-    async_forward_setup_entry,
-    async_setup_all_entity_ids_cache_invalidation,
-    link_sub_integrations,
-    unlink_sub_integrations,
-)
+from .setup_helpers import async_forward_setup_entry
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/custom_components/spook/binary_sensor.py
+++ b/custom_components/spook/binary_sensor.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/button.py
+++ b/custom_components/spook/button.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from homeassistant.components import automation
 from homeassistant.helpers import area_registry as ar
 
+from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
-from ....util import async_filter_known_area_ids, async_get_all_area_ids
 
 if TYPE_CHECKING:
     from typing import Any

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from homeassistant.components import automation
 from homeassistant.helpers import device_registry as dr
 
+from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
-from ....util import async_filter_known_device_ids, async_get_all_device_ids
 
 if TYPE_CHECKING:
     from typing import Any

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -10,8 +10,7 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
-from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
-from ....util import (
+from ....entity_filtering import (
     ENTITY_ID_PATTERN,
     async_extract_entities_from_config,
     async_extract_entities_from_template_string,
@@ -19,6 +18,7 @@ from ....util import (
     async_get_all_entity_ids,
     is_template_string,
 )
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_floor_references.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from homeassistant.components import automation
 from homeassistant.helpers import floor_registry as fr
 
+from ....entity_filtering import async_filter_known_floor_ids, async_get_all_floor_ids
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
-from ....util import async_filter_known_floor_ids, async_get_all_floor_ids
 
 if TYPE_CHECKING:
     from typing import Any

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_label_references.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from homeassistant.components import automation
 from homeassistant.helpers import label_registry as lr
 
+from ....entity_filtering import async_filter_known_label_ids, async_get_all_label_ids
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
-from ....util import async_filter_known_label_ids, async_get_all_label_ids
 
 if TYPE_CHECKING:
     from typing import Any

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
@@ -10,12 +10,12 @@ from homeassistant.const import (
     EVENT_SERVICE_REMOVED,
 )
 
-from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
-from ....util import (
+from ....entity_filtering import (
     async_filter_known_services,
     async_find_services_in_sequence,
     async_get_all_services,
 )
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
     from typing import Any

--- a/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
+++ b/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
@@ -10,8 +10,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPlatform
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -14,8 +14,8 @@ from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.lovelace.dashboard import (

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
@@ -9,8 +9,8 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.proximity.coordinator import (

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
@@ -9,8 +9,8 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.proximity.coordinator import (

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_zone.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_zone.py
@@ -8,8 +8,8 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.proximity.coordinator import (

--- a/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
@@ -8,8 +8,8 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_entity_ids, async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from homeassistant.components.homeassistant import scene

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_area_ids, async_get_all_area_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_device_ids, async_get_all_device_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -9,12 +9,12 @@ from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....repairs import AbstractSpookRepair
-from ....util import (
+from ....entity_filtering import (
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
     async_get_all_entity_ids,
 )
+from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import floor_registry as fr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_floor_ids, async_get_all_floor_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_floor_ids, async_get_all_floor_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
@@ -7,8 +7,8 @@ from homeassistant.helpers import label_registry as lr
 from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....const import LOGGER
+from ....entity_filtering import async_filter_known_label_ids, async_get_all_label_ids
 from ....repairs import AbstractSpookRepair
-from ....util import async_filter_known_label_ids, async_get_all_label_ids
 
 
 class SpookRepair(AbstractSpookRepair):

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -1,10 +1,7 @@
-"""Spook - Your homie."""
+"""Spook - Your homie. Entity, registry, and template filtering helpers."""
 
 from __future__ import annotations
 
-import asyncio
-import importlib
-from pathlib import Path
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -38,15 +35,12 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.template import Template
 
-from .const import DOMAIN, LOGGER
+from .const import LOGGER
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
-    from types import ModuleType
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
-    from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 
 # Entity domains to ignore when filtering unknown entities
@@ -221,98 +215,6 @@ def async_get_all_entity_ids(
     if include_all_none:
         return _CACHED_ALL_ENTITY_IDS.union({ENTITY_MATCH_ALL, ENTITY_MATCH_NONE})
     return _CACHED_ALL_ENTITY_IDS.copy()
-
-
-async def async_forward_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-) -> None:
-    """Set up Spook ectoplasms."""
-    LOGGER.debug("Setting up Spook ectoplasms")
-
-    modules: list[ModuleType] = []
-
-    def _load_all_ectoplasm_modules() -> None:
-        """Load all Spook ectoplasm modules."""
-        for module_file in Path(__file__).parent.rglob("ectoplasms/*/__init__.py"):
-            module_path = str(module_file.relative_to(Path(__file__).parent))[
-                :-3
-            ].replace(
-                "/",
-                ".",
-            )
-            LOGGER.debug("Loading Spook ectoplasm: %s", module_path)
-            module = importlib.import_module(f".{module_path}", __package__)
-            if hasattr(module, "async_setup_entry"):
-                modules.append(module)
-                LOGGER.debug("Setting up Spook ectoplasm: %s", module_path)
-
-    await hass.async_add_import_executor_job(_load_all_ectoplasm_modules)
-    await asyncio.gather(*(module.async_setup_entry(hass, entry) for module in modules))
-
-
-async def async_forward_platform_entry_setups_to_ectoplasm(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-    platform: Platform,
-) -> None:
-    """Set up Spook ectoplasm platform."""
-    LOGGER.debug("Setting up Spook ectoplasm platform: %s", platform)
-
-    modules: list[ModuleType] = []
-
-    def _load_all_ectoplasm_platform_modules() -> None:
-        """Load all Spook ectoplasm platform modules."""
-        for module_file in Path(__file__).parent.rglob(f"ectoplasms/*/{platform}.py"):
-            module_path = str(module_file.relative_to(Path(__file__).parent))[
-                :-3
-            ].replace(
-                "/",
-                ".",
-            )
-            LOGGER.debug("Loading Spook %s from ectoplasm: %s", platform, module_path)
-            modules.append(importlib.import_module(f".{module_path}", __package__))
-            LOGGER.debug("Setting up Spook ectoplasm %s: %s", platform, module_path)
-
-    await hass.async_add_import_executor_job(_load_all_ectoplasm_platform_modules)
-    await asyncio.gather(
-        *(
-            module.async_setup_entry(hass, entry, async_add_entities)
-            for module in modules
-        )
-    )
-
-
-def link_sub_integrations(hass: HomeAssistant) -> bool:
-    """Link Spook sub integrations."""
-    LOGGER.debug("Linking up Spook sub integrations")
-
-    changes = False
-    for manifest in Path(__file__).parent.rglob("integrations/*/manifest.json"):
-        LOGGER.debug("Linking Spook sub integration: %s", manifest.parent.name)
-        dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
-        if not dest.exists():
-            src = (
-                Path(hass.config.config_dir)
-                / "custom_components"
-                / DOMAIN
-                / "integrations"
-                / manifest.parent.name
-            )
-            dest.symlink_to(src)
-            changes = True
-    return changes
-
-
-def unlink_sub_integrations(hass: HomeAssistant) -> None:
-    """Unlink Spook sub integrations."""
-    LOGGER.debug("Unlinking Spook sub integrations")
-    for manifest in Path(__file__).parent.rglob("integrations/*/manifest.json"):
-        LOGGER.debug("Unlinking Spook sub integration: %s", manifest.parent.name)
-        dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
-        if dest.exists():
-            dest.unlink()
 
 
 @callback

--- a/custom_components/spook/event.py
+++ b/custom_components/spook/event.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/integration_linking.py
+++ b/custom_components/spook/integration_linking.py
@@ -1,0 +1,42 @@
+"""Spook - Your homie. Sub-integration symlinking helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .const import DOMAIN, LOGGER
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def link_sub_integrations(hass: HomeAssistant) -> bool:
+    """Link Spook sub integrations."""
+    LOGGER.debug("Linking up Spook sub integrations")
+
+    changes = False
+    for manifest in Path(__file__).parent.rglob("integrations/*/manifest.json"):
+        LOGGER.debug("Linking Spook sub integration: %s", manifest.parent.name)
+        dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
+        if not dest.exists():
+            src = (
+                Path(hass.config.config_dir)
+                / "custom_components"
+                / DOMAIN
+                / "integrations"
+                / manifest.parent.name
+            )
+            dest.symlink_to(src)
+            changes = True
+    return changes
+
+
+def unlink_sub_integrations(hass: HomeAssistant) -> None:
+    """Unlink Spook sub integrations."""
+    LOGGER.debug("Unlinking Spook sub integrations")
+    for manifest in Path(__file__).parent.rglob("integrations/*/manifest.json"):
+        LOGGER.debug("Unlinking Spook sub integration: %s", manifest.parent.name)
+        dest = Path(hass.config.config_dir) / "custom_components" / manifest.parent.name
+        if dest.exists():
+            dest.unlink()

--- a/custom_components/spook/number.py
+++ b/custom_components/spook/number.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -30,7 +30,7 @@ from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM
 from homeassistant.util.async_ import create_eager_task
 
 from .const import DOMAIN, LOGGER
-from .util import async_get_all_entity_ids
+from .entity_filtering import async_get_all_entity_ids
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Mapping

--- a/custom_components/spook/select.py
+++ b/custom_components/spook/select.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/sensor.py
+++ b/custom_components/spook/sensor.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/setup_helpers.py
+++ b/custom_components/spook/setup_helpers.py
@@ -1,0 +1,79 @@
+"""Spook - Your homie. Ectoplasm setup forwarding helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .const import LOGGER
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.const import Platform
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_forward_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> None:
+    """Set up Spook ectoplasms."""
+    LOGGER.debug("Setting up Spook ectoplasms")
+
+    modules: list[ModuleType] = []
+
+    def _load_all_ectoplasm_modules() -> None:
+        """Load all Spook ectoplasm modules."""
+        for module_file in Path(__file__).parent.rglob("ectoplasms/*/__init__.py"):
+            module_path = str(module_file.relative_to(Path(__file__).parent))[
+                :-3
+            ].replace(
+                "/",
+                ".",
+            )
+            LOGGER.debug("Loading Spook ectoplasm: %s", module_path)
+            module = importlib.import_module(f".{module_path}", __package__)
+            if hasattr(module, "async_setup_entry"):
+                modules.append(module)
+                LOGGER.debug("Setting up Spook ectoplasm: %s", module_path)
+
+    await hass.async_add_import_executor_job(_load_all_ectoplasm_modules)
+    await asyncio.gather(*(module.async_setup_entry(hass, entry) for module in modules))
+
+
+async def async_forward_platform_entry_setups_to_ectoplasm(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    platform: Platform,
+) -> None:
+    """Set up Spook ectoplasm platform."""
+    LOGGER.debug("Setting up Spook ectoplasm platform: %s", platform)
+
+    modules: list[ModuleType] = []
+
+    def _load_all_ectoplasm_platform_modules() -> None:
+        """Load all Spook ectoplasm platform modules."""
+        for module_file in Path(__file__).parent.rglob(f"ectoplasms/*/{platform}.py"):
+            module_path = str(module_file.relative_to(Path(__file__).parent))[
+                :-3
+            ].replace(
+                "/",
+                ".",
+            )
+            LOGGER.debug("Loading Spook %s from ectoplasm: %s", platform, module_path)
+            modules.append(importlib.import_module(f".{module_path}", __package__))
+            LOGGER.debug("Setting up Spook ectoplasm %s: %s", platform, module_path)
+
+    await hass.async_add_import_executor_job(_load_all_ectoplasm_platform_modules)
+    await asyncio.gather(
+        *(
+            module.async_setup_entry(hass, entry, async_add_entities)
+            for module in modules
+        )
+    )

--- a/custom_components/spook/switch.py
+++ b/custom_components/spook/switch.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/custom_components/spook/time.py
+++ b/custom_components/spook/time.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from .util import async_forward_platform_entry_setups_to_ectoplasm
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.13",
 ]
 keywords = [
   "automation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.13",
 ]
 keywords = [
   "automation",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from custom_components.spook.util import (
+from custom_components.spook.entity_filtering import (
     extract_template_strings_from_config,
     is_template_string,
     split_comma_separated_entity_ids,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Split `custom_components/spook/util.py` into three focused modules:

- `entity_filtering.py` for registry lookups, template entity extraction, comma-separated entity ID handling, and unknown-reference filtering.
- `setup_helpers.py` for config entry and ectoplasm setup forwarding.
- `integration_linking.py` for linking and unlinking sub-integrations.

The old `util.py` module is removed and imports are updated to point at the module that owns each concern.

## Motivation and Context

`util.py` mixed unrelated helper families in one large module. Splitting it along the existing concern boundaries makes the import graph clearer and reduces the amount of unrelated code a future change has to touch.

This PR is stacked on #1276 because that refactor already moves the unknown-reference repair boilerplate out of the leaf modules.

## How has this been tested?

- `uv run pytest -q`
- `uv run ruff check custom_components/spook tests`
- `uv run ruff format --check custom_components/spook tests`
- `uv run pylint custom_components/spook tests/test_util.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
