### PR TITLE
Split template extraction out of entity_filtering and cache template scans

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -11,15 +11,15 @@ from homeassistant.core import Event, callback
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
-from ....entity_filtering import (
+from ....entity_filtering import async_get_all_entity_ids
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+from ....template_extraction import (
     ENTITY_ID_PATTERN,
     async_extract_entities_from_config,
     async_extract_entities_from_template_string,
     async_filter_known_entity_ids_with_templates,
-    async_get_all_entity_ids,
     is_template_string,
 )
-from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
     from collections.abc import Mapping

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_entity_references.py
@@ -8,12 +8,12 @@ from homeassistant.components import script
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
 
-from ....entity_filtering import (
+from ....entity_filtering import async_get_all_entity_ids
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+from ....template_extraction import (
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
-    async_get_all_entity_ids,
 )
-from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -66,17 +66,6 @@ KNOWN_TIME_DATE_ENTITY_IDS = {
     "sensor.time_utc",
 }
 
-# Additional known domains that are not in the Platform enum
-
-# Build a list of all known domains
-
-# Home Assistant core entity ID validation patterns (from homeassistant/core.py)
-# Modified _DOMAIN pattern to only match known domains
-
-# Template function names that accept entity IDs as first parameter
-
-# Build regex patterns using Home Assistant's core validation patterns
-
 
 @dataclass
 class EntityIDsCache:

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import re
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import (
@@ -21,7 +20,6 @@ from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_HOMEASSISTANT_START,
     EVENT_STATE_CHANGED,
-    Platform,
 )
 from homeassistant.core import (
     callback,
@@ -35,7 +33,6 @@ from homeassistant.helpers import (
     floor_registry as fr,
     label_registry as lr,
 )
-from homeassistant.helpers.template import Template
 from homeassistant.util.hass_dict import HassKey
 
 from .const import LOGGER
@@ -70,76 +67,15 @@ KNOWN_TIME_DATE_ENTITY_IDS = {
 }
 
 # Additional known domains that are not in the Platform enum
-ADDITIONAL_DOMAINS = [
-    "alert",
-    "automation",
-    "counter",
-    "group",
-    "input_boolean",
-    "input_button",
-    "input_datetime",
-    "input_number",
-    "input_select",
-    "input_text",
-    "person",
-    "plant",
-    "proximity",
-    "schedule",
-    "script",
-    "sun",
-    "tag",
-    "timer",
-    "zone",
-]
 
 # Build a list of all known domains
-KNOWN_DOMAINS = [platform.value for platform in Platform] + ADDITIONAL_DOMAINS
 
 # Home Assistant core entity ID validation patterns (from homeassistant/core.py)
-_OBJECT_ID = r"(?!_)[\da-z_]+(?<!_)"
 # Modified _DOMAIN pattern to only match known domains
-_DOMAIN = r"(?:" + "|".join(KNOWN_DOMAINS) + r")"
-ENTITY_ID_PATTERN = _DOMAIN + r"\." + _OBJECT_ID
 
 # Template function names that accept entity IDs as first parameter
-_ENTITY_FUNCTIONS = [
-    "states",
-    "is_state",
-    "state_attr",
-    "is_state_attr",
-    "has_value",
-    "state_translated",
-    "device_id",
-    "device_name",
-    "device_attr",
-    "is_device_attr",
-    "config_entry_id",
-    "area_id",
-    "area_name",
-    "floor_id",
-    "floor_name",
-    "is_hidden_entity",
-    "expand",
-    "distance",
-    "closest",
-]
 
 # Build regex patterns using Home Assistant's core validation patterns
-_STATES_DOMAIN_ENTITY_GROUPS = 2
-ENTITY_ID_TEMPLATE_PATTERNS = [
-    # Template functions with entity ID as first parameter
-    rf"(?:{'|'.join(_ENTITY_FUNCTIONS)})\s*\(\s*['\"]({ENTITY_ID_PATTERN})['\"]",
-    # Direct entity state access patterns (states.domain.entity)
-    rf"states\.({_DOMAIN})\.({_OBJECT_ID})(?:\.state|\.attributes)",
-    # Entity IDs in any quoted context (captures all entity IDs in lists, etc.)
-    rf"['\"]({ENTITY_ID_PATTERN})['\"]",
-    # Entity IDs followed by filter functions (entity_id | function)
-    rf"['\"]({ENTITY_ID_PATTERN})['\"](?:\s*\|\s*(?:{'|'.join(_ENTITY_FUNCTIONS)}))",
-]
-COMPILED_ENTITY_ID_TEMPLATE_PATTERNS = tuple(
-    re.compile(pattern, re.IGNORECASE) for pattern in ENTITY_ID_TEMPLATE_PATTERNS
-)
-JINJA_COMMENT_PATTERN = re.compile(r"\{#.*?#\}", re.DOTALL)
 
 
 @dataclass
@@ -414,275 +350,6 @@ def async_filter_known_services(
     }
 
 
-def is_template_string(value: str) -> bool:
-    """Check if a string looks like a Jinja2 template."""
-    if not isinstance(value, str):
-        return False
-    return ("{{" in value and "}}" in value) or ("{%" in value and "%}" in value)
-
-
-async def async_extract_entities_from_template_string(
-    hass: HomeAssistant,
-    template_str: str,
-    known_services: set[str] | None = None,
-) -> set[str]:
-    """Extract entity IDs from a template string using regex analysis.
-
-    This function uses regex patterns based on Home Assistant's core validation
-    patterns to find entity IDs referenced in template functions.
-    """
-    if not is_template_string(template_str):
-        return set()
-
-    entities = set()
-
-    # Use regex patterns to find entities
-    try:
-        regex_entities = extract_entities_from_template_regex(
-            hass, template_str, known_services
-        )
-        entities.update(regex_entities)
-    # pylint: disable-next=broad-exception-caught
-    except Exception as exc:  # noqa: BLE001 - Keep broad for unexpected regex issues
-        LOGGER.debug(
-            "Failed to extract entities from template '%s...' using regex.",
-            template_str[:50],
-            exc_info=exc,  # Pass the exception for logging
-        )
-
-    return entities
-
-
-def _strip_jinja_comments(template_str: str) -> str:
-    """Remove Jinja comments from a template string."""
-    if "{#" not in template_str:
-        return template_str
-    return JINJA_COMMENT_PATTERN.sub("", template_str)
-
-
-def _is_concatenated_template_match(template_str: str, match: re.Match[str]) -> bool:
-    """Return if a quoted entity ID literal is part of a concatenated string."""
-    groups = match.groups()
-    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
-        return False
-
-    entity_start, entity_end = match.span(1)
-    before_entity = template_str[:entity_start].rstrip()
-    after_entity = template_str[entity_end:].lstrip()
-
-    if not (before_entity.endswith(("'", '"')) and after_entity.startswith(("'", '"'))):
-        return False
-
-    before_literal = before_entity[:-1].rstrip()
-    after_literal = after_entity[1:].lstrip()
-    return before_literal.endswith("~") or after_literal.startswith("~")
-
-
-def _is_jinja_import_match(template_str: str, match: re.Match[str]) -> bool:
-    """Return if a quoted entity-like literal is a Jinja import filename."""
-    groups = match.groups()
-    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
-        return False
-
-    entity_start, entity_end = match.span(1)
-    block_start = template_str.rfind("{%", 0, entity_start)
-    expression_start = template_str.rfind("{{", 0, entity_start)
-    if block_start == -1 or expression_start > block_start:
-        return False
-
-    block_end = template_str.find("%}", entity_end)
-    expression_end = template_str.find("}}", entity_end)
-    if block_end == -1 or (expression_end != -1 and expression_end < block_end):
-        return False
-
-    block = template_str[block_start : block_end + 2]
-    return bool(
-        re.match(
-            r"\{%-?\s*(?:from\s+['\"][^'\"]+['\"]\s+import|import\s+['\"][^'\"]+['\"]\s+as)",
-            block,
-        )
-    )
-
-
-def _is_string_method_argument_match(template_str: str, match: re.Match[str]) -> bool:
-    """Return if an entity-like literal is used as a string method argument."""
-    groups = match.groups()
-    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
-        return False
-
-    entity_start = match.span(1)[0]
-    before_entity = template_str[:entity_start].rstrip()
-    if not before_entity.endswith(("'", '"')):
-        return False
-
-    before_literal = before_entity[:-1].rstrip()
-    for method in (".startswith", ".endswith"):
-        if method not in before_literal:
-            continue
-
-        after_method = before_literal.rsplit(method, maxsplit=1)[1].lstrip()
-        if not after_method.startswith("("):
-            continue
-
-        between_call_and_argument = after_method[1:].strip()
-        if not between_call_and_argument or set(between_call_and_argument) == {"("}:
-            return True
-
-    return False
-
-
-def _entity_id_from_template_match(match: re.Match[str]) -> str:
-    """Return the entity ID captured by a template regex match."""
-    groups = match.groups()
-
-    # Handle the states.domain.entity pattern that captures (domain, object_id)
-    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
-        return f"{groups[0]}.{groups[1]}"
-
-    return groups[0]
-
-
-def extract_entities_from_template_regex(
-    hass: HomeAssistant,
-    template_str: str,
-    known_services: set[str] | None = None,
-) -> set[str]:
-    """Extract entity IDs from template string using regex patterns.
-
-    This function uses regex patterns based on Home Assistant's core validation
-    patterns to find entity IDs referenced in template functions. It's designed
-    to complement the RenderInfo analysis by catching entities that might be
-    missed by template parsing.
-    """
-    if not isinstance(template_str, str):
-        return set()
-
-    template_without_comments = _strip_jinja_comments(template_str)
-
-    entities = set()
-
-    for pattern in COMPILED_ENTITY_ID_TEMPLATE_PATTERNS:
-        for match in pattern.finditer(template_without_comments):
-            if (
-                _is_concatenated_template_match(template_without_comments, match)
-                or _is_jinja_import_match(template_without_comments, match)
-                or _is_string_method_argument_match(template_without_comments, match)
-            ):
-                continue
-
-            entity_id = _entity_id_from_template_match(match)
-
-            # For each entity ID (which might be comma-separated), add all valid ones
-            for individual_id in split_comma_separated_entity_ids(entity_id):
-                if valid_entity_id(individual_id):
-                    entities.add(individual_id)
-
-    # Filter out known services to avoid false positives
-    if known_services is None:
-        known_services = async_get_all_services(hass)
-    return entities - known_services
-
-
-async def _process_template_object(
-    hass: HomeAssistant,
-    template: Template,
-    known_entity_ids: set[str],
-    known_services: set[str],
-    unknown_entities: set[str],
-) -> None:
-    """Process a Template object and add unknown entities to the set."""
-    template_entities = set()
-
-    # Use regex patterns on the template string
-    try:
-        if hasattr(template, "template") and template.template:
-            regex_entities = extract_entities_from_template_regex(
-                hass, template.template, known_services
-            )
-            template_entities.update(regex_entities)
-    # pylint: disable-next=broad-exception-caught
-    except Exception:  # noqa: BLE001
-        LOGGER.debug("Error in regex entity extraction for Template object")
-
-    # Check if any of the template entities are unknown
-    for template_entity in template_entities:
-        if template_entity not in known_entity_ids:
-            unknown_entities.add(template_entity)
-
-
-async def _process_template_string(
-    hass: HomeAssistant,
-    template_str: str,
-    known_entity_ids: set[str],
-    known_services: set[str],
-    unknown_entities: set[str],
-) -> None:
-    """Process a template string and add unknown entities to the set."""
-    template_entities = await async_extract_entities_from_template_string(
-        hass, template_str, known_services
-    )
-    # Check if any of the template entities are unknown
-    for template_entity in template_entities:
-        # Handle comma-separated entity lists
-        for entity_id in split_comma_separated_entity_ids(template_entity):
-            if (
-                entity_id not in known_entity_ids
-                and valid_entity_id(entity_id)
-                and not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
-            ):
-                unknown_entities.add(entity_id)
-
-
-async def async_filter_known_entity_ids_with_templates(
-    hass: HomeAssistant,
-    entity_ids: Iterable[str],
-    known_entity_ids: set[str] | None = None,
-) -> set[str]:
-    """Async version that can process templates to extract entity dependencies.
-
-    This function processes both regular entity IDs and template strings,
-    extracting entity dependencies from templates using RenderInfo.
-    """
-    if known_entity_ids is None:
-        known_entity_ids = async_get_all_entity_ids(hass)
-    known_services: set[str] | None = None
-
-    unknown_entities = set()
-
-    for entity_id_raw in entity_ids:
-        # Handle Template objects
-        if isinstance(entity_id_raw, Template):
-            if known_services is None:
-                known_services = async_get_all_services(hass)
-            await _process_template_object(
-                hass, entity_id_raw, known_entity_ids, known_services, unknown_entities
-            )
-            continue
-
-        if not isinstance(entity_id_raw, str):
-            continue
-
-        # Check if this looks like a template string
-        if is_template_string(entity_id_raw):
-            if known_services is None:
-                known_services = async_get_all_services(hass)
-            await _process_template_string(
-                hass, entity_id_raw, known_entity_ids, known_services, unknown_entities
-            )
-        else:
-            # Process as regular entity ID(s), handling comma-separated lists
-            for entity_id in split_comma_separated_entity_ids(entity_id_raw):
-                if (
-                    not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
-                    and entity_id not in known_entity_ids
-                    and valid_entity_id(entity_id)
-                ):
-                    # Process as regular entity ID
-                    unknown_entities.add(entity_id)
-
-    return unknown_entities
-
-
 def split_comma_separated_entity_ids(entity_id: str) -> list[str]:
     """Split comma-separated entity IDs into a list of individual entity IDs.
 
@@ -704,60 +371,6 @@ def split_comma_separated_entity_ids(entity_id: str) -> list[str]:
 
     # Return the original entity ID in a list if it's not comma-separated
     return [entity_id]
-
-
-def extract_template_strings_from_config(
-    config: Any, strings: list[str] | None = None
-) -> list[str]:
-    """Recursively extract template strings from configuration data."""
-    if strings is None:
-        strings = []
-
-    if isinstance(config, str):
-        if is_template_string(config):  # Uses the util's is_template_string
-            strings.append(config)
-    elif isinstance(config, dict):
-        for value in config.values():
-            extract_template_strings_from_config(value, strings)
-    elif isinstance(config, (list, tuple)):
-        for item in config:
-            extract_template_strings_from_config(item, strings)
-    return strings
-
-
-async def async_extract_entities_from_config(
-    hass: HomeAssistant, config: Any
-) -> set[str]:
-    """Extract entity IDs referenced in templates within a configuration structure."""
-    entities = set()
-    if not config:
-        return entities
-
-    template_strings = extract_template_strings_from_config(config)
-    known_services = async_get_all_services(hass) if template_strings else set()
-    extracted_templates: dict[str, set[str]] = {}
-    for template_str in template_strings:
-        try:
-            # async_extract_entities_from_template_string already handles
-            # TemplateError and other exceptions internally, logging them.
-            if template_str not in extracted_templates:
-                extracted_templates[
-                    template_str
-                ] = await async_extract_entities_from_template_string(
-                    hass, template_str, known_services
-                )
-            referenced_entities = extracted_templates[template_str]
-            entities.update(referenced_entities)
-        # pylint: disable-next=broad-exception-caught
-        except Exception as exc:  # noqa: BLE001 - Keep broad for unexpected issues
-            # This catch is a safeguard; internal function should handle most.
-            LOGGER.debug(
-                "Unexpected error extracting entities from template string "
-                "'%s...' in config: %s",
-                template_str[:50],
-                exc,  # Pass the exception for logging
-            )
-    return entities
 
 
 @callback

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
     from homeassistant.core import HomeAssistant
 
+# Additional known domains that are not in the Platform enum
 ADDITIONAL_DOMAINS = [
     "alert",
     "automation",
@@ -45,19 +46,17 @@ ADDITIONAL_DOMAINS = [
     "zone",
 ]
 
-
+# Build a list of all known domains
 KNOWN_DOMAINS = [platform.value for platform in Platform] + ADDITIONAL_DOMAINS
 
-
+# Home Assistant core entity ID validation patterns (from homeassistant/core.py)
 _OBJECT_ID = r"(?!_)[\da-z_]+(?<!_)"
-
-
+# Modified _DOMAIN pattern to only match known domains
 _DOMAIN = r"(?:" + "|".join(KNOWN_DOMAINS) + r")"
-
-
 ENTITY_ID_PATTERN = _DOMAIN + r"\." + _OBJECT_ID
 
 
+# Template function names that accept entity IDs as first parameter
 _ENTITY_FUNCTIONS = [
     "states",
     "is_state",
@@ -81,6 +80,7 @@ _ENTITY_FUNCTIONS = [
 ]
 
 
+# Build regex patterns using Home Assistant's core validation patterns
 _STATES_DOMAIN_ENTITY_GROUPS = 2
 
 

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -1,0 +1,439 @@
+"""Spook - Your homie. Template entity reference extraction helpers."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+import re
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.const import Platform
+from homeassistant.core import valid_entity_id
+from homeassistant.helpers.template import Template
+
+from .const import LOGGER
+from .entity_filtering import (
+    IGNORED_ENTITY_DOMAINS,
+    async_get_all_entity_ids,
+    async_get_all_services,
+    split_comma_separated_entity_ids,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from homeassistant.core import HomeAssistant
+
+ADDITIONAL_DOMAINS = [
+    "alert",
+    "automation",
+    "counter",
+    "group",
+    "input_boolean",
+    "input_button",
+    "input_datetime",
+    "input_number",
+    "input_select",
+    "input_text",
+    "person",
+    "plant",
+    "proximity",
+    "schedule",
+    "script",
+    "sun",
+    "tag",
+    "timer",
+    "zone",
+]
+
+
+KNOWN_DOMAINS = [platform.value for platform in Platform] + ADDITIONAL_DOMAINS
+
+
+_OBJECT_ID = r"(?!_)[\da-z_]+(?<!_)"
+
+
+_DOMAIN = r"(?:" + "|".join(KNOWN_DOMAINS) + r")"
+
+
+ENTITY_ID_PATTERN = _DOMAIN + r"\." + _OBJECT_ID
+
+
+_ENTITY_FUNCTIONS = [
+    "states",
+    "is_state",
+    "state_attr",
+    "is_state_attr",
+    "has_value",
+    "state_translated",
+    "device_id",
+    "device_name",
+    "device_attr",
+    "is_device_attr",
+    "config_entry_id",
+    "area_id",
+    "area_name",
+    "floor_id",
+    "floor_name",
+    "is_hidden_entity",
+    "expand",
+    "distance",
+    "closest",
+]
+
+
+_STATES_DOMAIN_ENTITY_GROUPS = 2
+
+
+ENTITY_ID_TEMPLATE_PATTERNS = [
+    # Template functions with entity ID as first parameter
+    rf"(?:{'|'.join(_ENTITY_FUNCTIONS)})\s*\(\s*['\"]({ENTITY_ID_PATTERN})['\"]",
+    # Direct entity state access patterns (states.domain.entity)
+    rf"states\.({_DOMAIN})\.({_OBJECT_ID})(?:\.state|\.attributes)",
+    # Entity IDs in any quoted context (captures all entity IDs in lists, etc.)
+    rf"['\"]({ENTITY_ID_PATTERN})['\"]",
+    # Entity IDs followed by filter functions (entity_id | function)
+    rf"['\"]({ENTITY_ID_PATTERN})['\"](?:\s*\|\s*(?:{'|'.join(_ENTITY_FUNCTIONS)}))",
+]
+
+
+COMPILED_ENTITY_ID_TEMPLATE_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE) for pattern in ENTITY_ID_TEMPLATE_PATTERNS
+)
+
+
+JINJA_COMMENT_PATTERN = re.compile(r"\{#.*?#\}", re.DOTALL)
+
+
+def is_template_string(value: str) -> bool:
+    """Check if a string looks like a Jinja2 template."""
+    if not isinstance(value, str):
+        return False
+    return ("{{" in value and "}}" in value) or ("{%" in value and "%}" in value)
+
+
+async def async_extract_entities_from_template_string(
+    hass: HomeAssistant,
+    template_str: str,
+    known_services: set[str] | None = None,
+) -> set[str]:
+    """Extract entity IDs from a template string using regex analysis.
+
+    This function uses regex patterns based on Home Assistant's core validation
+    patterns to find entity IDs referenced in template functions.
+    """
+    if not is_template_string(template_str):
+        return set()
+
+    entities = set()
+
+    # Use regex patterns to find entities
+    try:
+        regex_entities = extract_entities_from_template_regex(
+            hass, template_str, known_services
+        )
+        entities.update(regex_entities)
+    # pylint: disable-next=broad-exception-caught
+    except Exception as exc:  # noqa: BLE001 - Keep broad for unexpected regex issues
+        LOGGER.debug(
+            "Failed to extract entities from template '%s...' using regex.",
+            template_str[:50],
+            exc_info=exc,  # Pass the exception for logging
+        )
+
+    return entities
+
+
+def _strip_jinja_comments(template_str: str) -> str:
+    """Remove Jinja comments from a template string."""
+    if "{#" not in template_str:
+        return template_str
+    return JINJA_COMMENT_PATTERN.sub("", template_str)
+
+
+def _is_concatenated_template_match(template_str: str, match: re.Match[str]) -> bool:
+    """Return if a quoted entity ID literal is part of a concatenated string."""
+    groups = match.groups()
+    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
+        return False
+
+    entity_start, entity_end = match.span(1)
+    before_entity = template_str[:entity_start].rstrip()
+    after_entity = template_str[entity_end:].lstrip()
+
+    if not (before_entity.endswith(("'", '"')) and after_entity.startswith(("'", '"'))):
+        return False
+
+    before_literal = before_entity[:-1].rstrip()
+    after_literal = after_entity[1:].lstrip()
+    return before_literal.endswith("~") or after_literal.startswith("~")
+
+
+def _is_jinja_import_match(template_str: str, match: re.Match[str]) -> bool:
+    """Return if a quoted entity-like literal is a Jinja import filename."""
+    groups = match.groups()
+    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
+        return False
+
+    entity_start, entity_end = match.span(1)
+    block_start = template_str.rfind("{%", 0, entity_start)
+    expression_start = template_str.rfind("{{", 0, entity_start)
+    if block_start == -1 or expression_start > block_start:
+        return False
+
+    block_end = template_str.find("%}", entity_end)
+    expression_end = template_str.find("}}", entity_end)
+    if block_end == -1 or (expression_end != -1 and expression_end < block_end):
+        return False
+
+    block = template_str[block_start : block_end + 2]
+    return bool(
+        re.match(
+            r"\{%-?\s*(?:from\s+['\"][^'\"]+['\"]\s+import|import\s+['\"][^'\"]+['\"]\s+as)",
+            block,
+        )
+    )
+
+
+def _is_string_method_argument_match(template_str: str, match: re.Match[str]) -> bool:
+    """Return if an entity-like literal is used as a string method argument."""
+    groups = match.groups()
+    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
+        return False
+
+    entity_start = match.span(1)[0]
+    before_entity = template_str[:entity_start].rstrip()
+    if not before_entity.endswith(("'", '"')):
+        return False
+
+    before_literal = before_entity[:-1].rstrip()
+    for method in (".startswith", ".endswith"):
+        if method not in before_literal:
+            continue
+
+        after_method = before_literal.rsplit(method, maxsplit=1)[1].lstrip()
+        if not after_method.startswith("("):
+            continue
+
+        between_call_and_argument = after_method[1:].strip()
+        if not between_call_and_argument or set(between_call_and_argument) == {"("}:
+            return True
+
+    return False
+
+
+def _entity_id_from_template_match(match: re.Match[str]) -> str:
+    """Return the entity ID captured by a template regex match."""
+    groups = match.groups()
+
+    # Handle the states.domain.entity pattern that captures (domain, object_id)
+    if len(groups) == _STATES_DOMAIN_ENTITY_GROUPS:
+        return f"{groups[0]}.{groups[1]}"
+
+    return groups[0]
+
+
+@lru_cache(maxsize=1024)
+def _extract_entity_candidates_from_template(template_str: str) -> frozenset[str]:
+    """Extract entity ID candidates from a template string.
+
+    Pure in the template string, so results are cached: repairs re-inspect
+    the same unchanged templates over and over.
+    """
+    template_without_comments = _strip_jinja_comments(template_str)
+
+    entities = set()
+
+    for pattern in COMPILED_ENTITY_ID_TEMPLATE_PATTERNS:
+        for match in pattern.finditer(template_without_comments):
+            if (
+                _is_concatenated_template_match(template_without_comments, match)
+                or _is_jinja_import_match(template_without_comments, match)
+                or _is_string_method_argument_match(template_without_comments, match)
+            ):
+                continue
+
+            entity_id = _entity_id_from_template_match(match)
+
+            # For each entity ID (which might be comma-separated), add all valid ones
+            for individual_id in split_comma_separated_entity_ids(entity_id):
+                if valid_entity_id(individual_id):
+                    entities.add(individual_id)
+
+    return frozenset(entities)
+
+
+def extract_entities_from_template_regex(
+    hass: HomeAssistant,
+    template_str: str,
+    known_services: set[str] | None = None,
+) -> set[str]:
+    """Extract entity IDs from template string using regex patterns.
+
+    This function uses regex patterns based on Home Assistant's core validation
+    patterns to find entity IDs referenced in template functions. It's designed
+    to complement the RenderInfo analysis by catching entities that might be
+    missed by template parsing.
+    """
+    if not isinstance(template_str, str):
+        return set()
+
+    entities = set(_extract_entity_candidates_from_template(template_str))
+
+    # Filter out known services to avoid false positives
+    if known_services is None:
+        known_services = async_get_all_services(hass)
+    return entities - known_services
+
+
+async def _process_template_object(
+    hass: HomeAssistant,
+    template: Template,
+    known_entity_ids: set[str],
+    known_services: set[str],
+    unknown_entities: set[str],
+) -> None:
+    """Process a Template object and add unknown entities to the set."""
+    template_entities = set()
+
+    # Use regex patterns on the template string
+    try:
+        if hasattr(template, "template") and template.template:
+            regex_entities = extract_entities_from_template_regex(
+                hass, template.template, known_services
+            )
+            template_entities.update(regex_entities)
+    # pylint: disable-next=broad-exception-caught
+    except Exception:  # noqa: BLE001
+        LOGGER.debug("Error in regex entity extraction for Template object")
+
+    # Check if any of the template entities are unknown
+    for template_entity in template_entities:
+        if template_entity not in known_entity_ids:
+            unknown_entities.add(template_entity)
+
+
+async def _process_template_string(
+    hass: HomeAssistant,
+    template_str: str,
+    known_entity_ids: set[str],
+    known_services: set[str],
+    unknown_entities: set[str],
+) -> None:
+    """Process a template string and add unknown entities to the set."""
+    template_entities = await async_extract_entities_from_template_string(
+        hass, template_str, known_services
+    )
+    # Check if any of the template entities are unknown
+    for template_entity in template_entities:
+        # Handle comma-separated entity lists
+        for entity_id in split_comma_separated_entity_ids(template_entity):
+            if (
+                entity_id not in known_entity_ids
+                and valid_entity_id(entity_id)
+                and not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
+            ):
+                unknown_entities.add(entity_id)
+
+
+async def async_filter_known_entity_ids_with_templates(
+    hass: HomeAssistant,
+    entity_ids: Iterable[str],
+    known_entity_ids: set[str] | None = None,
+) -> set[str]:
+    """Async version that can process templates to extract entity dependencies.
+
+    This function processes both regular entity IDs and template strings,
+    extracting entity dependencies from templates using RenderInfo.
+    """
+    if known_entity_ids is None:
+        known_entity_ids = async_get_all_entity_ids(hass)
+    known_services: set[str] | None = None
+
+    unknown_entities = set()
+
+    for entity_id_raw in entity_ids:
+        # Handle Template objects
+        if isinstance(entity_id_raw, Template):
+            if known_services is None:
+                known_services = async_get_all_services(hass)
+            await _process_template_object(
+                hass, entity_id_raw, known_entity_ids, known_services, unknown_entities
+            )
+            continue
+
+        if not isinstance(entity_id_raw, str):
+            continue
+
+        # Check if this looks like a template string
+        if is_template_string(entity_id_raw):
+            if known_services is None:
+                known_services = async_get_all_services(hass)
+            await _process_template_string(
+                hass, entity_id_raw, known_entity_ids, known_services, unknown_entities
+            )
+        else:
+            # Process as regular entity ID(s), handling comma-separated lists
+            for entity_id in split_comma_separated_entity_ids(entity_id_raw):
+                if (
+                    not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
+                    and entity_id not in known_entity_ids
+                    and valid_entity_id(entity_id)
+                ):
+                    # Process as regular entity ID
+                    unknown_entities.add(entity_id)
+
+    return unknown_entities
+
+
+def extract_template_strings_from_config(
+    config: Any, strings: list[str] | None = None
+) -> list[str]:
+    """Recursively extract template strings from configuration data."""
+    if strings is None:
+        strings = []
+
+    if isinstance(config, str):
+        if is_template_string(config):  # Uses the util's is_template_string
+            strings.append(config)
+    elif isinstance(config, dict):
+        for value in config.values():
+            extract_template_strings_from_config(value, strings)
+    elif isinstance(config, (list, tuple)):
+        for item in config:
+            extract_template_strings_from_config(item, strings)
+    return strings
+
+
+async def async_extract_entities_from_config(
+    hass: HomeAssistant, config: Any
+) -> set[str]:
+    """Extract entity IDs referenced in templates within a configuration structure."""
+    entities = set()
+    if not config:
+        return entities
+
+    template_strings = extract_template_strings_from_config(config)
+    known_services = async_get_all_services(hass) if template_strings else set()
+    extracted_templates: dict[str, set[str]] = {}
+    for template_str in template_strings:
+        try:
+            # async_extract_entities_from_template_string already handles
+            # TemplateError and other exceptions internally, logging them.
+            if template_str not in extracted_templates:
+                extracted_templates[
+                    template_str
+                ] = await async_extract_entities_from_template_string(
+                    hass, template_str, known_services
+                )
+            referenced_entities = extracted_templates[template_str]
+            entities.update(referenced_entities)
+        # pylint: disable-next=broad-exception-caught
+        except Exception as exc:  # noqa: BLE001 - Keep broad for unexpected issues
+            # This catch is a safeguard; internal function should handle most.
+            LOGGER.debug(
+                "Unexpected error extracting entities from template string "
+                "'%s...' in config: %s",
+                template_str[:50],
+                exc,  # Pass the exception for logging
+            )
+    return entities

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,16 +6,18 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from custom_components.spook import entity_filtering
+from custom_components.spook import entity_filtering, template_extraction
 from custom_components.spook.entity_filtering import (
     KNOWN_TIME_DATE_ENTITY_IDS,
+    async_get_all_entity_ids,
+    split_comma_separated_entity_ids,
+)
+from custom_components.spook.template_extraction import (
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
-    async_get_all_entity_ids,
     extract_entities_from_template_regex,
     extract_template_strings_from_config,
     is_template_string,
-    split_comma_separated_entity_ids,
 )
 
 if TYPE_CHECKING:
@@ -247,7 +249,7 @@ async def test_extract_entities_from_config_reuses_known_services(
         return {"light.turn_on"}
 
     monkeypatch.setattr(
-        entity_filtering,
+        template_extraction,
         "async_get_all_services",
         async_get_all_services,
     )
@@ -270,7 +272,7 @@ async def test_extract_entities_from_config_reuses_duplicate_template_results(
 ) -> None:
     """Test duplicate template strings are extracted once per config scan."""
     calls = 0
-    original = entity_filtering.async_extract_entities_from_template_string
+    original = template_extraction.async_extract_entities_from_template_string
 
     async def async_extract_entities_from_template_string(
         hass: HomeAssistant,
@@ -283,7 +285,7 @@ async def test_extract_entities_from_config_reuses_duplicate_template_results(
         return await original(hass, template_str, known_services)
 
     monkeypatch.setattr(
-        entity_filtering,
+        template_extraction,
         "async_extract_entities_from_template_string",
         async_extract_entities_from_template_string,
     )
@@ -310,7 +312,7 @@ async def test_filter_plain_entity_ids_does_not_get_services(
         return {"light.turn_on"}
 
     monkeypatch.setattr(
-        entity_filtering,
+        template_extraction,
         "async_get_all_services",
         async_get_all_services,
     )
@@ -384,3 +386,21 @@ async def test_entity_id_cache_lifecycle(hass: HomeAssistant) -> None:
     cache = hass.data[entity_filtering.DATA_ALL_ENTITY_IDS_CACHE]
     assert cache.entity_ids is None
     assert cache.unsubscribe is None
+
+
+def test_template_candidate_extraction_is_cached() -> None:
+    """Test repeated extraction of the same template hits the cache.
+
+    Repairs re-inspect the same unchanged templates on every cycle; the
+    regex scan must only run once per distinct template string.
+    """
+    # pylint: disable-next=protected-access
+    extract = template_extraction._extract_entity_candidates_from_template  # noqa: SLF001
+    extract.cache_clear()
+
+    template = "{{ states('sensor.cached') }}"
+    assert extract(template) == frozenset({"sensor.cached"})
+    assert extract(template) == frozenset({"sensor.cached"})
+
+    assert extract.cache_info().hits == 1
+    assert extract.cache_info().misses == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`entity_filtering.py` had grown to ~800 lines covering five unrelated jobs. It is now two focused modules:

- `entity_filtering.py`: known ID universes and the per-instance cache, registry filters, service helpers, comma splitting, and the script sequence walker.
- `template_extraction.py` (new): everything Jinja, the known-domain regex patterns, `is_template_string`, the extraction and exclusion helpers, the config-tree template walkers, and the template-aware entity filter. Depends one way on `entity_filtering`.

On top of the split, the pure regex scan is extracted into `_extract_entity_candidates_from_template`, cached with `lru_cache(1024)` keyed on the template string alone (the known-services subtraction stays outside the cache). Repairs re-inspect the same unchanged templates on every debounce cycle; the four-pattern regex scan now runs once per distinct template instead of once per template per inspection per repair.

The code moves are verbatim (extracted per top-level AST block); consumers updated are the automation and script unknown entity repairs and `tests/test_util.py`, including two monkeypatch targets that had to follow the moved functions into the new module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Each file now has one purpose, which keeps template work from turning `entity_filtering` into a dumping ground as reference detection grows. The memoization is the second half of keeping inspections cheap on large installations, alongside the event loop yields from #1352.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

A new test pins the cache behavior via `cache_info` (one miss, then hits). The existing template extraction tests all pass unchanged against the new module. Full suite passes (529 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.