### PR TITLE
Add regression test for templated action names in service repairs

### DIFF
--- a/tests/test_entity_filtering.py
+++ b/tests/test_entity_filtering.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
-from custom_components.spook.entity_filtering import async_find_services_in_sequence
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import config_validation as cv
+
+from custom_components.spook.entity_filtering import (
+    async_filter_known_services,
+    async_find_services_in_sequence,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 
 def test_find_services_skips_disabled_nested_steps() -> None:
@@ -48,3 +58,30 @@ def test_find_services_keeps_enabled_none_steps() -> None:
     sequence = [{"action": "light.turn_on", "enabled": None}]
 
     assert async_find_services_in_sequence(sequence) == {"light.turn_on"}
+
+
+async def test_templated_action_names_are_not_reported_unknown(
+    hass: HomeAssistant,
+) -> None:
+    """Test templated action names never surface as unknown services.
+
+    The service reference repairs walk validated script configs, where
+    ``cv.SERVICE_SCHEMA`` turns a templated action name into a ``Template``
+    object. The known-services filter drops non-string values, so templated
+    names must never be reported as unknown.
+
+    Note for future raw-config walkers: in raw (unvalidated) configs a
+    templated action name is a plain string and needs an explicit
+    ``is_template_string`` skip instead.
+    """
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {"action": "{{ 'notify.' ~ who }}"},
+            {"service": "{{ 'light.turn_' ~ toggle_state }}"},
+            {"action": "notify.ghost"},
+        ]
+    )
+
+    found = async_find_services_in_sequence(sequence)
+
+    assert async_filter_known_services(hass, services=found) == {"notify.ghost"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Test-only change. Adds a regression test pinning an invariant of the unknown service reference repairs: templated action names (`action: "{{ 'notify.' ~ who }}"`) must never be reported as unknown services.

The invariant holds today because the repairs walk *validated* script configs, where `cv.SERVICE_SCHEMA` turns a templated action name into a `Template` object, and `async_filter_known_services` drops non-string values. The test covers the full path: `cv.SCRIPT_SCHEMA` validation, `async_find_services_in_sequence`, and the known-services filter, asserting only a genuinely unknown service surfaces.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was investigated as a suspected false-positive bug and turned out not to be one. The behavior deserves a pin regardless: planned future work will walk *raw* (unvalidated) configs, where templated action names are plain strings and this false positive becomes real. The test docstring documents that trap for whoever builds those walkers.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

It is a test. It passes against current code, along with the full suite, ruff, pylint, and all prek hooks.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.