### PR TITLE
Ignore entity ID prefixes in templates

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -430,7 +430,7 @@ def _is_string_method_argument_match(template_str: str, match: re.Match[str]) ->
         return False
 
     before_literal = before_entity[:-1].rstrip()
-    return bool(re.search(r"\.(?:starts|ends)with\s*\($", before_literal))
+    return bool(re.search(r"\.(?:starts|ends)with\s*\(\s*\(*\s*$", before_literal))
 
 
 def _entity_id_from_template_match(match: re.Match[str]) -> str:

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -418,6 +418,21 @@ def _is_concatenated_template_match(template_str: str, match: re.Match[str]) -> 
     return before_literal.endswith("~") or after_literal.startswith("~")
 
 
+def _is_string_method_argument_match(template_str: str, match: re.Match[str]) -> bool:
+    """Return if an entity-like literal is used as a string method argument."""
+    groups = match.groups()
+    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
+        return False
+
+    entity_start = match.span(1)[0]
+    before_entity = template_str[:entity_start].rstrip()
+    if not before_entity.endswith(("'", '"')):
+        return False
+
+    before_literal = before_entity[:-1].rstrip()
+    return bool(re.search(r"\.(?:starts|ends)with\s*\($", before_literal))
+
+
 def _entity_id_from_template_match(match: re.Match[str]) -> str:
     """Return the entity ID captured by a template regex match."""
     groups = match.groups()
@@ -446,7 +461,9 @@ def extract_entities_from_template_regex(
 
     for pattern in ENTITY_ID_TEMPLATE_PATTERNS:
         for match in re.finditer(pattern, template_str, re.IGNORECASE):
-            if _is_concatenated_template_match(template_str, match):
+            if _is_concatenated_template_match(
+                template_str, match
+            ) or _is_string_method_argument_match(template_str, match):
                 continue
 
             entity_id = _entity_id_from_template_match(match)

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -430,7 +430,19 @@ def _is_string_method_argument_match(template_str: str, match: re.Match[str]) ->
         return False
 
     before_literal = before_entity[:-1].rstrip()
-    return bool(re.search(r"\.(?:starts|ends)with\s*\(\s*\(*\s*$", before_literal))
+    for method in (".startswith", ".endswith"):
+        if method not in before_literal:
+            continue
+
+        after_method = before_literal.rsplit(method, maxsplit=1)[1].lstrip()
+        if not after_method.startswith("("):
+            continue
+
+        between_call_and_argument = after_method[1:].strip()
+        if not between_call_and_argument or set(between_call_and_argument) == {"("}:
+            return True
+
+    return False
 
 
 def _entity_id_from_template_match(match: re.Match[str]) -> str:

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -80,6 +80,24 @@ async def test_value_template_ignores_entity_id_prefix_string_match(
     assert await extract_entities_from_value(hass, template) == set()
 
 
+async def test_value_template_ignores_grouped_entity_id_prefix_string_match(
+    hass: HomeAssistant,
+) -> None:
+    """String prefix checks can use grouping without becoming references."""
+    template = "{{ entity.entity_id.startswith( ('binary_sensor.proxmox')) }}"
+
+    assert await extract_entities_from_value(hass, template) == set()
+
+
+async def test_value_template_ignores_entity_id_suffix_string_match(
+    hass: HomeAssistant,
+) -> None:
+    """String suffix checks are not complete entity references."""
+    template = "{{ entity.entity_id.endswith('sensor.power') }}"
+
+    assert await extract_entities_from_value(hass, template) == set()
+
+
 async def test_value_template_ignores_concatenated_helper_entity_id(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -66,6 +66,20 @@ async def test_value_template_ignores_concatenated_entity_id_literal(
     assert await extract_entities_from_value(hass, template) == set()
 
 
+async def test_value_template_ignores_entity_id_prefix_string_match(
+    hass: HomeAssistant,
+) -> None:
+    """String prefix checks are not complete entity references."""
+    template = (
+        "{% for entity in states.binary_sensor if "
+        "entity.entity_id.startswith('binary_sensor.proxmox') %}"
+        "{{ entity.state }}"
+        "{% endfor %}"
+    )
+
+    assert await extract_entities_from_value(hass, template) == set()
+
+
 async def test_value_template_ignores_concatenated_helper_entity_id(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #1090 by ignoring entity-like strings that are used as string-prefix or string-suffix checks in Jinja templates.

A template such as `entity.entity_id.startswith('binary_sensor.proxmox')` uses `binary_sensor.proxmox` as a prefix, not as a concrete entity ID. Spook now keeps that out of the unknown entity repair while still detecting actual entity references.

## Validation

- `uv run pytest tests/ectoplasms/automation/repairs/test_unknown_entity_references.py -q`
- `uv run ruff format --check custom_components/spook/entity_filtering.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `uv run ruff check --output-format=github custom_components/spook/entity_filtering.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/entity_filtering.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
