### PR TITLE
Ignore event payloads in automation repair checks

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any
 
 from homeassistant.components import automation
 from homeassistant.helpers import device_registry as dr
@@ -10,8 +10,38 @@ from homeassistant.helpers import device_registry as dr
 from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
-if TYPE_CHECKING:
-    from typing import Any
+
+def extract_event_data_device_ids_from_trigger_config(
+    config: dict[str, Any] | list,
+) -> set[str]:
+    """Extract device IDs from event trigger data."""
+    device_ids = set()
+
+    if not config:
+        return device_ids
+
+    if isinstance(config, list):
+        for item in config:
+            device_ids.update(extract_event_data_device_ids_from_trigger_config(item))
+        return device_ids
+
+    if not isinstance(config, dict):
+        return device_ids
+
+    if config.get("platform", config.get("trigger")) == "event" and isinstance(
+        event_data := config.get("event_data"), dict
+    ):
+        value = event_data.get("device_id")
+        if isinstance(value, str):
+            device_ids.add(value)
+        elif isinstance(value, list):
+            device_ids.update(item for item in value if isinstance(item, str))
+
+    for value in config.values():
+        if isinstance(value, (dict, list)):
+            device_ids.update(extract_event_data_device_ids_from_trigger_config(value))
+
+    return device_ids
 
 
 class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
@@ -39,8 +69,17 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown device IDs referenced by ``entity``."""
+        device_ids = set(entity.referenced_devices)
+
+        if hasattr(entity, "raw_config") and entity.raw_config:
+            device_ids.difference_update(
+                extract_event_data_device_ids_from_trigger_config(
+                    entity.raw_config.get("trigger")
+                )
+            )
+
         return async_filter_known_device_ids(
             self.hass,
-            device_ids=entity.referenced_devices,
+            device_ids=device_ids,
             known_device_ids=self._known_device_ids,
         )

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -107,6 +107,34 @@ async def extract_entities_from_trigger_config(
     return entities
 
 
+def extract_event_types_from_trigger_config(config: dict[str, Any] | list) -> set[str]:
+    """Extract event types from trigger configuration."""
+    event_types = set()
+
+    if not config:
+        return event_types
+
+    if isinstance(config, list):
+        for item in config:
+            event_types.update(extract_event_types_from_trigger_config(item))
+        return event_types
+
+    if not isinstance(config, dict):
+        return event_types
+
+    value = config.get("event_type")
+    if isinstance(value, str):
+        event_types.add(value)
+    elif isinstance(value, list):
+        event_types.update(item for item in value if isinstance(item, str))
+
+    for value in config.values():
+        if isinstance(value, (dict, list)):
+            event_types.update(extract_event_types_from_trigger_config(value))
+
+    return event_types
+
+
 async def extract_entities_from_condition_config(
     hass: HomeAssistant, config: dict[str, Any] | list
 ) -> set[str]:
@@ -313,6 +341,11 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
             all_entities.update(
                 await extract_entities_from_automation_config(
                     self.hass, entity.raw_config
+                )
+            )
+            all_entities.difference_update(
+                extract_event_types_from_trigger_config(
+                    entity.raw_config.get("trigger")
                 )
             )
 

--- a/tests/ectoplasms/automation/repairs/test_unknown_device_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_device_references.py
@@ -1,0 +1,50 @@
+"""Tests for automation unknown device reference repairs."""
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,too-few-public-methods
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.spook.ectoplasms.automation.repairs.unknown_device_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from homeassistant.core import HomeAssistant
+
+
+class MockAutomationEntity:
+    """Mock automation entity."""
+
+    def __init__(
+        self,
+        *,
+        raw_config: dict[str, object],
+        referenced_devices: Iterable[str],
+    ) -> None:
+        """Initialize the mock automation entity."""
+        self.raw_config = raw_config
+        self.referenced_devices = set(referenced_devices)
+
+
+async def test_event_trigger_data_device_id_is_not_reported_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """Event trigger ``event_data.device_id`` values are not device references."""
+    entity = MockAutomationEntity(
+        raw_config={
+            "trigger": {
+                "trigger": "event",
+                "event_type": "hcu_integration_event",
+                "event_data": {"device_id": "3014F711A0001F20C98F2F47"},
+            },
+        },
+        referenced_devices={"3014F711A0001F20C98F2F47"},
+    )
+    repair = SpookRepair(hass)
+    repair._known_device_ids = set()
+
+    assert await repair._async_compute_unknown_references(entity) == set()

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -7,12 +7,14 @@ so the upcoming consolidation into a single recursive walker cannot regress them
 silently.
 """
 
-# pylint: disable=wrong-import-order
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,too-few-public-methods,wrong-import-order
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
+    SpookRepair,
     extract_entities_from_action_config,
     extract_entities_from_automation_config,
     extract_entities_from_condition_config,
@@ -22,7 +24,23 @@ from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_refere
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from homeassistant.core import HomeAssistant
+
+
+class MockAutomationEntity:
+    """Mock automation entity."""
+
+    def __init__(
+        self,
+        *,
+        raw_config: dict[str, object],
+        referenced_entities: Iterable[str],
+    ) -> None:
+        """Initialize the mock automation entity."""
+        self.raw_config = raw_config
+        self.referenced_entities = set(referenced_entities)
 
 
 async def test_value_plain_entity_id(hass: HomeAssistant) -> None:
@@ -178,6 +196,38 @@ async def test_trigger_state_entity_id(hass: HomeAssistant) -> None:
     assert await extract_entities_from_trigger_config(hass, config) == {
         "binary_sensor.door"
     }
+
+
+async def test_trigger_event_type_is_not_an_entity_id(
+    hass: HomeAssistant,
+) -> None:
+    """Event trigger ``event_type`` values are not entity references."""
+    config = {
+        "platform": "event",
+        "event_type": "timer.finished",
+        "event_data": {"entity_id": "timer.hot_tub"},
+    }
+    assert await extract_entities_from_trigger_config(hass, config) == {"timer.hot_tub"}
+
+
+async def test_event_trigger_type_reference_is_not_reported_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """Event trigger ``event_type`` references are not unknown entities."""
+    entity = MockAutomationEntity(
+        raw_config={
+            "trigger": {
+                "platform": "event",
+                "event_type": "timer.finished",
+                "event_data": {"entity_id": "timer.hot_tub"},
+            },
+        },
+        referenced_entities={"timer.finished", "timer.hot_tub"},
+    )
+    repair = SpookRepair(hass)
+    repair._known_entity_ids = {"timer.hot_tub"}
+
+    assert await repair._async_compute_unknown_references(entity) == set()
 
 
 async def test_trigger_zone_field(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spook now ignores event-trigger payload metadata when checking automation references.

This keeps `event_type` values like `timer.finished` out of the unknown entity repair, while still checking real entities from `event_data.entity_id`.

It also ignores `event_data.device_id` values for event triggers in the unknown device repair, since those values are event payload data and not Home Assistant device registry references.

## Motivation and Context

Event trigger payloads can contain strings that look like Home Assistant references, but are not references owned by the automation.

Fixes #1213.
Refs #1081.

## How has this been tested?

- `uv run pytest tests/ectoplasms/automation/repairs -q`
- `uv run pytest tests/ectoplasms/automation/repairs tests/test_translations.py -q`
- `uv run ruff format --check .`
- `uv run ruff check --output-format=github .`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_device_references.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
