### PR TITLE
Clarify hidden entity voice exposure

### DIFF
--- a/documentation/entities.md
+++ b/documentation/entities.md
@@ -142,7 +142,7 @@ data:
 This action allows you to hide an entity on the fly.
 
 It can be particularly useful when you have a lot of entities, and you want to hide some of them from the generated UI based programmatically.
-Hidden entities are also not exposed to external voice assistants, like Google Assistant or Alexa.
+Hidden entities are not exposed to external voice assistants, like Google Assistant or Alexa, by default. They can still be exposed explicitly in the voice assistant settings.
 
 ```{figure} ./images/entities/hide_entity.png
 :alt: Screenshot of the Home Assistant hide entity action in the developer tools.


### PR DESCRIPTION
## Summary

Fixes #818 by clarifying that hidden entities are not exposed to external voice assistants by default, but can still be explicitly exposed through the voice assistant settings.

## Validation

- `git diff --check`
