### PR TITLE
Cover already configured Spook config flow

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
@@ -70,3 +71,19 @@ async def test_config_flow_restart_now_sets_setup_restart_flag(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert hass.data[DOMAIN] == "Boo!"
+
+
+async def test_config_flow_aborts_when_spook_is_already_configured(
+    hass: HomeAssistant,
+) -> None:
+    """Test the config flow aborts when Spook already has an entry."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_spooked"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds coverage for the main Spook config flow abort path when Spook already has a config entry.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This finishes the remaining uncovered path from the config flow testing issue. The flow already aborts with `already_spooked`; this locks that behavior down in the Home Assistant test harness.

Fixes #1258

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- `uv run pytest tests/test_config_flow.py::test_config_flow_aborts_when_spook_is_already_configured -q`
- `uv run pytest -q`
- `uv run ruff check tests/test_config_flow.py`
- `uv run ruff format --check tests/test_config_flow.py`

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
