### PR TITLE
Collapse dependency release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,6 +27,7 @@ categories:
     labels:
       - "documentation"
   - title: "⬆️ Dependency updates"
+    collapse-after: 5
     labels:
       - "dependencies"
 


### PR DESCRIPTION
## Summary

Collapse the dependency update section in release drafts once it contains more than five entries.

This keeps normal releases readable while still preserving the full dependency list for the people who want to inspect it.

## Validation

- Parsed `.github/release-drafter.yml` with Python YAML loader and asserted `collapse-after: 5` for the dependency category
- `uv run --with yamllint yamllint .github/release-drafter.yml`
