### PR TITLE
Isolate setup failures so one broken feature cannot take down Spook

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -497,10 +497,27 @@ class SpookRepairManager:
         await self.hass.async_add_import_executor_job(_load_all_repair_modules)
         await asyncio.gather(
             *(
-                create_eager_task(self.async_activate(module.SpookRepair(self.hass)))
+                create_eager_task(self._async_setup_repair_module(module))
                 for module in modules
             )
         )
+
+    async def _async_setup_repair_module(self, module: ModuleType) -> None:
+        """Set up a single repair module, isolating failures.
+
+        A repair that fails to set up must not prevent the rest of Spook
+        from loading.
+        """
+        try:
+            await self.async_activate(module.SpookRepair(self.hass))
+        # pylint: disable-next=broad-exception-caught
+        except Exception:  # noqa: BLE001
+            LOGGER.exception(
+                "Spook repair %s failed to set up and has been skipped; "
+                "please report this issue at "
+                "https://github.com/frenck/spook/issues",
+                module.__name__,
+            )
 
     async def async_activate(self, repair: AbstractSpookRepair) -> None:
         """Register a Spook repair."""

--- a/custom_components/spook/services.py
+++ b/custom_components/spook/services.py
@@ -183,9 +183,14 @@ class AbstractSpookEntityService(AbstractSpookServiceBase, Generic[_EntityT]):
 
         if not (
             platform := next(
-                platform
-                for platform in self.hass.data[DATA_ENTITY_PLATFORM][self.domain]
-                if platform.domain == self.platform
+                (
+                    platform
+                    for platform in self.hass.data.get(DATA_ENTITY_PLATFORM, {}).get(
+                        self.domain, []
+                    )
+                    if platform.domain == self.platform
+                ),
+                None,
             )
         ):
             msg = (
@@ -229,7 +234,7 @@ class AbstractSpookEntityComponentService(AbstractSpookServiceBase, Generic[_Ent
             self.service,
         )
 
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
+        if self.domain not in self.hass.data.get(DATA_INSTANCES, {}):
             msg = (
                 f"Could not find entity component {self.domain} to register "
                 f"service: {self.domain}.{self.service}",
@@ -317,6 +322,22 @@ class SpookServiceManager:
         await self.hass.async_add_import_executor_job(_load_all_service_modules)
 
         for module in modules:
+            self._async_setup_service_module(module)
+
+        await self.async_inject_service_translations()
+        self._translation_listener = self.hass.bus.async_listen(
+            EVENT_CORE_CONFIG_UPDATE,
+            self._async_core_config_updated,
+        )
+
+    @callback
+    def _async_setup_service_module(self, module: ModuleType) -> None:
+        """Set up a single service module, isolating failures.
+
+        A service that fails to set up must not prevent the rest of Spook
+        from loading.
+        """
+        try:
             service = module.SpookService(self.hass)
             if isinstance(
                 service,
@@ -333,12 +354,14 @@ class SpookServiceManager:
                 ).pop(service.service)
 
             self.async_register_service(service)
-
-        await self.async_inject_service_translations()
-        self._translation_listener = self.hass.bus.async_listen(
-            EVENT_CORE_CONFIG_UPDATE,
-            self._async_core_config_updated,
-        )
+        # pylint: disable-next=broad-exception-caught
+        except Exception:  # noqa: BLE001
+            LOGGER.exception(
+                "Spook service %s failed to set up and has been skipped; "
+                "please report this issue at "
+                "https://github.com/frenck/spook/issues",
+                module.__name__,
+            )
 
     @callback
     def async_register_service(self, service: AbstractSpookService) -> None:

--- a/custom_components/spook/services.py
+++ b/custom_components/spook/services.py
@@ -337,6 +337,7 @@ class SpookServiceManager:
         A service that fails to set up must not prevent the rest of Spook
         from loading.
         """
+        service: AbstractSpookServiceBase | None = None
         try:
             service = module.SpookService(self.hass)
             if isinstance(
@@ -356,6 +357,18 @@ class SpookServiceManager:
             self.async_register_service(service)
         # pylint: disable-next=broad-exception-caught
         except Exception:  # noqa: BLE001
+            # If the service this one overrides was already unregistered,
+            # restore it; a failing setup must not silently remove a core
+            # service until the next restart.
+            if (
+                isinstance(service, ReplaceExistingService)
+                and service.overriden_service is not None
+            ):
+                # pylint: disable-next=protected-access
+                self.hass.services._services.setdefault(  # noqa: SLF001
+                    service.domain,
+                    {},
+                )[service.service] = service.overriden_service
             LOGGER.exception(
                 "Spook service %s failed to set up and has been skipped; "
                 "please report this issue at "

--- a/custom_components/spook/setup_helpers.py
+++ b/custom_components/spook/setup_helpers.py
@@ -43,7 +43,30 @@ async def async_forward_setup_entry(
                 LOGGER.debug("Setting up Spook ectoplasm: %s", module_path)
 
     await hass.async_add_import_executor_job(_load_all_ectoplasm_modules)
-    await asyncio.gather(*(module.async_setup_entry(hass, entry) for module in modules))
+    await asyncio.gather(
+        *(_async_setup_ectoplasm(hass, entry, module) for module in modules)
+    )
+
+
+async def _async_setup_ectoplasm(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    module: ModuleType,
+) -> None:
+    """Set up a single ectoplasm, isolating failures.
+
+    An ectoplasm that fails to set up must not prevent the rest of Spook
+    from loading.
+    """
+    try:
+        await module.async_setup_entry(hass, entry)
+    # pylint: disable-next=broad-exception-caught
+    except Exception:  # noqa: BLE001
+        LOGGER.exception(
+            "Spook ectoplasm %s failed to set up and has been skipped; "
+            "please report this issue at https://github.com/frenck/spook/issues",
+            module.__name__,
+        )
 
 
 async def async_forward_platform_entry_setups_to_ectoplasm(
@@ -73,7 +96,29 @@ async def async_forward_platform_entry_setups_to_ectoplasm(
     await hass.async_add_import_executor_job(_load_all_ectoplasm_platform_modules)
     await asyncio.gather(
         *(
-            module.async_setup_entry(hass, entry, async_add_entities)
+            _async_setup_ectoplasm_platform(hass, entry, async_add_entities, module)
             for module in modules
         )
     )
+
+
+async def _async_setup_ectoplasm_platform(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    module: ModuleType,
+) -> None:
+    """Set up a single ectoplasm platform, isolating failures.
+
+    An ectoplasm platform that fails to set up must not prevent the rest
+    of Spook from loading.
+    """
+    try:
+        await module.async_setup_entry(hass, entry, async_add_entities)
+    # pylint: disable-next=broad-exception-caught
+    except Exception:  # noqa: BLE001
+        LOGGER.exception(
+            "Spook ectoplasm platform %s failed to set up and has been skipped; "
+            "please report this issue at https://github.com/frenck/spook/issues",
+            module.__name__,
+        )

--- a/tests/test_setup_isolation.py
+++ b/tests/test_setup_isolation.py
@@ -1,0 +1,116 @@
+"""Tests for Spook setup failure isolation.
+
+A single repair, service, or ectoplasm that fails to set up must not
+prevent the rest of Spook from loading.
+"""
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from custom_components.spook import setup_helpers
+from custom_components.spook.repairs import AbstractSpookRepair, SpookRepairManager
+from custom_components.spook.services import SpookServiceManager
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    import pytest
+
+
+class _WorkingRepair(AbstractSpookRepair):
+    """Repair that activates fine."""
+
+    domain = "mock"
+    repair = "mock_working_repair"
+
+    async def async_inspect(self) -> None:
+        """Inspect the repair."""
+
+
+class _BrokenRepair:  # pylint: disable=too-few-public-methods
+    """Repair that explodes on construction."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the repair."""
+        del hass
+        msg = "Boo! This one is haunted"
+        raise RuntimeError(msg)
+
+
+async def test_broken_repair_module_does_not_abort_setup(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a repair failing to set up is skipped and logged."""
+    manager = SpookRepairManager(hass)
+
+    broken = SimpleNamespace(__name__="mock.broken_repair", SpookRepair=_BrokenRepair)
+    working = SimpleNamespace(
+        __name__="mock.working_repair", SpookRepair=_WorkingRepair
+    )
+
+    await manager._async_setup_repair_module(broken)
+    await manager._async_setup_repair_module(working)
+
+    assert len(manager._repairs) == 1
+    assert "mock.broken_repair failed to set up" in caplog.text
+    assert "Boo! This one is haunted" in caplog.text
+
+    await manager.async_on_unload()
+
+
+async def test_broken_ectoplasm_does_not_abort_setup(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test an ectoplasm failing to set up is skipped and logged."""
+
+    async def _boom(*_args: Any) -> None:
+        msg = "Boo! This one is haunted"
+        raise RuntimeError(msg)
+
+    module = SimpleNamespace(__name__="mock.broken_ectoplasm", async_setup_entry=_boom)
+
+    await setup_helpers._async_setup_ectoplasm(hass, SimpleNamespace(), module)
+
+    assert "mock.broken_ectoplasm failed to set up" in caplog.text
+
+
+async def test_broken_ectoplasm_platform_does_not_abort_setup(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test an ectoplasm platform failing to set up is skipped and logged."""
+
+    async def _boom(*_args: Any) -> None:
+        msg = "Boo! This one is haunted"
+        raise RuntimeError(msg)
+
+    module = SimpleNamespace(__name__="mock.broken_platform", async_setup_entry=_boom)
+
+    await setup_helpers._async_setup_ectoplasm_platform(
+        hass,
+        SimpleNamespace(),
+        lambda *_: None,
+        module,
+    )
+
+    assert "mock.broken_platform failed to set up" in caplog.text
+
+
+async def test_broken_service_module_does_not_abort_setup(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a service failing to set up is skipped and logged."""
+    manager = SpookServiceManager(hass)
+
+    module = SimpleNamespace(__name__="mock.broken_service", SpookService=_BrokenRepair)
+
+    manager._async_setup_service_module(module)
+
+    assert not manager._services
+    assert "mock.broken_service failed to set up" in caplog.text

--- a/tests/test_setup_isolation.py
+++ b/tests/test_setup_isolation.py
@@ -11,9 +11,14 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
+from pytest_homeassistant_custom_component.common import async_mock_service
+
 from custom_components.spook import setup_helpers
 from custom_components.spook.repairs import AbstractSpookRepair, SpookRepairManager
-from custom_components.spook.services import SpookServiceManager
+from custom_components.spook.services import (
+    ReplaceExistingService,
+    SpookServiceManager,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -30,8 +35,8 @@ class _WorkingRepair(AbstractSpookRepair):
         """Inspect the repair."""
 
 
-class _BrokenRepair:  # pylint: disable=too-few-public-methods
-    """Repair that explodes on construction."""
+class _ExplodingConstructor:  # pylint: disable=too-few-public-methods
+    """Stand-in repair or service that explodes on construction."""
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the repair."""
@@ -47,7 +52,9 @@ async def test_broken_repair_module_does_not_abort_setup(
     """Test a repair failing to set up is skipped and logged."""
     manager = SpookRepairManager(hass)
 
-    broken = SimpleNamespace(__name__="mock.broken_repair", SpookRepair=_BrokenRepair)
+    broken = SimpleNamespace(
+        __name__="mock.broken_repair", SpookRepair=_ExplodingConstructor
+    )
     working = SimpleNamespace(
         __name__="mock.working_repair", SpookRepair=_WorkingRepair
     )
@@ -108,9 +115,47 @@ async def test_broken_service_module_does_not_abort_setup(
     """Test a service failing to set up is skipped and logged."""
     manager = SpookServiceManager(hass)
 
-    module = SimpleNamespace(__name__="mock.broken_service", SpookService=_BrokenRepair)
+    module = SimpleNamespace(
+        __name__="mock.broken_service", SpookService=_ExplodingConstructor
+    )
 
     manager._async_setup_service_module(module)
 
     assert not manager._services
     assert "mock.broken_service failed to set up" in caplog.text
+
+
+class _BrokenOverrideService(ReplaceExistingService):
+    """Service override that explodes during registration."""
+
+    domain = "light"
+    service = "turn_on"
+
+    def async_register(self) -> None:
+        """Register the service."""
+        msg = "Boo! This one is haunted"
+        raise RuntimeError(msg)
+
+
+async def test_failed_service_override_restores_original_service(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a failing service override restores the original service.
+
+    When the service to override was already unregistered but the
+    replacement fails to register, the original must be put back instead
+    of silently disappearing until the next restart.
+    """
+    async_mock_service(hass, "light", "turn_on")
+    manager = SpookServiceManager(hass)
+
+    module = SimpleNamespace(
+        __name__="mock.broken_override",
+        SpookService=_BrokenOverrideService,
+    )
+
+    manager._async_setup_service_module(module)
+
+    assert hass.services.has_service("light", "turn_on")
+    assert "mock.broken_override failed to set up" in caplog.text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Spook sets up its repairs, services, and ectoplasms with `asyncio.gather` fan-outs. A single feature raising during setup aborted the whole gather and failed Spook's config entry setup. Given how many Home Assistant internals Spook reaches into by design, a single core refactor breaking one repair would take down all of Spook.

Each fan-out now goes through a per-module wrapper that catches the failure, logs it with the module name and a request to report it, and continues with the rest:

- `SpookRepairManager._async_setup_repair_module`: note that `return_exceptions=True` alone would not have been enough here, since `SpookRepair(self.hass)` was constructed eagerly inside the gather arguments, so a raising constructor escaped the gather entirely.
- `setup_helpers._async_setup_ectoplasm` and `_async_setup_ectoplasm_platform` for the two ectoplasm gathers.
- `SpookServiceManager._async_setup_service_module` wrapping construction, service override, and registration per service.

Two adjacent hardening fixes in the same theme: the entity service registration used `next()` without a default, making its intended `RuntimeError` unreachable (a missing platform raised a confusing `StopIteration` instead) and indexed `hass.data[DATA_ENTITY_PLATFORM]` without `.get`; the entity component variant got the same `.get` treatment.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Failing gracefully per feature converts "Spook fails to load after a Home Assistant upgrade" into "one Spook feature is disabled and the log says exactly which one", which is a much better place to debug from, for users and for issue reports.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

New `tests/test_setup_isolation.py` covers all four paths: a repair whose constructor raises is skipped and logged while a working repair still activates, and the same isolation for an ectoplasm, an ectoplasm platform, and a service module. Full suite passes (519 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.