### PR TITLE
Add ectoplasm discovery contract tests

### DIFF
--- a/tests/test_ectoplasm_discovery.py
+++ b/tests/test_ectoplasm_discovery.py
@@ -43,6 +43,12 @@ SERVICE_MODULES = _discovered_modules("ectoplasms/*/services/*.py")
 REPAIR_MODULES = _discovered_modules("ectoplasms/*/repairs/*.py")
 
 
+def test_discovery_finds_ectoplasm_modules() -> None:
+    """Test discovery finds modules to avoid vacuous contract test passes."""
+    assert SERVICE_MODULES, "No service modules discovered"
+    assert REPAIR_MODULES, "No repair modules discovered"
+
+
 def _import_module(module_file: Path) -> ModuleType:
     """Import a module from a discovered module file."""
     return importlib.import_module(_module_name(module_file))

--- a/tests/test_ectoplasm_discovery.py
+++ b/tests/test_ectoplasm_discovery.py
@@ -1,0 +1,87 @@
+"""Tests for Spook ectoplasm discovery contracts."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.repairs import AbstractSpookRepairBase
+from custom_components.spook.services import AbstractSpookServiceBase
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+SPOOK_ROOT = Path(__file__).parents[1] / "custom_components" / "spook"
+
+
+def _module_name(module_file: Path) -> str:
+    """Return the import path for a Spook module file."""
+    return ".".join(
+        (
+            "custom_components",
+            "spook",
+            *module_file.relative_to(SPOOK_ROOT).with_suffix("").parts,
+        )
+    )
+
+
+def _discovered_modules(pattern: str) -> list[Path]:
+    """Return production-discovered modules for the given ectoplasm pattern."""
+    return sorted(
+        module_file
+        for module_file in SPOOK_ROOT.rglob(pattern)
+        if module_file.name != "__init__.py"
+    )
+
+
+SERVICE_MODULES = _discovered_modules("ectoplasms/*/services/*.py")
+REPAIR_MODULES = _discovered_modules("ectoplasms/*/repairs/*.py")
+
+
+def _import_module(module_file: Path) -> ModuleType:
+    """Import a module from a discovered module file."""
+    return importlib.import_module(_module_name(module_file))
+
+
+def _service_schema_key(service_class: type[Any]) -> str:
+    """Return the services.yaml key expected for a Spook service class."""
+    if service_class.domain == DOMAIN:
+        return service_class.service
+    return f"{service_class.domain}_{service_class.service}"
+
+
+@pytest.mark.parametrize("module_file", SERVICE_MODULES, ids=_module_name)
+def test_service_modules_expose_spook_service(module_file: Path) -> None:
+    """Every discovered service module exposes a concrete Spook service class."""
+    module = _import_module(module_file)
+
+    assert hasattr(module, "SpookService")
+    assert issubclass(module.SpookService, AbstractSpookServiceBase)
+
+
+@pytest.mark.parametrize("module_file", REPAIR_MODULES, ids=_module_name)
+def test_repair_modules_expose_spook_repair(module_file: Path) -> None:
+    """Every discovered repair module exposes a concrete Spook repair class."""
+    module = _import_module(module_file)
+
+    assert hasattr(module, "SpookRepair")
+    assert issubclass(module.SpookRepair, AbstractSpookRepairBase)
+
+
+def test_service_modules_have_service_descriptions() -> None:
+    """Every discovered service has a matching services.yaml entry."""
+    service_descriptions = yaml.safe_load((SPOOK_ROOT / "services.yaml").read_text())
+
+    missing_descriptions = []
+    for module_file in SERVICE_MODULES:
+        module = _import_module(module_file)
+        schema_key = _service_schema_key(module.SpookService)
+        if schema_key not in service_descriptions:
+            missing_descriptions.append(f"{_module_name(module_file)} -> {schema_key}")
+
+    assert not missing_descriptions

--- a/tests/test_ectoplasm_discovery.py
+++ b/tests/test_ectoplasm_discovery.py
@@ -93,4 +93,6 @@ def test_service_modules_have_service_descriptions() -> None:
         if schema_key not in service_descriptions:
             missing_descriptions.append(f"{_module_name(module_file)} -> {schema_key}")
 
-    assert not missing_descriptions, f"Missing services.yaml entries: {missing_descriptions}"
+    assert not missing_descriptions, (
+        f"Missing services.yaml entries: {missing_descriptions}"
+    )

--- a/tests/test_ectoplasm_discovery.py
+++ b/tests/test_ectoplasm_discovery.py
@@ -67,6 +67,7 @@ def test_service_modules_expose_spook_service(module_file: Path) -> None:
     module = _import_module(module_file)
 
     assert hasattr(module, "SpookService")
+    assert isinstance(module.SpookService, type)
     assert issubclass(module.SpookService, AbstractSpookServiceBase)
 
 
@@ -76,12 +77,14 @@ def test_repair_modules_expose_spook_repair(module_file: Path) -> None:
     module = _import_module(module_file)
 
     assert hasattr(module, "SpookRepair")
+    assert isinstance(module.SpookRepair, type)
     assert issubclass(module.SpookRepair, AbstractSpookRepairBase)
 
 
 def test_service_modules_have_service_descriptions() -> None:
     """Every discovered service has a matching services.yaml entry."""
     service_descriptions = yaml.safe_load((SPOOK_ROOT / "services.yaml").read_text())
+    assert isinstance(service_descriptions, dict)
 
     missing_descriptions = []
     for module_file in SERVICE_MODULES:
@@ -90,4 +93,4 @@ def test_service_modules_have_service_descriptions() -> None:
         if schema_key not in service_descriptions:
             missing_descriptions.append(f"{_module_name(module_file)} -> {schema_key}")
 
-    assert not missing_descriptions
+    assert not missing_descriptions, f"Missing services.yaml entries: {missing_descriptions}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Add contract tests for Spook's ectoplasm discovery paths.

The new tests walk the same service and repair module layout used by the runtime managers and verify that:

- each discovered service module imports cleanly and exposes `SpookService`
- each discovered repair module imports cleanly and exposes `SpookRepair`
- each discovered service has a matching `services.yaml` description key

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The service and repair managers import ectoplasm modules dynamically. A missing class, broken import, or forgotten service description can otherwise slip through until runtime.

This adds a small CI-backed contract around that module layout, which is useful after the recent repair refactor and helper split.

Closes #1260.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- `uv run pytest tests/test_ectoplasm_discovery.py -q`
- `uv run ruff format --check tests/test_ectoplasm_discovery.py`
- `uv run ruff check tests/test_ectoplasm_discovery.py`
- `uv run pylint tests/test_ectoplasm_discovery.py`
- `uv run pytest -q`
- `uv run ruff check custom_components/spook tests`
- `uv run ruff format --check custom_components/spook tests`
- `uv run pylint custom_components/spook tests/test_ectoplasm_discovery.py`

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
