### PR TITLE
Migrate script reference repairs to the shared base class

### DIFF
--- a/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import script
 from homeassistant.helpers import area_registry as ar
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
 from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced areas in scripts."""
 
     domain = script.DOMAIN
@@ -19,44 +22,21 @@ class SpookRepair(AbstractSpookRepair):
     inspect_events = {ar.EVENT_AREA_REGISTRY_UPDATED}
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = script.UnavailableScriptEntity
+    entity_label = "script"
+    reference_label = "areas"
+    edit_url_pattern = "/config/script/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_area_ids: set[str]
 
-        entity_component: EntityComponent[script.ScriptEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known area IDs for this inspection cycle."""
+        self._known_area_ids = async_get_all_area_ids(self.hass)
 
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-
-        known_area_ids = async_get_all_area_ids(self.hass)
-
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if not isinstance(entity, script.UnavailableScriptEntity) and (
-                unknown_areas := async_filter_known_area_ids(
-                    self.hass,
-                    area_ids=entity.script.referenced_areas,
-                    known_area_ids=known_area_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "areas": "\n".join(f"- `{area}`" for area in unknown_areas),
-                        "script": entity.name,
-                        "edit": f"/config/script/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    (
-                        "Spook found unknown areas in %s "
-                        "and created an issue for it; Areas: %s"
-                    ),
-                    entity.entity_id,
-                    ", ".join(unknown_areas),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown area IDs referenced by ``entity``."""
+        return async_filter_known_area_ids(
+            self.hass,
+            area_ids=entity.script.referenced_areas,
+            known_area_ids=self._known_area_ids,
+        )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import script
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
 from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced devices in scripts."""
 
     domain = script.DOMAIN
@@ -20,43 +23,21 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = script.UnavailableScriptEntity
+    entity_label = "script"
+    reference_label = "devices"
+    edit_url_pattern = "/config/script/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_device_ids: set[str]
 
-        entity_component: EntityComponent[script.ScriptEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known device IDs for this inspection cycle."""
+        self._known_device_ids = async_get_all_device_ids(self.hass)
 
-        known_device_ids = async_get_all_device_ids(self.hass)
-
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if not isinstance(entity, script.UnavailableScriptEntity) and (
-                unknown_devices := async_filter_known_device_ids(
-                    self.hass,
-                    device_ids=entity.script.referenced_devices,
-                    known_device_ids=known_device_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "devices": "\n".join(
-                            f"- `{device}`" for device in unknown_devices
-                        ),
-                        "script": entity.name,
-                        "edit": f"/config/script/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    "Spook found unknown devices in %s "
-                    "and created an issue for it; Devices: %s",
-                    entity.entity_id,
-                    ", ".join(unknown_devices),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown device IDs referenced by ``entity``."""
+        return async_filter_known_device_ids(
+            self.hass,
+            device_ids=entity.script.referenced_devices,
+            known_device_ids=self._known_device_ids,
+        )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -7,14 +7,13 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components import script
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from ....entity_filtering import (
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
     async_get_all_entity_ids,
 )
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -86,7 +85,7 @@ async def extract_template_entities_from_script_entity(
     return await async_extract_entities_from_config(hass, config)
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced entity in scripts."""
 
     domain = script.DOMAIN
@@ -98,7 +97,12 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = script.UnavailableScriptEntity
+    entity_label = "script"
+    reference_label = "entities"
+    edit_url_pattern = "/config/script/edit/{unique_id}"
+
+    _known_entity_ids: set[str]
 
     def _get_blueprint_trigger_entities(self, entity: script.ScriptEntity) -> set[str]:
         """Extract entity references from blueprint trigger inputs."""
@@ -128,49 +132,27 @@ class SpookRepair(AbstractSpookRepair):
 
         return entities
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    async def _async_setup_inspection(self) -> None:
+        """Cache known entity IDs (including ALL/NONE) for this inspection cycle."""
+        self._known_entity_ids = async_get_all_entity_ids(
+            self.hass, include_all_none=True
+        )
 
-        entity_component: EntityComponent[script.ScriptEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown entity IDs referenced by ``entity`` (incl. templates)."""
+        # Get all referenced entities from the script
+        all_entities = extract_referenced_entities_from_script(entity)
 
-        known_entity_ids = async_get_all_entity_ids(self.hass, include_all_none=True)
+        # Check for blueprint trigger inputs
+        all_entities.update(self._get_blueprint_trigger_entities(entity))
 
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if isinstance(entity, script.UnavailableScriptEntity):
-                continue
+        # Extract entities from Template objects within the script entity
+        all_entities.update(
+            await extract_template_entities_from_script_entity(self.hass, entity)
+        )
 
-            # Get all referenced entities from the script
-            all_entities = extract_referenced_entities_from_script(entity)
-
-            # Check for blueprint trigger inputs
-            blueprint_entities = self._get_blueprint_trigger_entities(entity)
-            all_entities.update(blueprint_entities)
-
-            # Extract entities from Template objects within the script entity
-            template_entities = await extract_template_entities_from_script_entity(
-                self.hass, entity
-            )
-            all_entities.update(template_entities)
-
-            # Check for unknown entities
-            if unknown_entities := await async_filter_known_entity_ids_with_templates(
-                self.hass,
-                entity_ids=all_entities,
-                known_entity_ids=known_entity_ids,
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in unknown_entities
-                        ),
-                        "script": entity.name,
-                        "edit": f"/config/script/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
+        return await async_filter_known_entity_ids_with_templates(
+            self.hass,
+            entity_ids=all_entities,
+            known_entity_ids=self._known_entity_ids,
+        )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import script
 from homeassistant.helpers import floor_registry as fr
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
 from ....entity_filtering import async_filter_known_floor_ids, async_get_all_floor_ids
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced floors in scripts."""
 
     domain = script.DOMAIN
@@ -19,41 +22,21 @@ class SpookRepair(AbstractSpookRepair):
     inspect_events = {fr.EVENT_FLOOR_REGISTRY_UPDATED}
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = script.UnavailableScriptEntity
+    entity_label = "script"
+    reference_label = "floors"
+    edit_url_pattern = "/config/script/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_floor_ids: set[str]
 
-        entity_component: EntityComponent[script.ScriptEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known floor IDs for this inspection cycle."""
+        self._known_floor_ids = async_get_all_floor_ids(self.hass)
 
-        known_floor_ids = async_get_all_floor_ids(self.hass)
-
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if not isinstance(entity, script.UnavailableScriptEntity) and (
-                unknown_floors := async_filter_known_floor_ids(
-                    self.hass,
-                    floor_ids=entity.script.referenced_floors,
-                    known_floor_ids=known_floor_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "floors": "\n".join(f"- `{floor}`" for floor in unknown_floors),
-                        "script": entity.name,
-                        "edit": f"/config/script/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    "Spook found unknown floors in %s "
-                    "and created an issue for it; Floors: %s",
-                    entity.entity_id,
-                    ", ".join(unknown_floors),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown floor IDs referenced by ``entity``."""
+        return async_filter_known_floor_ids(
+            self.hass,
+            floor_ids=entity.script.referenced_floors,
+            known_floor_ids=self._known_floor_ids,
+        )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components import script
 from homeassistant.helpers import label_registry as lr
-from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
-from ....const import LOGGER
 from ....entity_filtering import async_filter_known_label_ids, async_get_all_label_ids
-from ....repairs import AbstractSpookRepair
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-class SpookRepair(AbstractSpookRepair):
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     """Spook repair tries to find unknown referenced labels in scripts."""
 
     domain = script.DOMAIN
@@ -19,41 +22,21 @@ class SpookRepair(AbstractSpookRepair):
     inspect_events = {lr.EVENT_LABEL_REGISTRY_UPDATED}
     inspect_on_reload = True
 
-    automatically_clean_up_issues = True
+    unavailable_entity_class = script.UnavailableScriptEntity
+    entity_label = "script"
+    reference_label = "labels"
+    edit_url_pattern = "/config/script/edit/{unique_id}"
 
-    async def async_inspect(self) -> None:
-        """Trigger a inspection."""
-        if self.domain not in self.hass.data[DATA_INSTANCES]:
-            return
+    _known_label_ids: set[str]
 
-        entity_component: EntityComponent[script.ScriptEntity] = self.hass.data[
-            DATA_INSTANCES
-        ][self.domain]
+    async def _async_setup_inspection(self) -> None:
+        """Cache known label IDs for this inspection cycle."""
+        self._known_label_ids = async_get_all_label_ids(self.hass)
 
-        known_label_ids = async_get_all_label_ids(self.hass)
-
-        LOGGER.debug("Spook is inspecting: %s", self.repair)
-        for entity in entity_component.entities:
-            self.possible_issue_ids.add(entity.entity_id)
-            if not isinstance(entity, script.UnavailableScriptEntity) and (
-                unknown_labels := async_filter_known_label_ids(
-                    self.hass,
-                    label_ids=entity.script.referenced_labels,
-                    known_label_ids=known_label_ids,
-                )
-            ):
-                self.async_create_issue(
-                    issue_id=entity.entity_id,
-                    translation_placeholders={
-                        "labels": "\n".join(f"- `{label}`" for label in unknown_labels),
-                        "script": entity.name,
-                        "edit": f"/config/script/edit/{entity.unique_id}",
-                        "entity_id": entity.entity_id,
-                    },
-                )
-                LOGGER.debug(
-                    "Spook found unknown labels in %s "
-                    "and created an issue for it; Labels: %s",
-                    entity.entity_id,
-                    ", ".join(unknown_labels),
-                )
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown label IDs referenced by ``entity``."""
+        return async_filter_known_label_ids(
+            self.hass,
+            label_ids=entity.script.referenced_labels,
+            known_label_ids=self._known_label_ids,
+        )

--- a/tests/ectoplasms/script/repairs/test_unknown_area_references.py
+++ b/tests/ectoplasms/script/repairs/test_unknown_area_references.py
@@ -32,7 +32,9 @@ async def test_script_with_unknown_area_creates_issue(
         unique_id="spooky",
         script=SimpleNamespace(referenced_areas={area.id, "ghost_area"}),
     )
-    hass.data[DATA_INSTANCES] = {"script": SimpleNamespace(entities=[entity])}
+    hass.data.setdefault(DATA_INSTANCES, {})["script"] = SimpleNamespace(
+        entities=[entity],
+    )
 
     repair = SpookRepair(hass)
     await repair.async_inspect()

--- a/tests/ectoplasms/script/repairs/test_unknown_area_references.py
+++ b/tests/ectoplasms/script/repairs/test_unknown_area_references.py
@@ -1,0 +1,47 @@
+"""Tests for the script unknown area references repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.entity_component import DATA_INSTANCES
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.script.repairs.unknown_area_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import area_registry as ar, issue_registry as ir
+
+
+async def test_script_with_unknown_area_creates_issue(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a script referencing a nonexistent area raises an issue."""
+    area = area_registry.async_create("Upstairs")
+
+    entity = SimpleNamespace(
+        entity_id="script.spooky",
+        name="Spooky",
+        unique_id="spooky",
+        script=SimpleNamespace(referenced_areas={area.id, "ghost_area"}),
+    )
+    hass.data[DATA_INSTANCES] = {"script": SimpleNamespace(entities=[entity])}
+
+    repair = SpookRepair(hass)
+    await repair.async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "script_unknown_area_references_script.spooky",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert issue.translation_placeholders["areas"] == "- `ghost_area`"
+    assert issue.translation_placeholders["edit"] == "/config/script/edit/spooky"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The five script reference repairs (areas, devices, entities, floors, labels) still open-coded the entity-component inspection loop that their automation counterparts already delegate to `AbstractSpookEntityComponentUnknownReferencesRepair`. They now use the same base class: declarative class attributes plus the two hooks, `_async_setup_inspection` caching the known ID set and `_async_compute_unknown_references` reading `entity.script.referenced_*`. The entity repair keeps its module-level extractors and blueprint input helper unchanged; only its inspection loop collapsed into the hook.

Beyond removing the duplication (132 insertions against 223 deletions), the script repairs now inherit the base class behaviors they had drifted away from: per-inspection `possible_issue_ids` reset (safe since the cleanup rework), the edit URL fallback for YAML scripts without a unique ID, and uniform debug logging.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Every improvement to the shared inspection loop previously had to be replicated by hand into five drifted copies (the recent garbled-logging fix lived only in those copies, for example). One implementation, two domains. This also unblocks upcoming reference detection work where automation and script repairs must share a config walker.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The twelve existing script extractor tests pass untouched, the ectoplasm discovery contract test covers all five modules, and a new wiring test proves the migrated area repair end to end: a mock script referencing a real area plus a ghost area yields an issue in the real issue registry with the expected placeholders and edit URL. Full suite passes (527 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.