### PR TITLE
Remove dead pre-2025.10 compatibility branch

### DIFF
--- a/custom_components/spook/services.py
+++ b/custom_components/spook/services.py
@@ -8,13 +8,9 @@ import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, final
 
-from awesomeversion import AwesomeVersion
 import voluptuous as vol
 
-from homeassistant.const import (
-    EVENT_CORE_CONFIG_UPDATE,
-    __short_version__ as current_version,
-)
+from homeassistant.const import EVENT_CORE_CONFIG_UPDATE
 from homeassistant.core import (
     Event,
     HomeAssistant,
@@ -284,26 +280,13 @@ class SpookServiceManager:
 
         # Load service schemas
         integration = await async_get_integration(self.hass, DOMAIN)
-        # Ensure compatibility with Home Assistant version
-        # As of Home Assistant 2025.10, the _load_services_file function no
-        # longer has the hass parameter.
-        if AwesomeVersion(current_version) >= AwesomeVersion("2025.10"):
-            self._service_schemas = cast(
-                dict[str, Any],
-                await self.hass.async_add_executor_job(
-                    _load_services_file,
-                    integration,
-                ),
-            )
-        else:
-            self._service_schemas = cast(
-                dict[str, Any],
-                await self.hass.async_add_executor_job(
-                    _load_services_file,
-                    self.hass,
-                    integration,
-                ),
-            )
+        self._service_schemas = cast(
+            dict[str, Any],
+            await self.hass.async_add_executor_job(
+                _load_services_file,
+                integration,
+            ),
+        )
 
         modules: list[ModuleType] = []
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`SpookServiceManager.async_setup` carried an `AwesomeVersion` check to support the pre-2025.10 signature of `_load_services_file` (which still took `hass`). Spook requires Home Assistant `>=2026.3.0` per `pyproject.toml`, so the legacy path is unreachable. This removes the version check, the dead call path, and the now-unused `AwesomeVersion` and `__short_version__` imports.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Dead code with a version comparison reads like it still does something. It does not; it just costs a version parse on every setup and a detour for every reader.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

No behavior change: the surviving code path is the one every existing test already exercises. Full suite passes (521 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.