### PR TITLE
Add inverse cover helper support

### DIFF
--- a/custom_components/spook/integrations/spook_inverse/config_flow.py
+++ b/custom_components/spook/integrations/spook_inverse/config_flow.py
@@ -83,6 +83,10 @@ CONFIG_FLOW = {
         config_schema(Platform.BINARY_SENSOR),
         validate_user_input=set_inverse_type(Platform.BINARY_SENSOR),
     ),
+    Platform.COVER: SchemaFlowFormStep(
+        config_schema(Platform.COVER),
+        validate_user_input=set_inverse_type(Platform.COVER),
+    ),
     Platform.SWITCH: SchemaFlowFormStep(
         config_schema(Platform.SWITCH),
         validate_user_input=set_inverse_type(Platform.SWITCH),
@@ -95,6 +99,7 @@ OPTIONS_FLOW = {
     Platform.BINARY_SENSOR: SchemaFlowFormStep(
         partial(options_schema, Platform.BINARY_SENSOR),
     ),
+    Platform.COVER: SchemaFlowFormStep(partial(options_schema, Platform.COVER)),
     Platform.SWITCH: SchemaFlowFormStep(partial(options_schema, Platform.SWITCH)),
 }
 

--- a/custom_components/spook/integrations/spook_inverse/const.py
+++ b/custom_components/spook/integrations/spook_inverse/const.py
@@ -5,6 +5,7 @@ from homeassistant.const import Platform
 DOMAIN = "spook_inverse"
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.COVER,
     Platform.SWITCH,
 ]
 

--- a/custom_components/spook/integrations/spook_inverse/cover.py
+++ b/custom_components/spook/integrations/spook_inverse/cover.py
@@ -1,0 +1,166 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_CLOSE_COVER_TILT,
+    SERVICE_OPEN_COVER,
+    SERVICE_OPEN_COVER_TILT,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
+    SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
+    CoverEntity,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ENTITY_ID,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.helpers import entity_registry as er
+
+from .entity import InverseEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize inverse config entry."""
+    er.async_validate_entity_id(
+        er.async_get(hass),
+        config_entry.options[CONF_ENTITY_ID],
+    )
+    async_add_entities([InverseCover(hass, config_entry)])
+
+
+class InverseCover(InverseEntity, CoverEntity):
+    """Inverse cover."""
+
+    @callback
+    def async_update_state(self, state: State) -> None:
+        """Query the source and determine the cover state."""
+        self._attr_is_opening = state.state == STATE_CLOSING
+        self._attr_is_closing = state.state == STATE_OPENING
+        if state.state == STATE_UNKNOWN:
+            self._attr_is_closed = None
+        else:
+            self._attr_is_closed = state.state == STATE_OPEN
+
+        self._attr_current_cover_position = self._inverse_position(
+            state.attributes.get(ATTR_CURRENT_POSITION)
+        )
+        self._attr_current_cover_tilt_position = self._inverse_position(
+            state.attributes.get(ATTR_CURRENT_TILT_POSITION)
+        )
+
+    @staticmethod
+    @callback
+    def _inverse_position(position: Any) -> int | None:
+        """Return the inverse of a cover position."""
+        if not isinstance(position, int):
+            return None
+        return 100 - position
+
+    async def async_open_cover(self, **_: Any) -> None:
+        """Open the cover."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLOSE_COVER,
+            {ATTR_ENTITY_ID: self._entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_close_cover(self, **_: Any) -> None:
+        """Close the cover."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_OPEN_COVER,
+            {ATTR_ENTITY_ID: self._entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move the cover to a specific position."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            {
+                ATTR_ENTITY_ID: self._entity_id,
+                ATTR_POSITION: 100 - kwargs[ATTR_POSITION],
+            },
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_stop_cover(self, **_: Any) -> None:
+        """Stop the cover."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_STOP_COVER,
+            {ATTR_ENTITY_ID: self._entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_open_cover_tilt(self, **_: Any) -> None:
+        """Open the cover tilt."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLOSE_COVER_TILT,
+            {ATTR_ENTITY_ID: self._entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_close_cover_tilt(self, **_: Any) -> None:
+        """Close the cover tilt."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_OPEN_COVER_TILT,
+            {ATTR_ENTITY_ID: self._entity_id},
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Move the cover tilt to a specific position."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_COVER_TILT_POSITION,
+            {
+                ATTR_ENTITY_ID: self._entity_id,
+                ATTR_TILT_POSITION: 100 - kwargs[ATTR_TILT_POSITION],
+            },
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_stop_cover_tilt(self, **_: Any) -> None:
+        """Stop the cover tilt."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_STOP_COVER_TILT,
+            {ATTR_ENTITY_ID: self._entity_id},
+            blocking=True,
+            context=self._context,
+        )

--- a/custom_components/spook/integrations/spook_inverse/translations/en.json
+++ b/custom_components/spook/integrations/spook_inverse/translations/en.json
@@ -9,6 +9,14 @@
         },
         "title": "Inverse 👻"
       },
+      "cover": {
+        "data": {
+          "entity_id": "Source entity",
+          "hide_source": "Hide source entity",
+          "name": "Name"
+        },
+        "title": "Inverse 👻"
+      },
       "switch": {
         "data": {
           "entity_id": "Source entity",
@@ -18,9 +26,10 @@
         "title": "Inverse 👻"
       },
       "user": {
-        "description": "This helper allow you to inverse the behavior of an entity. For example, reverse the open/close or on/off of binary sensors, and switches.",
+        "description": "This helper allows you to invert the behavior of an entity. For example, reverse the open/close or on/off of binary sensors, covers, and switches.",
         "menu_options": {
           "binary_sensor": "Inverse a binary sensor",
+          "cover": "Inverse a cover",
           "switch": "Inverse a switch"
         },
         "title": "Inverse 👻"
@@ -30,6 +39,14 @@
   "options": {
     "step": {
       "binary_sensor": {
+        "data": {
+          "entity_id": "Source entity",
+          "hide_source": "Hide source entity",
+          "name": "Name"
+        },
+        "title": "Inverse 👻"
+      },
+      "cover": {
         "data": {
           "entity_id": "Source entity",
           "hide_source": "Hide source entity",

--- a/tests/integrations/spook_inverse/test_config_flow.py
+++ b/tests/integrations/spook_inverse/test_config_flow.py
@@ -33,7 +33,9 @@ def _create_source_entity(hass: HomeAssistant, domain: str) -> str:
     return entity_entry.entity_id
 
 
-@pytest.mark.parametrize("platform", [Platform.BINARY_SENSOR, Platform.SWITCH])
+@pytest.mark.parametrize(
+    "platform", [Platform.BINARY_SENSOR, Platform.COVER, Platform.SWITCH]
+)
 async def test_config_flow_creates_inverse_entry(
     hass: HomeAssistant,
     platform: Platform,
@@ -47,7 +49,11 @@ async def test_config_flow_creates_inverse_entry(
     )
 
     assert result["type"] is FlowResultType.MENU
-    assert result["menu_options"] == [Platform.BINARY_SENSOR, Platform.SWITCH]
+    assert result["menu_options"] == [
+        Platform.BINARY_SENSOR,
+        Platform.COVER,
+        Platform.SWITCH,
+    ]
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/integrations/spook_inverse/test_cover.py
+++ b/tests/integrations/spook_inverse/test_cover.py
@@ -1,0 +1,159 @@
+"""Tests for the Spook inverse cover platform."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_CLOSE_COVER_TILT,
+    SERVICE_OPEN_COVER,
+    SERVICE_OPEN_COVER_TILT,
+    SERVICE_SET_COVER_POSITION,
+    SERVICE_SET_COVER_TILT_POSITION,
+    SERVICE_STOP_COVER,
+    SERVICE_STOP_COVER_TILT,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_ENTITY_ID,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import State
+
+from custom_components.spook.integrations.spook_inverse.const import (
+    CONF_HIDE_SOURCE,
+    DOMAIN,
+)
+from custom_components.spook.integrations.spook_inverse.cover import InverseCover
+
+INVERTED_POSITION = 75
+INVERTED_TILT_POSITION = 40
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+
+def _create_inverse_cover(hass: HomeAssistant) -> InverseCover:
+    """Create an inverse cover entity."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Inverse cover",
+        options={
+            CONF_ENTITY_ID: "cover.source",
+            CONF_HIDE_SOURCE: False,
+            "inverse_type": Platform.COVER,
+        },
+    )
+    return InverseCover(hass, entry)
+
+
+def test_inverse_cover_inverts_state_and_position(hass: HomeAssistant) -> None:
+    """Test inverse cover state and position are inverted."""
+    cover = _create_inverse_cover(hass)
+
+    cover.async_update_state(
+        State(
+            "cover.source",
+            STATE_OPEN,
+            {
+                ATTR_CURRENT_POSITION: 25,
+                ATTR_CURRENT_TILT_POSITION: 60,
+            },
+        )
+    )
+
+    assert cover.is_closed is True
+    assert cover.is_opening is False
+    assert cover.is_closing is False
+    assert cover.current_cover_position == INVERTED_POSITION
+    assert cover.current_cover_tilt_position == INVERTED_TILT_POSITION
+
+
+def test_inverse_cover_inverts_opening_and_closing(hass: HomeAssistant) -> None:
+    """Test inverse cover swaps opening and closing."""
+    cover = _create_inverse_cover(hass)
+
+    cover.async_update_state(State("cover.source", STATE_OPENING))
+
+    assert cover.is_opening is False
+    assert cover.is_closing is True
+
+    cover.async_update_state(State("cover.source", STATE_CLOSING))
+
+    assert cover.is_opening is True
+    assert cover.is_closing is False
+
+
+def test_inverse_cover_handles_closed_and_unknown_state(hass: HomeAssistant) -> None:
+    """Test inverse cover handles closed and unknown source states."""
+    cover = _create_inverse_cover(hass)
+
+    cover.async_update_state(State("cover.source", STATE_CLOSED))
+
+    assert cover.is_closed is False
+
+    cover.async_update_state(State("cover.source", STATE_UNKNOWN))
+
+    assert cover.is_closed is None
+
+
+async def test_inverse_cover_calls_inverse_services(hass: HomeAssistant) -> None:
+    """Test inverse cover calls the opposite source cover services."""
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def _service_handler(call: ServiceCall) -> None:
+        """Record service calls."""
+        calls.append((call.service, dict(call.data)))
+
+    for service in (
+        SERVICE_CLOSE_COVER,
+        SERVICE_OPEN_COVER,
+        SERVICE_SET_COVER_POSITION,
+        SERVICE_STOP_COVER,
+        SERVICE_CLOSE_COVER_TILT,
+        SERVICE_OPEN_COVER_TILT,
+        SERVICE_SET_COVER_TILT_POSITION,
+        SERVICE_STOP_COVER_TILT,
+    ):
+        hass.services.async_register(COVER_DOMAIN, service, _service_handler)
+
+    cover = _create_inverse_cover(hass)
+
+    await cover.async_open_cover()
+    await cover.async_close_cover()
+    await cover.async_set_cover_position(position=30)
+    await cover.async_stop_cover()
+    await cover.async_open_cover_tilt()
+    await cover.async_close_cover_tilt()
+    await cover.async_set_cover_tilt_position(tilt_position=40)
+    await cover.async_stop_cover_tilt()
+
+    assert calls == [
+        (SERVICE_CLOSE_COVER, {ATTR_ENTITY_ID: "cover.source"}),
+        (SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: "cover.source"}),
+        (
+            SERVICE_SET_COVER_POSITION,
+            {ATTR_ENTITY_ID: "cover.source", ATTR_POSITION: 70},
+        ),
+        (SERVICE_STOP_COVER, {ATTR_ENTITY_ID: "cover.source"}),
+        (SERVICE_CLOSE_COVER_TILT, {ATTR_ENTITY_ID: "cover.source"}),
+        (SERVICE_OPEN_COVER_TILT, {ATTR_ENTITY_ID: "cover.source"}),
+        (
+            SERVICE_SET_COVER_TILT_POSITION,
+            {ATTR_ENTITY_ID: "cover.source", ATTR_TILT_POSITION: 60},
+        ),
+        (SERVICE_STOP_COVER_TILT, {ATTR_ENTITY_ID: "cover.source"}),
+    ]


### PR DESCRIPTION
## Summary

Adds cover support to the inverse helper.

This lets a cover helper expose the opposite open/close semantics of a source cover while inverting reported position and tilt values. Commands are inverted as well: opening the helper closes the source, closing the helper opens the source, and set-position values are translated with `100 - position`.

This came from the most commented Ideas discussion in the repo: https://github.com/frenck/spook/discussions/581

## Tests

- `uv run pytest tests/integrations/spook_inverse -q`
- `uv run ruff format --check custom_components/spook/integrations/spook_inverse tests/integrations/spook_inverse`
- `uv run ruff check --output-format=github custom_components/spook/integrations/spook_inverse tests/integrations/spook_inverse`
- `uv run --with pre-commit pre-commit run pylint --files custom_components/spook/integrations/spook_inverse/cover.py custom_components/spook/integrations/spook_inverse/config_flow.py custom_components/spook/integrations/spook_inverse/const.py tests/integrations/spook_inverse/test_cover.py tests/integrations/spook_inverse/test_config_flow.py`
