### PR TITLE
Purge orphaned database entities

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/delete_all_orphaned_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/delete_all_orphaned_entities.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components.homeassistant import DOMAIN
-from homeassistant.const import ATTR_RESTORED
+from homeassistant.components.recorder import DOMAIN as RECORDER_DOMAIN
+from homeassistant.components.recorder.services import (
+    ATTR_KEEP_DAYS,
+    SERVICE_PURGE_ENTITIES,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_RESTORED
 from homeassistant.helpers import entity_registry as er
 
 from ....services import AbstractSpookAdminService
+from .list_orphaned_database_entities import async_get_orphaned_database_entities
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -22,6 +28,21 @@ class SpookService(AbstractSpookAdminService):
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
+        orphaned_database_entities = await async_get_orphaned_database_entities(
+            self.hass
+        )
+        if orphaned_database_entities:
+            await self.hass.services.async_call(
+                RECORDER_DOMAIN,
+                SERVICE_PURGE_ENTITIES,
+                {
+                    ATTR_ENTITY_ID: sorted(orphaned_database_entities),
+                    ATTR_KEEP_DAYS: 0,
+                },
+                blocking=True,
+                context=call.context,
+            )
+
         entity_registry = er.async_get(self.hass)
         for state in self.hass.states.async_all():
             if not state.attributes.get(ATTR_RESTORED):

--- a/custom_components/spook/ectoplasms/homeassistant/services/list_orphaned_database_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/list_orphaned_database_entities.py
@@ -7,15 +7,42 @@ from typing import TYPE_CHECKING
 from sqlalchemy import create_engine, text
 
 from homeassistant.components.homeassistant import DOMAIN
-from homeassistant.components.recorder import (
-    get_instance,
-)
+from homeassistant.components.recorder import get_instance
 from homeassistant.core import ServiceResponse, SupportsResponse
 
 from ....services import AbstractSpookService
 
 if TYPE_CHECKING:
-    from homeassistant.core import ServiceCall
+    from collections.abc import Iterable
+
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+
+def _list_database_entity_ids(db_url: str) -> list[str]:
+    """List entity IDs stored in the recorder database."""
+    query = text(
+        """
+        SELECT DISTINCT(entity_id) FROM states_meta
+        """
+    )
+    engine = create_engine(db_url)
+    try:
+        with engine.connect() as conn:
+            response = conn.execute(query)
+            return [entity_id for (entity_id,) in response]
+    finally:
+        engine.dispose()
+
+
+async def async_get_orphaned_database_entities(
+    hass: HomeAssistant,
+) -> set[str]:
+    """Return recorder entity IDs that are not in the state machine."""
+    db_url = get_instance(hass).db_url
+    db_list: Iterable[str] = await hass.async_add_executor_job(
+        _list_database_entity_ids, db_url
+    )
+    return set(db_list).difference(hass.states.async_entity_ids())
 
 
 class SpookService(AbstractSpookService):
@@ -27,21 +54,10 @@ class SpookService(AbstractSpookService):
 
     async def async_handle_service(self, call: ServiceCall) -> ServiceResponse:
         """Handle the service call."""
-        query = text(
-            """
-            SELECT DISTINCT(entity_id) FROM states_meta
-            """
-        )
-        db_url = get_instance(self.hass).db_url
-        engine = create_engine(db_url)
-        with engine.connect() as conn:
-            response = conn.execute(query)
-            db_list = [e[0] for e in response]
-        states_list = self.hass.states.async_entity_ids()
-        compared_list = set(db_list).difference(states_list)
+        entities = await async_get_orphaned_database_entities(self.hass)
         if call.return_response:
             return {
-                "count": len(compared_list),
-                "entities": list(compared_list),
+                "count": len(entities),
+                "entities": sorted(entities),
             }
         return None

--- a/tests/ectoplasms/homeassistant/services/test_orphaned_entities.py
+++ b/tests/ectoplasms/homeassistant/services/test_orphaned_entities.py
@@ -1,0 +1,146 @@
+"""Tests for Home Assistant orphaned entity services."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.components.recorder import DOMAIN as RECORDER_DOMAIN
+from homeassistant.components.recorder.services import (
+    ATTR_KEEP_DAYS,
+    SERVICE_PURGE_ENTITIES,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_RESTORED
+from homeassistant.core import Context, ServiceCall
+from homeassistant.helpers import entity_registry as er
+import pytest
+
+from custom_components.spook.ectoplasms.homeassistant.services import (
+    delete_all_orphaned_entities,
+    list_orphaned_database_entities,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+    from homeassistant.core import HomeAssistant
+
+
+async def test_delete_all_orphaned_entities_purges_database_entities(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test database orphaned entities are passed to recorder purge."""
+    calls: list[ServiceCall] = []
+    context = Context()
+
+    async def async_get_orphaned_database_entities(_: HomeAssistant) -> set[str]:
+        """Return orphaned recorder entities."""
+        return {"sensor.orphaned_a", "sensor.orphaned_b"}
+
+    async def async_handle_purge_entities(call: ServiceCall) -> None:
+        """Capture recorder purge service calls."""
+        calls.append(call)
+
+    monkeypatch.setattr(
+        delete_all_orphaned_entities,
+        "async_get_orphaned_database_entities",
+        async_get_orphaned_database_entities,
+    )
+    hass.services.async_register(
+        RECORDER_DOMAIN,
+        SERVICE_PURGE_ENTITIES,
+        async_handle_purge_entities,
+    )
+
+    await delete_all_orphaned_entities.SpookService(hass).async_handle_service(
+        ServiceCall(
+            hass,
+            DOMAIN,
+            "delete_all_orphaned_entities",
+            {},
+            context=context,
+        )
+    )
+
+    assert len(calls) == 1
+    assert calls[0].context is context
+    assert calls[0].data[ATTR_KEEP_DAYS] == 0
+    assert calls[0].data[ATTR_ENTITY_ID] == ["sensor.orphaned_a", "sensor.orphaned_b"]
+
+
+async def test_get_orphaned_database_entities_uses_executor(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test orphaned database entities are fetched outside the event loop."""
+    calls = []
+
+    def list_database_entity_ids(db_url: str) -> list[str]:
+        """List entity IDs stored in the recorder database."""
+        calls.append(db_url)
+        return ["sensor.active", "sensor.orphaned"]
+
+    async def async_add_executor_job(func: Callable[..., Any], *args: Any) -> Any:
+        """Run executor jobs inline for the test."""
+        return func(*args)
+
+    monkeypatch.setattr(
+        list_orphaned_database_entities,
+        "_list_database_entity_ids",
+        list_database_entity_ids,
+    )
+    monkeypatch.setattr(hass, "async_add_executor_job", async_add_executor_job)
+    hass.data.setdefault(
+        "recorder_instance", type("Recorder", (), {"db_url": "sqlite://"})()
+    )
+    hass.states.async_set("sensor.active", "on")
+
+    assert await list_orphaned_database_entities.async_get_orphaned_database_entities(
+        hass
+    ) == {"sensor.orphaned"}
+    assert calls == ["sqlite://"]
+
+
+async def test_delete_all_orphaned_entities_removes_restored_states(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test restored state entities are still removed locally."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "restored",
+        suggested_object_id="restored",
+    )
+    hass.states.async_set("sensor.restored", "unavailable", {ATTR_RESTORED: True})
+    hass.states.async_set("sensor.active", "on")
+
+    async def async_get_orphaned_database_entities(_: HomeAssistant) -> set[str]:
+        """Return no orphaned recorder entities."""
+        return set()
+
+    async def async_fail_purge_entities(_: ServiceCall) -> None:
+        """Fail if recorder purge is called without orphaned entities."""
+        pytest.fail("recorder.purge_entities should not be called")
+
+    monkeypatch.setattr(
+        delete_all_orphaned_entities,
+        "async_get_orphaned_database_entities",
+        async_get_orphaned_database_entities,
+    )
+    hass.services.async_register(
+        RECORDER_DOMAIN,
+        SERVICE_PURGE_ENTITIES,
+        async_fail_purge_entities,
+    )
+
+    await delete_all_orphaned_entities.SpookService(hass).async_handle_service(
+        ServiceCall(hass, DOMAIN, "delete_all_orphaned_entities", {})
+    )
+
+    assert hass.states.get("sensor.restored") is None
+    assert hass.states.get("sensor.active") is not None
+    assert entity_registry.async_get("sensor.restored") is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `homeassistant.delete_all_orphaned_entities` action now purges orphaned recorder database entities using Home Assistant's `recorder.purge_entities` service.

The action still removes restored entities from the entity registry and state machine, so the existing cleanup behavior remains in place.

The matching list action now reads recorder metadata through an executor job instead of doing the SQLAlchemy query in the service handler directly.

## Motivation and Context

The list action reports entity IDs that exist in recorder's `states_meta` table but no longer exist in the state machine. The delete action was not deleting those rows. It only removed restored state entities, which is a different cleanup path.

That made the action appear successful while `homeassistant.list_orphaned_database_entities` could still return the same entries afterward.

Fixes #1136.

## How has this been tested?

- `uv run pytest tests/ectoplasms/homeassistant/services/test_orphaned_entities.py -q`
- `uv run pytest tests/ectoplasms/homeassistant/services -q`
- `uv run ruff format --check .`
- `uv run ruff check --output-format=github .`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/homeassistant/services/delete_all_orphaned_entities.py custom_components/spook/ectoplasms/homeassistant/services/list_orphaned_database_entities.py tests/ectoplasms/homeassistant/services/test_orphaned_entities.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
