### PR TITLE
Fix recorder statistics metadata import

### DIFF
--- a/custom_components/spook/ectoplasms/recorder/services/import_statistics.py
+++ b/custom_components/spook/ectoplasms/recorder/services/import_statistics.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.components.recorder import DOMAIN
+from homeassistant.components.recorder.models import StatisticMeanType
 from homeassistant.components.recorder.statistics import (
+    STATISTIC_UNIT_TO_UNIT_CONVERTER,
     async_add_external_statistics,
     async_import_statistics,
 )
@@ -48,11 +50,20 @@ class SpookService(AbstractSpookAdminService):
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
         metadata: StatisticMetaData = {
-            "has_mean": call.data["has_mean"],
             "has_sum": call.data["has_sum"],
+            "mean_type": (
+                StatisticMeanType.ARITHMETIC
+                if call.data["has_mean"]
+                else StatisticMeanType.NONE
+            ),
             "name": call.data["name"],
             "source": call.data["source"],
             "statistic_id": call.data["statistic_id"],
+            "unit_class": STATISTIC_UNIT_TO_UNIT_CONVERTER.get(
+                call.data["unit_of_measurement"]
+            ).UNIT_CLASS
+            if call.data["unit_of_measurement"] in STATISTIC_UNIT_TO_UNIT_CONVERTER
+            else None,
             "unit_of_measurement": call.data["unit_of_measurement"],
         }
 

--- a/tests/ectoplasms/recorder/__init__.py
+++ b/tests/ectoplasms/recorder/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for recorder ectoplasms."""

--- a/tests/ectoplasms/recorder/services/__init__.py
+++ b/tests/ectoplasms/recorder/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for recorder services."""

--- a/tests/ectoplasms/recorder/services/test_import_statistics.py
+++ b/tests/ectoplasms/recorder/services/test_import_statistics.py
@@ -1,0 +1,123 @@
+"""Tests for the recorder import statistics service."""
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from homeassistant.components.recorder import DOMAIN
+from homeassistant.components.recorder.models import StatisticMeanType
+from homeassistant.components.recorder.statistics import (
+    STATISTIC_UNIT_TO_UNIT_CONVERTER,
+)
+from homeassistant.core import Context, HomeAssistant
+
+from custom_components.spook.ectoplasms.recorder.services import import_statistics
+
+if TYPE_CHECKING:
+    from homeassistant.components.recorder.models import (
+        StatisticData,
+        StatisticMetaData,
+    )
+
+    from tests.common import MockUser
+
+
+@pytest.fixture
+def recorder_import_statistics_service(hass: HomeAssistant) -> None:
+    """Register the Spook recorder import statistics service."""
+    hass.config.components.add(DOMAIN)
+    import_statistics.SpookService(hass).async_register()
+
+
+@pytest.mark.usefixtures("recorder_import_statistics_service")
+async def test_import_statistics_service_sets_required_metadata(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the import statistics service sets required metadata fields."""
+    calls: list[tuple[StatisticMetaData, list[StatisticData]]] = []
+
+    def mock_import_statistics(
+        _hass: HomeAssistant,
+        metadata: StatisticMetaData,
+        statistics: list[StatisticData],
+    ) -> None:
+        """Mock importing internal statistics."""
+        calls.append((metadata, statistics))
+
+    monkeypatch.setattr(
+        import_statistics,
+        "async_import_statistics",
+        mock_import_statistics,
+    )
+
+    stats = [{"start": datetime(2026, 1, 1, tzinfo=UTC), "mean": 21.0}]
+
+    await hass.services.async_call(
+        DOMAIN,
+        "import_statistics",
+        {
+            "has_mean": True,
+            "has_sum": False,
+            "source": DOMAIN,
+            "statistic_id": "sensor.temperature",
+            "unit_of_measurement": "°C",
+            "stats": stats,
+        },
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    metadata, imported_stats = calls[0]
+
+    assert metadata["mean_type"] is StatisticMeanType.ARITHMETIC
+    assert metadata["unit_class"] == STATISTIC_UNIT_TO_UNIT_CONVERTER["°C"].UNIT_CLASS
+    assert "has_mean" not in metadata
+    assert imported_stats == [{**stats[0], "last_reset": None}]
+
+
+@pytest.mark.usefixtures("recorder_import_statistics_service")
+async def test_import_statistics_service_sets_no_mean_metadata(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the import statistics service sets no mean metadata."""
+    calls: list[dict[str, Any]] = []
+
+    def mock_add_external_statistics(
+        _hass: HomeAssistant,
+        metadata: StatisticMetaData,
+        _statistics: list[StatisticData],
+    ) -> None:
+        """Mock importing external statistics."""
+        calls.append(dict(metadata))
+
+    monkeypatch.setattr(
+        import_statistics,
+        "async_add_external_statistics",
+        mock_add_external_statistics,
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "import_statistics",
+        {
+            "has_mean": False,
+            "has_sum": True,
+            "source": "spook",
+            "statistic_id": "spook:total",
+            "stats": [{"start": datetime(2026, 1, 1, tzinfo=UTC), "sum": 42.0}],
+        },
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert calls[0]["mean_type"] is StatisticMeanType.NONE
+    assert calls[0]["unit_class"] == STATISTIC_UNIT_TO_UNIT_CONVERTER[None].UNIT_CLASS
+    assert "has_mean" not in calls[0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Passes the recorder statistics metadata fields Home Assistant now expects when importing statistics.

The service still accepts the existing `has_mean` input, but translates it into the new `mean_type` metadata before calling Home Assistant recorder helpers. It also sets `unit_class` using the same unit mapping Home Assistant used as its fallback.

This keeps the public Spook service shape unchanged while avoiding the upcoming Home Assistant 2026.11 deprecation warnings.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1230.

Home Assistant warns when `async_import_statistics` or `async_add_external_statistics` is called without `mean_type`. The compatibility fallback is scheduled to stop working in Home Assistant 2026.11.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- `uv run pytest tests/ectoplasms/recorder/services/test_import_statistics.py -q`
- `uv run ruff format --check custom_components/spook/ectoplasms/recorder/services/import_statistics.py tests/ectoplasms/recorder/services/test_import_statistics.py tests/ectoplasms/recorder/__init__.py tests/ectoplasms/recorder/services/__init__.py`
- `uv run ruff check --output-format=github custom_components/spook/ectoplasms/recorder/services/import_statistics.py tests/ectoplasms/recorder/services/test_import_statistics.py tests/ectoplasms/recorder/__init__.py tests/ectoplasms/recorder/services/__init__.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/recorder/services/import_statistics.py tests/ectoplasms/recorder/services/test_import_statistics.py tests/ectoplasms/recorder/__init__.py tests/ectoplasms/recorder/services/__init__.py`

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
