### PR TITLE
Add helper management actions

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/expose_entity.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/expose_entity.py
@@ -1,0 +1,55 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.components.homeassistant.exposed_entities import (
+    KNOWN_ASSISTANTS,
+    async_expose_entity,
+)
+from homeassistant.const import ATTR_ENTITY_ID, CLOUD_NEVER_EXPOSED_ENTITIES
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_ASSISTANTS = "assistants"
+
+
+class SpookService(AbstractSpookAdminService):
+    """Service to expose entities to voice assistants."""
+
+    domain = DOMAIN
+    service = "expose_entity"
+    schema = {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+        vol.Required(CONF_ASSISTANTS): vol.All(
+            cv.ensure_list, [vol.In(KNOWN_ASSISTANTS)]
+        ),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        entity_registry = er.async_get(self.hass)
+
+        for entity_id in call.data[ATTR_ENTITY_ID]:
+            if entity_id in CLOUD_NEVER_EXPOSED_ENTITIES:
+                msg = f"Entity cannot be exposed: {entity_id}"
+                raise HomeAssistantError(msg)
+            if (
+                self.hass.states.get(entity_id) is None
+                and entity_registry.async_get(entity_id) is None
+            ):
+                msg = f"Unknown entity: {entity_id}"
+                raise HomeAssistantError(msg)
+
+            for assistant in call.data[CONF_ASSISTANTS]:
+                should_expose = True
+                async_expose_entity(self.hass, assistant, entity_id, should_expose)

--- a/custom_components/spook/ectoplasms/homeassistant/services/unexpose_entity.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/unexpose_entity.py
@@ -1,0 +1,52 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.components.homeassistant.exposed_entities import (
+    KNOWN_ASSISTANTS,
+    async_expose_entity,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_ASSISTANTS = "assistants"
+
+
+class SpookService(AbstractSpookAdminService):
+    """Service to unexpose entities from voice assistants."""
+
+    domain = DOMAIN
+    service = "unexpose_entity"
+    schema = {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+        vol.Required(CONF_ASSISTANTS): vol.All(
+            cv.ensure_list, [vol.In(KNOWN_ASSISTANTS)]
+        ),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        entity_registry = er.async_get(self.hass)
+
+        for entity_id in call.data[ATTR_ENTITY_ID]:
+            if (
+                self.hass.states.get(entity_id) is None
+                and entity_registry.async_get(entity_id) is None
+            ):
+                msg = f"Unknown entity: {entity_id}"
+                raise HomeAssistantError(msg)
+
+            for assistant in call.data[CONF_ASSISTANTS]:
+                should_expose = False
+                async_expose_entity(self.hass, assistant, entity_id, should_expose)

--- a/custom_components/spook/ectoplasms/input_number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/input_number/services/decrement.py
@@ -25,7 +25,10 @@ class SpookService(
 
     domain = DOMAIN
     service = "decrement"
-    schema = {vol.Optional("amount"): vol.Coerce(float)}
+    schema = {
+        vol.Optional("amount"): vol.Coerce(float),
+        vol.Optional("cycle", default=False): bool,
+    }
 
     async def async_handle_service(
         self,
@@ -42,9 +45,12 @@ class SpookService(
             )
             raise ValueError(msg)
 
-        await entity.async_set_value(
-            max(
-                entity._current_value - amount,  # noqa: SLF001
-                entity._minimum,  # noqa: SLF001
-            ),
-        )
+        new_value = entity._current_value - amount  # noqa: SLF001
+        if new_value < entity._minimum:  # noqa: SLF001
+            new_value = (
+                entity._maximum  # noqa: SLF001
+                if call.data["cycle"]
+                else entity._minimum  # noqa: SLF001
+            )
+
+        await entity.async_set_value(new_value)

--- a/custom_components/spook/ectoplasms/input_number/services/increment.py
+++ b/custom_components/spook/ectoplasms/input_number/services/increment.py
@@ -25,7 +25,10 @@ class SpookService(
 
     domain = DOMAIN
     service = "increment"
-    schema = {vol.Optional("amount"): vol.Coerce(float)}
+    schema = {
+        vol.Optional("amount"): vol.Coerce(float),
+        vol.Optional("cycle", default=False): bool,
+    }
 
     async def async_handle_service(
         self,
@@ -42,9 +45,12 @@ class SpookService(
             )
             raise ValueError(msg)
 
-        await entity.async_set_value(
-            min(
-                entity._current_value + amount,  # noqa: SLF001
-                entity._maximum,  # noqa: SLF001
-            ),
-        )
+        new_value = entity._current_value + amount  # noqa: SLF001
+        if new_value > entity._maximum:  # noqa: SLF001
+            new_value = (
+                entity._minimum  # noqa: SLF001
+                if call.data["cycle"]
+                else entity._maximum  # noqa: SLF001
+            )
+
+        await entity.async_set_value(new_value)

--- a/custom_components/spook/ectoplasms/sensor/__init__.py
+++ b/custom_components/spook/ectoplasms/sensor/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/sensor/services/__init__.py
+++ b/custom_components/spook/ectoplasms/sensor/services/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/sensor/services/set_display_precision.py
+++ b/custom_components/spook/ectoplasms/sensor/services/set_display_precision.py
@@ -1,0 +1,54 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import split_entity_id
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_DISPLAY_PRECISION = "display_precision"
+
+
+class SpookService(AbstractSpookAdminService):
+    """Service to set a sensor display precision."""
+
+    domain = DOMAIN
+    service = "set_display_precision"
+    schema = {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+        vol.Required(CONF_DISPLAY_PRECISION): vol.All(
+            vol.Coerce(int), vol.Range(min=0)
+        ),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        entity_registry = er.async_get(self.hass)
+        display_precision = call.data[CONF_DISPLAY_PRECISION]
+
+        for entity_id in call.data[ATTR_ENTITY_ID]:
+            if (
+                split_entity_id(entity_id)[0] != DOMAIN
+                or entity_registry.async_get(entity_id) is None
+            ):
+                msg = f"Unknown sensor entity: {entity_id}"
+                raise HomeAssistantError(msg)
+
+            sensor_options = dict(
+                entity_registry.async_get(entity_id).options.get(DOMAIN, {})  # type: ignore[union-attr]
+            )
+            sensor_options[CONF_DISPLAY_PRECISION] = display_precision
+            entity_registry.async_update_entity_options(
+                entity_id, DOMAIN, sensor_options
+            )

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -334,6 +334,60 @@ homeassistant_rename_entity:
       selector:
         text:
 
+homeassistant_expose_entity:
+  name: Expose entity to assistants 👻
+  description: >-
+    Exposes an entity (or entities) to voice assistants.
+  fields:
+    entity_id:
+      name: Entity
+      description: The entity/entities to expose.
+      required: true
+      selector:
+        entity:
+          multiple: true
+    assistants:
+      name: Assistants
+      description: The assistant(s) to expose the entity to.
+      required: true
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Alexa
+              value: cloud.alexa
+            - label: Google Assistant
+              value: cloud.google_assistant
+            - label: Assist
+              value: conversation
+
+homeassistant_unexpose_entity:
+  name: Unexpose entity from assistants 👻
+  description: >-
+    Unexposes an entity (or entities) from voice assistants.
+  fields:
+    entity_id:
+      name: Entity
+      description: The entity/entities to unexpose.
+      required: true
+      selector:
+        entity:
+          multiple: true
+    assistants:
+      name: Assistants
+      description: The assistant(s) to unexpose the entity from.
+      required: true
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Alexa
+              value: cloud.alexa
+            - label: Google Assistant
+              value: cloud.google_assistant
+            - label: Assist
+              value: conversation
+
 homeassistant_unhide_entity:
   name: Unhide an entity 👻
   description: >-
@@ -826,6 +880,28 @@ recorder_import_statistics:
       required: true
       selector:
         object:
+
+sensor_set_display_precision:
+  name: Set display precision 👻
+  description: >-
+    Sets the display precision for a sensor entity.
+  fields:
+    entity_id:
+      name: Entity
+      description: The sensor entity/entities to update.
+      required: true
+      selector:
+        entity:
+          multiple: true
+          domain: sensor
+    display_precision:
+      name: Display precision
+      description: The number of decimals to show for the sensor.
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box
 
 select_random:
   name: Select random option 👻

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -584,6 +584,20 @@
         }
       }
     },
+    "homeassistant_expose_entity": {
+      "name": "Expose an entity to assistants",
+      "description": "Exposes an entity (or entities) to voice assistants.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity/entities to expose."
+        },
+        "assistants": {
+          "name": "Assistants",
+          "description": "The assistant(s) to expose the entity to."
+        }
+      }
+    },
     "homeassistant_rename_entity": {
       "name": "Rename an entity",
       "description": "Renames an entity (or entities) on the fly.",
@@ -605,6 +619,20 @@
         "entity_id": {
           "name": "Entity",
           "description": "The entity/entities to unhide."
+        }
+      }
+    },
+    "homeassistant_unexpose_entity": {
+      "name": "Unexpose an entity from assistants",
+      "description": "Unexposes an entity (or entities) from voice assistants.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity/entities to unexpose."
+        },
+        "assistants": {
+          "name": "Assistants",
+          "description": "The assistant(s) to unexpose the entity from."
         }
       }
     },
@@ -971,6 +999,10 @@
         "amount": {
           "name": "Amount",
           "description": "The amount to decrease the input number with. If not provided, the step of the number entity will be used."
+        },
+        "cycle": {
+          "name": "Cycle",
+          "description": "Wrap to the maximum value instead of stopping at the minimum value."
         }
       }
     },
@@ -981,6 +1013,10 @@
         "amount": {
           "name": "Amount",
           "description": "The amount to increase the input number with. If not provided, the step of the number entity will be used."
+        },
+        "cycle": {
+          "name": "Cycle",
+          "description": "Wrap to the minimum value instead of stopping at the maximum value."
         }
       }
     },
@@ -991,6 +1027,20 @@
     "input_number_min": {
       "name": "Set minimum value",
       "description": "Set an input number entity to its minimum value."
+    },
+    "sensor_set_display_precision": {
+      "name": "Set display precision",
+      "description": "Sets the display precision for a sensor entity.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "The sensor entity/entities to update."
+        },
+        "display_precision": {
+          "name": "Display precision",
+          "description": "The number of decimals to show for the sensor."
+        }
+      }
     },
     "input_number_create": {
       "name": "Create an input number",

--- a/tests/ectoplasms/homeassistant/services/test_voice_assistant_exposure.py
+++ b/tests/ectoplasms/homeassistant/services/test_voice_assistant_exposure.py
@@ -1,0 +1,115 @@
+"""Tests for the voice assistant exposure services."""
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+from re import escape
+from typing import TYPE_CHECKING
+
+import pytest
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.components.homeassistant.const import DATA_EXPOSED_ENTITIES
+from homeassistant.components.homeassistant.exposed_entities import (
+    ExposedEntities,
+    async_should_expose,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.spook.ectoplasms.homeassistant.services import (
+    expose_entity,
+    unexpose_entity,
+)
+
+if TYPE_CHECKING:
+    from tests.common import MockUser
+
+
+@pytest.fixture
+async def voice_exposed_entities(hass: HomeAssistant) -> None:
+    """Set up the exposed entities manager."""
+    exposed = ExposedEntities(hass)
+    await exposed.async_initialize()
+    hass.data[DATA_EXPOSED_ENTITIES] = exposed
+
+
+@pytest.fixture
+async def voice_assistant_exposure_services(
+    hass: HomeAssistant,
+    voice_exposed_entities: None,
+) -> None:
+    """Register the voice assistant exposure services."""
+    assert voice_exposed_entities is None
+    hass.config.components.add(DOMAIN)
+    expose_entity.SpookService(hass).async_register()
+    unexpose_entity.SpookService(hass).async_register()
+
+
+@pytest.mark.usefixtures("voice_assistant_exposure_services")
+async def test_expose_entity_exposes_to_assistants(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test the expose entity service updates assistant exposure."""
+    hass.states.async_set("light.test", "on")
+
+    await hass.services.async_call(
+        DOMAIN,
+        "expose_entity",
+        {
+            ATTR_ENTITY_ID: "light.test",
+            "assistants": ["conversation", "cloud.google_assistant"],
+        },
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert async_should_expose(hass, "conversation", "light.test")
+    assert async_should_expose(hass, "cloud.google_assistant", "light.test")
+
+
+@pytest.mark.usefixtures("voice_assistant_exposure_services")
+async def test_unexpose_entity_unexposes_from_assistants(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test the unexpose entity service updates assistant exposure."""
+    hass.states.async_set("light.test", "on")
+    expose_entity.SpookService(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "expose_entity",
+        {ATTR_ENTITY_ID: "light.test", "assistants": ["conversation"]},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        "unexpose_entity",
+        {ATTR_ENTITY_ID: "light.test", "assistants": ["conversation"]},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert not async_should_expose(hass, "conversation", "light.test")
+
+
+@pytest.mark.usefixtures("voice_assistant_exposure_services")
+async def test_expose_entity_rejects_unknown_entity(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test the expose entity service rejects unknown entities."""
+    with pytest.raises(
+        HomeAssistantError, match=escape("Unknown entity: light.missing")
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "expose_entity",
+            {ATTR_ENTITY_ID: "light.missing", "assistants": ["conversation"]},
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )

--- a/tests/ectoplasms/input_number/services/test_increment_decrement.py
+++ b/tests/ectoplasms/input_number/services/test_increment_decrement.py
@@ -1,0 +1,103 @@
+"""Tests for the input number increment and decrement services."""
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from re import escape
+
+import pytest
+
+from custom_components.spook.ectoplasms.input_number.services import (
+    decrement,
+    increment,
+)
+
+
+class MockInputNumberEntity:  # pylint: disable=too-few-public-methods
+    """Mock input number entity."""
+
+    entity_id = "input_number.test"
+    _maximum = 10
+    _minimum = 0
+    _step = 0.5
+
+    def __init__(self, value: float) -> None:
+        """Initialize the mock input number entity."""
+        self._current_value = value
+        self.value: float | None = None
+
+    async def async_set_value(self, value: float) -> None:
+        """Set the value."""
+        self.value = value
+
+
+@pytest.mark.parametrize(
+    ("service_cls", "start_value", "amount", "expected"),
+    [
+        (increment.SpookService, 9.5, 0.5, 10),
+        (increment.SpookService, 9.5, 1, 10),
+        (decrement.SpookService, 0.5, 0.5, 0),
+        (decrement.SpookService, 0.5, 1, 0),
+    ],
+)
+async def test_input_number_services_clamp_at_range(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+    start_value: float,
+    amount: float,
+    expected: float,
+) -> None:
+    """Test input number services keep the existing clamping behavior."""
+    entity = MockInputNumberEntity(start_value)
+    call = SimpleNamespace(data={"amount": amount, "cycle": False})
+
+    await service_cls(hass).async_handle_service(entity, call)
+
+    assert entity.value == expected
+
+
+@pytest.mark.parametrize(
+    ("service_cls", "start_value", "amount", "expected"),
+    [
+        (increment.SpookService, 9.5, 1, 0),
+        (decrement.SpookService, 0.5, 1, 10),
+    ],
+)
+async def test_input_number_services_cycle_at_range(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+    start_value: float,
+    amount: float,
+    expected: float,
+) -> None:
+    """Test input number services can cycle past their range."""
+    entity = MockInputNumberEntity(start_value)
+    call = SimpleNamespace(data={"amount": amount, "cycle": True})
+
+    await service_cls(hass).async_handle_service(entity, call)
+
+    assert entity.value == expected
+
+
+@pytest.mark.parametrize(
+    "service_cls",
+    [increment.SpookService, decrement.SpookService],
+)
+async def test_input_number_services_raise_readable_error_for_invalid_amount(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+) -> None:
+    """Test invalid amounts raise a readable error."""
+    entity = MockInputNumberEntity(1.5)
+    call = SimpleNamespace(data={"amount": 0.2, "cycle": False})
+
+    with pytest.raises(
+        ValueError,
+        match=escape(
+            "Amount 0.2 not valid for input_number.test, "
+            "it needs to be a multiple of 0.5"
+        ),
+    ):
+        await service_cls(hass).async_handle_service(entity, call)

--- a/tests/ectoplasms/sensor/__init__.py
+++ b/tests/ectoplasms/sensor/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the sensor ectoplasm."""

--- a/tests/ectoplasms/sensor/services/__init__.py
+++ b/tests/ectoplasms/sensor/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the sensor services."""

--- a/tests/ectoplasms/sensor/services/test_set_display_precision.py
+++ b/tests/ectoplasms/sensor/services/test_set_display_precision.py
@@ -1,0 +1,71 @@
+"""Tests for the sensor set_display_precision service."""
+
+from __future__ import annotations
+
+from re import escape
+from typing import TYPE_CHECKING
+
+import pytest
+
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.spook.ectoplasms.sensor.services import set_display_precision
+
+DISPLAY_PRECISION = 3
+
+if TYPE_CHECKING:
+    from homeassistant.helpers import entity_registry as er
+
+    from tests.common import MockUser
+
+
+@pytest.fixture
+async def sensor_set_display_precision_service(hass: HomeAssistant) -> None:
+    """Register the set display precision service."""
+    hass.config.components.add(DOMAIN)
+    set_display_precision.SpookService(hass).async_register()
+
+
+@pytest.mark.usefixtures("sensor_set_display_precision_service")
+async def test_set_display_precision_updates_sensor_options(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test the service stores the display precision in entity options."""
+    entity_registry.async_get_or_create(
+        DOMAIN, "test", "unique-id", suggested_object_id="test"
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_display_precision",
+        {ATTR_ENTITY_ID: "sensor.test", "display_precision": DISPLAY_PRECISION},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    entry = entity_registry.async_get("sensor.test")
+    assert entry is not None
+    assert entry.options[DOMAIN]["display_precision"] == DISPLAY_PRECISION
+
+
+@pytest.mark.usefixtures("sensor_set_display_precision_service")
+async def test_set_display_precision_rejects_unknown_sensor(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test the service rejects unknown sensor entities."""
+    with pytest.raises(
+        HomeAssistantError, match=escape("Unknown sensor entity: sensor.missing")
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_display_precision",
+            {ATTR_ENTITY_ID: "sensor.missing", "display_precision": DISPLAY_PRECISION},
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )


### PR DESCRIPTION
## Summary

Adds three helper-focused actions requested from discussions:

- `sensor.set_display_precision`, admin-only, stores the display precision in the sensor entity registry options.
- `homeassistant.expose_entity` / `homeassistant.unexpose_entity`, admin-only, toggles explicit exposure for Assist, Google Assistant, and Alexa.
- `input_number.increment` / `input_number.decrement` now accept `cycle` to wrap around at the configured min/max instead of clamping.

## Tests

- `uv run pytest tests/ectoplasms/input_number/services/test_increment_decrement.py tests/ectoplasms/sensor/services/test_set_display_precision.py tests/ectoplasms/homeassistant/services/test_voice_assistant_exposure.py tests/test_ectoplasm_discovery.py -q`
- `uv run ruff format --check ...`
- `uv run ruff check --output-format=github ...`
- `uv run pylint ...`
