### PR TITLE
Add Home Assistant dev canary and helper repair smoke tests

### DIFF
--- a/.github/workflows/tests-ha-dev.yml
+++ b/.github/workflows/tests-ha-dev.yml
@@ -1,0 +1,47 @@
+name: Tests (Home Assistant dev)
+
+# Daily canary: run the test suite against the Home Assistant dev branch.
+# Spook reaches into Home Assistant internals by design; this catches
+# upstream changes that break Spook before they ship in a release.
+# Failures here are an early warning, not a release blocker.
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DEFAULT_PYTHON: "3.14"
+
+jobs:
+  test-ha-dev:
+    name: Pytest against Home Assistant dev
+    runs-on: ubuntu-latest
+    if: github.repository == 'frenck/spook'
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 🏗 Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          python-version: ${{ env.DEFAULT_PYTHON }}
+
+      - name: 🏗 Install dependencies
+        run: uv sync --frozen --dev
+
+      - name: 👻 Install Home Assistant dev
+        run: |
+          uv pip install --prerelease=allow \
+            "homeassistant @ git+https://github.com/home-assistant/core.git@dev"
+          uv run --no-sync python -c \
+            'from homeassistant.const import __version__; print(f"Home Assistant {__version__}")'
+
+      - name: 🚀 Run tests
+        run: uv run --no-sync pytest --no-cov

--- a/tests/test_helper_source_repairs_smoke.py
+++ b/tests/test_helper_source_repairs_smoke.py
@@ -1,0 +1,102 @@
+"""Smoke tests for the unknown source entity repairs.
+
+These repairs read private attributes of helper entities provided by
+Home Assistant core (like ``_sensor_source_id``). Each test sets up the
+real helper integration with a nonexistent source entity and runs the
+repair against it, so a core rename of those private attributes fails
+here instead of at the user's place.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.spook.const import DOMAIN
+import pytest
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+@pytest.mark.parametrize(
+    ("helper_domain", "options"),
+    [
+        pytest.param(
+            "integration",
+            {
+                "name": "Ghostly integral",
+                "source": "sensor.ghost",
+                "method": "trapezoidal",
+                "round": 1.0,
+                "unit_prefix": "k",
+                "unit_time": "h",
+            },
+            id="integration",
+        ),
+        pytest.param(
+            "utility_meter",
+            {
+                "name": "Ghostly meter",
+                "source": "sensor.ghost",
+                "cycle": "monthly",
+                "offset": 0,
+                "net_consumption": False,
+                "delta_values": False,
+                "periodically_resetting": True,
+                "always_available": False,
+                "tariffs": [],
+            },
+            id="utility_meter",
+        ),
+        pytest.param(
+            "trend",
+            {
+                "name": "Ghostly trend",
+                "entity_id": "sensor.ghost",
+                "invert": False,
+            },
+            id="trend",
+        ),
+        pytest.param(
+            "switch_as_x",
+            {
+                "entity_id": "switch.ghost",
+                "target_domain": "light",
+                "invert": False,
+            },
+            id="switch_as_x",
+        ),
+    ],
+)
+async def test_unknown_source_repair_smoke(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    helper_domain: str,
+    options: dict[str, Any],
+) -> None:
+    """Test the repair detects a helper wrapping a nonexistent source."""
+    entry = MockConfigEntry(
+        domain=helper_domain,
+        title=str(options.get("name", "Ghostly")),
+        options=options,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    repair_module = importlib.import_module(
+        f"custom_components.spook.ectoplasms.{helper_domain}.repairs.unknown_source",
+    )
+    repair = repair_module.SpookRepair(hass)
+    await repair.async_inspect()
+
+    prefix = f"{repair.repair}_"
+    assert any(
+        issue_domain == DOMAIN and issue_id.startswith(prefix)
+        for issue_domain, issue_id in issue_registry.issues
+    ), f"No {repair.repair} issue was created for the ghost source"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Spook reaches into Home Assistant internals by design, which means core refactors can break it. Until now the first detection was a user report after a release. Two additions turn that into an early warning:

1. **`tests-ha-dev.yml`**: a daily scheduled workflow (plus manual dispatch) that installs Home Assistant straight from the `dev` branch on top of the locked test environment and runs the full suite. Guarded to this repository so forks do not burn CI minutes on it. Failures here are informational canary signals, not release blockers, so there is no coverage upload and nothing depends on it.

2. **`tests/test_helper_source_repairs_smoke.py`**: a parametrized smoke test that sets up the four real helper integrations Spook wraps via private entity attributes (`integration`, `utility_meter`, `trend`, `switch_as_x`), each with a nonexistent source entity, runs the corresponding unknown source repair, and asserts an issue is created in the real issue registry. These repairs read `_sensor_source_id`, `_switch_entity_id`, and `_entity_id` from core entities; a rename of any of them now fails the nightly canary instead of surfacing at a user's place. These are also the first behavior tests these four repairs have.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The most fragile code in Spook (private core attribute access) previously had the least detection. The smoke tests give it coverage; the dev canary runs that coverage against tomorrow's Home Assistant every night.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Full suite passes locally (525 tests), ruff, pylint, zizmor, and all prek hooks pass. The workflow can be exercised via `workflow_dispatch` after merge.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.