### PR TITLE
Move entity ID cache from module globals into hass.data

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -35,6 +36,7 @@ from homeassistant.helpers import (
     label_registry as lr,
 )
 from homeassistant.helpers.template import Template
+from homeassistant.util.hass_dict import HassKey
 
 from .const import LOGGER
 from .listeners import async_listen_once_tracked
@@ -139,17 +141,26 @@ COMPILED_ENTITY_ID_TEMPLATE_PATTERNS = tuple(
 )
 JINJA_COMMENT_PATTERN = re.compile(r"\{#.*?#\}", re.DOTALL)
 
-_CACHED_ALL_ENTITY_IDS: set[str] | None = None
-_UNSUB_CACHE_INVALIDATION: Callable[[], None] | None = None
+
+@dataclass
+class EntityIDsCache:
+    """Per Home Assistant instance cache of all known entity IDs."""
+
+    entity_ids: set[str] | None = None
+    unsubscribe: Callable[[], None] | None = None
+
+
+DATA_ALL_ENTITY_IDS_CACHE: HassKey[EntityIDsCache] = HassKey(
+    "spook_all_entity_ids_cache",
+)
 
 
 @callback
-def _clear_all_entity_ids_cache(*_args: Any) -> None:
-    """Clear the cached set of all entity IDs."""
-    # pylint: disable-next=global-statement
-    global _CACHED_ALL_ENTITY_IDS  # noqa: PLW0603
-    LOGGER.debug("Clearing all_entity_ids cache.")
-    _CACHED_ALL_ENTITY_IDS = None
+def _async_get_cache(hass: HomeAssistant) -> EntityIDsCache:
+    """Return the entity IDs cache container for this instance."""
+    if DATA_ALL_ENTITY_IDS_CACHE not in hass.data:
+        hass.data[DATA_ALL_ENTITY_IDS_CACHE] = EntityIDsCache()
+    return hass.data[DATA_ALL_ENTITY_IDS_CACHE]
 
 
 def async_setup_all_entity_ids_cache_invalidation(
@@ -159,16 +170,21 @@ def async_setup_all_entity_ids_cache_invalidation(
 
     Returns a callable to unsubscribe the listeners.
     """
-    # pylint: disable-next=global-statement
-    global _UNSUB_CACHE_INVALIDATION  # noqa: PLW0603
+    cache = _async_get_cache(hass)
 
-    if _UNSUB_CACHE_INVALIDATION is not None:
+    if cache.unsubscribe is not None:
         LOGGER.debug(
             "Spook's entity ID cache invalidation already set up. Skipping.",
         )
-        return _UNSUB_CACHE_INVALIDATION
+        return cache.unsubscribe
 
     LOGGER.debug("Setting up Spook's all_entity_ids cache invalidation listeners.")
+
+    @callback
+    def _clear_cache(*_args: Any) -> None:
+        """Clear the cached set of all entity IDs."""
+        LOGGER.debug("Clearing all_entity_ids cache.")
+        cache.entity_ids = None
 
     @callback
     def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
@@ -179,29 +195,25 @@ def async_setup_all_entity_ids_cache_invalidation(
 
     # Listen for entity registry updates
     unsub_registry_update = hass.bus.async_listen(
-        er.EVENT_ENTITY_REGISTRY_UPDATED, _clear_all_entity_ids_cache
+        er.EVENT_ENTITY_REGISTRY_UPDATED, _clear_cache
     )
     # Listen for Home Assistant start to ensure cache is clear then
     unsub_hass_start = async_listen_once_tracked(
-        hass, EVENT_HOMEASSISTANT_START, _clear_all_entity_ids_cache
+        hass, EVENT_HOMEASSISTANT_START, _clear_cache
     )
     # Listen for components loading
-    unsub_component_loaded = hass.bus.async_listen(
-        EVENT_COMPONENT_LOADED, _clear_all_entity_ids_cache
-    )
+    unsub_component_loaded = hass.bus.async_listen(EVENT_COMPONENT_LOADED, _clear_cache)
     # Listen for state-only entities being added or removed.
     unsub_state_changed = hass.bus.async_listen(
         EVENT_STATE_CHANGED,
-        _clear_all_entity_ids_cache,
+        _clear_cache,
         event_filter=_state_entity_changed,
     )
 
     # Perform an initial clear, just in case.
-    _clear_all_entity_ids_cache()
+    _clear_cache()
 
     def _unsubscribe_listeners() -> None:
-        # pylint: disable-next=global-statement
-        global _UNSUB_CACHE_INVALIDATION  # noqa: PLW0603
         LOGGER.debug(
             "Unsubscribing from Spook's all_entity_ids cache invalidation listeners.",
         )
@@ -209,9 +221,10 @@ def async_setup_all_entity_ids_cache_invalidation(
         unsub_hass_start()
         unsub_component_loaded()
         unsub_state_changed()
-        _UNSUB_CACHE_INVALIDATION = None  # Mark as unsubscribed
+        cache.entity_ids = None
+        cache.unsubscribe = None  # Mark as unsubscribed
 
-    _UNSUB_CACHE_INVALIDATION = _unsubscribe_listeners
+    cache.unsubscribe = _unsubscribe_listeners
     return _unsubscribe_listeners
 
 
@@ -220,10 +233,9 @@ def async_get_all_entity_ids(
     hass: HomeAssistant, *, include_all_none: bool = False
 ) -> set[str]:
     """Return entity IDs known to Home Assistant or treated as known by Spook."""
-    # pylint: disable-next=global-statement
-    global _CACHED_ALL_ENTITY_IDS  # noqa: PLW0603
+    cache = _async_get_cache(hass)
 
-    if _CACHED_ALL_ENTITY_IDS is None:
+    if (entity_ids := cache.entity_ids) is None:
         LOGGER.debug(
             "Spook's all_entity_ids cache is empty, populating...",
         )
@@ -239,20 +251,21 @@ def async_get_all_entity_ids(
         )
 
         # Filter out ignored domains
-        _CACHED_ALL_ENTITY_IDS = {
+        entity_ids = {
             entity_id
             for entity_id in combined_entity_ids
             if not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
         }
+        cache.entity_ids = entity_ids
         LOGGER.debug(
             "Spook's all_entity_ids cache populated with %s entities",
-            len(_CACHED_ALL_ENTITY_IDS),
+            len(entity_ids),
         )
 
     # Return a copy from the cache, optionally adding ALL/NONE
     if include_all_none:
-        return _CACHED_ALL_ENTITY_IDS.union({ENTITY_MATCH_ALL, ENTITY_MATCH_NONE})
-    return _CACHED_ALL_ENTITY_IDS.copy()
+        return entity_ids.union({ENTITY_MATCH_ALL, ENTITY_MATCH_NONE})
+    return entity_ids.copy()
 
 
 @callback

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,7 @@ from pytest_homeassistant_custom_component.syrupy import HomeAssistantSnapshotEx
 
 from homeassistant import config_entries, loader, setup
 
-from custom_components.spook import entity_filtering
-
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
     from syrupy.assertion import SnapshotAssertion
 
     from homeassistant.core import HomeAssistant
@@ -30,22 +26,6 @@ def allow_unreleased_spook(monkeypatch: pytest.MonkeyPatch) -> None:
 def auto_enable_custom_integrations(enable_custom_integrations: None) -> None:
     """Enable custom integrations in Home Assistant tests."""
     _ = enable_custom_integrations
-
-
-@pytest.fixture(autouse=True)
-def reset_entity_id_cache() -> Generator[None]:
-    """Reset Spook's module-global entity ID cache state between tests.
-
-    The cache and its invalidation listeners live at module level in
-    ``entity_filtering``; without a reset, a cache populated from one
-    test's ``hass`` instance leaks into the next test.
-    """
-    yield
-    # pylint: disable-next=protected-access
-    if (unsub := entity_filtering._UNSUB_CACHE_INVALIDATION) is not None:  # noqa: SLF001
-        unsub()
-    # pylint: disable-next=protected-access
-    entity_filtering._clear_all_entity_ids_cache()  # noqa: SLF001
 
 
 @pytest.fixture

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -362,3 +362,25 @@ async def test_async_filter_known_floor_ids_defaults_to_floor_registry(
         hass,
         floor_ids={floor.floor_id, label.label_id, "ghost_floor"},
     ) == {label.label_id, "ghost_floor"}
+
+
+async def test_entity_id_cache_lifecycle(hass: HomeAssistant) -> None:
+    """Test the per-instance entity ID cache wiring.
+
+    Setting up invalidation twice returns the same unsubscribe callable,
+    a state addition invalidates the cache, and unsubscribing clears it.
+    """
+    unsub = entity_filtering.async_setup_all_entity_ids_cache_invalidation(hass)
+    assert entity_filtering.async_setup_all_entity_ids_cache_invalidation(hass) is unsub
+
+    assert "light.new" not in async_get_all_entity_ids(hass)
+
+    hass.states.async_set("light.new", "on")
+    await hass.async_block_till_done()
+
+    assert "light.new" in async_get_all_entity_ids(hass)
+
+    unsub()
+    cache = hass.data[entity_filtering.DATA_ALL_ENTITY_IDS_CACHE]
+    assert cache.entity_ids is None
+    assert cache.unsubscribe is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The all-entity-IDs cache and its invalidation unsubscribe callable lived as module globals in `entity_filtering.py`. They now live in a typed per-instance container in `hass.data`: a `HassKey("spook_all_entity_ids_cache")` holding a small `EntityIDsCache` dataclass with the cached set and the unsubscribe callable. The invalidation listeners are closures over that container, which removes all `global` statements and their lint suppressions.

Behavior is unchanged: the same events invalidate the cache, setting up invalidation twice returns the existing unsubscribe callable, and unsubscribing clears both the listeners and the cache.

The autouse test fixture that reset the module globals between tests is removed: with per-instance storage, a fresh `hass` per test means a fresh cache per test, so cross-test leakage is impossible by construction. A new lifecycle test pins the wiring instead (idempotent setup, event-driven invalidation on state addition, unsubscribe clearing the container).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Module-global state made reload correctness depend on Home Assistant's teardown ordering: an unload had to run before the next setup or the guard silently reused listeners bound to a previous lifecycle. Upcoming work adds live settings that reload behavior, which is exactly when this would have become a real bug. Per-instance state in `hass.data` makes the lifecycle explicit.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

New `test_entity_id_cache_lifecycle` covers the container wiring. Full suite passes (526 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.