### PR TITLE
Cascade device enable and disable actions

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/device.py
@@ -1,10 +1,12 @@
-"""Device service helpers."""
+"""Device helpers for Home Assistant services."""
 
 from __future__ import annotations
 
+from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 
 
+@callback
 def async_disable_device_and_parent_if_needed(
     device_registry: dr.DeviceRegistry,
     device_id: str,
@@ -28,16 +30,20 @@ def async_disable_device_and_parent_if_needed(
         )
 
 
+@callback
 def async_enable_device_and_parent(
     device_registry: dr.DeviceRegistry,
     device_id: str,
 ) -> None:
     """Enable a device and its parent device chain."""
-    device = device_registry.async_update_device(
+    device = device_registry.async_get(device_id)
+    if device is None:
+        return
+
+    if device.via_device_id is not None:
+        async_enable_device_and_parent(device_registry, device.via_device_id)
+
+    device_registry.async_update_device(
         device_id=device_id,
         disabled_by=None,
     )
-    if device is None or device.via_device_id is None:
-        return
-
-    async_enable_device_and_parent(device_registry, device.via_device_id)

--- a/custom_components/spook/ectoplasms/homeassistant/device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/device.py
@@ -12,15 +12,21 @@ def async_disable_device_and_parent_if_needed(
     device_id: str,
 ) -> None:
     """Disable a device and its parent when no enabled child devices remain."""
-    device = device_registry.async_update_device(
-        device_id=device_id,
-        disabled_by=dr.DeviceEntryDisabler.USER,
-    )
-    if device is None or device.via_device_id is None:
+    device = device_registry.async_get(device_id)
+    if device is None:
+        return
+
+    if device.disabled_by is None:
+        device_registry.async_update_device(
+            device_id=device_id,
+            disabled_by=dr.DeviceEntryDisabler.USER,
+        )
+
+    if device.via_device_id is None:
         return
 
     if all(
-        child.disabled_by is not None
+        child.id == device_id or child.disabled_by is not None
         for child in device_registry.devices.values()
         if child.via_device_id == device.via_device_id
     ):

--- a/custom_components/spook/ectoplasms/homeassistant/device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/device.py
@@ -1,0 +1,43 @@
+"""Device service helpers."""
+
+from __future__ import annotations
+
+from homeassistant.helpers import device_registry as dr
+
+
+def async_disable_device_and_parent_if_needed(
+    device_registry: dr.DeviceRegistry,
+    device_id: str,
+) -> None:
+    """Disable a device and its parent when no enabled child devices remain."""
+    device = device_registry.async_update_device(
+        device_id=device_id,
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+    if device is None or device.via_device_id is None:
+        return
+
+    if all(
+        child.disabled_by is not None
+        for child in device_registry.devices.values()
+        if child.via_device_id == device.via_device_id
+    ):
+        async_disable_device_and_parent_if_needed(
+            device_registry,
+            device.via_device_id,
+        )
+
+
+def async_enable_device_and_parent(
+    device_registry: dr.DeviceRegistry,
+    device_id: str,
+) -> None:
+    """Enable a device and its parent device chain."""
+    device = device_registry.async_update_device(
+        device_id=device_id,
+        disabled_by=None,
+    )
+    if device is None or device.via_device_id is None:
+        return
+
+    async_enable_device_and_parent(device_registry, device.via_device_id)

--- a/custom_components/spook/ectoplasms/homeassistant/services/disable_device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/disable_device.py
@@ -10,6 +10,7 @@ from homeassistant.components.homeassistant import DOMAIN
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from ....services import AbstractSpookAdminService
+from ..device import async_disable_device_and_parent_if_needed
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -26,7 +27,4 @@ class SpookService(AbstractSpookAdminService):
         """Handle the service call."""
         device_registry = dr.async_get(self.hass)
         for device_id in call.data["device_id"]:
-            device_registry.async_update_device(
-                device_id=device_id,
-                disabled_by=dr.DeviceEntryDisabler.USER,
-            )
+            async_disable_device_and_parent_if_needed(device_registry, device_id)

--- a/custom_components/spook/ectoplasms/homeassistant/services/enable_device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/enable_device.py
@@ -10,6 +10,7 @@ from homeassistant.components.homeassistant import DOMAIN
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from ....services import AbstractSpookAdminService
+from ..device import async_enable_device_and_parent
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -26,7 +27,4 @@ class SpookService(AbstractSpookAdminService):
         """Handle the service call."""
         device_registry = dr.async_get(self.hass)
         for device_id in call.data["device_id"]:
-            device_registry.async_update_device(
-                device_id=device_id,
-                disabled_by=None,
-            )
+            async_enable_device_and_parent(device_registry, device_id)

--- a/tests/ectoplasms/homeassistant/services/test_device.py
+++ b/tests/ectoplasms/homeassistant/services/test_device.py
@@ -174,8 +174,14 @@ async def test_disable_device_service_preserves_parent_disabled_reason(
     )
 
     assert device_registry.async_get(child.id).disabled_by is DeviceEntryDisabler.USER
-    assert device_registry.async_get(parent.id).disabled_by is DeviceEntryDisabler.CONFIG_ENTRY
-    assert device_registry.async_get(grandparent.id).disabled_by is DeviceEntryDisabler.USER
+    assert (
+        device_registry.async_get(parent.id).disabled_by
+        is DeviceEntryDisabler.CONFIG_ENTRY
+    )
+    assert (
+        device_registry.async_get(grandparent.id).disabled_by
+        is DeviceEntryDisabler.USER
+    )
 
 
 @pytest.mark.usefixtures("device_services")

--- a/tests/ectoplasms/homeassistant/services/test_device.py
+++ b/tests/ectoplasms/homeassistant/services/test_device.py
@@ -142,6 +142,43 @@ async def test_disable_device_service_disables_parent_without_other_children(
 
 
 @pytest.mark.usefixtures("device_services")
+async def test_disable_device_service_preserves_parent_disabled_reason(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test disabling a child device does not override the parent disable reason."""
+    grandparent = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "grandparent-device")},
+    )
+    parent = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "parent-device")},
+        disabled_by=DeviceEntryDisabler.CONFIG_ENTRY,
+        via_device=("test", "grandparent-device"),
+    )
+    child = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "child-device")},
+        via_device=("test", "parent-device"),
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "disable_device",
+        {"device_id": child.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert device_registry.async_get(child.id).disabled_by is DeviceEntryDisabler.USER
+    assert device_registry.async_get(parent.id).disabled_by is DeviceEntryDisabler.CONFIG_ENTRY
+    assert device_registry.async_get(grandparent.id).disabled_by is DeviceEntryDisabler.USER
+
+
+@pytest.mark.usefixtures("device_services")
 async def test_disable_device_service_keeps_parent_enabled_with_enabled_children(
     hass: HomeAssistant,
     hass_admin_user: MockUser,

--- a/tests/ectoplasms/homeassistant/services/test_device.py
+++ b/tests/ectoplasms/homeassistant/services/test_device.py
@@ -109,3 +109,100 @@ async def test_device_services_accept_multiple_devices(
     assert all(
         device_registry.async_get(device.id).disabled_by is None for device in devices
     )
+
+
+@pytest.mark.usefixtures("device_services")
+async def test_disable_device_service_disables_parent_without_other_children(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test disabling a child device also disables its parent device."""
+    parent = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "parent-device")},
+    )
+    child = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "child-device")},
+        via_device=("test", "parent-device"),
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "disable_device",
+        {"device_id": child.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert device_registry.async_get(child.id).disabled_by is DeviceEntryDisabler.USER
+    assert device_registry.async_get(parent.id).disabled_by is DeviceEntryDisabler.USER
+
+
+@pytest.mark.usefixtures("device_services")
+async def test_disable_device_service_keeps_parent_enabled_with_enabled_children(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test disabling one child device keeps a parent with enabled children enabled."""
+    parent = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "parent-device")},
+    )
+    child = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "child-device")},
+        via_device=("test", "parent-device"),
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "sibling-device")},
+        via_device=("test", "parent-device"),
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "disable_device",
+        {"device_id": child.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert device_registry.async_get(child.id).disabled_by is DeviceEntryDisabler.USER
+    assert device_registry.async_get(parent.id).disabled_by is None
+
+
+@pytest.mark.usefixtures("device_services")
+async def test_enable_device_service_enables_parent_device(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test enabling a child device also enables its parent device."""
+    parent = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "parent-device")},
+        disabled_by=DeviceEntryDisabler.USER,
+    )
+    child = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "child-device")},
+        disabled_by=DeviceEntryDisabler.USER,
+        via_device=("test", "parent-device"),
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "enable_device",
+        {"device_id": child.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert device_registry.async_get(child.id).disabled_by is None
+    assert device_registry.async_get(parent.id).disabled_by is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `homeassistant.disable_device` action now disables parent devices when the last enabled child device is disabled.

The `homeassistant.enable_device` action now also enables the parent device chain for the selected device. This keeps a child device from being enabled while its parent device remains disabled.

## Motivation and Context

Fixes #1058.
Fixes #1063.

Some integrations expose subdevices through a parent device. Disabling only the subdevice can leave the parent active, while enabling only the subdevice can leave the device effectively unusable because its parent is still disabled.

## How has this been tested?

- `uv run pytest tests/ectoplasms/homeassistant/services/test_device.py -q`
- `uv run pytest tests/ectoplasms/homeassistant/services -q`
- `uv run ruff format --check custom_components/spook/ectoplasms/homeassistant/device.py custom_components/spook/ectoplasms/homeassistant/services/disable_device.py custom_components/spook/ectoplasms/homeassistant/services/enable_device.py tests/ectoplasms/homeassistant/services/test_device.py`
- `uv run ruff check --output-format=github custom_components/spook/ectoplasms/homeassistant/device.py custom_components/spook/ectoplasms/homeassistant/services/disable_device.py custom_components/spook/ectoplasms/homeassistant/services/enable_device.py tests/ectoplasms/homeassistant/services/test_device.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/homeassistant/device.py custom_components/spook/ectoplasms/homeassistant/services/disable_device.py custom_components/spook/ectoplasms/homeassistant/services/enable_device.py tests/ectoplasms/homeassistant/services/test_device.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
