### PR TITLE
Fix known floor IDs defaulting to label IDs

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -345,7 +345,7 @@ def async_filter_known_floor_ids(
 ) -> set[str]:
     """Filter out known floor IDs."""
     if known_floor_ids is None:
-        known_floor_ids = async_get_all_label_ids(hass)
+        known_floor_ids = async_get_all_floor_ids(hass)
     return {
         floor_id
         for floor_id in floor_ids - known_floor_ids

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,6 +20,10 @@ from custom_components.spook.entity_filtering import (
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import (
+        floor_registry as fr,
+        label_registry as lr,
+    )
 
 
 @pytest.mark.parametrize(
@@ -343,3 +347,18 @@ async def test_time_date_entities_are_known(
         )
         == set()
     )
+
+
+async def test_async_filter_known_floor_ids_defaults_to_floor_registry(
+    hass: HomeAssistant,
+    floor_registry: fr.FloorRegistry,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Test floor IDs are filtered against the floor registry by default."""
+    floor = floor_registry.async_create("Upstairs")
+    label = label_registry.async_create("Basement")
+
+    assert entity_filtering.async_filter_known_floor_ids(
+        hass,
+        floor_ids={floor.floor_id, label.label_id, "ghost_floor"},
+    ) == {label.label_id, "ghost_floor"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`async_filter_known_floor_ids` in `entity_filtering.py` defaulted its `known_floor_ids` set to `async_get_all_label_ids(hass)` instead of `async_get_all_floor_ids(hass)`. A copy-paste slip: floor IDs were compared against the label registry.

This change fixes the default to use the floor registry, and adds a regression test proving a label ID no longer counts as a known floor.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The bug is latent today: both existing callers (the automation and script unknown floor reference repairs) pass `known_floor_ids` explicitly, so users are not affected. But the function contract was broken, and any future caller relying on the default would have reported every floor as unknown, guaranteeing false positives. Fixing it now, before more repairs build on this helper.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

New test `test_async_filter_known_floor_ids_defaults_to_floor_registry`: creates a floor and a label, calls the function without `known_floor_ids`, and asserts the real floor is filtered out while the label ID and a nonexistent floor ID are reported as unknown. With the old code, the label ID would incorrectly pass as a known floor. Full `tests/test_util.py` suite passes (66 tests), ruff and prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.