### PR TITLE
Fix notify actions reported as unknown entities

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -17,6 +17,7 @@ from ....entity_filtering import (
     async_extract_entities_from_template_string,
     async_filter_known_entity_ids_with_templates,
     async_get_all_entity_ids,
+    extract_called_services_from_config,
     is_template_string,
 )
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
@@ -369,6 +370,9 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
         # Also extract entities directly from raw configuration if available
         if hasattr(entity, "raw_config") and entity.raw_config:
+            all_entities.difference_update(
+                extract_called_services_from_config(entity.raw_config)
+            )
             all_entities.update(
                 await extract_entities_from_automation_config(
                     self.hass, entity.raw_config

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -13,6 +13,7 @@ from ....entity_filtering import (
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
     async_get_all_entity_ids,
+    extract_called_services_from_config,
 )
 from ....repairs import AbstractSpookRepair
 
@@ -54,11 +55,19 @@ def extract_entities_from_trigger_config(config: dict[str, Any] | list) -> set[s
 def extract_referenced_entities_from_script(entity: script.ScriptEntity) -> set[str]:
     """Return entity references from a script entity."""
     try:
-        return set(entity.script.referenced_entities)
+        referenced_entities = set(entity.script.referenced_entities)
     except TypeError as err:
         if str(err) != "unhashable type: 'dict'":
             raise
         return set()
+
+    config = None
+    if hasattr(entity.script, "config"):
+        config = entity.script.config
+    elif hasattr(entity.script, "_config"):
+        config = getattr(entity.script, "_config", None)
+
+    return referenced_entities - extract_called_services_from_config(config)
 
 
 async def extract_template_entities_from_script_entity(

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -747,6 +747,25 @@ async def async_extract_entities_from_config(
     return entities
 
 
+def extract_called_services_from_config(config: Any) -> set[str]:
+    """Extract services called from an automation or script config."""
+    if isinstance(config, list):
+        return async_find_services_in_sequence(config)
+
+    if not isinstance(config, dict):
+        return set()
+
+    called_services: set[str] = set()
+    for key in ("action", "actions", CONF_SEQUENCE):
+        sequence = config.get(key)
+        if isinstance(sequence, dict):
+            called_services |= async_find_services_in_sequence([sequence])
+        elif isinstance(sequence, list):
+            called_services |= async_find_services_in_sequence(sequence)
+
+    return called_services
+
+
 @callback
 def async_find_services_in_sequence(  # noqa: C901
     sequence: Sequence[dict[str, Any]],

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -492,6 +492,27 @@ async def test_plural_condition_entity_is_reported_unknown(
     }
 
 
+async def test_notify_action_is_not_reported_as_unknown_entity(
+    hass: HomeAssistant,
+) -> None:
+    """A notify action name reported by Home Assistant is not an entity."""
+    entity = MockAutomationEntity(
+        raw_config={
+            "actions": [
+                {
+                    "action": "notify.my_phone",
+                    "data": {"message": "Doorbell"},
+                }
+            ],
+        },
+        referenced_entities={"notify.my_phone"},
+    )
+    repair = SpookRepair(hass)
+    repair._known_entity_ids = set()
+
+    assert await repair._async_compute_unknown_references(entity) == set()
+
+
 async def test_automation_non_dict_returns_empty(hass: HomeAssistant) -> None:
     """A non-dict argument short-circuits to an empty set."""
     assert await extract_entities_from_automation_config(hass, []) == set()

--- a/tests/ectoplasms/script/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/script/repairs/test_unknown_entity_references.py
@@ -101,9 +101,14 @@ def test_trigger_blueprint_input_shape() -> None:
 class MockScript:  # pylint: disable=too-few-public-methods
     """Mock script object."""
 
-    def __init__(self, referenced_entities: set[str]) -> None:
+    def __init__(
+        self,
+        referenced_entities: set[str],
+        config: dict[str, Any] | None = None,
+    ) -> None:
         """Initialize the mock script."""
         self.referenced_entities = referenced_entities
+        self.config = config
 
 
 class MockBrokenScript:  # pylint: disable=too-few-public-methods
@@ -141,6 +146,25 @@ def test_extract_referenced_entities_from_script() -> None:
     entity = MockScriptEntity(MockScript({"light.kitchen"}))
 
     assert extract_referenced_entities_from_script(entity) == {"light.kitchen"}
+
+
+def test_extract_referenced_entities_from_script_ignores_notify_action() -> None:
+    """Test notify action names reported by Home Assistant are not entities."""
+    entity = MockScriptEntity(
+        MockScript(
+            {"notify.my_phone"},
+            config={
+                "sequence": [
+                    {
+                        "action": "notify.my_phone",
+                        "data": {"message": "Doorbell"},
+                    }
+                ],
+            },
+        )
+    )
+
+    assert extract_referenced_entities_from_script(entity) == set()
 
 
 def test_extract_referenced_entities_handles_home_assistant_type_error() -> None:


### PR DESCRIPTION
## Description

This filters called services/actions out of the entity-reference repair path before unknown entities are reported.

Home Assistant can expose action names such as `notify.my_phone` through `referenced_entities`. Those action names look like entity IDs, but they are service calls, not entities. Spook now subtracts the called services from the automation and script config before filtering for unknown entity references.

## Motivation and Context

Fixes #1331.

Spook 5 could report notify actions and notify groups as unknown entities in automations and scripts. That created noisy repairs for valid `action: notify.*` calls.

## How has this been tested?

```text
uv run pytest tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py tests/test_entity_filtering.py -q
uv run ruff format --check custom_components/spook/entity_filtering.py custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py
uv run ruff check --output-format=github custom_components/spook/entity_filtering.py custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py
uv run --with pre-commit pre-commit run pylint --files custom_components/spook/entity_filtering.py custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py tests/ectoplasms/automation/repairs/test_unknown_entity_references.py tests/ectoplasms/script/repairs/test_unknown_entity_references.py
```

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
