### PR TITLE
Recheck automation repairs on state changes

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -6,7 +6,8 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import automation
-from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_STATE_CHANGED
+from homeassistant.core import Event, callback
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
@@ -21,6 +22,8 @@ from ....entity_filtering import (
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from homeassistant.core import HomeAssistant
 
 
@@ -324,6 +327,31 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     edit_url_pattern = "/config/automation/edit/{unique_id}"
 
     _known_entity_ids: set[str]
+
+    async def async_activate(self) -> None:
+        """Activate the repair."""
+        await super().async_activate()
+
+        @callback
+        def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
+            """Return if a state entity was added or removed."""
+            return (
+                event_data.get("old_state") is None
+                or event_data.get("new_state") is None
+            )
+
+        @callback
+        def _async_call_inspect_debouncer(_: Event) -> None:
+            """Trigger an inspection when a state entity is added or removed."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            self.hass.bus.async_listen(
+                EVENT_STATE_CHANGED,
+                _async_call_inspect_debouncer,
+                event_filter=_state_entity_changed,
+            ),
+        )
 
     async def _async_setup_inspection(self) -> None:
         """Cache known entity IDs (including ALL/NONE) for this inspection cycle."""

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     ENTITY_MATCH_NONE,
     EVENT_COMPONENT_LOADED,
     EVENT_HOMEASSISTANT_START,
+    EVENT_STATE_CHANGED,
     Platform,
 )
 from homeassistant.core import (
@@ -39,7 +40,7 @@ from .const import LOGGER
 from .listeners import async_listen_once_tracked
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Callable, Iterable, Mapping, Sequence
 
     from homeassistant.core import HomeAssistant
 
@@ -169,6 +170,13 @@ def async_setup_all_entity_ids_cache_invalidation(
 
     LOGGER.debug("Setting up Spook's all_entity_ids cache invalidation listeners.")
 
+    @callback
+    def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
+        """Return if a state was added or removed."""
+        return (
+            event_data.get("old_state") is None or event_data.get("new_state") is None
+        )
+
     # Listen for entity registry updates
     unsub_registry_update = hass.bus.async_listen(
         er.EVENT_ENTITY_REGISTRY_UPDATED, _clear_all_entity_ids_cache
@@ -180,6 +188,12 @@ def async_setup_all_entity_ids_cache_invalidation(
     # Listen for components loading
     unsub_component_loaded = hass.bus.async_listen(
         EVENT_COMPONENT_LOADED, _clear_all_entity_ids_cache
+    )
+    # Listen for state-only entities being added or removed.
+    unsub_state_changed = hass.bus.async_listen(
+        EVENT_STATE_CHANGED,
+        _clear_all_entity_ids_cache,
+        event_filter=_state_entity_changed,
     )
 
     # Perform an initial clear, just in case.
@@ -194,6 +208,7 @@ def async_setup_all_entity_ids_cache_invalidation(
         unsub_registry_update()
         unsub_hass_start()
         unsub_component_loaded()
+        unsub_state_changed()
         _UNSUB_CACHE_INVALIDATION = None  # Mark as unsubscribed
 
     _UNSUB_CACHE_INVALIDATION = _unsubscribe_listeners

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -12,6 +12,10 @@ silently.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from types import SimpleNamespace
+
+from homeassistant.const import EVENT_STATE_CHANGED
+from homeassistant.core import State
 
 from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
     SpookRepair,
@@ -512,3 +516,71 @@ async def test_automation_missing_sections(hass: HomeAssistant, section: str) ->
         "action": {"binary_sensor.t", "binary_sensor.c"},
     }[section]
     assert result == expected
+
+
+async def test_state_only_entity_addition_rechecks_automation_repairs(
+    hass: HomeAssistant,
+) -> None:
+    """Test state-only entities trigger automation repair rechecks."""
+    repair = SpookRepair(hass)
+    await repair.async_activate()
+    repair.inspect_debouncer.async_shutdown()
+    calls = 0
+
+    def async_schedule_call() -> None:
+        """Capture scheduled inspections."""
+        nonlocal calls
+        calls += 1
+
+    repair.inspect_debouncer = SimpleNamespace(
+        async_schedule_call=async_schedule_call,
+        async_shutdown=lambda: None,
+    )
+
+    hass.bus.async_fire(
+        EVENT_STATE_CHANGED,
+        {
+            "entity_id": "sensor.backup_state",
+            "old_state": None,
+            "new_state": State("sensor.backup_state", "on"),
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert calls == 1
+
+    await repair.async_deactivate()
+
+
+async def test_state_only_entity_update_does_not_recheck_automation_repairs(
+    hass: HomeAssistant,
+) -> None:
+    """Test normal state changes do not trigger automation repair rechecks."""
+    repair = SpookRepair(hass)
+    await repair.async_activate()
+    repair.inspect_debouncer.async_shutdown()
+    calls = 0
+
+    def async_schedule_call() -> None:
+        """Capture scheduled inspections."""
+        nonlocal calls
+        calls += 1
+
+    repair.inspect_debouncer = SimpleNamespace(
+        async_schedule_call=async_schedule_call,
+        async_shutdown=lambda: None,
+    )
+
+    hass.bus.async_fire(
+        EVENT_STATE_CHANGED,
+        {
+            "entity_id": "sensor.backup_state",
+            "old_state": State("sensor.backup_state", "off"),
+            "new_state": State("sensor.backup_state", "on"),
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert calls == 0
+
+    await repair.async_deactivate()


### PR DESCRIPTION
## Summary

Recheck automation entity-reference repairs when state-only entities are added or removed.

Some integrations and apps create entities only in the state machine and only after startup. Spook already rechecked automations when components loaded or the entity registry changed, but state-only entities do not hit the entity registry. That could leave an "unknown entity" repair around forever after the entity appeared.

## Tests

- `uv run pytest tests/test_entity_filtering.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/test_setup.py -q`
- `uv run ruff format --check custom_components/spook/entity_filtering.py custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `uv run ruff check --output-format=github custom_components/spook/entity_filtering.py custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/entity_filtering.py custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py`

Fixes #1081.
Fixes #1107.
