### PR TITLE
Handle string native number values

### DIFF
--- a/custom_components/spook/ectoplasms/number/services/__init__.py
+++ b/custom_components/spook/ectoplasms/number/services/__init__.py
@@ -1,1 +1,19 @@
 """Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.exceptions import HomeAssistantError
+
+if TYPE_CHECKING:
+    from homeassistant.components.number import NumberEntity
+
+
+def native_value_as_float(entity: NumberEntity) -> float:
+    """Return the native value of a number entity as a float."""
+    try:
+        return float(entity.value)
+    except (TypeError, ValueError) as err:
+        msg = f"Native value {entity.value!r} for {entity.entity_id} is not a number"
+        raise HomeAssistantError(msg) from err

--- a/custom_components/spook/ectoplasms/number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/number/services/decrement.py
@@ -36,7 +36,7 @@ class SpookService(AbstractSpookEntityComponentService[NumberEntity]):
             )
             raise ValueError(msg)
 
-        value = entity.value - amount
+        value = float(entity.value) - amount
 
         if entity.min_value is not None:
             value = max(value, entity.min_value)

--- a/custom_components/spook/ectoplasms/number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/number/services/decrement.py
@@ -33,7 +33,7 @@ class SpookService(AbstractSpookEntityComponentService[NumberEntity]):
         if not math.isclose(amount % entity.step, 0, abs_tol=1e-9):
             msg = (
                 f"Amount {amount} not valid for {entity.entity_id}, "
-                f"it needs to be a multiple of {entity.step}",
+                f"it needs to be a multiple of {entity.step}"
             )
             raise ValueError(msg)
 

--- a/custom_components/spook/ectoplasms/number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/number/services/decrement.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from homeassistant.components.number import DOMAIN, NumberEntity
 
 from ....services import AbstractSpookEntityComponentService
+from . import native_value_as_float
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -36,7 +37,7 @@ class SpookService(AbstractSpookEntityComponentService[NumberEntity]):
             )
             raise ValueError(msg)
 
-        value = float(entity.value) - amount
+        value = native_value_as_float(entity) - amount
 
         if entity.min_value is not None:
             value = max(value, entity.min_value)

--- a/custom_components/spook/ectoplasms/number/services/increment.py
+++ b/custom_components/spook/ectoplasms/number/services/increment.py
@@ -36,7 +36,7 @@ class SpookService(AbstractSpookEntityComponentService[NumberEntity]):
             )
             raise ValueError(msg)
 
-        value = entity.value + amount
+        value = float(entity.value) + amount
 
         if entity.max_value is not None:
             value = min(value, entity.max_value)

--- a/custom_components/spook/ectoplasms/number/services/increment.py
+++ b/custom_components/spook/ectoplasms/number/services/increment.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from homeassistant.components.number import DOMAIN, NumberEntity
 
 from ....services import AbstractSpookEntityComponentService
+from . import native_value_as_float
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -36,7 +37,7 @@ class SpookService(AbstractSpookEntityComponentService[NumberEntity]):
             )
             raise ValueError(msg)
 
-        value = float(entity.value) + amount
+        value = native_value_as_float(entity) + amount
 
         if entity.max_value is not None:
             value = min(value, entity.max_value)

--- a/custom_components/spook/ectoplasms/number/services/increment.py
+++ b/custom_components/spook/ectoplasms/number/services/increment.py
@@ -33,7 +33,7 @@ class SpookService(AbstractSpookEntityComponentService[NumberEntity]):
         if not math.isclose(amount % entity.step, 0, abs_tol=1e-9):
             msg = (
                 f"Amount {amount} not valid for {entity.entity_id}, "
-                f"it needs to be a multiple of {entity.step}",
+                f"it needs to be a multiple of {entity.step}"
             )
             raise ValueError(msg)
 

--- a/tests/ectoplasms/number/__init__.py
+++ b/tests/ectoplasms/number/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook number ectoplasms."""

--- a/tests/ectoplasms/number/services/__init__.py
+++ b/tests/ectoplasms/number/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook number service ectoplasms."""

--- a/tests/ectoplasms/number/services/test_increment_decrement.py
+++ b/tests/ectoplasms/number/services/test_increment_decrement.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
+from re import escape
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.spook.ectoplasms.number.services import decrement, increment
 
@@ -48,3 +50,22 @@ async def test_number_services_handle_string_native_values(
     await service_cls(hass).async_handle_service(entity, call)
 
     assert entity.set_value == expected
+
+
+@pytest.mark.parametrize(
+    "service_cls",
+    [increment.SpookService, decrement.SpookService],
+)
+async def test_number_services_raise_context_for_invalid_native_values(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+) -> None:
+    """Test invalid native values raise an actionable error."""
+    entity = MockNumberEntity("unavailable")
+    call = SimpleNamespace(data={"amount": 0.5})
+
+    with pytest.raises(
+        HomeAssistantError,
+        match=escape("Native value 'unavailable' for number.test is not a number"),
+    ):
+        await service_cls(hass).async_handle_service(entity, call)

--- a/tests/ectoplasms/number/services/test_increment_decrement.py
+++ b/tests/ectoplasms/number/services/test_increment_decrement.py
@@ -56,6 +56,27 @@ async def test_number_services_handle_string_native_values(
     "service_cls",
     [increment.SpookService, decrement.SpookService],
 )
+async def test_number_services_raise_readable_error_for_invalid_amount(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+) -> None:
+    """Test invalid amounts raise a readable error."""
+    entity = MockNumberEntity(1.5)
+    call = SimpleNamespace(data={"amount": 0.2})
+
+    with pytest.raises(
+        ValueError,
+        match=escape(
+            "Amount 0.2 not valid for number.test, it needs to be a multiple of 0.5"
+        ),
+    ):
+        await service_cls(hass).async_handle_service(entity, call)
+
+
+@pytest.mark.parametrize(
+    "service_cls",
+    [increment.SpookService, decrement.SpookService],
+)
 async def test_number_services_raise_context_for_invalid_native_values(
     hass: Any,
     service_cls: type[increment.SpookService | decrement.SpookService],

--- a/tests/ectoplasms/number/services/test_increment_decrement.py
+++ b/tests/ectoplasms/number/services/test_increment_decrement.py
@@ -1,0 +1,50 @@
+"""Tests for the number increment and decrement services."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.spook.ectoplasms.number.services import decrement, increment
+
+
+class MockNumberEntity:  # pylint: disable=too-few-public-methods
+    """Mock number entity."""
+
+    entity_id = "number.test"
+    max_value = 10
+    min_value = 0
+    step = 0.5
+
+    def __init__(self, value: Any) -> None:
+        """Initialize the mock number entity."""
+        self.value = value
+        self.set_value: float | None = None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the native value."""
+        self.set_value = value
+
+
+@pytest.mark.parametrize(
+    ("service_cls", "start_value", "expected"),
+    [
+        (increment.SpookService, "1.5", 2.0),
+        (decrement.SpookService, "1.5", 1.0),
+    ],
+)
+async def test_number_services_handle_string_native_values(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+    start_value: str,
+    expected: float,
+) -> None:
+    """Test number services handle integrations exposing string native values."""
+    entity = MockNumberEntity(start_value)
+    call = SimpleNamespace(data={"amount": 0.5})
+
+    await service_cls(hass).async_handle_service(entity, call)
+
+    assert entity.set_value == expected


### PR DESCRIPTION
## Summary

Fixes #985 by converting number entity native values to `float` before applying increment/decrement amounts.

Some custom number entities expose their native value as a string. The current implementation tried to add/subtract a float amount directly, which raised a `TypeError` before the updated value could be sent back to the entity.

## Validation

- `uv run pytest tests/ectoplasms/number/services/test_increment_decrement.py -q`
- `uv run ruff format --check custom_components/spook/ectoplasms/number/services/increment.py custom_components/spook/ectoplasms/number/services/decrement.py tests/ectoplasms/number/services/test_increment_decrement.py tests/ectoplasms/number`
- `uv run ruff check --output-format=github custom_components/spook/ectoplasms/number/services/increment.py custom_components/spook/ectoplasms/number/services/decrement.py tests/ectoplasms/number/services/test_increment_decrement.py tests/ectoplasms/number`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/number/services/increment.py custom_components/spook/ectoplasms/number/services/decrement.py tests/ectoplasms/number/services/test_increment_decrement.py`
