### PR TITLE
Recheck automation services when components load

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components import automation
 from homeassistant.const import (
+    EVENT_COMPONENT_LOADED,
     EVENT_SERVICE_REGISTERED,
     EVENT_SERVICE_REMOVED,
 )
@@ -28,6 +29,7 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     repair = "automation_unknown_service_references"
     inspect_events = {
         automation.EVENT_AUTOMATION_RELOADED,
+        EVENT_COMPONENT_LOADED,
         EVENT_SERVICE_REGISTERED,
         EVENT_SERVICE_REMOVED,
     }

--- a/tests/ectoplasms/automation/repairs/test_unknown_service_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_service_references.py
@@ -1,0 +1,14 @@
+"""Tests for automation unknown service reference repairs."""
+
+from __future__ import annotations
+
+from homeassistant.const import EVENT_COMPONENT_LOADED
+
+from custom_components.spook.ectoplasms.automation.repairs.unknown_service_references import (
+    SpookRepair,
+)
+
+
+def test_automation_unknown_service_repair_inspects_when_components_load() -> None:
+    """Test automation service references are rechecked when components load."""
+    assert EVENT_COMPONENT_LOADED in SpookRepair.inspect_events


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Recheck automation service references when Home Assistant components finish loading.

The automation unknown-service repair already listened for service registration changes, service removals, automation reloads, and reload service calls. Scripts also listened for component load events, but automations did not. This adds the same component-loaded trigger to automations and adds regression coverage for it.

## Motivation and Context

Fixes #1297.

Some integrations register services after Spook's first automation inspection during startup. When that happens, an automation can be reported as using an unknown action even though the service becomes available shortly after and the automation runs normally.

Rechecking after components load gives the repair another chance to clear stale startup findings for late-loaded services.

## How has this been tested?

- `uv run pytest tests/ectoplasms/automation/repairs/test_unknown_service_references.py -q`
- `uv run pytest tests/ectoplasms/automation/repairs -q`
- `uv run ruff format --check custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py tests/ectoplasms/automation/repairs/test_unknown_service_references.py`
- `uv run ruff check --output-format=github custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py tests/ectoplasms/automation/repairs/test_unknown_service_references.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py tests/ectoplasms/automation/repairs/test_unknown_service_references.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
