### PR TITLE
Fix add area to floor service schema

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/add_area_to_floor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/add_area_to_floor.py
@@ -27,7 +27,7 @@ class SpookService(AbstractSpookAdminService):
     service = "add_area_to_floor"
     schema = {
         vol.Required("floor_id"): cv.string,
-        vol.Required("entity_id"): vol.All(cv.ensure_list, [cv.string]),
+        vol.Required("area_id"): vol.All(cv.ensure_list, [cv.string]),
     }
 
     async def async_handle_service(self, call: ServiceCall) -> None:

--- a/tests/ectoplasms/homeassistant/services/test_area_floor.py
+++ b/tests/ectoplasms/homeassistant/services/test_area_floor.py
@@ -1,0 +1,94 @@
+"""Tests for the homeassistant area floor services."""
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.spook.ectoplasms.homeassistant.services import add_area_to_floor
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.area_registry import AreaRegistry
+    from homeassistant.helpers.floor_registry import FloorRegistry
+
+    from tests.common import MockUser
+
+
+@pytest.fixture
+def area_floor_services(hass: HomeAssistant) -> None:
+    """Register the Spook area floor services."""
+    hass.config.components.add(DOMAIN)
+    add_area_to_floor.SpookService(hass).async_register()
+
+
+@pytest.mark.usefixtures("area_floor_services")
+async def test_add_area_to_floor_service_adds_area_to_floor(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    area_registry: AreaRegistry,
+    floor_registry: FloorRegistry,
+) -> None:
+    """Test the add area to floor service adds an area to a floor."""
+    area = area_registry.async_create("Kitchen")
+    floor = floor_registry.async_create("First floor")
+
+    await hass.services.async_call(
+        DOMAIN,
+        "add_area_to_floor",
+        {"floor_id": floor.floor_id, "area_id": area.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert area_registry.async_get_area(area.id).floor_id == floor.floor_id
+
+
+@pytest.mark.usefixtures("area_floor_services")
+async def test_add_area_to_floor_service_accepts_multiple_areas(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    area_registry: AreaRegistry,
+    floor_registry: FloorRegistry,
+) -> None:
+    """Test the add area to floor service accepts multiple area IDs."""
+    areas = [area_registry.async_create("Kitchen"), area_registry.async_create("Hall")]
+    floor = floor_registry.async_create("First floor")
+
+    await hass.services.async_call(
+        DOMAIN,
+        "add_area_to_floor",
+        {"floor_id": floor.floor_id, "area_id": [area.id for area in areas]},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert all(
+        area_registry.async_get_area(area.id).floor_id == floor.floor_id
+        for area in areas
+    )
+
+
+@pytest.mark.usefixtures("area_floor_services")
+async def test_add_area_to_floor_service_raises_on_missing_floor(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    area_registry: AreaRegistry,
+) -> None:
+    """Test the add area to floor service raises when the floor does not exist."""
+    area = area_registry.async_create("Kitchen")
+
+    with pytest.raises(HomeAssistantError, match=re.escape("Floor missing not found")):
+        await hass.services.async_call(
+            DOMAIN,
+            "add_area_to_floor",
+            {"floor_id": "missing", "area_id": area.id},
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the `homeassistant.add_area_to_floor` service schema so it accepts `area_id` instead of `entity_id`.

The implementation already used `call.data["area_id"]`, and the service description documents `area_id`. The schema was the only part still expecting `entity_id`, which made valid service calls fail validation before the handler could run.

This also adds coverage for adding one area, adding multiple areas, and the missing-floor error path.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1106.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- `uv run pytest tests/ectoplasms/homeassistant/services/test_area_floor.py -q`
- `uv run pytest tests/ectoplasms/homeassistant/services -q`
- `uv run ruff format --check custom_components/spook/ectoplasms/homeassistant/services/add_area_to_floor.py tests/ectoplasms/homeassistant/services/test_area_floor.py`
- `uv run ruff check --output-format=github custom_components/spook/ectoplasms/homeassistant/services/add_area_to_floor.py tests/ectoplasms/homeassistant/services/test_area_floor.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/homeassistant/services/add_area_to_floor.py tests/ectoplasms/homeassistant/services/test_area_floor.py`

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
