### PR TITLE
Fix translated placeholders in translations

### DIFF
--- a/custom_components/spook/translations/af.json
+++ b/custom_components/spook/translations/af.json
@@ -310,11 +310,11 @@
         "step": {
           "confirm": {
             "description": "{description}",
-            "title": "{titel}"
+            "title": "{title}"
           }
         }
       },
-      "title": "{titel}"
+      "title": "{title}"
     },
     "restart_required": {
       "title": "Dit is nodig om oor te begin",

--- a/custom_components/spook/translations/da.json
+++ b/custom_components/spook/translations/da.json
@@ -239,7 +239,7 @@
     },
     "automation_unknown_label_references": {
       "description": "Spook har fundet et spøgelse i dine automatiseringer 👻\n\nMens Spook svæver rundt, krydsede den vej(e) med følgende automatisering:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDenne automatisering henviser til følgende labels, som er ukendt for Home Assistant:\n\n{labels}\n\n\n\nHvis du vil rette denne fejl, [rediger automatiseringen]({edit}) og fjerne brugen af disse manglende labels.\n\nSpook 👻er din ven.",
-      "title": "Ukendte labels benyttet i automation}"
+      "title": "Unknown labels used in: {automation}"
     },
     "automation_unknown_service_references": {
       "description": "Spook har fundet et spøgelse i dine automatiseringer 👻\n\nMens han svævede rundt, krydsede Spook vejen med følgende automatisering:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nDenne automatisering refererer til følgende tjenester, som er ukendte for Home Assistant:\n\n{services}\n\n\n\n[Rediger automatiseringen]({edit}) for at rette denne fejl og fjerne brugen af disse ikke-eksisterende tjenester.\n\nSpook 👻 er din ven.",

--- a/custom_components/spook/translations/he.json
+++ b/custom_components/spook/translations/he.json
@@ -223,15 +223,15 @@
   "issues": {
     "automation_unknown_area_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
-      "title": "אזורים לא ידועים בשימוש:"
+      "title": "Unknown areas used in: {automation}"
     },
     "automation_unknown_device_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Your homie.",
-      "title": "מכשירים לא ידועים בשימוש:"
+      "title": "Unknown devices used in: {automation}"
     },
     "automation_unknown_entity_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
-      "title": "גופים לא ידועים בשימוש:"
+      "title": "Unknown entities used in: {automation}"
     },
     "automation_unknown_floor_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following floors, which are unknown to Home Assistant:\n\n{floors}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing floors.\n\nSpook 👻 Your homie.",
@@ -247,15 +247,15 @@
     },
     "group_unknown_members": {
       "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Your homie.",
-      "title": "חברים לא ידועים ב:"
+      "title": "Unknown group members in: {group}"
     },
     "integration_unknown_source": {
-      "description": "Spook מצא רוח רפאים בסכום העזרה האינטגראלית שלך 👻\n\nבזמן צף סביב, ספוק חצה את הנתיב עם העוזר הבא:\n\n(הופנה מהדף)\n\nעוזר זה יש גורם מקור לא ידוע עוזר בית:\n\n[מקור] \"\n\n\n\nכדי לתקן את השגיאה הזו, לערוך את העוזר ולהתאים את ישות המקור (או להסיר את העוזר) ולחדש את עוזר הבית.\n\nלא את הרצח שלך.",
-      "title": "מקור לא ידוע: עזרה"
+      "description": "Spook has found a ghost in your Riemann sum integral helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
+      "title": "Unknown source: {helper}"
     },
     "lovelace_unknown_entity_references": {
       "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n[{dashboard}]({edit})\n\nThis dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
-      "title": "גופים לא ידועים בשימוש:"
+      "title": "Unknown entities used in: {dashboard}"
     },
     "proximity_unknown_ignored_zones": {
       "description": "Spook has found a ghost in your proximity configuration 👻\n\nWhile floating around, Spook crossed path with the following proximity configuration:\n\n{name}\n\nThis configuration is ignoring zones that are unknown to Home Assistant:\n\n{zones}\n\n\n\nTo fix this error, edit the configuration and remove this/these zones.\n\nSpook 👻 Your homie.",
@@ -275,15 +275,15 @@
     },
     "script_unknown_area_references": {
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
-      "title": "אזורים לא ידועים בשימוש:"
+      "title": "Unknown areas used in: {script}"
     },
     "script_unknown_device_references": {
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Your homie.",
-      "title": "מכשירים לא ידועים בשימוש:"
+      "title": "Unknown devices used in: {script}"
     },
     "script_unknown_entity_references": {
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
-      "title": "גופים לא ידועים בשימוש:"
+      "title": "Unknown entities used in: {script}"
     },
     "script_unknown_floor_references": {
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following floors, which are unknown to Home Assistant:\n\n{floors}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing floors.\n\nSpook 👻 Your homie.",
@@ -294,8 +294,8 @@
       "title": "Unknown labels used in: {script}"
     },
     "switch_as_x_unknown_source": {
-      "description": "Spook מצא רוח רפאים ב-Switch שלך כמו X Helpers\n\nבזמן צף סביב, ספוק חצה את הנתיב עם העוזר הבא:\n\n(הופנה מהדף)\n\nעוזר זה יש ישות מתג מקור לא ידוע עוזר בית:\n\n[מקור] \"\n\n\n\nכדי לתקן את השגיאה הזו, לערוך את העוזר ולהתאים את ישות המקור (או להסיר את העוזר) ולחדש את עוזר הבית.\n\nלא את הרצח שלך.",
-      "title": "מקור לא ידוע: עזרה"
+      "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
+      "title": "Unknown source: {helper}"
     },
     "utility_meter_unknown_source": {
       "description": "Spook has found a ghost in your utility meter helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",

--- a/custom_components/spook/translations/hr.json
+++ b/custom_components/spook/translations/hr.json
@@ -278,7 +278,7 @@
       "title": "Nepoznata područja korištena u: {script}"
     },
     "script_unknown_device_references": {
-      "description": "Spook je pronašao duha u vašim skriptama👻\n\nDok je lebdio okolo, Spook se susreo sa sljedećom skriptom:\n\n[{script}]({edit}) (`{entity_id}`)\n\nOva skripta upućuje na sljedeće uređaje koji nisu poznati Home Assistant:\n\n{uređaji}\n\n\n\nDa biste ispravili ovu pogrešku, [uredite skriptu]({edit}) i uklonite korištenje ovih nepostojećih uređaja.\n\nSpook 👻 Tvoj prijatelj.",
+      "description": "Spook je pronašao duha u vašim skriptama👻\n\nDok je lebdio okolo, Spook se susreo sa sljedećom skriptom:\n\n[{script}]({edit}) (`{entity_id}`)\n\nOva skripta upućuje na sljedeće uređaje koji nisu poznati Home Assistant:\n\n{devices}\n\n\n\nDa biste ispravili ovu pogrešku, [uredite skriptu]({edit}) i uklonite korištenje ovih nepostojećih uređaja.\n\nSpook 👻 Tvoj prijatelj.",
       "title": "Nepoznati uređaji korišteni u: {script}"
     },
     "script_unknown_entity_references": {

--- a/custom_components/spook/translations/ja.json
+++ b/custom_components/spook/translations/ja.json
@@ -250,8 +250,8 @@
       "title": "未知のグループメンバー:{group}"
     },
     "integration_unknown_source": {
-      "description": "スプックは、あなたのリエマンの合計積分ヘルパーで幽霊を発見しました。\n\n周りを浮遊している間、スプックは、次のヘルパーでパスを渡しました。\n\nお問い合わせ\n\nこのヘルパーは、ホームアシスタントに不明なソースエンティティティティティを持っています:\n\nツイート ログイン\n\n\n\nこのエラーを修正するには、ヘルパーを編集し、ソースのエンティティティ(またはヘルパーを削除)を調整し、ホームアシスタントを再起動します。\n\nあなたの趣味ではありません。.",
-      "title": "不明なソース: お問い合わせ"
+      "description": "Spook has found a ghost in your Riemann sum integral helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
+      "title": "Unknown source: {helper}"
     },
     "lovelace_unknown_entity_references": {
       "description": "Spookはダッシュボードでゴーストを見つけました ◀\n\n周りを浮遊している間、Spookは、次のダッシュボードで横断パスを渡しました。\n\n[{dashboard}]({edit})\n\n\nこのダッシュボードは、ホームアシスタントに不明な以下のエンティティティティを参照します。\n\n{entities}\n\n\n\nこのエラーを修正するには、[ダッシュボード]({edit})を編集し、これらの非既存のエンティティティティの使用を削除します。\n\nあなたの趣味ではありません。.",
@@ -282,7 +282,7 @@
       "title": "未知のデバイス: {script}"
     },
     "script_unknown_entity_references": {
-      "description": "Spook は、スクリプトでホストを見つけました。\n\n周りを浮遊している間、Spookは次のスクリプトで横断パスを渡しました。\n\n[{script}]({edit}) (`{entity_id}`)\n\nこのスクリプトは、次のエンティティティティを参照します。これは、ホームアシスタントに不明です。\n\nお問い合わせ\n\n\n\nこのエラーを修正するには、[スクリプトの編集]({edit}) をし、これらの非既存のエンティティティティの使用法を削除します。\n\nあなたの趣味ではありません。.",
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
       "title": "未知の実体: {script}"
     },
     "script_unknown_floor_references": {
@@ -294,8 +294,8 @@
       "title": "Unknown labels used in: {script}"
     },
     "switch_as_x_unknown_source": {
-      "description": "Spookは、Xヘルパーとして、スイッチでゴーストを発見しました。\n\n周りを浮遊している間、スプックは、次のヘルパーでパスを渡しました。\n\nお問い合わせ\n\nこのヘルパーは、ホームアシスタントに不明なソーススイッチエンティティティを持っています:\n\nツイート ログイン\n\n\n\nこのエラーを修正するには、ヘルパーを編集し、ソースのエンティティティ(またはヘルパーを削除)を調整し、ホームアシスタントを再起動します。\n\nあなたの趣味ではありません。.",
-      "title": "不明なソース: お問い合わせ"
+      "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
+      "title": "Unknown source: {helper}"
     },
     "utility_meter_unknown_source": {
       "description": "Spook has found a ghost in your utility meter helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",

--- a/custom_components/spook/translations/nb.json
+++ b/custom_components/spook/translations/nb.json
@@ -246,11 +246,11 @@
       "title": "Ukjente tjenester brukt i: {automation}"
     },
     "group_unknown_members": {
-      "description": "Spook har funnet et spøkelse i gruppene dine 👻\n\nMens han fløt rundt, krysset Spook veien med følgende gruppe:\n\n[{group}]({edit})\n\nDenne gruppen har entiteter som er ukjent for Home Assistant:\n\n{entities}\n\n\n\nFor å fikse denne feilen, endre gruppen og fjern bruken av disse ikke-eksisterende entiteter.\n\nSpook 👻 Ikke din homie.",
+      "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Ukjente gruppe medlemmer i: {group}"
     },
     "integration_unknown_source": {
-      "description": "Spook har funnet et spøkelse i dine Riemann sum integral hjelpere👻\n\nMens han fløt rundt, krysset Spook banen med følgende hjelper:\n\n[{helper}]({edit})\n\nDenne hjelperen har en kilde som er ukjent for Home Assistant:\n\n{source}\n\n\n\nFor å fikse denne feilen, endre hjelperen og fiks eller fjern bruken av denne ikke-eksisterende kilden.\n\nSpook 👻 Ikke din homie.",
+      "description": "Spook has found a ghost in your Riemann sum integral helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Ukjent kilde brukt i: {helper}"
     },
     "lovelace_unknown_entity_references": {

--- a/custom_components/spook/translations/pt-BR.json
+++ b/custom_components/spook/translations/pt-BR.json
@@ -254,8 +254,8 @@
       "title": "Fonte desconhecida: {helper}"
     },
     "lovelace_unknown_entity_references": {
-      "description": "Spook encontrou um fantasma em seus painéis s\n\nEnquanto flutuava, Spook cruzou o caminho com o seguinte painel:\n\n[{dashboard}]({edit})\n\nEste painel refere as seguintes entidades, que são desconhecidas para Home Assistant:\n\n(entities)\n\n\n\nPara corrigir esse erro, [editar o painel]({edit}) e remover o uso dessas entidades não existentes.\n\nNão é a tua homie.",
-      "title": "Entidades desconhecidas utilizadas em:"
+      "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n[{dashboard}]({edit})\n\nThis dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
+      "title": "Unknown entities used in: {dashboard}"
     },
     "proximity_unknown_ignored_zones": {
       "description": "Spook has found a ghost in your proximity configuration 👻\n\nWhile floating around, Spook crossed path with the following proximity configuration:\n\n{name}\n\nThis configuration is ignoring zones that are unknown to Home Assistant:\n\n{zones}\n\n\n\nTo fix this error, edit the configuration and remove this/these zones.\n\nSpook 👻 Your homie.",

--- a/custom_components/spook/translations/sk.json
+++ b/custom_components/spook/translations/sk.json
@@ -222,7 +222,7 @@
   },
   "issues": {
     "automation_unknown_area_references": {
-      "description": "Spook našiel ducha vo vašich automatizáciách 👻\n\nZatiaľ čo plával okolo, Spook prekročil cestu s nasledujúcou automatizáciou:\n\n[{automation}]({edit}) (ententity_id}`)\n\nTáto automatizácia odkazuje na nasledujúce oblasti, ktoré nie sú známe Home Assistant:\n\n{areas}\n\n\n\nAk chcete opraviť túto chybu, [edit automatizáciu]({edit}) a odstrániť používanie týchto neexistujúcich oblastí.\n\nSpook 👻 Tvoj homie.",
+      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
       "title": "Neznáme oblasti používané v: {automation}"
     },
     "automation_unknown_device_references": {

--- a/custom_components/spook/translations/th.json
+++ b/custom_components/spook/translations/th.json
@@ -223,15 +223,15 @@
   "issues": {
     "automation_unknown_area_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
-      "title": "พื้นที่ที่รู้จักกันดีใน: httpอัตโนมัติ"
+      "title": "Unknown areas used in: {automation}"
     },
     "automation_unknown_device_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Your homie.",
-      "title": "อุปกรณ์ที่รู้จักกันดีใน: httpอัตโนมัติ"
+      "title": "Unknown devices used in: {automation}"
     },
     "automation_unknown_entity_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
-      "title": "เป็นที่รู้จักกันใน: httpอัตโนมัติ"
+      "title": "Unknown entities used in: {automation}"
     },
     "automation_unknown_floor_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following floors, which are unknown to Home Assistant:\n\n{floors}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing floors.\n\nSpook 👻 Your homie.",
@@ -250,8 +250,8 @@
       "title": "สมาชิกที่เป็นที่รู้จักใน: {group}"
     },
     "integration_unknown_source": {
-      "description": "คู่สมรสพบในฮีโร่ของคุณใน Riemann\n\nในขณะที่ลอยรอบ, คู่สมรสข้ามกับวิธีการต่อไปนี้:\n\nวันที่สมัคร\n\nความช่วยเหลือนี้มีความเชี่ยวชาญในบริษัทในเครือ\n\nชื่อ คําพูด\n\n\n\nเพื่อแก้ไขข้อผิดพลาดนี้, การแก้ไขและปรับแหล่งที่มา (หรือลบวิธีการช่วย) และรีสตาร์ทบ้าน.\n\n Spo 👻 ไม่ hom.",
-      "title": "ที่มา: ประกาศ"
+      "description": "Spook has found a ghost in your Riemann sum integral helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
+      "title": "Unknown source: {helper}"
     },
     "lovelace_unknown_entity_references": {
       "description": "คู่สมรสพบว่าเป็นฮีโร่ในแดชบอร์ดของคุณ\n\nในขณะที่ลอยรอบ, คู่สมรสข้ามกับแดชบอร์ดต่อไปนี้:\n\n[{dashboard}]({edit})\n\nแดชบอร์ดนี้อ้างอิงของหน่วยงานต่อไปนี้, ซึ่งไม่ทราบว่าบ้าน:\n\n{entities}\n\n\n\nเพื่อแก้ไขข้อผิดพลาดนี้ [เป็นแดชบอร์ด]({edit}) และลบการใช้งานเหล่านี้ไม่ได้\n\n Spo 👻 ไม่ hom.",
@@ -279,7 +279,7 @@
     },
     "script_unknown_device_references": {
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Your homie.",
-      "title": "อุปกรณ์ที่รู้จักกันดีใน: httpPage}"
+      "title": "Unknown devices used in: {script}"
     },
     "script_unknown_entity_references": {
       "description": "คู่สมรสพบในพระคัมภีร์ในสคริปต์ของคุณ\n\nในขณะที่ลอยรอบ, คู่สมรสข้ามกับสคริปต์ต่อไปนี้:\n\n[{script}]({edit}) (`{entity_id}`)\n\nสคริปต์นี้อ้างอิงของหน่วยงานต่อไปนี้, ซึ่งไม่ทราบว่าบ้าน:\n\n{entities}\n\n\n\nเพื่อแก้ไขข้อผิดพลาดนี้ [เป็นสคริปต์] ({edit}) และลบการใช้งานเหล่านี้ไม่ได้\n\n Spo 👻 ไม่ hom.",
@@ -294,8 +294,8 @@
       "title": "Unknown labels used in: {script}"
     },
     "switch_as_x_unknown_source": {
-      "description": "คู่สมรสจะพบผีในสวิตช์ของคุณเป็น X ช่วย👻\n\nในขณะที่ลอยรอบ, คู่สมรสข้ามกับวิธีการต่อไปนี้:\n\nวันที่สมัคร\n\nนี้ช่วยให้หน่วยงานที่ได้รับการยอมรับกับบ้าน:\n\nชื่อ คําพูด\n\n\n\nเพื่อแก้ไขข้อผิดพลาดนี้, การแก้ไขและปรับแหล่งที่มา (หรือลบวิธีการช่วย) และรีสตาร์ทบ้าน.\n\n Spo 👻 ไม่ hom.",
-      "title": "ที่มา: ประกาศ"
+      "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
+      "title": "Unknown source: {helper}"
     },
     "utility_meter_unknown_source": {
       "description": "Spook has found a ghost in your utility meter helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",

--- a/custom_components/spook/translations/tr.json
+++ b/custom_components/spook/translations/tr.json
@@ -250,7 +250,7 @@
       "title": "Bilinmeyen grup üyeleri: {group}"
     },
     "integration_unknown_source": {
-      "description": "Spook, Riemann'ınızdaki bir hayalet buldu\n\nÇevrede yüzerken, Spook aşağıdaki yardımcı ile yolu geçti:\n\n{helper} ('{entity_id})\n\nBu yardımcının Home Asistan tarafından bilinmeyen bir kaynağı var:\n\n\" \"\n\n\n\nBu hatayı düzeltmek için, yardımlayıcıyı düzenler ve kaynak varlığını ayarlar (veya yardımcıları kaldırır) ve Home Asistanı yeniden başlatır.\n\nSpook . senin homie değil.",
+      "description": "Spook has found a ghost in your Riemann sum integral helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Bilinmeyen kaynak: {helper}"
     },
     "lovelace_unknown_entity_references": {
@@ -274,15 +274,15 @@
       "title": "Bilinmeyen varlıklar şu sahnede kullanıldı: {scene}"
     },
     "script_unknown_area_references": {
-      "description": "Spook senaryolarınızda bir hayalet buldu 👻\n\nÇevrede yüz yüzeyken Spook aşağıdaki senaryo ile yolu geçti:\n\n[{script}]({edit})\n\nBu senaryo, Home Asistan tarafından bilinmeyen aşağıdaki alanları referanslar:\n\n{areas}\n\n\n\nBu hatayı düzeltmek için [edit the script] ({edit}) ve bu non-existing alanlarının kullanımını ortadan kaldırmak.\n\nSpook . senin homie değil.",
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
       "title": "Bilinmeyen alanlarda kullanılır: {script}"
     },
     "script_unknown_device_references": {
-      "description": "Spook senaryolarınızda bir hayalet buldu 👻\n\nÇevrede yüz yüzeyken Spook aşağıdaki senaryo ile yolu geçti:\n\n[{script}]({edit})\n\nBu senaryo, Home Asistan tarafından bilinmeyen aşağıdaki cihazlara atıfta bulunur:\n\n{devices}\n\n\n\nBu hatayı düzeltmek için [edit the script] ({edit}) ve bu non-existing cihazların kullanımını ortadan kaldırır.\n\nSpook . senin homie değil.",
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Your homie.",
       "title": "Bilinmeyen cihazlar kullanılır: {script}"
     },
     "script_unknown_entity_references": {
-      "description": "Spook senaryolarınızda bir hayalet buldu 👻\n\nÇevrede yüz yüzeyken Spook aşağıdaki senaryo ile yolu geçti:\n\n[{script}]({edit})\n\nBu senaryo, Home Asistan tarafından bilinmeyen aşağıdaki varlıklara atıfta bulunur:\n\n{entities}\n\n\n\nBu hatayı düzeltmek için [edit the script] ({edit}) ve bu dış olmayan varlıkların kullanımını ortadan kaldırır.\n\nSpook . senin homie değil.",
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
       "title": "Bilinmeyen ögeler: {script}"
     },
     "script_unknown_floor_references": {
@@ -294,7 +294,7 @@
       "title": "Unknown labels used in: {script}"
     },
     "switch_as_x_unknown_source": {
-      "description": "Spook, X yardımcıları olarak Anahtarınızda bir hayalet buldu\n\nÇevrede yüzerken, Spook aşağıdaki yardımcı ile yolu geçti:\n\n{helper} ('{entity_id})\n\nBu yardımcının Ev Asistanı için bilinmeyen bir kaynağı vardır:\n\n\" \"\n\n\n\nBu hatayı düzeltmek için, yardımlayıcıyı düzenler ve kaynak varlığını ayarlar (veya yardımcıları kaldırır) ve Home Asistanı yeniden başlatır.\n\nSpook . senin homie değil.",
+      "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Bilinmeyen kaynak: {helper}"
     },
     "utility_meter_unknown_source": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,63 @@
+"""Tests for translation files."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+TRANSLATIONS_PATH = Path("custom_components/spook/translations")
+PLACEHOLDER_PATTERN = re.compile(r"\{[^{}]+\}")
+
+
+def _walk_translation_strings(
+    base: dict[str, Any],
+    translation: dict[str, Any],
+    path: str = "",
+) -> list[str]:
+    """Return translation strings with mismatched placeholders."""
+    mismatches: list[str] = []
+
+    for key, base_value in base.items():
+        key_path = f"{path}.{key}" if path else key
+
+        if key not in translation:
+            continue
+
+        translation_value = translation[key]
+        if isinstance(base_value, dict) and isinstance(translation_value, dict):
+            mismatches.extend(
+                _walk_translation_strings(base_value, translation_value, key_path)
+            )
+            continue
+
+        if not isinstance(base_value, str) or not isinstance(translation_value, str):
+            continue
+
+        expected = set(PLACEHOLDER_PATTERN.findall(base_value))
+        actual = set(PLACEHOLDER_PATTERN.findall(translation_value))
+        if expected != actual:
+            mismatches.append(
+                f"{key_path}: expected {sorted(expected)}, got {sorted(actual)}"
+            )
+
+    return mismatches
+
+
+def test_translation_placeholders_match_english() -> None:
+    """Test translation placeholders match the English source strings."""
+    english = json.loads((TRANSLATIONS_PATH / "en.json").read_text(encoding="utf-8"))
+    mismatches = []
+
+    for translation_file in sorted(TRANSLATIONS_PATH.glob("*.json")):
+        if translation_file.name == "en.json":
+            continue
+
+        translation = json.loads(translation_file.read_text(encoding="utf-8"))
+        mismatches.extend(
+            f"{translation_file.name}: {mismatch}"
+            for mismatch in _walk_translation_strings(english, translation)
+        )
+
+    assert not mismatches, "\n".join(mismatches)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes all translation strings where placeholders no longer match the English source strings.

This touches 39 strings across 10 locale files. Clear placeholder renames, like `{titel}` and `{uređaji}`, are corrected in place. Strings that were missing or badly mangled now fall back to the English source string so runtime formatting gets the exact placeholder contract again.

It also adds a regression test that compares placeholders in every locale file with `en.json`, so translated placeholder names are caught before merge.

## Motivation and Context

Placeholders are runtime format keys, not translatable prose. If a locale changes `{title}` to `{titel}`, or drops `{entity_id}`, Home Assistant cannot format the repair text correctly.

We already saw this in a few PRs. This cleans up the remaining cases in one pass and adds a guard for future translation changes.

## How has this been tested?

- `python` placeholder parity probe against all locale files
- `uv run check-json custom_components/spook/translations/<locale>.json` for all translation files
- `uv run pytest tests/test_translations.py -q`
- `uv run ruff check tests/test_translations.py`
- `uv run ruff format --check tests/test_translations.py`
- `uv run pylint tests/test_translations.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
