### PR TITLE
Ignore entity references in Jinja comments

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -122,6 +122,7 @@ ENTITY_ID_TEMPLATE_PATTERNS = [
 COMPILED_ENTITY_ID_TEMPLATE_PATTERNS = tuple(
     re.compile(pattern, re.IGNORECASE) for pattern in ENTITY_ID_TEMPLATE_PATTERNS
 )
+JINJA_COMMENT_PATTERN = re.compile(r"\{#.*?#\}", re.DOTALL)
 
 _CACHED_ALL_ENTITY_IDS: set[str] | None = None
 _UNSUB_CACHE_INVALIDATION: Callable[[], None] | None = None
@@ -409,7 +410,9 @@ async def async_extract_entities_from_template_string(
 
 def _strip_jinja_comments(template_str: str) -> str:
     """Remove Jinja comments from a template string."""
-    return re.sub(r"\{#.*?#\}", "", template_str, flags=re.DOTALL)
+    if "{#" not in template_str:
+        return template_str
+    return JINJA_COMMENT_PATTERN.sub("", template_str)
 
 
 def _is_concatenated_template_match(template_str: str, match: re.Match[str]) -> bool:

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -407,6 +407,11 @@ async def async_extract_entities_from_template_string(
     return entities
 
 
+def _strip_jinja_comments(template_str: str) -> str:
+    """Remove Jinja comments from a template string."""
+    return re.sub(r"\{#.*?#\}", "", template_str, flags=re.DOTALL)
+
+
 def _is_concatenated_template_match(template_str: str, match: re.Match[str]) -> bool:
     """Return if a quoted entity ID literal is part of a concatenated string."""
     groups = match.groups()
@@ -504,14 +509,16 @@ def extract_entities_from_template_regex(
     if not isinstance(template_str, str):
         return set()
 
+    template_without_comments = _strip_jinja_comments(template_str)
+
     entities = set()
 
     for pattern in COMPILED_ENTITY_ID_TEMPLATE_PATTERNS:
-        for match in pattern.finditer(template_str):
+        for match in pattern.finditer(template_without_comments):
             if (
-                _is_concatenated_template_match(template_str, match)
-                or _is_jinja_import_match(template_str, match)
-                or _is_string_method_argument_match(template_str, match)
+                _is_concatenated_template_match(template_without_comments, match)
+                or _is_jinja_import_match(template_without_comments, match)
+                or _is_string_method_argument_match(template_without_comments, match)
             ):
                 continue
 

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -161,7 +161,7 @@ async def test_value_template_ignores_entity_id_in_jinja_comment(
 ) -> None:
     """Entity-like strings inside Jinja comments are not active references."""
     template = (
-        "{#{ state_translated('sensor.toothbrush_change_head') | string }} "
+        "{# {{ state_translated('sensor.toothbrush_change_head') | string }} "
         "indicates time to change, toothbrush head #}"
         "{{ trigger.to_state.attributes.friendly_name | string }}"
     )

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -156,6 +156,19 @@ async def test_value_template_ignores_entity_id_suffix_string_match(
     assert await extract_entities_from_value(hass, template) == set()
 
 
+async def test_value_template_ignores_entity_id_in_jinja_comment(
+    hass: HomeAssistant,
+) -> None:
+    """Entity-like strings inside Jinja comments are not active references."""
+    template = (
+        "{#{ state_translated('sensor.toothbrush_change_head') | string }} "
+        "indicates time to change, toothbrush head #}"
+        "{{ trigger.to_state.attributes.friendly_name | string }}"
+    )
+
+    assert await extract_entities_from_value(hass, template) == set()
+
+
 async def test_value_template_ignores_concatenated_helper_entity_id(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spook's regex fallback now strips Jinja comments before scanning templates for entity IDs. Entity-like strings in commented-out template code no longer count as active references.

## Motivation and Context

This addresses the Jinja comment false positive reported in #1081. The commented `sensor.toothbrush_change_head` example was still seen by the regex fallback, even though Jinja would ignore it at render time.

## How has this been tested?

- `uv run pytest tests/ectoplasms/automation/repairs/test_unknown_entity_references.py::test_value_template_ignores_entity_id_in_jinja_comment -q`
- `uv run pytest tests/test_entity_filtering.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py -q`
- `uv run ruff check custom_components/spook/entity_filtering.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `uv run pylint custom_components/spook/entity_filtering.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
