### PR TITLE
Ignore event data device IDs in plural triggers

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -77,6 +77,11 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
                     entity.raw_config.get("trigger")
                 )
             )
+            device_ids.difference_update(
+                extract_event_data_device_ids_from_trigger_config(
+                    entity.raw_config.get("triggers")
+                )
+            )
 
         return async_filter_known_device_ids(
             self.hass,

--- a/tests/ectoplasms/automation/repairs/test_unknown_device_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_device_references.py
@@ -48,3 +48,25 @@ async def test_event_trigger_data_device_id_is_not_reported_unknown(
     repair._known_device_ids = set()
 
     assert await repair._async_compute_unknown_references(entity) == set()
+
+
+async def test_event_trigger_data_device_id_in_plural_triggers_is_not_reported_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """Plural event triggers can contain device IDs that are not device references."""
+    entity = MockAutomationEntity(
+        raw_config={
+            "triggers": [
+                {
+                    "trigger": "event",
+                    "event_type": "hcu_integration_event",
+                    "event_data": {"device_id": "3014F711A0001F20C98F2F47"},
+                },
+            ],
+        },
+        referenced_devices={"3014F711A0001F20C98F2F47"},
+    )
+    repair = SpookRepair(hass)
+    repair._known_device_ids = set()
+
+    assert await repair._async_compute_unknown_references(entity) == set()


### PR DESCRIPTION
## Summary

Plural automation triggers can contain event payload data with a `device_id` key. That value is event data, not necessarily a Home Assistant device registry ID.

Spook already ignored this shape for the legacy singular `trigger` config. This extends the same handling to modern `triggers`, so event payload identifiers are not reported as unknown devices.

## Tests

- `uv run pytest tests/ectoplasms/automation/repairs/test_unknown_device_references.py -q`
- `uv run ruff check custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py tests/ectoplasms/automation/repairs/test_unknown_device_references.py`
- `uv run pylint custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py tests/ectoplasms/automation/repairs/test_unknown_device_references.py`

Addresses part of #1081
