### PR TITLE
Preserve repair issue dismissal state

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -123,6 +123,9 @@ class AbstractSpookRepairBase(ABC):
 
     async def async_deactivate(self) -> None:
         """Unregister the repair."""
+        if self.hass.is_stopping:
+            return
+
         for issue_id in self.issue_ids.copy():
             self.async_delete_issue(issue_id)
 
@@ -482,8 +485,11 @@ class SpookRepairManager:
             )
             await repair.async_deactivate()
 
+            if self.hass.is_stopping:
+                continue
+
             # Remove issues created by this Spook repair
-            for domain, issue_id in self.issue_registry.issues:
+            for domain, issue_id in list(self.issue_registry.issues):
                 if domain == DOMAIN and issue_id.startswith(
                     f"{repair.domain}_{repair.repair}",
                 ):

--- a/tests/test_repairs_cleanup.py
+++ b/tests/test_repairs_cleanup.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from custom_components.spook import repairs
+from custom_components.spook.const import DOMAIN
 from custom_components.spook.repairs import AbstractSpookRepair, AbstractSpookRepairBase
 
 EXPECTED_UNSUBSCRIBE_COUNT = 3
@@ -30,6 +31,10 @@ class MockRepairBase(AbstractSpookRepairBase):
 
     async def async_inspect(self) -> None:
         """Inspect the repair."""
+
+    async def async_deactivate(self) -> None:
+        """Deactivate the repair."""
+        await super().async_deactivate()
 
 
 class MockRepair(AbstractSpookRepair):
@@ -56,6 +61,33 @@ async def test_deactivate_deletes_issues_from_snapshot(hass: HomeAssistant) -> N
     await repair.async_deactivate()
 
     assert not repair.issue_ids
+
+
+async def test_deactivate_keeps_issues_registered_when_stopping(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test shutdown keeps issues for the issue registry to restore."""
+    deleted: list[tuple[str, str]] = []
+
+    def async_delete_issue(
+        _hass: HomeAssistant,
+        domain: str,
+        issue_id: str,
+    ) -> None:
+        """Capture deleted issues."""
+        deleted.append((domain, issue_id))
+
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", async_delete_issue)
+    monkeypatch.setattr(hass, "is_stopping", True)
+
+    repair = MockRepairBase(hass)
+    repair.issue_ids = {"one", "two"}
+
+    await repair.async_deactivate()
+
+    assert repair.issue_ids == {"one", "two"}
+    assert not deleted
 
 
 async def test_deactivate_unsubscribes_all_activation_listeners(
@@ -90,3 +122,35 @@ async def test_deactivate_unsubscribes_all_activation_listeners(
 
     assert len(unsubscribed) == 1
     assert not repair._event_subs
+
+
+async def test_repair_manager_removes_issues_on_unload(hass: HomeAssistant) -> None:
+    """Test unloading removes issues created by the repair."""
+    repair = MockRepair(hass)
+    await repair.async_activate()
+    manager = repairs.SpookRepairManager(hass)
+    manager._repairs.add(repair)
+    manager.issue_registry.issues[(DOMAIN, "mock_mock_repair_one")] = None
+    manager.issue_registry.issues[(DOMAIN, "unrelated_issue")] = None
+
+    await manager.async_on_unload()
+
+    assert (DOMAIN, "mock_mock_repair_one") not in manager.issue_registry.issues
+    assert (DOMAIN, "unrelated_issue") in manager.issue_registry.issues
+
+
+async def test_repair_manager_keeps_issues_on_shutdown(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test shutdown keeps issues for the issue registry to restore."""
+    repair = MockRepair(hass)
+    await repair.async_activate()
+    manager = repairs.SpookRepairManager(hass)
+    manager._repairs.add(repair)
+    manager.issue_registry.issues[(DOMAIN, "mock_mock_repair_one")] = None
+    monkeypatch.setattr(hass, "is_stopping", True)
+
+    await manager.async_on_unload()
+
+    assert (DOMAIN, "mock_mock_repair_one") in manager.issue_registry.issues


### PR DESCRIPTION
## Summary

Spook no longer deletes its repair issues while Home Assistant is shutting down.

Home Assistant's issue registry already keeps the dismissed version for non-persistent issues. Deleting the issue during shutdown removes that stored dismissal, so the next startup can re-create the repair as visible noise again.

Normal unload still cleans up Spook repair issues. That keeps the existing behavior for removing or disabling the integration.

Fixes #763

## Tests

- `uv run pytest tests/test_repairs_cleanup.py tests/test_setup.py tests/ectoplasms/repairs -q`
- `uv run ruff format --check custom_components/spook/repairs.py tests/test_repairs_cleanup.py`
- `uv run ruff check --output-format=github custom_components/spook/repairs.py tests/test_repairs_cleanup.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/repairs.py tests/test_repairs_cleanup.py`
