### PR TITLE
Cover entity extraction helpers

### DIFF
--- a/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
@@ -334,7 +334,7 @@ def test_card_picture_elements_walked(repair: SpookRepair) -> None:
 
 
 def test_card_mushroom_chips(repair: SpookRepair) -> None:
-    """``chips`` on a mushroom chips card are walked and conditions captured."""
+    """Mushroom chips and their conditions contribute entities."""
     config = {
         "type": "custom:mushroom-chips-card",
         "chips": [
@@ -352,6 +352,31 @@ def test_card_mushroom_chips(repair: SpookRepair) -> None:
         "sensor.temperature",
         "switch.lamp",
         "input_boolean.guest",
+    }
+
+
+def test_heading_card_badges(repair: SpookRepair) -> None:
+    """Heading card badges contribute entities and action targets."""
+    config = {
+        "type": "heading",
+        "badges": [
+            {"type": "entity", "entity": "sensor.temperature"},
+            {
+                "type": "entity",
+                "entity": "binary_sensor.door",
+                "tap_action": {
+                    "action": "call-service",
+                    "service": "light.turn_on",
+                    "target": {"entity_id": "light.kitchen"},
+                },
+            },
+        ],
+    }
+
+    assert _extract_card(repair, config) == {
+        "sensor.temperature",
+        "binary_sensor.door",
+        "light.kitchen",
     }
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from custom_components.spook.entity_filtering import (
+    async_filter_known_entity_ids_with_templates,
+    extract_entities_from_template_regex,
     extract_template_strings_from_config,
     is_template_string,
     split_comma_separated_entity_ids,
 )
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 
 @pytest.mark.parametrize(
@@ -139,3 +144,82 @@ def test_extract_templates_appends_to_caller_supplied_list() -> None:
 
     assert result is sink
     assert sink == ["{{ preexisting }}", "{{ added }}"]
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        ("{{ states('light.kitchen') }}", {"light.kitchen"}),
+        ("{{ state_attr('sensor.energy', 'unit') }}", {"sensor.energy"}),
+        ("{{ is_state('switch.fan', 'on') }}", {"switch.fan"}),
+        ("{{ is_state_attr('climate.hvac', 'mode', 'heat') }}", {"climate.hvac"}),
+        ("{{ has_value('sensor.power') }}", {"sensor.power"}),
+        ("{{ state_translated('binary_sensor.motion') }}", {"binary_sensor.motion"}),
+        ("{{ device_id('light.kitchen') }}", {"light.kitchen"}),
+        ("{{ device_name('switch.fan') }}", {"switch.fan"}),
+        ("{{ device_attr('sensor.router', 'name') }}", {"sensor.router"}),
+        (
+            "{{ is_device_attr('sensor.router', 'manufacturer', 'x') }}",
+            {"sensor.router"},
+        ),
+        ("{{ config_entry_id('sensor.power') }}", {"sensor.power"}),
+        ("{{ area_id('sensor.hall') }}", {"sensor.hall"}),
+        ("{{ area_name('sensor.hall') }}", {"sensor.hall"}),
+        ("{{ floor_id('sensor.upstairs') }}", {"sensor.upstairs"}),
+        ("{{ floor_name('sensor.upstairs') }}", {"sensor.upstairs"}),
+        ("{{ is_hidden_entity('sensor.hidden') }}", {"sensor.hidden"}),
+        ("{{ expand('group.lights') }}", {"group.lights"}),
+        ("{{ distance('sensor.home') }}", {"sensor.home"}),
+        ("{{ closest('sensor.a') }}", {"sensor.a"}),
+        ("{{ states.binary_sensor.door.state }}", {"binary_sensor.door"}),
+        (
+            "{{ states.sensor.temperature.attributes.unit_of_measurement }}",
+            {"sensor.temperature"},
+        ),
+        ("{{ ['light.a', 'switch.b'] }}", {"light.a", "switch.b"}),
+        (
+            "{{ expand('light.kitchen', 'switch.fan') }}",
+            {"light.kitchen", "switch.fan"},
+        ),
+        (
+            "{{ ['light.kitchen'] | select('is_state', 'on') | list }}",
+            {"light.kitchen"},
+        ),
+        ("{{ 'light.' ~ room }}", set()),
+        ("{{ states('unknown_domain.foo') }}", set()),
+        ("{{ states('light.') }}", set()),
+        ("{{ 'light.turn_on' }}", set()),
+    ],
+)
+def test_extract_entities_from_template_regex(
+    hass: HomeAssistant,
+    template: str,
+    expected: set[str],
+) -> None:
+    """Test entity IDs are extracted from supported template forms."""
+    hass.services.async_register(
+        "light",
+        "turn_on",
+        lambda _: None,
+    )
+
+    assert extract_entities_from_template_regex(hass, template) == expected
+
+
+async def test_filter_template_entities_ignores_ignored_domains(
+    hass: HomeAssistant,
+) -> None:
+    """Test ignored entity domains do not leak as unknown template entities."""
+    unknown = await async_filter_known_entity_ids_with_templates(
+        hass,
+        {
+            "{{ states('scene.goodnight') }}",
+            "{{ states('group.family') }}",
+            "{{ states('device_tracker.phone') }}",
+            "persistent_notification.update",
+            "{{ states('light.missing') }}",
+        },
+        known_entity_ids=set(),
+    )
+
+    assert unknown == {"light.missing"}


### PR DESCRIPTION
## Description

Adds regression coverage for the entity extraction helpers used by unknown entity reference repairs.

This covers template entity extraction forms, service false-positive filtering, ignored entity domains, and the Lovelace heading card badge extraction path added by #1173.

## Motivation and Context

Closes #1261.

These helpers are regex-heavy and shared by multiple repair flows. A small parametrized test table gives quick feedback when future tweaks change what entities are discovered.

## How has this been tested?

- `uv run pytest tests/test_util.py tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py -q`
- `uv run ruff check tests/test_util.py tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py`
- `uv run ruff format --check tests/test_util.py tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py`
- `uv run pytest -q`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
