### PR TITLE
Fix garbled debug logging in script reference repairs

### DIFF
--- a/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
@@ -55,10 +55,8 @@ class SpookRepair(AbstractSpookRepair):
                     },
                 )
                 LOGGER.debug(
-                    (
-                        "Spook found unknown devices in %s "
-                        "and created an issue for it; Devices: %s",
-                    ),
+                    "Spook found unknown devices in %s "
+                    "and created an issue for it; Devices: %s",
                     entity.entity_id,
                     ", ".join(unknown_devices),
                 )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
@@ -52,10 +52,8 @@ class SpookRepair(AbstractSpookRepair):
                     },
                 )
                 LOGGER.debug(
-                    (
-                        "Spook found unknown floors in %s "
-                        "and created an issue for it; Floors: %s",
-                    ),
+                    "Spook found unknown floors in %s "
+                    "and created an issue for it; Floors: %s",
                     entity.entity_id,
                     ", ".join(unknown_floors),
                 )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
@@ -52,10 +52,8 @@ class SpookRepair(AbstractSpookRepair):
                     },
                 )
                 LOGGER.debug(
-                    (
-                        "Spook found unknown labels in %s "
-                        "and created an issue for it; Labels: %s",
-                    ),
+                    "Spook found unknown labels in %s "
+                    "and created an issue for it; Labels: %s",
                     entity.entity_id,
                     ", ".join(unknown_labels),
                 )

--- a/tests/test_logging_format.py
+++ b/tests/test_logging_format.py
@@ -1,0 +1,47 @@
+"""Tests for logger call formatting across the Spook codebase."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SPOOK_DIR = Path(__file__).parent.parent / "custom_components" / "spook"
+LOGGER_METHODS = {"debug", "info", "warning", "error", "exception", "critical"}
+
+MODULES = sorted(
+    path
+    for path in SPOOK_DIR.rglob("*.py")
+    if "__pycache__" not in path.parts and ".venv" not in path.parts
+)
+
+
+@pytest.mark.parametrize(
+    "module", MODULES, ids=[str(path.relative_to(SPOOK_DIR)) for path in MODULES]
+)
+def test_logger_calls_use_string_format(module: Path) -> None:
+    """Test logger calls pass a string, not a tuple, as the format message.
+
+    A stray trailing comma turns implicitly concatenated string literals into
+    a single-element tuple, making the log record render as the tuple's repr
+    instead of the intended message.
+    """
+    tree = ast.parse(module.read_text(encoding="utf-8"))
+
+    offenders = [
+        call.lineno
+        for call in ast.walk(tree)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr in LOGGER_METHODS
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "LOGGER"
+        and call.args
+        and isinstance(call.args[0], ast.Tuple)
+    ]
+
+    assert not offenders, (
+        f"LOGGER call with a tuple as format message at "
+        f"{module.relative_to(SPOOK_DIR)} line(s) {offenders}"
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Three debug log calls in the script reference repairs (`unknown_floor_references.py`, `unknown_label_references.py`, `unknown_device_references.py`) wrapped their format string in parentheses with a trailing comma. That turns the implicitly concatenated string literals into a single-element tuple, so the log record renders the tuple's repr instead of the intended message. Debug output for these repairs came out garbled.

This change removes the stray parentheses and trailing commas, and adds `tests/test_logging_format.py`: a parametrized AST scan over every module in `custom_components/spook/` asserting no `LOGGER` call passes a tuple as its format message. Neither ruff nor pylint catches this pattern, which is how it survived; the test guards the whole bug class from returning.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Debug logs are the first thing asked for when triaging repair reports. These three repairs produced tuple-repr noise instead of readable messages, exactly when readable output matters most.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The new AST guard test was run before the fix and failed on exactly the three known offenders and nothing else, validating both the test and that the rest of the codebase is clean. After the fix the full test suite passes (173 tests), along with ruff and all prek hooks.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.