### PR TITLE
Cover Spook inverse config flow

### DIFF
--- a/tests/integrations/spook_inverse/test_config_flow.py
+++ b/tests/integrations/spook_inverse/test_config_flow.py
@@ -1,0 +1,156 @@
+"""Tests for the Spook inverse config flow."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_ENTITY_ID, CONF_NAME, Platform
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.spook.integrations.spook_inverse.const import (
+    CONF_HIDE_SOURCE,
+    DOMAIN,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _create_source_entity(hass: HomeAssistant, domain: str) -> str:
+    """Create a source entity and return its entity ID."""
+    entity_registry = er.async_get(hass)
+    entity_entry = entity_registry.async_get_or_create(
+        domain,
+        "test",
+        "source",
+        suggested_object_id="source",
+    )
+    return entity_entry.entity_id
+
+
+@pytest.mark.parametrize("platform", [Platform.BINARY_SENSOR, Platform.SWITCH])
+async def test_config_flow_creates_inverse_entry(
+    hass: HomeAssistant,
+    platform: Platform,
+) -> None:
+    """Test config flow creates an inverse helper entry."""
+    source_entity_id = _create_source_entity(hass, platform)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["menu_options"] == [Platform.BINARY_SENSOR, Platform.SWITCH]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": platform},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == platform
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_NAME: "Inverse source",
+            CONF_ENTITY_ID: source_entity_id,
+            CONF_HIDE_SOURCE: True,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Inverse source"
+    assert result["data"] == {}
+    assert result["options"] == {
+        "inverse_type": platform,
+        CONF_NAME: "Inverse source",
+        CONF_ENTITY_ID: source_entity_id,
+        CONF_HIDE_SOURCE: True,
+    }
+    assert (
+        er.async_get(hass).async_get(source_entity_id).hidden_by
+        is er.RegistryEntryHider.INTEGRATION
+    )
+
+
+async def test_options_flow_updates_hide_source_state(
+    hass: HomeAssistant,
+) -> None:
+    """Test options flow hides and unhides the source entity."""
+    source_entity_id = _create_source_entity(hass, Platform.SWITCH)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Inverse source",
+        options={
+            "inverse_type": Platform.SWITCH,
+            CONF_ENTITY_ID: source_entity_id,
+            CONF_HIDE_SOURCE: False,
+        },
+    )
+    entry.add_to_hass(hass)
+    own_entity_id = (
+        er.async_get(hass)
+        .async_get_or_create(
+            Platform.SWITCH,
+            DOMAIN,
+            "inverse_source",
+            config_entry=entry,
+            suggested_object_id="inverse_source",
+        )
+        .entity_id
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == Platform.SWITCH
+    schema = result["data_schema"].schema
+    entity_selector = schema[next(iter(schema))]
+    assert entity_selector.config["domain"] == [Platform.SWITCH]
+    assert entity_selector.config["exclude_entities"] == [own_entity_id]
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_ENTITY_ID: source_entity_id,
+            CONF_HIDE_SOURCE: True,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "inverse_type": Platform.SWITCH,
+        CONF_ENTITY_ID: source_entity_id,
+        CONF_HIDE_SOURCE: True,
+    }
+    assert (
+        er.async_get(hass).async_get(source_entity_id).hidden_by
+        is er.RegistryEntryHider.INTEGRATION
+    )
+
+    hass.config_entries.async_update_entry(entry, options=result["data"])
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_ENTITY_ID: source_entity_id,
+            CONF_HIDE_SOURCE: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "inverse_type": Platform.SWITCH,
+        CONF_ENTITY_ID: source_entity_id,
+        CONF_HIDE_SOURCE: False,
+    }
+    assert er.async_get(hass).async_get(source_entity_id).hidden_by is None

--- a/tests/integrations/spook_inverse/test_init.py
+++ b/tests/integrations/spook_inverse/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from custom_components.spook.integrations.spook_inverse import (
     MIGRATION_MINOR_VERSION,
     async_get_source_entity_device_id,
+    async_remove_entry,
 )
 from custom_components.spook.integrations.spook_inverse.const import (
     CONF_HIDE_SOURCE,
@@ -116,3 +117,60 @@ async def test_async_migrate_entry_handles_unresolved_source_entity_id(
     await hass.async_block_till_done()
 
     assert migrated_entry.minor_version == MIGRATION_MINOR_VERSION
+
+
+async def test_async_remove_entry_unhides_integration_hidden_source(
+    hass: HomeAssistant,
+) -> None:
+    """Test remove entry unhides the source entity."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "switch",
+        "test",
+        "source",
+        suggested_object_id="source",
+        hidden_by=er.RegistryEntryHider.INTEGRATION,
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Inverse",
+        options={
+            CONF_ENTITY_ID: "switch.source",
+            CONF_HIDE_SOURCE: True,
+            "inverse_type": Platform.SWITCH,
+        },
+    )
+
+    await async_remove_entry(hass, entry)
+
+    assert entity_registry.async_get("switch.source").hidden_by is None
+
+
+async def test_async_remove_entry_preserves_user_hidden_source(
+    hass: HomeAssistant,
+) -> None:
+    """Test remove entry leaves non-integration hidden source entities alone."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "switch",
+        "test",
+        "source",
+        suggested_object_id="source",
+        hidden_by=er.RegistryEntryHider.USER,
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Inverse",
+        options={
+            CONF_ENTITY_ID: "switch.source",
+            CONF_HIDE_SOURCE: True,
+            "inverse_type": Platform.SWITCH,
+        },
+    )
+
+    await async_remove_entry(hass, entry)
+
+    assert (
+        entity_registry.async_get("switch.source").hidden_by
+        is er.RegistryEntryHider.USER
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds Spook inverse test coverage for:

- binary sensor and switch config flow creation
- `hide_source` side effects during config flow creation
- options flow hide and unhide behavior
- excluding the helper's own entity from the options flow entity selector
- remove-entry cleanup for integration-hidden source entities
- preserving source entities hidden by the user

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The inverse helper has user-visible registry side effects. These tests lock down the parts that can otherwise silently hide or unhide the wrong entity.

Fixes #1259

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- `uv run pytest tests/integrations/spook_inverse/test_config_flow.py tests/integrations/spook_inverse/test_init.py -q`
- `uv run pytest -q`
- `uv run ruff check tests/integrations/spook_inverse/test_config_flow.py tests/integrations/spook_inverse/test_init.py`
- `uv run ruff format --check tests/integrations/spook_inverse/test_config_flow.py tests/integrations/spook_inverse/test_init.py`

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
