### PR TITLE
Skip disabled automations for service repairs

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py
@@ -47,6 +47,10 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
         """Cache known services for this inspection cycle."""
         self._known_services = async_get_all_services(self.hass)
 
+    def _should_inspect_entity(self, entity: Any) -> bool:
+        """Skip disabled automations."""
+        return entity.enabled
+
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown services called by ``entity``."""
         return async_filter_known_services(

--- a/tests/ectoplasms/automation/repairs/test_unknown_service_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_service_references.py
@@ -1,6 +1,11 @@
 """Tests for automation unknown service reference repairs."""
 
+# pylint: disable=protected-access
+
 from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 from homeassistant.const import EVENT_COMPONENT_LOADED
 
@@ -8,7 +13,20 @@ from custom_components.spook.ectoplasms.automation.repairs.unknown_service_refer
     SpookRepair,
 )
 
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
 
 def test_automation_unknown_service_repair_inspects_when_components_load() -> None:
     """Test automation service references are rechecked when components load."""
     assert EVENT_COMPONENT_LOADED in SpookRepair.inspect_events
+
+
+def test_automation_unknown_service_repair_skips_disabled_automations(
+    hass: HomeAssistant,
+) -> None:
+    """Test disabled automations are not inspected for unknown services."""
+    repair = SpookRepair(hass)
+    entity = SimpleNamespace(enabled=False)
+
+    assert not repair._should_inspect_entity(entity)  # noqa: SLF001


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Automation unknown-service repairs now use the same disabled-automation filter as the automation unknown-entity repair. Disabled automations are skipped instead of producing service-reference repairs for config that Home Assistant is not running.

## Motivation and Context

This addresses the disabled automation part raised in #916. The late service registration part is handled separately by the component/service recheck work.

## How has this been tested?

- `uv run pytest tests/ectoplasms/automation/repairs/test_unknown_service_references.py -q`
- `uv run ruff check custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py tests/ectoplasms/automation/repairs/test_unknown_service_references.py`
- `uv run pylint custom_components/spook/ectoplasms/automation/repairs/unknown_service_references.py tests/ectoplasms/automation/repairs/test_unknown_service_references.py`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
