### PR TITLE
Ignore repair events without action

### DIFF
--- a/custom_components/spook/ectoplasms/repairs/event.py
+++ b/custom_components/spook/ectoplasms/repairs/event.py
@@ -51,17 +51,21 @@ class RepairsSpookEventEntity(RepairsSpookEntity, EventEntity):
     entity_description: RepairsSpookEventEntityDescription
     _attr_name = None
 
+    @callback
+    def _handle_repairs_issue_registry_updated_event(self, event: Event) -> None:
+        """Handle repairs issue registry updates."""
+        data = {**event.data}
+        if (event_type := data.pop("action", None)) is None:
+            return
+
+        self._trigger_event(event_type, data)
+        self.async_schedule_update_ha_state()
+
     async def async_added_to_hass(self) -> None:
         """Register for event updates."""
-
-        @callback
-        def _fire(event: Event) -> None:
-            """Update state."""
-            data = {**event.data}
-            event_type = data.pop("action")
-            self._trigger_event(event_type, data)
-            self.async_schedule_update_ha_state()
-
         self.async_on_remove(
-            self.hass.bus.async_listen(EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED, _fire),
+            self.hass.bus.async_listen(
+                EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED,
+                self._handle_repairs_issue_registry_updated_event,
+            ),
         )

--- a/tests/ectoplasms/repairs/__init__.py
+++ b/tests/ectoplasms/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook repairs ectoplasm."""

--- a/tests/ectoplasms/repairs/test_event.py
+++ b/tests/ectoplasms/repairs/test_event.py
@@ -1,0 +1,84 @@
+"""Tests for repairs event entity."""
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.core import Event
+
+from custom_components.spook.ectoplasms.repairs.event import (
+    RepairsSpookEventEntity,
+    RepairsSpookEventEntityDescription,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _create_entity() -> RepairsSpookEventEntity:
+    """Create a repairs event entity."""
+    return RepairsSpookEventEntity(
+        RepairsSpookEventEntityDescription(
+            key="event",
+            translation_key="repairs_event",
+            entity_id="event.repair",
+            event_types=["create", "remove", "update"],
+        ),
+    )
+
+
+def test_repairs_event_ignores_event_without_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test repairs events without an action are ignored."""
+    entity = _create_entity()
+    triggered = False
+    scheduled = False
+
+    def _trigger_event(*_: object) -> None:
+        nonlocal triggered
+        triggered = True
+
+    def _schedule_update() -> None:
+        nonlocal scheduled
+        scheduled = True
+
+    monkeypatch.setattr(entity, "_trigger_event", _trigger_event)
+    monkeypatch.setattr(entity, "async_schedule_update_ha_state", _schedule_update)
+
+    entity._handle_repairs_issue_registry_updated_event(  # noqa: SLF001
+        Event("repairs_issue_registry_updated", {"domain": "spook"})
+    )
+
+    assert not triggered
+    assert not scheduled
+
+
+def test_repairs_event_copies_event_data_before_popping_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test repairs event handling does not mutate the shared event data."""
+    entity = _create_entity()
+    calls: list[tuple[str, dict[str, str]]] = []
+    scheduled = False
+
+    def _trigger_event(event_type: str, data: dict[str, str]) -> None:
+        calls.append((event_type, data))
+
+    def _schedule_update() -> None:
+        nonlocal scheduled
+        scheduled = True
+
+    monkeypatch.setattr(entity, "_trigger_event", _trigger_event)
+    monkeypatch.setattr(entity, "async_schedule_update_ha_state", _schedule_update)
+    event = Event(
+        "repairs_issue_registry_updated",
+        {"action": "create", "domain": "spook"},
+    )
+
+    entity._handle_repairs_issue_registry_updated_event(event)  # noqa: SLF001
+
+    assert calls == [("create", {"domain": "spook"})]
+    assert scheduled
+    assert event.data == {"action": "create", "domain": "spook"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handle Home Assistant repair registry update events without assuming every event still contains an `action` field.

The repair event entity now copies the event payload, ignores events without an action, and only triggers the Spook event entity when there is a repair action to publish.

## Motivation and Context

Fixes #1245.

Another listener can mutate the shared repair registry event data before Spook handles it. When that happens, Spook tried to pop a missing `action` key and raised a `KeyError` from the event listener.

Ignoring events without an action keeps the listener defensive while preserving the existing behavior for normal `create`, `remove`, and `update` events.

## How has this been tested?

- `uv run pytest tests/ectoplasms/repairs/test_event.py -q`
- `uv run ruff format --check custom_components/spook/ectoplasms/repairs/event.py tests/ectoplasms/repairs`
- `uv run ruff check --output-format=github custom_components/spook/ectoplasms/repairs/event.py tests/ectoplasms/repairs`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/repairs/event.py tests/ectoplasms/repairs/test_event.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
