### PR TITLE
Yield to the event loop during repair inspections

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -41,8 +41,9 @@ if TYPE_CHECKING:
     from homeassistant.util.event_type import EventType
 
 
-# Yield to the event loop every this many inspected entities; inspections
-# are CPU-bound and must not stall the loop on large installations.
+# Yield to the event loop after every batch of this many inspected
+# entities; inspections are CPU-bound and must not stall the loop on
+# large installations.
 INSPECTION_YIELD_INTERVAL = 50
 
 
@@ -443,11 +444,11 @@ class AbstractSpookEntityPlatformUnknownSourceRepair(AbstractSpookRepair, ABC):
                 continue
 
             for entity in platform.entities.values():
-                inspected += 1
-                if inspected % INSPECTION_YIELD_INTERVAL == 0:
+                if inspected and inspected % INSPECTION_YIELD_INTERVAL == 0:
                     # Inspections are CPU-bound; periodically yield to the
                     # event loop so large installations do not stall it.
                     await asyncio.sleep(0)
+                inspected += 1
 
                 self.possible_issue_ids.add(entity.entity_id)
                 source = self._get_source_entity_id(entity)

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -41,6 +41,11 @@ if TYPE_CHECKING:
     from homeassistant.util.event_type import EventType
 
 
+# Yield to the event loop every this many inspected entities; inspections
+# are CPU-bound and must not stall the loop on large installations.
+INSPECTION_YIELD_INTERVAL = 50
+
+
 class AbstractSpookRepairBase(ABC):
     """Abstract base class to hold a Spook repairs."""
 
@@ -354,7 +359,12 @@ class AbstractSpookEntityComponentUnknownReferencesRepair(AbstractSpookRepair, A
 
         await self._async_setup_inspection()
 
-        for entity in entity_component.entities:
+        for index, entity in enumerate(entity_component.entities):
+            if index and index % INSPECTION_YIELD_INTERVAL == 0:
+                # Inspections are CPU-bound; periodically yield to the event
+                # loop so large installations do not stall it.
+                await asyncio.sleep(0)
+
             self.possible_issue_ids.add(entity.entity_id)
 
             if isinstance(entity, self.unavailable_entity_class):
@@ -424,6 +434,7 @@ class AbstractSpookEntityPlatformUnknownSourceRepair(AbstractSpookRepair, ABC):
 
         known_entity_ids = async_get_all_entity_ids(self.hass)
 
+        inspected = 0
         for platform in platforms:
             if (
                 self.source_platform_domain is not None
@@ -432,6 +443,12 @@ class AbstractSpookEntityPlatformUnknownSourceRepair(AbstractSpookRepair, ABC):
                 continue
 
             for entity in platform.entities.values():
+                inspected += 1
+                if inspected % INSPECTION_YIELD_INTERVAL == 0:
+                    # Inspections are CPU-bound; periodically yield to the
+                    # event loop so large installations do not stall it.
+                    await asyncio.sleep(0)
+
                 self.possible_issue_ids.add(entity.entity_id)
                 source = self._get_source_entity_id(entity)
                 if source not in known_entity_ids:

--- a/tests/test_repairs_yields.py
+++ b/tests/test_repairs_yields.py
@@ -1,0 +1,113 @@
+"""Tests for event loop yielding during repair inspections."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.helpers.entity_component import DATA_INSTANCES
+from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM
+
+from custom_components.spook.repairs import (
+    AbstractSpookEntityComponentUnknownReferencesRepair,
+    AbstractSpookEntityPlatformUnknownSourceRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    import pytest
+
+ENTITY_COUNT = 120
+EXPECTED_YIELDS = 2  # After entity 50 and entity 100.
+
+
+class _UnavailableEntity:  # pylint: disable=too-few-public-methods
+    """Marker class for unavailable entities."""
+
+
+class _ReferencesRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
+    """Mock unknown-references repair."""
+
+    domain = "automation"
+    repair = "mock_repair"
+    unavailable_entity_class = _UnavailableEntity
+    entity_label = "automation"
+    reference_label = "entities"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
+
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return no unknown references."""
+        del entity
+        return set()
+
+
+class _SourceRepair(AbstractSpookEntityPlatformUnknownSourceRepair):
+    """Mock unknown-source repair."""
+
+    domain = "integration"
+    repair = "mock_repair"
+
+    def _get_source_entity_id(self, entity: Any) -> str:
+        """Return a source entity ID that is always known."""
+        del entity
+        return "sensor.time"
+
+
+def _count_sleeps(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record asyncio.sleep calls made during the test."""
+    calls: list[float] = []
+    original_sleep = asyncio.sleep
+
+    async def _counting_sleep(delay: float) -> None:
+        calls.append(delay)
+        await original_sleep(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", _counting_sleep)
+    return calls
+
+
+async def test_component_inspection_yields_to_event_loop(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the entity component inspection yields periodically."""
+    entities = [
+        SimpleNamespace(entity_id=f"automation.spooky_{index}")
+        for index in range(ENTITY_COUNT)
+    ]
+    hass.data.setdefault(DATA_INSTANCES, {})["automation"] = SimpleNamespace(
+        entities=entities,
+    )
+
+    repair = _ReferencesRepair(hass)
+    calls = _count_sleeps(monkeypatch)
+
+    await repair.async_inspect()
+
+    assert calls == [0] * EXPECTED_YIELDS
+
+
+async def test_platform_inspection_yields_to_event_loop(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the entity platform inspection yields periodically."""
+    platform = SimpleNamespace(
+        domain="sensor",
+        entities={
+            f"sensor.spooky_{index}": SimpleNamespace(
+                entity_id=f"sensor.spooky_{index}",
+            )
+            for index in range(ENTITY_COUNT)
+        },
+    )
+    hass.data.setdefault(DATA_ENTITY_PLATFORM, {})["integration"] = [platform]
+
+    repair = _SourceRepair(hass)
+    calls = _count_sleeps(monkeypatch)
+
+    await repair.async_inspect()
+
+    assert calls == [0] * EXPECTED_YIELDS

--- a/tests/test_repairs_yields.py
+++ b/tests/test_repairs_yields.py
@@ -60,9 +60,9 @@ def _count_sleeps(monkeypatch: pytest.MonkeyPatch) -> list[float]:
     calls: list[float] = []
     original_sleep = asyncio.sleep
 
-    async def _counting_sleep(delay: float) -> None:
+    async def _counting_sleep(delay: float, result: object = None) -> object:
         calls.append(delay)
-        await original_sleep(delay)
+        return await original_sleep(delay, result)
 
     monkeypatch.setattr(asyncio, "sleep", _counting_sleep)
     return calls


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The shared repair inspection loops (entity component and entity platform) are pure CPU work: regex analysis over template strings, set operations across every automation, script, and helper. On large installations a single inspection could hold the event loop for hundreds of milliseconds, stalling state updates and websocket responses, and with a dozen repairs re-inspecting on entity churn that adds up.

Both loops now `await asyncio.sleep(0)` every 50 inspected entities (`INSPECTION_YIELD_INTERVAL`), letting the event loop breathe. The platform variant counts across platforms so the interval holds even when an integration has many small platforms.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Spook inspects everything, frequently, by design. That must never be noticeable in Home Assistant's responsiveness.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two new tests drive 120 mock entities through each base class with a counting wrapper around `asyncio.sleep` and assert exactly two zero-delay yields, pinning the cadence. Full suite passes (529 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.