### PR TITLE
Use event-payload PR label verification

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,8 +3,7 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  # yamllint disable-line rule:comments
-  pull_request_target: # zizmor: ignore[dangerous-triggers] - Safe: only reads PR metadata, no code checkout
+  pull_request:
     types:
       - opened
       - labeled
@@ -12,22 +11,16 @@ on:
       - synchronize
   workflow_call:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   pr_labels:
     name: Verify
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0
+        uses: ludeeus/action-require-labels@7ef0dba93830452589680da7cdea2e2c4c0f8dff # 1.1.0
         with:
-          pull-request-number: "${{ github.event.pull_request.number }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: >-
+          labels: >-
             breaking-change, bugfix, documentation, enhancement,
             refactor, performance, new-feature, maintenance, ci, dependencies
-          disable-reviews: true

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,7 +3,8 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
+  # yamllint disable-line rule:comments
+  pull_request_target: # zizmor: ignore[dangerous-triggers] - Safe: only reads PR metadata, no code checkout
     types:
       - opened
       - labeled
@@ -12,12 +13,14 @@ on:
   workflow_call:
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
   pr_labels:
     name: Verify
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: 🏷 Verify PR has a valid label
         uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Replace the PR label verification workflow with `ludeeus/action-require-labels`.

This keeps the workflow on the regular `pull_request` trigger and removes the need for `pull_request_target`. The action reads labels from the pull request event payload, so it does not need a token or elevated workflow permissions.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Forked pull requests currently fail the label verification job because the existing action rejects fork PRs on the `pull_request` trigger:

`ERROR: PRs from forks are only supported when trigger on "pull_request_target"`

Using an action that works from the event payload fixes the fork PR noise without switching to `pull_request_target`. Better trade-off.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- `uv run check-yaml .github/workflows/pr-labels.yaml`
- `uv run zizmor .github/workflows/pr-labels.yaml`

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
