### PR TITLE
Skip disabled service sequence steps

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -632,6 +632,9 @@ def async_find_services_in_sequence(  # noqa: C901
     """Find all services called in a sequence."""
     called_services: set[str] = set()
     for step in sequence:
+        if not step.get(CONF_ENABLED, True):
+            continue
+
         action = cv.determine_script_action(step)
 
         if (

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -632,23 +632,15 @@ def async_find_services_in_sequence(  # noqa: C901
     """Find all services called in a sequence."""
     called_services: set[str] = set()
     for step in sequence:
-        if not step.get(CONF_ENABLED, True):
+        if step.get(CONF_ENABLED) is False:
             continue
 
         action = cv.determine_script_action(step)
 
-        if (
-            action == cv.SCRIPT_ACTION_CALL_SERVICE
-            and CONF_SERVICE in step
-            and step.get(CONF_ENABLED, True)
-        ):
+        if action == cv.SCRIPT_ACTION_CALL_SERVICE and CONF_SERVICE in step:
             called_services.add(step[CONF_SERVICE])
 
-        if (
-            action == cv.SCRIPT_ACTION_CALL_SERVICE
-            and "action" in step
-            and step.get(CONF_ENABLED, True)
-        ):
+        if action == cv.SCRIPT_ACTION_CALL_SERVICE and "action" in step:
             called_services.add(step["action"])
 
         if action == cv.SCRIPT_ACTION_CHOOSE:

--- a/tests/test_entity_filtering.py
+++ b/tests/test_entity_filtering.py
@@ -9,11 +9,42 @@ def test_find_services_skips_disabled_nested_steps() -> None:
     """Test disabled sequence branches do not report services."""
     sequence = [
         {
-            "if": "{{ true }}",
-            "then": [{"action": "notify.missing_service"}],
+            "if": [{"condition": "template", "value_template": "{{ true }}"}],
+            "then": [{"action": "notify.disabled_if_service"}],
+            "enabled": False,
+        },
+        {
+            "choose": [
+                {
+                    "conditions": [
+                        {"condition": "template", "value_template": "{{ true }}"}
+                    ],
+                    "sequence": [{"action": "notify.disabled_choose_service"}],
+                }
+            ],
+            "enabled": False,
+        },
+        {
+            "parallel": [
+                {"sequence": [{"action": "notify.disabled_parallel_service"}]}
+            ],
+            "enabled": False,
+        },
+        {
+            "repeat": {
+                "count": 1,
+                "sequence": [{"action": "notify.disabled_repeat_service"}],
+            },
             "enabled": False,
         },
         {"action": "light.turn_on"},
     ]
+
+    assert async_find_services_in_sequence(sequence) == {"light.turn_on"}
+
+
+def test_find_services_keeps_enabled_none_steps() -> None:
+    """Test only explicitly disabled steps are skipped."""
+    sequence = [{"action": "light.turn_on", "enabled": None}]
 
     assert async_find_services_in_sequence(sequence) == {"light.turn_on"}

--- a/tests/test_entity_filtering.py
+++ b/tests/test_entity_filtering.py
@@ -1,0 +1,19 @@
+"""Tests for entity filtering helpers."""
+
+from __future__ import annotations
+
+from custom_components.spook.entity_filtering import async_find_services_in_sequence
+
+
+def test_find_services_skips_disabled_nested_steps() -> None:
+    """Test disabled sequence branches do not report services."""
+    sequence = [
+        {
+            "if": "{{ true }}",
+            "then": [{"action": "notify.missing_service"}],
+            "enabled": False,
+        },
+        {"action": "light.turn_on"},
+    ]
+
+    assert async_find_services_in_sequence(sequence) == {"light.turn_on"}


### PR DESCRIPTION
## Summary

Skip disabled script sequence steps when extracting service calls for the unknown service repairs.

Spook already ignored disabled direct service calls, but nested disabled branches, such as disabled `if`, `choose`, `parallel`, or `repeat` steps, were still walked and could report services that Home Assistant would not execute.

## Validation

- `uv run pytest tests/test_entity_filtering.py -q`
- `uv run ruff format --check custom_components/spook/entity_filtering.py tests/test_entity_filtering.py`
- `uv run ruff check --output-format=github custom_components/spook/entity_filtering.py tests/test_entity_filtering.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/entity_filtering.py tests/test_entity_filtering.py`
