### PR TITLE
Fix repair issue cleanup on unload never matching

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -526,11 +526,10 @@ class SpookRepairManager:
             if self.hass.is_stopping:
                 continue
 
-            # Remove issues created by this Spook repair
+            # Remove issues created by this Spook repair. Issue IDs are
+            # created as "<repair>_<issue_id>" (see async_create_issue).
             for domain, issue_id in list(self.issue_registry.issues):
-                if domain == DOMAIN and issue_id.startswith(
-                    f"{repair.domain}_{repair.repair}",
-                ):
+                if domain == DOMAIN and issue_id.startswith(f"{repair.repair}_"):
                     self.issue_registry.async_delete(domain, issue_id)
 
 

--- a/tests/test_repairs_cleanup.py
+++ b/tests/test_repairs_cleanup.py
@@ -133,12 +133,12 @@ async def test_repair_manager_removes_issues_on_unload(hass: HomeAssistant) -> N
     await repair.async_activate()
     manager = repairs.SpookRepairManager(hass)
     manager._repairs.add(repair)
-    manager.issue_registry.issues[(DOMAIN, "mock_mock_repair_one")] = None
+    manager.issue_registry.issues[(DOMAIN, "mock_repair_one")] = None
     manager.issue_registry.issues[(DOMAIN, "unrelated_issue")] = None
 
     await manager.async_on_unload()
 
-    assert (DOMAIN, "mock_mock_repair_one") not in manager.issue_registry.issues
+    assert (DOMAIN, "mock_repair_one") not in manager.issue_registry.issues
     assert (DOMAIN, "unrelated_issue") in manager.issue_registry.issues
 
 
@@ -151,12 +151,12 @@ async def test_repair_manager_keeps_issues_on_shutdown(
     await repair.async_activate()
     manager = repairs.SpookRepairManager(hass)
     manager._repairs.add(repair)
-    manager.issue_registry.issues[(DOMAIN, "mock_mock_repair_one")] = None
+    manager.issue_registry.issues[(DOMAIN, "mock_repair_one")] = None
     monkeypatch.setattr(hass, "is_stopping", True)
 
     await manager.async_on_unload()
 
-    assert (DOMAIN, "mock_mock_repair_one") in manager.issue_registry.issues
+    assert (DOMAIN, "mock_repair_one") in manager.issue_registry.issues
 
 
 class MockCleanupRepair(AbstractSpookRepair):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`SpookRepairManager.async_on_unload` sweeps the issue registry to remove all issues created by a repair, matching on `issue_id.startswith(f"{repair.domain}_{repair.repair}")`. Issues are created as `f"{repair.repair}_{issue_id}"` though, so for every real repair (like `automation_unknown_entity_references`) that prefix (`automation_automation_...`) never matches anything: the sweep was dead code. Per-repair deactivation covered most cleanup in practice, but the registry sweep is the safety net for issues the in-memory bookkeeping lost track of.

The sweep now matches the actual creation format, `f"{repair.repair}_"`, with a comment pointing at `async_create_issue`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removing Spook should remove all its repair issues. The existing manager tests seeded issue IDs in the same wrong format the sweep expected (`mock_mock_repair_one`), which is why they passed against broken code; they now use the format repairs actually create (`mock_repair_one`).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

With realistic issue IDs, `test_repair_manager_removes_issues_on_unload` fails against the previous code and passes with the fix, while still asserting unrelated issues are not deleted. Full suite passes (515 tests), ruff, pylint, and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.