### PR TITLE
Offer to enable existing Spook entry

### DIFF
--- a/custom_components/spook/config_flow.py
+++ b/custom_components/spook/config_flow.py
@@ -71,6 +71,7 @@ class UptimeConfigFlow(ConfigFlow, domain=DOMAIN):
         _: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Enable the existing disabled Spook config entry."""
+        self._disabled_entry = self._async_get_user_disabled_entry()
         if self._disabled_entry is None:
             return self.async_abort(reason="already_spooked")
 

--- a/custom_components/spook/config_flow.py
+++ b/custom_components/spook/config_flow.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigEntryDisabler,
+    ConfigFlow,
+    ConfigFlowResult,
+)
 
 from .const import DOMAIN
 
@@ -17,19 +22,28 @@ class UptimeConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     _disabled_entry: ConfigEntry | None = None
 
+    def _async_get_user_disabled_entry(self) -> ConfigEntry | None:
+        """Return an existing user-disabled Spook config entry."""
+        for entry in self._async_current_entries():
+            if entry.disabled_by is ConfigEntryDisabler.USER:
+                return entry
+        return None
+
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Handle a flow initialized someone that didn't read the warnings."""
+        """Handle a flow initialized by someone that didn't read the warnings."""
         if current_entries := self._async_current_entries():
-            for entry in current_entries:
-                if entry.disabled_by:
-                    self._disabled_entry = entry
-                    return self.async_show_menu(
-                        step_id="already_configured",
-                        menu_options=["enable_existing"],
-                    )
+            if any(entry.disabled_by is None for entry in current_entries):
+                return self.async_abort(reason="already_spooked")
+
+            self._disabled_entry = self._async_get_user_disabled_entry()
+            if self._disabled_entry is not None:
+                return self.async_show_menu(
+                    step_id="already_configured",
+                    menu_options=["enable_existing"],
+                )
 
             return self.async_abort(reason="already_spooked")
 
@@ -43,6 +57,10 @@ class UptimeConfigFlow(ConfigFlow, domain=DOMAIN):
         _: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Handle an already configured disabled Spook entry."""
+        self._disabled_entry = self._async_get_user_disabled_entry()
+        if self._disabled_entry is None:
+            return self.async_abort(reason="already_spooked")
+
         return self.async_show_menu(
             step_id="already_configured",
             menu_options=["enable_existing"],
@@ -58,7 +76,7 @@ class UptimeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if await self.hass.config_entries.async_set_disabled_by(
             self._disabled_entry.entry_id,
-            None,
+            disabled_by=None,
         ):
             return self.async_abort(reason="enabled_existing")
 

--- a/custom_components/spook/config_flow.py
+++ b/custom_components/spook/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
 
 from .const import DOMAIN
 
@@ -15,19 +15,54 @@ class UptimeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Spook."""
 
     VERSION = 1
+    _disabled_entry: ConfigEntry | None = None
 
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Handle a flow initialized someone that didn't read the warnings."""
-        if self._async_current_entries():
+        if current_entries := self._async_current_entries():
+            for entry in current_entries:
+                if entry.disabled_by:
+                    self._disabled_entry = entry
+                    return self.async_show_menu(
+                        step_id="already_configured",
+                        menu_options=["enable_existing"],
+                    )
+
             return self.async_abort(reason="already_spooked")
 
         if user_input is not None:
             return await self.async_step_choice_restart()
 
         return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+
+    async def async_step_already_configured(
+        self,
+        _: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle an already configured disabled Spook entry."""
+        return self.async_show_menu(
+            step_id="already_configured",
+            menu_options=["enable_existing"],
+        )
+
+    async def async_step_enable_existing(
+        self,
+        _: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Enable the existing disabled Spook config entry."""
+        if self._disabled_entry is None:
+            return self.async_abort(reason="already_spooked")
+
+        if await self.hass.config_entries.async_set_disabled_by(
+            self._disabled_entry.entry_id,
+            None,
+        ):
+            return self.async_abort(reason="enabled_existing")
+
+        return self.async_abort(reason="enable_failed")
 
     async def async_step_choice_restart(
         self,

--- a/custom_components/spook/translations/en-GB.json
+++ b/custom_components/spook/translations/en-GB.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "abort": {
-      "already_spooked": "Right... well... no. Cheers, ta-ra!"
+      "already_spooked": "Spook is already configured."
     },
     "step": {
       "user": {

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1,7 +1,9 @@
 {
   "config": {
     "abort": {
-      "already_spooked": "Yeah... well... no. K, thx, bye!"
+      "already_spooked": "Spook is already configured.",
+      "enabled_existing": "The existing Spook entry has been enabled.",
+      "enable_failed": "The existing Spook entry could not be enabled."
     },
     "step": {
       "user": {
@@ -12,6 +14,12 @@
         "menu_options": {
           "restart_now": "Restart now",
           "restart_later": "Restart later"
+        }
+      },
+      "already_configured": {
+        "description": "Spook is already configured, but the existing entry is disabled. Do you want to enable it?",
+        "menu_options": {
+          "enable_existing": "Enable existing entry"
         }
       }
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -125,4 +125,58 @@ async def test_config_flow_can_enable_existing_disabled_entry(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "enabled_existing"
-    async_set_disabled_by.assert_awaited_once_with(entry.entry_id, None)
+    async_set_disabled_by.assert_awaited_once_with(entry.entry_id, disabled_by=None)
+
+
+async def test_config_flow_enable_existing_disabled_entry_can_fail(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the config flow aborts when enabling an existing entry fails."""
+    entry = MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER,
+        domain=DOMAIN,
+        title="Your homie",
+        data={},
+    )
+    entry.add_to_hass(hass)
+    async_set_disabled_by = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        hass.config_entries,
+        "async_set_disabled_by",
+        async_set_disabled_by,
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "enable_existing"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "enable_failed"
+    async_set_disabled_by.assert_awaited_once_with(entry.entry_id, disabled_by=None)
+
+
+async def test_config_flow_aborts_when_enabled_and_disabled_entries_exist(
+    hass: HomeAssistant,
+) -> None:
+    """Test enabled entries take precedence over disabled ones."""
+    MockConfigEntry(domain=DOMAIN, title="Your homie", data={}).add_to_hass(hass)
+    MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER,
+        domain=DOMAIN,
+        title="Your homie",
+        data={},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_spooked"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -87,3 +88,41 @@ async def test_config_flow_aborts_when_spook_is_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_spooked"
+
+
+async def test_config_flow_can_enable_existing_disabled_entry(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the config flow can enable an existing disabled Spook entry."""
+    entry = MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER,
+        domain=DOMAIN,
+        title="Your homie",
+        data={},
+    )
+    entry.add_to_hass(hass)
+    async_set_disabled_by = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        hass.config_entries,
+        "async_set_disabled_by",
+        async_set_disabled_by,
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "already_configured"
+    assert result["menu_options"] == ["enable_existing"]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "enable_existing"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "enabled_existing"
+    async_set_disabled_by.assert_awaited_once_with(entry.entry_id, None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The setup flow now handles the "Spook already exists, but it is disabled" case directly.

When a disabled Spook config entry already exists, the flow offers an "Enable existing entry" option and uses Home Assistant's config entry manager to enable that entry. If Spook is already configured and enabled, the flow still aborts as before.

Fixes #946

## Motivation and Context

#946 has multiple reports where users hit the already-configured abort but could not see Spook because the existing entry was disabled. Pointing them at disabled integrations is better than the old message, but still makes them search for something the flow can already identify.

This keeps the single-entry behavior and removes that dead end from the setup flow.

## How Has This Been Tested?

- [x] `uv run pytest tests/test_config_flow.py tests/test_translations.py -q`
- [x] `uv run ruff check --fix custom_components/spook/config_flow.py tests/test_config_flow.py`
- [x] `uv run ruff format custom_components/spook/config_flow.py tests/test_config_flow.py`
- [x] Strict JSON parse of `custom_components/spook/translations/en.json`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have read the [CONTRIBUTING](https://github.com/frenck/spook/blob/main/CONTRIBUTING.md) document.
- [x] I have checked my code and corrected any misspellings.
