### PR TITLE
Allow templates for zone coordinates

### DIFF
--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -1245,26 +1245,16 @@ zone_create:
           placeholder: mdi:map-marker
     latitude:
       name: Latitude
-      description: Latitude of the zone
+      description: Latitude of the zone. This can be a template.
       required: true
       selector:
-        number:
-          min: -90
-          max: 90
-          step: any
-          mode: box
-          unit_of_measurement: °
+        template:
     longitude:
       name: Longitude
-      description: Longitude of the zone
+      description: Longitude of the zone. This can be a template.
       required: true
       selector:
-        number:
-          min: -180
-          max: 180
-          step: any
-          mode: box
-          unit_of_measurement: °
+        template:
     radius:
       name: Radius
       description: Radius of the zone
@@ -1305,26 +1295,16 @@ zone_update:
           placeholder: mdi:map-marker
     latitude:
       name: Latitude
-      description: Latitude of the zone
+      description: Latitude of the zone. This can be a template.
       required: false
       selector:
-        number:
-          min: -90
-          max: 90
-          step: any
-          mode: box
-          unit_of_measurement: °
+        template:
     longitude:
       name: Longitude
-      description: Longitude of the zone
+      description: Longitude of the zone. This can be a template.
       required: false
       selector:
-        number:
-          min: -180
-          max: 180
-          step: any
-          mode: box
-          unit_of_measurement: °
+        template:
     radius:
       name: Radius
       description: Radius of the zone


### PR DESCRIPTION
## Summary

Fixes #1008 by switching the `zone.create` and `zone.update` latitude/longitude fields from number selectors to template selectors.

The service schema already coerces the rendered values to floats. This change makes the action UI stop forcing static numbers, so coordinates can come from templates or another entity's attributes.

## Validation

- Parsed `custom_components/spook/services.yaml` and asserted the zone coordinate selectors are `template`
- Validated those selectors with Home Assistant's selector schema
- `git diff --check`
