### PR TITLE
Ignore notify targets in automation entity checks

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -193,6 +193,20 @@ async def _extract_entities_from_target(
     return entities
 
 
+def _get_action_service(config: dict[str, Any]) -> str | None:
+    """Return the service/action name configured for an action."""
+    service = config.get("service", config.get("action"))
+    return service if isinstance(service, str) else None
+
+
+def _should_skip_service_data_value(
+    service: str | None,
+    key: str,
+) -> bool:
+    """Return if a service data value should not be scanned for entity IDs."""
+    return service is not None and service.startswith("notify.") and key == "target"
+
+
 async def _extract_entities_from_service_data(
     hass: HomeAssistant, config: dict[str, Any]
 ) -> set[str]:
@@ -204,8 +218,11 @@ async def _extract_entities_from_service_data(
             # data field is a template string itself
             entities.update(await extract_entities_from_value(hass, data_value))
         elif isinstance(data_value, dict):
+            service = _get_action_service(config)
             # data field is a dictionary, process all its values
-            for value in data_value.values():
+            for key, value in data_value.items():
+                if _should_skip_service_data_value(service, key):
+                    continue
                 entities.update(await extract_entities_from_value(hass, value))
     return entities
 

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -165,8 +165,46 @@ async def test_action_target_block(hass: HomeAssistant) -> None:
 async def test_action_data_dict(hass: HomeAssistant) -> None:
     """Entities buried inside ``data`` values are captured."""
     config = {
-        "service": "notify.notify",
+        "service": "light.turn_on",
         "data": {"message": "hello", "target": "person.alice"},
+    }
+    assert await extract_entities_from_action_config(hass, config) == {"person.alice"}
+
+
+async def test_notify_action_data_target_is_not_an_entity_reference(
+    hass: HomeAssistant,
+) -> None:
+    """Notify ``data.target`` values are service targets, not entity references."""
+    config = {
+        "action": "notify.mobile_app_phone",
+        "data": {
+            "target": "notify.old_tablet",
+            "message": "{{ states('sensor.temperature') }}",
+        },
+    }
+    assert await extract_entities_from_action_config(hass, config) == {
+        "sensor.temperature"
+    }
+
+
+async def test_notify_service_data_target_is_not_an_entity_reference(
+    hass: HomeAssistant,
+) -> None:
+    """Legacy service syntax follows the same notify target rule."""
+    config = {
+        "service": "notify.mobile_app_phone",
+        "data": {"target": ["notify.old_tablet", "notify.old_phone"]},
+    }
+    assert await extract_entities_from_action_config(hass, config) == set()
+
+
+async def test_non_notify_action_data_target_remains_entity_reference(
+    hass: HomeAssistant,
+) -> None:
+    """Non-notify service data is still scanned for entity IDs."""
+    config = {
+        "action": "calendar.create_event",
+        "data": {"target": "person.alice"},
     }
     assert await extract_entities_from_action_config(hass, config) == {"person.alice"}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ignore `data.target` values on notify actions when extracting entity references from automation action data.

Notify targets are service-specific notification targets. They are not Home Assistant entity references, even when they look like `notify.*`. Other action data values are still scanned, including templates, and non-notify `target` values keep the existing behavior.

## Motivation and Context

Fixes #1253.

Spook could keep reporting an old notify target as an unknown entity after an automation had already been updated. The scanner was treating the notify action's `data.target` as an entity ID, which made the repair noisy for mobile app notification targets.

## How has this been tested?

- `ruff check custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `ruff format --check custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `pylint custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `pytest -q tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `pytest -q`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
