### PR TITLE
Add end-to-end repairs test and reset cache state between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,11 @@ from pytest_homeassistant_custom_component.syrupy import HomeAssistantSnapshotEx
 
 from homeassistant import config_entries, loader, setup
 
+from custom_components.spook import entity_filtering
+
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from syrupy.assertion import SnapshotAssertion
 
     from homeassistant.core import HomeAssistant
@@ -26,6 +30,22 @@ def allow_unreleased_spook(monkeypatch: pytest.MonkeyPatch) -> None:
 def auto_enable_custom_integrations(enable_custom_integrations: None) -> None:
     """Enable custom integrations in Home Assistant tests."""
     _ = enable_custom_integrations
+
+
+@pytest.fixture(autouse=True)
+def reset_entity_id_cache() -> Generator[None]:
+    """Reset Spook's module-global entity ID cache state between tests.
+
+    The cache and its invalidation listeners live at module level in
+    ``entity_filtering``; without a reset, a cache populated from one
+    test's ``hass`` instance leaks into the next test.
+    """
+    yield
+    # pylint: disable-next=protected-access
+    if (unsub := entity_filtering._UNSUB_CACHE_INVALIDATION) is not None:  # noqa: SLF001
+        unsub()
+    # pylint: disable-next=protected-access
+    entity_filtering._clear_all_entity_ids_cache()  # noqa: SLF001
 
 
 @pytest.fixture

--- a/tests/test_e2e_repairs.py
+++ b/tests/test_e2e_repairs.py
@@ -1,0 +1,133 @@
+"""End-to-end test for Spook's repair machinery.
+
+Sets up the Spook config entry with the real repair manager, lets the
+inspection debouncers fire through simulated time, and asserts an issue
+for an automation with dangling references lands in the real issue
+registry.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.setup import async_setup_component
+
+from custom_components import spook
+from custom_components.spook.const import DOMAIN
+import pytest
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+pytestmark = pytest.mark.usefixtures("skip_dependency_setup")
+
+
+class _NoopSpookServiceManager:
+    """No-op service manager.
+
+    Spook's services register against entity platforms of integrations
+    that are not loaded in this test environment.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the no-op service manager."""
+        self.hass = hass
+
+    async def async_setup(self) -> None:
+        """Set up no services."""
+
+    def async_on_unload(self) -> None:
+        """Unload no services."""
+
+
+async def test_automation_with_dangling_references_creates_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the full path from automation config to a repairs issue."""
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "id": "spooky_test",
+                    "alias": "Spooky Test",
+                    "triggers": [
+                        {"trigger": "state", "entity_id": "binary_sensor.ghost"},
+                    ],
+                    "actions": [
+                        {
+                            "action": "light.turn_on",
+                            "target": {"entity_id": "light.ghost"},
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    async def _async_forward_no_ectoplasms(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+    ) -> None:
+        """Skip ectoplasm setup; this test targets the repair manager."""
+
+    monkeypatch.setattr(spook, "PLATFORMS", [])
+    monkeypatch.setattr(spook, "link_sub_integrations", lambda _: False)
+    monkeypatch.setattr(
+        spook, "async_forward_setup_entry", _async_forward_no_ectoplasms
+    )
+    monkeypatch.setattr(spook, "SpookServiceManager", _NoopSpookServiceManager)
+
+    # The Lovelace repair requires the Lovelace data container during
+    # activation; provide an empty one instead of setting up the frontend.
+    hass.data["lovelace"] = SimpleNamespace(dashboards={})
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Repairs are set up once Home Assistant signals it has started.
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    # Let the inspection debouncers (3 second cooldown) fire.
+    freezer.tick(timedelta(seconds=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "automation_unknown_entity_references_automation.spooky_test",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    entities = issue.translation_placeholders["entities"]
+    assert "binary_sensor.ghost" in entities
+    assert "light.ghost" in entities
+
+    # The dangling action also surfaces as an unknown service reference.
+    assert issue_registry.async_get_issue(
+        DOMAIN,
+        "automation_unknown_service_references_automation.spooky_test",
+    )
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Test infrastructure only, two additions:

1. An autouse fixture in `conftest.py` that unsubscribes and clears the module-global entity ID cache in `entity_filtering` after every test. Without it, a cache populated from one test's torn-down `hass` instance leaks into subsequent tests; the suite passed on ordering luck.

2. The first end-to-end repairs test: the real `SpookRepairManager` discovers and activates all repair modules, an automation is set up with a dangling trigger entity and a dangling action target, the started event fires, the 3 second inspection debouncers are driven with `freezer.tick` plus `async_fire_time_changed`, and the test asserts against the real issue registry: the unknown entity reference issue exists with both ghost entities in its placeholders, and the unknown service reference issue exists as well. The entry unloads cleanly at the end, which also proves the debouncers shut down without lingering timers.

Scoping notes, documented in the test: the service manager is substituted with a no-op because Spook's entity services register against platforms of integrations that are not loaded in the test environment, and the Lovelace repair needs a stub `hass.data["lovelace"]` container since its activation dereferences it unguarded. With the setup isolation from #1346 in place, extending the end-to-end test to the real service manager is a natural follow-up.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Nothing previously tested the full path from "automation references something that does not exist" to "an issue appears in the repairs dashboard", including the event wiring and debouncer timing. This is the regression net for the repair machinery changes landing lately, and the cache reset removes a latent cross-test contamination bug.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Full suite passes (516 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.