### PR TITLE
Clean up repair issues for removed items reliably

### DIFF
--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_zone.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_zone.py
@@ -41,8 +41,8 @@ class SpookRepair(AbstractSpookRepair):
         known_entity_ids = async_get_all_entity_ids(self.hass)
 
         for entry_id, coordinator in coordinators.items():
+            self.possible_issue_ids.add(entry_id)
             if coordinator.proximity_zone_id not in known_entity_ids:
-                self.possible_issue_ids.add(entry_id)
                 self.async_create_issue(
                     issue_id=entry_id,
                     translation_placeholders={

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -149,29 +149,38 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
         self._event_subs = set()
         self.possible_issue_ids = set()
 
+    async def _async_inspect_with_cleanup(self) -> None:
+        """Run an inspection and clean up issues that are no longer valid."""
+        # Don't inspect if we are stopping
+        if self.hass.is_stopping:
+            return
+
+        if not self.automatically_clean_up_issues:
+            await self.async_inspect()
+            return
+
+        # Issues registered by earlier inspections. Anything not re-registered
+        # during this inspection is no longer valid, including issues for
+        # items that were removed entirely since the previous inspection.
+        previous_issue_ids = self.issue_ids.copy()
+
+        # Reset registered issues. If they are still valid, they will be
+        # re-registered during the inspection.
+        self.issue_ids.clear()
+
+        await self.async_inspect()
+
+        # Remove issues that are no longer valid after the inspection:
+        # - previous_issue_ids covers issues whose item was resolved or
+        #   removed since the previous inspection.
+        # - possible_issue_ids covers stale issues for inspected items that
+        #   this runtime never registered, like leftovers from before a
+        #   restart.
+        for issue_id in (previous_issue_ids | self.possible_issue_ids) - self.issue_ids:
+            self.async_delete_issue(issue_id)
+
     async def async_activate(self) -> None:  # noqa: C901
         """Handle the activating a repair."""
-
-        async def _async_inspect() -> None:
-            # Don't inspect if we are stopping
-            if self.hass.is_stopping:
-                return
-
-            if self.automatically_clean_up_issues:
-                # Reset registered issues. If they are still valid, they will be
-                # re-registered during the inspection.
-                self.issue_ids.clear()
-
-            await self.async_inspect()
-
-            if self.automatically_clean_up_issues:
-                # Remove issues that are not longer created after inspection.
-                for issue_id in self.possible_issue_ids - self.issue_ids:
-                    self.async_delete_issue(issue_id)
-                # Remove issues that are no longer valid.
-                for issue_id in self.issue_ids - self.possible_issue_ids:
-                    self.async_delete_issue(issue_id)
-
         # Debouncer to prevent multiple inspections / inspections fired quickly
         # after each other.
         self.inspect_debouncer = Debouncer(
@@ -179,7 +188,7 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
             LOGGER,
             cooldown=3,
             immediate=False,
-            function=_async_inspect,
+            function=self._async_inspect_with_cleanup,
         )
 
         # Spook says: Bounce!

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -164,19 +164,38 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
         # items that were removed entirely since the previous inspection.
         previous_issue_ids = self.issue_ids.copy()
 
+        # Issues persisted in the issue registry for this repair. Covers
+        # leftovers from before a restart, including those for items that
+        # were removed while Home Assistant was down.
+        prefix = f"{self.repair}_"
+        registry_issue_ids = {
+            issue_id.removeprefix(prefix)
+            for domain, issue_id in self.issue_registry.issues
+            if domain == DOMAIN and issue_id.startswith(prefix)
+        }
+
         # Reset registered issues. If they are still valid, they will be
         # re-registered during the inspection.
         self.issue_ids.clear()
 
-        await self.async_inspect()
+        try:
+            await self.async_inspect()
+        except Exception:
+            # Restore the bookkeeping so the next successful inspection can
+            # still clean up issues from before the failure.
+            self.issue_ids.update(previous_issue_ids)
+            raise
 
         # Remove issues that are no longer valid after the inspection:
         # - previous_issue_ids covers issues whose item was resolved or
         #   removed since the previous inspection.
-        # - possible_issue_ids covers stale issues for inspected items that
-        #   this runtime never registered, like leftovers from before a
-        #   restart.
-        for issue_id in (previous_issue_ids | self.possible_issue_ids) - self.issue_ids:
+        # - registry_issue_ids covers stale issues persisted from an earlier
+        #   runtime.
+        # - possible_issue_ids covers inspected items, as a safety net.
+        stale_issue_ids = (
+            previous_issue_ids | registry_issue_ids | self.possible_issue_ids
+        ) - self.issue_ids
+        for issue_id in stale_issue_ids:
             self.async_delete_issue(issue_id)
 
     async def async_activate(self) -> None:  # noqa: C901

--- a/tests/test_repairs_cleanup.py
+++ b/tests/test_repairs_cleanup.py
@@ -1,14 +1,17 @@
 """Tests for Spook repair cleanup."""
 # ruff: noqa: SLF001
-# pylint: disable=protected-access
+# pylint: disable=protected-access,wrong-import-order
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.exceptions import HomeAssistantError
+
 from custom_components.spook import repairs
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.repairs import AbstractSpookRepair, AbstractSpookRepairBase
+import pytest
 
 EXPECTED_UNSUBSCRIBE_COUNT = 3
 
@@ -18,7 +21,6 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry, ConfigEntryChange
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import issue_registry as ir
-    import pytest
 
 
 class MockRepairBase(AbstractSpookRepairBase):
@@ -166,9 +168,13 @@ class MockCleanupRepair(AbstractSpookRepair):
 
     inspected_ids: set[str] = set()
     current_issue_ids: set[str] = set()
+    raise_on_inspect = False
 
     async def async_inspect(self) -> None:
         """Inspect the repair."""
+        if self.raise_on_inspect:
+            msg = "Inspection went bump in the night"
+            raise HomeAssistantError(msg)
         self.possible_issue_ids.clear()
         self.possible_issue_ids.update(self.inspected_ids)
         for issue_id in self.current_issue_ids:
@@ -253,3 +259,63 @@ async def test_cleanup_deletes_stale_issues_for_inspected_items(
     await repair._async_inspect_with_cleanup()
 
     assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one") is None
+
+
+async def test_cleanup_survives_failing_inspection(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a failing inspection keeps the cleanup bookkeeping intact.
+
+    When an inspection raises, the previously registered issue IDs must be
+    restored so the next successful inspection can still clean up issues
+    for items that were resolved or removed in the meantime.
+    """
+    repair = MockCleanupRepair(hass)
+    repair.inspected_ids = {"one"}
+    repair.current_issue_ids = {"one"}
+
+    await repair._async_inspect_with_cleanup()
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one")
+
+    repair.raise_on_inspect = True
+    with pytest.raises(HomeAssistantError):
+        await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one")
+    assert repair.issue_ids == {"one"}
+
+    repair.raise_on_inspect = False
+    repair.inspected_ids = set()
+    repair.current_issue_ids = set()
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one") is None
+
+
+async def test_cleanup_deletes_stale_issues_for_items_removed_before_restart(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test stale issues for items removed while Home Assistant was down.
+
+    Issues persist in the issue registry across restarts. An issue whose
+    item no longer exists at all is never inspected again, so cleanup must
+    consider the persisted issues of this repair as candidates too.
+    """
+    repairs.ir.async_create_issue(
+        hass,
+        domain=DOMAIN,
+        issue_id="mock_repair_gone",
+        is_fixable=False,
+        severity=repairs.ir.IssueSeverity.WARNING,
+        translation_key="mock_repair",
+    )
+
+    repair = MockCleanupRepair(hass)
+    repair.inspected_ids = set()
+    repair.current_issue_ids = set()
+
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_gone") is None

--- a/tests/test_repairs_cleanup.py
+++ b/tests/test_repairs_cleanup.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
     from homeassistant.config_entries import ConfigEntry, ConfigEntryChange
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
     import pytest
 
 
@@ -154,3 +155,101 @@ async def test_repair_manager_keeps_issues_on_shutdown(
     await manager.async_on_unload()
 
     assert (DOMAIN, "mock_mock_repair_one") in manager.issue_registry.issues
+
+
+class MockCleanupRepair(AbstractSpookRepair):
+    """Mock repair with automatic issue cleanup."""
+
+    domain = "mock"
+    repair = "mock_repair"
+    automatically_clean_up_issues = True
+
+    inspected_ids: set[str] = set()
+    current_issue_ids: set[str] = set()
+
+    async def async_inspect(self) -> None:
+        """Inspect the repair."""
+        self.possible_issue_ids.clear()
+        self.possible_issue_ids.update(self.inspected_ids)
+        for issue_id in self.current_issue_ids:
+            self.async_create_issue(issue_id=issue_id)
+
+
+async def test_cleanup_keeps_valid_issues(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test issues re-registered during an inspection are kept."""
+    repair = MockCleanupRepair(hass)
+    repair.inspected_ids = {"one"}
+    repair.current_issue_ids = {"one"}
+
+    await repair._async_inspect_with_cleanup()
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one")
+
+
+async def test_cleanup_deletes_resolved_issues(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test issues are deleted when the inspected item no longer has one."""
+    repair = MockCleanupRepair(hass)
+    repair.inspected_ids = {"one"}
+    repair.current_issue_ids = {"one"}
+
+    await repair._async_inspect_with_cleanup()
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one")
+
+    repair.current_issue_ids = set()
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one") is None
+
+
+async def test_cleanup_deletes_issues_for_removed_items(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test issues are deleted when their item is removed entirely."""
+    repair = MockCleanupRepair(hass)
+    repair.inspected_ids = {"one"}
+    repair.current_issue_ids = {"one"}
+
+    await repair._async_inspect_with_cleanup()
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one")
+
+    repair.inspected_ids = set()
+    repair.current_issue_ids = set()
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one") is None
+
+
+async def test_cleanup_deletes_stale_issues_for_inspected_items(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test stale issues from an earlier runtime are deleted.
+
+    Issues persist in the issue registry across restarts, while the repair's
+    in-memory bookkeeping starts empty. An inspected item without a current
+    problem must have its leftover issue removed.
+    """
+    repairs.ir.async_create_issue(
+        hass,
+        domain=DOMAIN,
+        issue_id="mock_repair_one",
+        is_fixable=False,
+        severity=repairs.ir.IssueSeverity.WARNING,
+        translation_key="mock_repair",
+    )
+
+    repair = MockCleanupRepair(hass)
+    repair.inspected_ids = {"one"}
+    repair.current_issue_ids = set()
+
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, "mock_repair_one") is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The repair issue cleanup had two related flaws in how `possible_issue_ids` and `issue_ids` interact:

- Repairs using the shared base classes clear their bookkeeping at inspection start, which meant an issue for an item that was *removed entirely* (like a deleted automation) landed in neither cleanup diff and survived in the issue registry forever.
- Repairs that never clear `possible_issue_ids` (scene, lovelace, group, proximity) only cleaned up correctly *because* of that unbounded accumulation, which is fragile: aligning them with the base classes would have silently broken their cleanup.

This change fixes it once, in the shared wrapper: the inspection closure is extracted into a testable `_async_inspect_with_cleanup` method that snapshots the previous cycle's issue ids before clearing, and afterwards deletes `(previous | possible) - current`. That covers resolved issues, removed items, and stale registry leftovers from before a restart, for every repair. The proximity `unknown_zone` repair now also registers every config entry in `possible_issue_ids` unconditionally, consistent with its sibling repairs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Deleting an automation, script, scene, or dashboard that had a Spook issue could leave that issue lingering in the repairs dashboard with nothing left to fix. Cleanup now works by explicit bookkeeping instead of by accident, which also unblocks aligning the remaining repairs to clear their state per inspection.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Four new tests in `tests/test_repairs_cleanup.py` against the real issue registry: valid issues are kept, resolved issues are deleted, issues for removed items are deleted, and stale pre-restart registry issues for inspected items are deleted. The removed-items test fails on the previous implementation (verified by running it against the old code). Full suite passes (334 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.