### PR TITLE
Allow enabling disabled devices by ID

### DIFF
--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -226,12 +226,13 @@ homeassistant_enable_device:
     Enables a device on the fly.
   fields:
     device_id:
-      name: Device
-      description: The device(s) to enable.
+      name: Device ID
+      description: >-
+        The ID(s) of the device(s) to enable. Disabled devices are not shown by
+        Home Assistant's device selector, so this accepts the raw device ID.
       required: true
       selector:
-        device:
-          multiple: true
+        object:
 
 homeassistant_disable_user:
   name: Disable a user 👻

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -228,11 +228,11 @@ homeassistant_enable_device:
     device_id:
       name: Device ID
       description: >-
-        The ID(s) of the device(s) to enable. Disabled devices are not shown by
-        Home Assistant's device selector, so this accepts the raw device ID.
+        The raw device ID to enable. Disabled devices are not shown by Home
+        Assistant's device selector. Multiple IDs can be provided as a YAML list.
       required: true
       selector:
-        object:
+        text:
 
 homeassistant_disable_user:
   name: Disable a user 👻

--- a/tests/ectoplasms/homeassistant/services/test_device.py
+++ b/tests/ectoplasms/homeassistant/services/test_device.py
@@ -1,0 +1,111 @@
+"""Tests for the homeassistant enable_device and disable_device services."""
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryDisabler
+
+from custom_components.spook.ectoplasms.homeassistant.services import (
+    disable_device,
+    enable_device,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.device_registry import DeviceRegistry
+
+    from tests.common import MockUser
+
+
+@pytest.fixture
+def device_services(hass: HomeAssistant) -> None:
+    """Register the Spook device services."""
+    hass.config.components.add(DOMAIN)
+    enable_device.SpookService(hass).async_register()
+    disable_device.SpookService(hass).async_register()
+
+
+@pytest.fixture
+def config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a config entry for test devices."""
+    entry = MockConfigEntry(domain="test", title="Test")
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.mark.usefixtures("device_services")
+async def test_enable_device_service_enables_disabled_device(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test the enable device service enables a disabled device."""
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "target-device")},
+        disabled_by=DeviceEntryDisabler.USER,
+    )
+
+    assert device.disabled_by is DeviceEntryDisabler.USER
+
+    await hass.services.async_call(
+        DOMAIN,
+        "enable_device",
+        {"device_id": device.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert device_registry.async_get(device.id).disabled_by is None
+
+
+@pytest.mark.usefixtures("device_services")
+async def test_device_services_accept_multiple_devices(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test the device services accept multiple device IDs."""
+    devices = [
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={("test", "first-device")},
+        ),
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={("test", "second-device")},
+        ),
+    ]
+
+    await hass.services.async_call(
+        DOMAIN,
+        "disable_device",
+        {"device_id": [device.id for device in devices]},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert all(
+        device_registry.async_get(device.id).disabled_by is DeviceEntryDisabler.USER
+        for device in devices
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "enable_device",
+        {"device_id": [device.id for device in devices]},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert all(
+        device_registry.async_get(device.id).disabled_by is None for device in devices
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updates the `homeassistant.enable_device` service description to accept raw device IDs instead of using Home Assistant's device selector.

The Python service schema already accepts one or more string IDs, so the service behavior stays the same. This only changes the UI input shape for the service.

## Motivation and Context

Disabled devices are hidden from Home Assistant's device selector. That meant the service could enable a disabled device by ID, but the UI made it hard to select the disabled device in the first place.

Fixes #1273

## How has this been tested?

- `uv run pytest tests/ectoplasms/homeassistant/services/test_device.py -q`
- `uv run pytest tests/ectoplasms/homeassistant/services -q`
- `uv run ruff format --check tests/ectoplasms/homeassistant/services/test_device.py`
- `uv run ruff check --output-format=github tests/ectoplasms/homeassistant/services/test_device.py`
- `uv run --with pre-commit pre-commit run pylint --files tests/ectoplasms/homeassistant/services/test_device.py`
- Validated `homeassistant_enable_device.fields.device_id.selector` with Home Assistant's selector validator

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
