### PR TITLE
Fix fired one-time listener cleanup

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import issue_registry as ir
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .entity_filtering import async_setup_all_entity_ids_cache_invalidation
 from .integration_linking import link_sub_integrations, unlink_sub_integrations
+from .listeners import async_listen_once_tracked
 from .repairs import SpookRepairManager
 from .services import SpookServiceManager
 from .setup_helpers import async_forward_setup_entry
@@ -93,23 +94,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await repairs.async_setup()
         entry.async_on_unload(repairs.async_on_unload)
 
-    @callback
-    def _unsubscribe_ghost_busters() -> None:
-        """Unsubscribe the ghost busters listener."""
-        if _ghost_busters_unsub:
-            try:
-                _ghost_busters_unsub()
-            except ValueError:
-                LOGGER.debug(
-                    "Failed to unsubscribe _ghost_busters listener, "
-                    "it might have already been removed or never registered.",
-                )
-
     # Wait until Home Assistant is started, before doing repairs
-    _ghost_busters_unsub = hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STARTED, _ghost_busters
+    _ghost_busters_unsub = async_listen_once_tracked(
+        hass, EVENT_HOMEASSISTANT_STARTED, _ghost_busters
     )
-    entry.async_on_unload(_unsubscribe_ghost_busters)
+    entry.async_on_unload(_ghost_busters_unsub)
 
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/spook/ectoplasms/homeassistant/sensor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/sensor.py
@@ -39,6 +39,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.event import async_call_later
 
 from ...entity import SpookEntityDescription
+from ...listeners import async_listen_once_tracked
 from .entity import HomeAssistantSpookEntity
 
 if TYPE_CHECKING:
@@ -615,7 +616,9 @@ class HomeAssistantSpookSensorEntity(HomeAssistantSpookEntity, SensorEntity):
             self.async_on_remove(self.hass.bus.async_listen(event, _update_state))
 
         self.async_on_remove(
-            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _update_state),
+            async_listen_once_tracked(
+                self.hass, EVENT_HOMEASSISTANT_STARTED, _update_state
+            ),
         )
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/spook/ectoplasms/repairs/sensor.py
+++ b/custom_components/spook/ectoplasms/repairs/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 
 from ...entity import SpookEntityDescription
+from ...listeners import async_listen_once_tracked
 from .entity import RepairsSpookEntity
 
 if TYPE_CHECKING:
@@ -104,7 +105,9 @@ class HomeAssistantSpookSensorEntity(RepairsSpookEntity, SensorEntity):
             self.async_on_remove(self.hass.bus.async_listen(event, _update_state))
 
         self.async_on_remove(
-            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _update_state),
+            async_listen_once_tracked(
+                self.hass, EVENT_HOMEASSISTANT_STARTED, _update_state
+            ),
         )
 
     @property

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -36,6 +36,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.template import Template
 
 from .const import LOGGER
+from .listeners import async_listen_once_tracked
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
@@ -154,8 +155,8 @@ def async_setup_all_entity_ids_cache_invalidation(
         er.EVENT_ENTITY_REGISTRY_UPDATED, _clear_all_entity_ids_cache
     )
     # Listen for Home Assistant start to ensure cache is clear then
-    unsub_hass_start = hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_START, _clear_all_entity_ids_cache
+    unsub_hass_start = async_listen_once_tracked(
+        hass, EVENT_HOMEASSISTANT_START, _clear_all_entity_ids_cache
     )
     # Listen for components loading
     unsub_component_loaded = hass.bus.async_listen(

--- a/custom_components/spook/listeners.py
+++ b/custom_components/spook/listeners.py
@@ -1,0 +1,55 @@
+"""Listener helpers for Spook."""
+
+from __future__ import annotations
+
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING, Any, cast
+
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+    from homeassistant.util.event_type import EventType
+
+
+def async_listen_once_tracked(
+    hass: HomeAssistant,
+    event_type: EventType[Any] | str,
+    listener: Callable[[Event[Any]], Coroutine[Any, Any, None] | None],
+) -> CALLBACK_TYPE:
+    """Listen once for an event and return an idempotent unsubscribe callback."""
+    remove: CALLBACK_TYPE | None = None
+
+    if iscoroutinefunction(listener):
+
+        async def _async_event_listener(event: Event[Any]) -> None:
+            """Handle the one-time event."""
+            nonlocal remove
+            remove = None
+            await listener(event)
+
+        remove = hass.bus.async_listen_once(event_type, _async_event_listener)
+
+    else:
+
+        @callback
+        def _event_listener(event: Event[Any]) -> None:
+            """Handle the one-time event."""
+            nonlocal remove
+            remove = None
+            cast("Callable[[Event[Any]], None]", listener)(event)
+
+        remove = hass.bus.async_listen_once(event_type, _event_listener)
+
+    @callback
+    def _remove_listener() -> None:
+        """Remove the listener if it has not fired yet."""
+        nonlocal remove
+        if remove is None:
+            return
+        _remove = remove
+        remove = None
+        _remove()
+
+    return _remove_listener

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -1,0 +1,71 @@
+"""Tests for Spook listener helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import callback
+
+from custom_components.spook.listeners import async_listen_once_tracked
+
+if TYPE_CHECKING:
+    import pytest
+
+    from homeassistant.core import Event, HomeAssistant
+
+
+async def test_tracked_one_time_listener_unsub_after_fire_is_noop(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test tracked one-time listener unsubscribe is a no-op after firing."""
+    calls = 0
+
+    @callback
+    def _listener(_: Event) -> None:
+        """Handle the event."""
+        nonlocal calls
+        calls += 1
+
+    unsubscribe = async_listen_once_tracked(
+        hass, EVENT_HOMEASSISTANT_STARTED, _listener
+    )
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    with caplog.at_level(logging.ERROR, logger="homeassistant.core"):
+        unsubscribe()
+
+    assert calls == 1
+    assert "Unable to remove unknown job listener" not in caplog.text
+
+
+async def test_tracked_one_time_listener_unsub_is_idempotent(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test tracked one-time listener unsubscribe can be called repeatedly."""
+    calls = 0
+
+    @callback
+    def _listener(_: Event) -> None:
+        """Handle the event."""
+        nonlocal calls
+        calls += 1
+
+    unsubscribe = async_listen_once_tracked(
+        hass, EVENT_HOMEASSISTANT_STARTED, _listener
+    )
+
+    with caplog.at_level(logging.ERROR, logger="homeassistant.core"):
+        unsubscribe()
+        unsubscribe()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert calls == 0
+    assert "Unable to remove unknown job listener" not in caplog.text

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import logging
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 
 from custom_components import spook
 from custom_components.spook.const import DOMAIN
@@ -83,3 +85,38 @@ async def test_setup_entry_loads_and_unloads(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_unload_after_start_does_not_remove_fired_one_time_listeners(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test unloading after start does not remove fired one-time listeners again."""
+
+    async def async_forward_no_platforms(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+    ) -> None:
+        """Forward no ectoplasm setup during the lifecycle smoke test."""
+
+    monkeypatch.setattr(spook, "PLATFORMS", [])
+    monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_noop)
+    monkeypatch.setattr(spook, "async_forward_setup_entry", async_forward_no_platforms)
+    monkeypatch.setattr(spook, "SpookServiceManager", _NoopSpookServiceManager)
+    monkeypatch.setattr(spook, "SpookRepairManager", _NoopSpookRepairManager)
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    with caplog.at_level(logging.ERROR, logger="homeassistant.core"):
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert "Unable to remove unknown job listener" not in caplog.text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wrap one-time Home Assistant listeners in a tracked unsubscribe helper. Once the listener fires, the stored unload callback becomes a no-op instead of calling Home Assistant's already-removed unsubscribe callback again.

## Motivation and Context

Fixes #1210.

Home Assistant removes `async_listen_once` listeners internally when they fire. Spook kept those original unsubscribe callbacks in unload handlers, which caused Home Assistant to log `Unable to remove unknown job listener` during unload after startup events had already fired.

## How has this been tested?

- `ruff check custom_components/spook tests/test_setup.py tests/test_listeners.py`
- `pytest -q`
- `pylint custom_components/spook tests/test_setup.py tests/test_listeners.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
