### PR TITLE
Align script and automation counts with UI

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/sensor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/sensor.py
@@ -66,7 +66,8 @@ class HomeAssistantSpookSensorEntityDescription(
 def _count_active_domain_entities(hass: HomeAssistant, domain: str) -> int:
     """Count domain entities that are not restored placeholders."""
     return sum(
-        not hass.states.get(entity_id).attributes.get("restored", False)
+        (state := hass.states.get(entity_id)) is not None
+        and not state.attributes.get("restored", False)
         for entity_id in hass.states.async_entity_ids(domain)
     )
 

--- a/custom_components/spook/ectoplasms/homeassistant/sensor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/sensor.py
@@ -62,6 +62,15 @@ class HomeAssistantSpookSensorEntityDescription(
     update_events: set[EventType[Any] | str] = field(default_factory=set)
 
 
+@callback
+def _count_active_domain_entities(hass: HomeAssistant, domain: str) -> int:
+    """Count domain entities that are not restored placeholders."""
+    return sum(
+        not hass.states.get(entity_id).attributes.get("restored", False)
+        for entity_id in hass.states.async_entity_ids(domain)
+    )
+
+
 SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.AIR_QUALITY,
@@ -103,7 +112,7 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
         update_events={automation.EVENT_AUTOMATION_RELOADED},
-        value_fn=lambda hass: len(hass.states.async_entity_ids(automation.DOMAIN)),
+        value_fn=lambda hass: _count_active_domain_entities(hass, automation.DOMAIN),
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.BINARY_SENSOR,
@@ -422,7 +431,7 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
         update_events={EVENT_COMPONENT_LOADED, er.EVENT_ENTITY_REGISTRY_UPDATED},
-        value_fn=lambda hass: len(hass.states.async_entity_ids(script.DOMAIN)),
+        value_fn=lambda hass: _count_active_domain_entities(hass, script.DOMAIN),
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.SELECT,

--- a/tests/ectoplasms/homeassistant/test_sensor.py
+++ b/tests/ectoplasms/homeassistant/test_sensor.py
@@ -1,0 +1,33 @@
+"""Tests for Spook Home Assistant sensors."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import automation, script
+
+from custom_components.spook.ectoplasms.homeassistant.sensor import SENSORS
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _value_for_sensor(hass: HomeAssistant, key: str) -> int | None:
+    """Return the value for a Spook sensor by key."""
+    return next(sensor.value_fn(hass) for sensor in SENSORS if sensor.key == key)
+
+
+async def test_script_count_excludes_restored_entities(hass: HomeAssistant) -> None:
+    """Test restored script entities are not counted."""
+    hass.states.async_set("script.active", "off")
+    hass.states.async_set("script.restored", "unavailable", {"restored": True})
+
+    assert _value_for_sensor(hass, script.DOMAIN) == 1
+
+
+async def test_automation_count_excludes_restored_entities(hass: HomeAssistant) -> None:
+    """Test restored automation entities are not counted."""
+    hass.states.async_set("automation.active", "off")
+    hass.states.async_set("automation.restored", "unavailable", {"restored": True})
+
+    assert _value_for_sensor(hass, automation.DOMAIN) == 1


### PR DESCRIPTION
## Summary

The Home Assistant scripts and automations dashboards ignore restored placeholder entities. Spook counted every state in those domains, which made `sensor.scripts` higher than the Scripts dashboard when a restored script was still present.

This changes those two counters to skip restored placeholders, matching the frontend behavior.

## Tests

- `uv run pytest tests/ectoplasms/homeassistant/test_sensor.py -q`
- `uv run ruff check custom_components/spook/ectoplasms/homeassistant/sensor.py tests/ectoplasms/homeassistant/test_sensor.py`
- `uv run pylint custom_components/spook/ectoplasms/homeassistant/sensor.py tests/ectoplasms/homeassistant/test_sensor.py`

Fixes #943
