### PR TITLE
Handle script referenced entity extraction errors

### DIFF
--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -51,6 +51,14 @@ def extract_entities_from_trigger_config(config: dict[str, Any] | list) -> set[s
     return entities
 
 
+def extract_referenced_entities_from_script(entity: script.ScriptEntity) -> set[str]:
+    """Return entity references from a script entity."""
+    try:
+        return set(entity.script.referenced_entities)
+    except TypeError:
+        return set()
+
+
 async def extract_template_entities_from_script_entity(
     hass: HomeAssistant, entity: Any
 ) -> set[str]:
@@ -135,7 +143,7 @@ class SpookRepair(AbstractSpookRepair):
                 continue
 
             # Get all referenced entities from the script
-            all_entities = set(entity.script.referenced_entities)
+            all_entities = extract_referenced_entities_from_script(entity)
 
             # Check for blueprint trigger inputs
             blueprint_entities = self._get_blueprint_trigger_entities(entity)

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -55,7 +55,9 @@ def extract_referenced_entities_from_script(entity: script.ScriptEntity) -> set[
     """Return entity references from a script entity."""
     try:
         return set(entity.script.referenced_entities)
-    except TypeError:
+    except TypeError as err:
+        if str(err) != "unhashable type: 'dict'":
+            raise
         return set()
 
 

--- a/tests/ectoplasms/script/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/script/repairs/test_unknown_entity_references.py
@@ -116,10 +116,22 @@ class MockBrokenScript:  # pylint: disable=too-few-public-methods
         raise TypeError(msg)
 
 
+class MockUnexpectedBrokenScript:  # pylint: disable=too-few-public-methods
+    """Mock script object with an unrelated TypeError."""
+
+    @property
+    def referenced_entities(self) -> set[str]:
+        """Raise an unexpected TypeError."""
+        msg = "unexpected failure"
+        raise TypeError(msg)
+
+
 class MockScriptEntity:  # pylint: disable=too-few-public-methods
     """Mock script entity."""
 
-    def __init__(self, script: MockScript | MockBrokenScript) -> None:
+    def __init__(
+        self, script: MockScript | MockBrokenScript | MockUnexpectedBrokenScript
+    ) -> None:
         """Initialize the mock script entity."""
         self.script = script
 
@@ -136,3 +148,11 @@ def test_extract_referenced_entities_handles_home_assistant_type_error() -> None
     entity = MockScriptEntity(MockBrokenScript())
 
     assert extract_referenced_entities_from_script(entity) == set()
+
+
+def test_extract_referenced_entities_reraises_unexpected_type_error() -> None:
+    """Test unrelated TypeErrors are not swallowed."""
+    entity = MockScriptEntity(MockUnexpectedBrokenScript())
+
+    with pytest.raises(TypeError, match="unexpected failure"):
+        extract_referenced_entities_from_script(entity)

--- a/tests/ectoplasms/script/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/script/repairs/test_unknown_entity_references.py
@@ -8,6 +8,7 @@ import pytest
 
 from custom_components.spook.ectoplasms.script.repairs.unknown_entity_references import (
     extract_entities_from_trigger_config,
+    extract_referenced_entities_from_script,
 )
 
 
@@ -95,3 +96,43 @@ def test_trigger_blueprint_input_shape() -> None:
         "light.a",
         "light.b",
     }
+
+
+class MockScript:  # pylint: disable=too-few-public-methods
+    """Mock script object."""
+
+    def __init__(self, referenced_entities: set[str]) -> None:
+        """Initialize the mock script."""
+        self.referenced_entities = referenced_entities
+
+
+class MockBrokenScript:  # pylint: disable=too-few-public-methods
+    """Mock script object with broken referenced entity extraction."""
+
+    @property
+    def referenced_entities(self) -> set[str]:
+        """Raise the same error Home Assistant can raise for dict entity IDs."""
+        msg = "unhashable type: 'dict'"
+        raise TypeError(msg)
+
+
+class MockScriptEntity:  # pylint: disable=too-few-public-methods
+    """Mock script entity."""
+
+    def __init__(self, script: MockScript | MockBrokenScript) -> None:
+        """Initialize the mock script entity."""
+        self.script = script
+
+
+def test_extract_referenced_entities_from_script() -> None:
+    """Test script referenced entities are returned as a set."""
+    entity = MockScriptEntity(MockScript({"light.kitchen"}))
+
+    assert extract_referenced_entities_from_script(entity) == {"light.kitchen"}
+
+
+def test_extract_referenced_entities_handles_home_assistant_type_error() -> None:
+    """Test broken Home Assistant referenced entity extraction is ignored."""
+    entity = MockScriptEntity(MockBrokenScript())
+
+    assert extract_referenced_entities_from_script(entity) == set()


### PR DESCRIPTION
## Summary

Fixes #1012 by keeping the script unknown entity repair running when Home Assistant's `referenced_entities` extraction raises a `TypeError` for dict-shaped entity IDs.

Spook still collects the other script references it can inspect, but a single broken script shape no longer aborts the whole repair inspection.

## Validation

- `uv run pytest tests/ectoplasms/script/repairs/test_unknown_entity_references.py -q`
- `uv run ruff format --check custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py`
- `uv run ruff check --output-format=github custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py`
