### PR TITLE
Inspect plural automation config sections

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -53,22 +53,25 @@ async def extract_entities_from_automation_config(
         return entities
 
     # Extract entities from trigger config
-    if "trigger" in config:
-        entities.update(
-            await extract_entities_from_trigger_config(hass, config["trigger"])
-        )
+    for key in ("trigger", "triggers"):
+        if key in config:
+            entities.update(
+                await extract_entities_from_trigger_config(hass, config[key])
+            )
 
     # Extract entities from condition config
-    if "condition" in config:
-        entities.update(
-            await extract_entities_from_condition_config(hass, config["condition"])
-        )
+    for key in ("condition", "conditions"):
+        if key in config:
+            entities.update(
+                await extract_entities_from_condition_config(hass, config[key])
+            )
 
     # Extract entities from action config
-    if "action" in config:
-        entities.update(
-            await extract_entities_from_action_config(hass, config["action"])
-        )
+    for key in ("action", "actions"):
+        if key in config:
+            entities.update(
+                await extract_entities_from_action_config(hass, config[key])
+            )
 
     return entities
 
@@ -343,11 +346,10 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
                     self.hass, entity.raw_config
                 )
             )
-            all_entities.difference_update(
-                extract_event_types_from_trigger_config(
-                    entity.raw_config.get("trigger")
+            for key in ("trigger", "triggers"):
+                all_entities.difference_update(
+                    extract_event_types_from_trigger_config(entity.raw_config.get(key))
                 )
-            )
 
         # Extract entities from Template objects within the automation entity
         all_entities.update(

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -427,6 +427,54 @@ async def test_automation_full_config(hass: HomeAssistant) -> None:
     }
 
 
+async def test_automation_full_config_with_plural_keys(hass: HomeAssistant) -> None:
+    """A modern automation config yields entities from plural sections."""
+    config = {
+        "alias": "Test",
+        "triggers": [{"trigger": "state", "entity_id": "binary_sensor.motion"}],
+        "conditions": [
+            {
+                "condition": "state",
+                "entity_id": "input_boolean.snooze_uptime_alerts",
+                "state": "off",
+            }
+        ],
+        "actions": [
+            {"action": "light.turn_on", "target": {"entity_id": "light.kitchen"}},
+        ],
+    }
+
+    assert await extract_entities_from_automation_config(hass, config) == {
+        "binary_sensor.motion",
+        "input_boolean.snooze_uptime_alerts",
+        "light.kitchen",
+    }
+
+
+async def test_plural_condition_entity_is_reported_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """A missing entity in a plural ``conditions`` section is reported."""
+    entity = MockAutomationEntity(
+        raw_config={
+            "conditions": [
+                {
+                    "condition": "state",
+                    "entity_id": "input_boolean.snooze_uptime_alerts",
+                    "state": "off",
+                }
+            ],
+        },
+        referenced_entities=set(),
+    )
+    repair = SpookRepair(hass)
+    repair._known_entity_ids = set()
+
+    assert await repair._async_compute_unknown_references(entity) == {
+        "input_boolean.snooze_uptime_alerts"
+    }
+
+
 async def test_automation_non_dict_returns_empty(hass: HomeAssistant) -> None:
     """A non-dict argument short-circuits to an empty set."""
     assert await extract_entities_from_automation_config(hass, []) == set()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spook now inspects both the legacy singular automation config sections and the modern plural sections when extracting entity references:

- `trigger` and `triggers`
- `condition` and `conditions`
- `action` and `actions`

The event-trigger cleanup that ignores event bus topics also checks both `trigger` and `triggers`.

## Motivation and Context

Fixes #1162.

Home Assistant's current automation editor can store automations with plural section keys. Spook only looked at the singular keys in the raw config fallback, so a missing entity in `conditions` could be missed even when the editor itself showed it as unknown.

## How has this been tested?

- `uv run pytest tests/ectoplasms/automation/repairs/test_unknown_entity_references.py::test_automation_full_config_with_plural_keys tests/ectoplasms/automation/repairs/test_unknown_entity_references.py::test_plural_condition_entity_is_reported_unknown -q`
- `uv run pytest tests/ectoplasms/automation/repairs/test_unknown_entity_references.py -q`
- `uv run ruff format --check custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `uv run ruff check --output-format=github custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
