### PR TITLE
Treat time date sensors as known entities

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -52,6 +52,20 @@ IGNORED_ENTITY_DOMAINS = (
     "scene.",
 )
 
+# Home Assistant's legacy time_date platform can create these entity IDs without
+# entity-registry entries. Treat them as known so references to configured
+# time/date sensors are not reported as unknown when they are not in the state
+# machine during an inspection.
+KNOWN_TIME_DATE_ENTITY_IDS = {
+    "sensor.time",
+    "sensor.date",
+    "sensor.date_time",
+    "sensor.date_time_utc",
+    "sensor.date_time_iso",
+    "sensor.time_date",
+    "sensor.time_utc",
+}
+
 # Additional known domains that are not in the Platform enum
 ADDITIONAL_DOMAINS = [
     "alert",
@@ -203,7 +217,10 @@ def async_get_all_entity_ids(
         }
         entity_ids_from_states = hass.states.async_entity_ids()
 
-        combined_entity_ids = entity_ids_from_registry.union(entity_ids_from_states)
+        combined_entity_ids = entity_ids_from_registry.union(
+            entity_ids_from_states,
+            KNOWN_TIME_DATE_ENTITY_IDS,
+        )
 
         # Filter out ignored domains
         _CACHED_ALL_ENTITY_IDS = {

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -203,7 +203,7 @@ def async_setup_all_entity_ids_cache_invalidation(
 def async_get_all_entity_ids(
     hass: HomeAssistant, *, include_all_none: bool = False
 ) -> set[str]:
-    """Return all entity IDs, known to Home Assistant, using a cache."""
+    """Return entity IDs known to Home Assistant or treated as known by Spook."""
     # pylint: disable-next=global-statement
     global _CACHED_ALL_ENTITY_IDS  # noqa: PLW0603
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ import pytest
 
 from custom_components.spook import entity_filtering
 from custom_components.spook.entity_filtering import (
+    KNOWN_TIME_DATE_ENTITY_IDS,
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
     async_get_all_entity_ids,
@@ -327,7 +328,7 @@ async def test_time_date_entities_are_known(
     assert (
         await async_filter_known_entity_ids_with_templates(
             hass,
-            {"sensor.date", "sensor.time"},
+            KNOWN_TIME_DATE_ENTITY_IDS,
             known_entity_ids=known_entity_ids,
         )
         == set()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -323,12 +323,22 @@ async def test_time_date_entities_are_known(
     hass: HomeAssistant,
 ) -> None:
     """Test Home Assistant time/date entities are treated as known."""
+    expected_entity_ids = {
+        "sensor.time",
+        "sensor.date",
+        "sensor.date_time",
+        "sensor.date_time_utc",
+        "sensor.date_time_iso",
+        "sensor.time_date",
+        "sensor.time_utc",
+    }
     known_entity_ids = async_get_all_entity_ids(hass)
 
+    assert expected_entity_ids == KNOWN_TIME_DATE_ENTITY_IDS
     assert (
         await async_filter_known_entity_ids_with_templates(
             hass,
-            KNOWN_TIME_DATE_ENTITY_IDS,
+            expected_entity_ids,
             known_entity_ids=known_entity_ids,
         )
         == set()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,6 +10,7 @@ from custom_components.spook import entity_filtering
 from custom_components.spook.entity_filtering import (
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
+    async_get_all_entity_ids,
     extract_entities_from_template_regex,
     extract_template_strings_from_config,
     is_template_string,
@@ -315,3 +316,19 @@ async def test_filter_plain_entity_ids_does_not_get_services(
         known_entity_ids=set(),
     ) == {"sensor.missing", "light.unknown"}
     assert calls == 0
+
+
+async def test_time_date_entities_are_known(
+    hass: HomeAssistant,
+) -> None:
+    """Test Home Assistant time/date entities are treated as known."""
+    known_entity_ids = async_get_all_entity_ids(hass)
+
+    assert (
+        await async_filter_known_entity_ids_with_templates(
+            hass,
+            {"sensor.date", "sensor.time"},
+            known_entity_ids=known_entity_ids,
+        )
+        == set()
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spook now treats Home Assistant's legacy `time_date` sensor entity IDs as known entities when filtering unknown entity references.

This covers:

- `sensor.time`
- `sensor.date`
- `sensor.date_time`
- `sensor.date_time_utc`
- `sensor.date_time_iso`
- `sensor.time_date`
- `sensor.time_utc`

These entity IDs can come from the YAML-based `time_date` platform without entity registry entries, so a reference can be valid even when the entity is not present in the state machine during a Spook inspection.

## Motivation and Context

Fixes #1231.

The reported false positive was for `sensor.time` and `sensor.date`. Treating the complete `time_date` entity ID set as known avoids the same false positive for the other display options from that platform.

## How has this been tested?

- `uv run pytest tests/test_util.py::test_time_date_entities_are_known -q`
- `uv run pytest tests/test_util.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py -q`
- `uv run ruff format --check .`
- `uv run ruff check --output-format=github .`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/entity_filtering.py tests/test_util.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
