### PR TITLE
Cover Spook setup restart paths

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -28,6 +28,8 @@ from custom_components.spook.integration_linking import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -236,6 +238,10 @@ async def test_setup_entry_restart_required_paths(
     ) -> None:
         """Forward no platform setup during restart tests."""
 
+    def setup_cache_invalidation_noop(_hass: HomeAssistant) -> Callable[[], None]:
+        """Skip entity ID cache invalidation listeners during restart tests."""
+        return lambda: None
+
     monkeypatch.setattr(spook, "PLATFORMS", [])
     monkeypatch.setattr(spook, "async_forward_setup_entry", async_forward_no_platforms)
     monkeypatch.setattr(
@@ -246,6 +252,11 @@ async def test_setup_entry_restart_required_paths(
     monkeypatch.setattr(spook, "SpookServiceManager", _NoopSpookServiceManager)
     monkeypatch.setattr(spook, "SpookRepairManager", _NoopSpookRepairManager)
     monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_changed)
+    monkeypatch.setattr(
+        spook,
+        "async_setup_all_entity_ids_cache_invalidation",
+        setup_cache_invalidation_noop,
+    )
     monkeypatch.setattr(hass, "async_stop", async_stop)
     monkeypatch.setattr(hass, "state", state)
     if restart_now:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,17 +2,30 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
 import logging
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STARTED,
+    RESTART_EXIT_CODE,
+)
+from homeassistant.core import CoreState
+from homeassistant.helpers import issue_registry as ir
 
 from custom_components import spook
 from custom_components.spook.const import DOMAIN
+from custom_components.spook.integration_linking import (
+    link_sub_integrations,
+    unlink_sub_integrations,
+)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -48,6 +61,30 @@ class _NoopSpookRepairManager:
 
     async def async_on_unload(self) -> None:
         """Unload no repairs."""
+
+
+def _sub_integration_names() -> set[str]:
+    """Return bundled Spook sub-integration names."""
+    return {
+        manifest.parent.name
+        for manifest in (
+            Path(__file__).parents[1] / "custom_components" / DOMAIN / "integrations"
+        ).rglob("*/manifest.json")
+    }
+
+
+def _create_sub_integration_sources(config_dir: Path) -> None:
+    """Create matching config-dir source folders for Spook sub-integrations."""
+    for name in _sub_integration_names():
+        (config_dir / "custom_components" / DOMAIN / "integrations" / name).mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+
+
+def _link_sub_integrations_changed(_hass: HomeAssistant) -> bool:
+    """Pretend sub-integration symlink creation changed the config dir."""
+    return True
 
 
 def _link_sub_integrations_noop(_hass: HomeAssistant) -> bool:
@@ -120,3 +157,121 @@ async def test_unload_after_start_does_not_remove_fired_one_time_listeners(
         await hass.async_block_till_done()
 
     assert "Unable to remove unknown job listener" not in caplog.text
+
+
+def test_link_sub_integrations_creates_links_idempotently_and_unlinks(
+    tmp_path: Path,
+) -> None:
+    """Test sub-integration links are created, skipped, and removed."""
+    fake_hass = SimpleNamespace(config=SimpleNamespace(config_dir=tmp_path))
+    _create_sub_integration_sources(tmp_path)
+
+    assert link_sub_integrations(fake_hass) is True
+
+    for name in _sub_integration_names():
+        link = tmp_path / "custom_components" / name
+        assert link.is_symlink()
+        assert link.readlink() == (
+            tmp_path / "custom_components" / DOMAIN / "integrations" / name
+        )
+
+    assert link_sub_integrations(fake_hass) is False
+
+    unlink_sub_integrations(fake_hass)
+
+    for name in _sub_integration_names():
+        assert not (tmp_path / "custom_components" / name).exists()
+
+
+async def test_remove_entry_unlinks_sub_integrations(tmp_path: Path) -> None:
+    """Test removing Spook unlinks the sub-integrations."""
+    fake_hass = SimpleNamespace(
+        config=SimpleNamespace(config_dir=tmp_path),
+        async_add_executor_job=AsyncMock(side_effect=lambda func, *args: func(*args)),
+    )
+    _create_sub_integration_sources(tmp_path)
+    assert link_sub_integrations(fake_hass) is True
+
+    await spook.async_remove_entry(fake_hass, MockConfigEntry(domain=DOMAIN, data={}))
+
+    for name in _sub_integration_names():
+        assert not (tmp_path / "custom_components" / name).exists()
+
+
+@pytest.mark.parametrize(
+    ("state", "restart_choice"),
+    [
+        (CoreState.not_running, "later"),
+        (CoreState.starting, "later"),
+        (CoreState.running, "later"),
+        (CoreState.not_running, "now"),
+    ],
+)
+async def test_setup_entry_restart_required_paths(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    state: CoreState,
+    restart_choice: str,
+) -> None:
+    """Test setup behavior when sub-integration linking requires a restart."""
+    restart_now = restart_choice == "now"
+    async_stop = AsyncMock(wraps=hass.async_stop)
+
+    async def async_forward_no_platforms(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+    ) -> None:
+        """Forward no ectoplasm setup during restart tests."""
+
+    async def async_forward_entry_setups_noop(
+        _entry: ConfigEntry,
+        _platforms: list[str],
+    ) -> None:
+        """Forward no platform setup during restart tests."""
+
+    monkeypatch.setattr(spook, "PLATFORMS", [])
+    monkeypatch.setattr(spook, "async_forward_setup_entry", async_forward_no_platforms)
+    monkeypatch.setattr(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        async_forward_entry_setups_noop,
+    )
+    monkeypatch.setattr(spook, "SpookServiceManager", _NoopSpookServiceManager)
+    monkeypatch.setattr(spook, "SpookRepairManager", _NoopSpookRepairManager)
+    monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_changed)
+    monkeypatch.setattr(hass, "async_stop", async_stop)
+    hass.state = state
+    if restart_now:
+        hass.data[DOMAIN] = "Boo!"
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+
+    result = await spook.async_setup_entry(hass, entry)
+
+    if state == CoreState.running and not restart_now:
+        assert result is True
+    else:
+        assert result is False
+
+    if restart_now or state == CoreState.starting:
+        await hass.async_block_till_done()
+        hass.async_stop.assert_awaited_once_with(RESTART_EXIT_CODE)
+        assert ir.async_get(hass).async_get_issue(DOMAIN, "restart_required") is None
+        return
+
+    if state == CoreState.not_running:
+        hass.async_stop.assert_not_called()
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        await hass.async_block_till_done()
+
+        hass.async_stop.assert_awaited_once_with(RESTART_EXIT_CODE)
+        assert ir.async_get(hass).async_get_issue(DOMAIN, "restart_required") is None
+        return
+
+    hass.async_stop.assert_not_called()
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, "restart_required")
+    assert issue is not None
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.translation_key == "restart_required"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -215,7 +215,14 @@ async def test_setup_entry_restart_required_paths(
 ) -> None:
     """Test setup behavior when sub-integration linking requires a restart."""
     restart_now = restart_choice == "now"
-    async_stop = AsyncMock(wraps=hass.async_stop)
+    original_async_stop = hass.async_stop
+
+    async def async_cleanup_hass() -> None:
+        """Stop Home Assistant after the restart request is asserted."""
+        monkeypatch.setattr(hass, "state", CoreState.running)
+        await original_async_stop()
+
+    async_stop = AsyncMock()
 
     async def async_forward_no_platforms(
         _hass: HomeAssistant,
@@ -240,7 +247,7 @@ async def test_setup_entry_restart_required_paths(
     monkeypatch.setattr(spook, "SpookRepairManager", _NoopSpookRepairManager)
     monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_changed)
     monkeypatch.setattr(hass, "async_stop", async_stop)
-    hass.state = state
+    monkeypatch.setattr(hass, "state", state)
     if restart_now:
         hass.data[DOMAIN] = "Boo!"
 
@@ -258,6 +265,7 @@ async def test_setup_entry_restart_required_paths(
         await hass.async_block_till_done()
         hass.async_stop.assert_awaited_once_with(RESTART_EXIT_CODE)
         assert ir.async_get(hass).async_get_issue(DOMAIN, "restart_required") is None
+        await async_cleanup_hass()
         return
 
     if state == CoreState.not_running:
@@ -268,6 +276,7 @@ async def test_setup_entry_restart_required_paths(
 
         hass.async_stop.assert_awaited_once_with(RESTART_EXIT_CODE)
         assert ir.async_get(hass).async_get_issue(DOMAIN, "restart_required") is None
+        await async_cleanup_hass()
         return
 
     hass.async_stop.assert_not_called()
@@ -275,3 +284,4 @@ async def test_setup_entry_restart_required_paths(
     assert issue is not None
     assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_key == "restart_required"
+    await original_async_stop()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds characterization coverage for Spook's setup path that links bundled sub-integrations into the Home Assistant config directory.

The tests now cover symlink creation, idempotency, removal through `async_remove_entry`, and the setup branches that either restart Home Assistant or create the `restart_required` repair issue.

## Motivation and Context

This pins down the operational setup path around sub-integration linking and restart handling. That path mutates the local config directory and decides whether Home Assistant should restart, so it is worth having direct coverage.

Fixes #1262

## How has this been tested?

- `uv run pytest tests/test_setup.py -q`
- `uv run pytest -q`
- `uv run ruff check`
- `uv run ruff format --check`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
