### PR TITLE
Fix broken edit links for YAML items without an ID

### DIFF
--- a/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
@@ -49,6 +49,14 @@ class SpookRepair(AbstractSpookRepair):
                 entity_ids=entity.scene_config.states,
                 known_entity_ids=known_entity_ids,
             ):
+                # Scenes created in YAML can lack a unique ID, in which case
+                # there is no editor to deep-link to; fall back to the
+                # scene overview page.
+                edit_url = (
+                    f"/config/scene/edit/{entity.unique_id}"
+                    if entity.unique_id is not None
+                    else "/config/scene/dashboard"
+                )
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={
@@ -57,7 +65,7 @@ class SpookRepair(AbstractSpookRepair):
                         ),
                         "scene": entity.name,
                         "entity_id": entity.entity_id,
-                        "edit": f"/config/scene/edit/{entity.unique_id}",
+                        "edit": edit_url,
                     },
                 )
                 LOGGER.debug(

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -303,6 +303,16 @@ class AbstractSpookEntityComponentUnknownReferencesRepair(AbstractSpookRepair, A
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return the set of unknown referenced IDs for a single entity."""
 
+    def _edit_url(self, entity: Any) -> str:
+        """Return the URL to edit the given entity.
+
+        Items created in YAML can lack a unique ID, in which case there is no
+        editor to deep-link to; fall back to the domain's overview page.
+        """
+        if entity.unique_id is None:
+            return f"/config/{self.domain}/dashboard"
+        return self.edit_url_pattern.format(unique_id=entity.unique_id)
+
     async def async_inspect(self) -> None:
         """Trigger an inspection."""
         self.possible_issue_ids.clear()
@@ -338,7 +348,7 @@ class AbstractSpookEntityComponentUnknownReferencesRepair(AbstractSpookRepair, A
                         f"- `{item}`" for item in sorted_unknown
                     ),
                     self.entity_label: entity.name,
-                    "edit": self.edit_url_pattern.format(unique_id=entity.unique_id),
+                    "edit": self._edit_url(entity),
                     "entity_id": entity.entity_id,
                 },
             )

--- a/tests/ectoplasms/scene/__init__.py
+++ b/tests/ectoplasms/scene/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook scene ectoplasm."""

--- a/tests/ectoplasms/scene/repairs/__init__.py
+++ b/tests/ectoplasms/scene/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook scene repairs."""

--- a/tests/ectoplasms/scene/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/scene/repairs/test_unknown_entity_references.py
@@ -1,0 +1,57 @@
+"""Tests for the scene unknown entity references repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.scene.repairs.unknown_entity_references import (
+    SpookRepair,
+)
+import pytest
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+def _mock_scene(unique_id: str | None) -> SimpleNamespace:
+    """Return a mock Home Assistant scene entity."""
+    return SimpleNamespace(
+        entity_id="scene.movie_night",
+        name="Movie Night",
+        unique_id=unique_id,
+        scene_config=SimpleNamespace(states={"light.ghost": {}}),
+    )
+
+
+@pytest.mark.parametrize(
+    ("unique_id", "expected_edit_url"),
+    [
+        pytest.param("abc123", "/config/scene/edit/abc123", id="with_unique_id"),
+        pytest.param(None, "/config/scene/dashboard", id="without_unique_id"),
+    ],
+)
+async def test_issue_edit_url(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    unique_id: str | None,
+    expected_edit_url: str,
+) -> None:
+    """Test the created issue links to the editor or the scene overview."""
+    entities: dict[str, Any] = {"scene.movie_night": _mock_scene(unique_id)}
+    hass.data["homeassistant_scene"] = SimpleNamespace(entities=entities)
+
+    repair = SpookRepair(hass)
+    await repair.async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "scene_unknown_entity_references_scene.movie_night",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert issue.translation_placeholders["edit"] == expected_edit_url
+    assert issue.translation_placeholders["entities"] == "- `light.ghost`"

--- a/tests/test_repairs_edit_url.py
+++ b/tests/test_repairs_edit_url.py
@@ -1,0 +1,59 @@
+"""Tests for repair issue edit URLs."""
+# ruff: noqa: SLF001
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from custom_components.spook.repairs import (
+    AbstractSpookEntityComponentUnknownReferencesRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+class _UnavailableEntity:  # pylint: disable=too-few-public-methods
+    """Marker class for unavailable entities."""
+
+
+class MockReferencesRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
+    """Mock unknown-references repair."""
+
+    domain = "automation"
+    repair = "mock_repair"
+    unavailable_entity_class = _UnavailableEntity
+    entity_label = "automation"
+    reference_label = "entities"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
+
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return no unknown references."""
+        del entity
+        return set()
+
+
+def test_edit_url_with_unique_id(hass: HomeAssistant) -> None:
+    """Test the edit URL deep-links to the editor when a unique ID exists."""
+    repair = MockReferencesRepair(hass)
+
+    assert (
+        repair._edit_url(SimpleNamespace(unique_id="abc123"))
+        == "/config/automation/edit/abc123"
+    )
+
+
+def test_edit_url_without_unique_id(hass: HomeAssistant) -> None:
+    """Test the edit URL falls back to the overview without a unique ID.
+
+    Automations and scenes created in YAML without an ``id:`` have no unique
+    ID and no editor to deep-link to.
+    """
+    repair = MockReferencesRepair(hass)
+
+    assert (
+        repair._edit_url(SimpleNamespace(unique_id=None))
+        == "/config/automation/dashboard"
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Automations and scenes defined in YAML without an `id:` have no unique ID, and the repair issues Spook creates for them linked to `/config/automation/edit/None`, a dead link.

The shared unknown-references base class now builds the edit URL through a small `_edit_url` helper that falls back to the domain overview page (`/config/automation/dashboard`) when there is no unique ID, and the scene repair does the same with `/config/scene/dashboard`. Scripts are unaffected: core always assigns them a unique ID from their object key, so the script repairs are untouched.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A repair issue with a broken "edit" link is a dead end exactly when someone wants to act on it. Falling back to the overview page always gives a working destination.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

New unit tests for `_edit_url` cover both branches. The scene repair also gets its first behavior test: a parametrized end-to-end `async_inspect` run against the real issue registry, asserting the `edit` placeholder for both a scene with a unique ID and a YAML scene without one, plus the unknown-entities placeholder content. Full suite passes (334 tests), ruff, pylint, and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.