### PR TITLE
Add target reference walker for raw configurations

### DIFF
--- a/custom_components/spook/reference_extraction.py
+++ b/custom_components/spook/reference_extraction.py
@@ -1,0 +1,106 @@
+"""Spook - Your homie. Target reference extraction from raw configurations.
+
+Home Assistant's built-in ``referenced_areas``/``referenced_devices``/
+``referenced_floors``/``referenced_labels`` walkers only know a fixed set
+of script step types and miss references nested in others (most notably
+``repeat`` sequences). This module walks a raw automation or script
+configuration generically instead: every ``target:`` block and every
+direct reference key is collected, wherever it nests.
+
+Results are meant to be unioned with Home Assistant's built-in extraction,
+never to replace it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from homeassistant.const import ENTITY_MATCH_ALL, ENTITY_MATCH_NONE
+
+from .template_extraction import is_template_string
+
+# Direct reference keys, mapped to their reference type.
+_REFERENCE_KEYS = (
+    "area_id",
+    "device_id",
+    "floor_id",
+    "label_id",
+)
+
+# Keys whose subtree carries arbitrary payload data, not references.
+# ``event_data`` matches event payloads (an ``area_id`` in there filters
+# incoming events); ``variables`` hold user-defined values that only become
+# references where they are used.
+_EXCLUDED_KEYS = frozenset(
+    {
+        "event_data",
+        "event_data_template",
+        "variables",
+        "trigger_variables",
+    },
+)
+
+
+@dataclass
+class ExtractedTargets:
+    """Target references extracted from a raw configuration."""
+
+    area_ids: set[str] = field(default_factory=set)
+    device_ids: set[str] = field(default_factory=set)
+    floor_ids: set[str] = field(default_factory=set)
+    label_ids: set[str] = field(default_factory=set)
+
+
+def _collect_ids(value: Any) -> set[str]:
+    """Return the plain string IDs in a config value.
+
+    Templated values cannot be resolved statically and the ``all``/``none``
+    match constants are not references; both are skipped.
+    """
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, list):
+        values = [item for item in value if isinstance(item, str)]
+    else:
+        return set()
+
+    return {
+        item
+        for item in values
+        if item
+        and item not in (ENTITY_MATCH_ALL, ENTITY_MATCH_NONE)
+        and not is_template_string(item)
+    }
+
+
+def _walk(config: Any, targets: ExtractedTargets) -> None:
+    """Recursively collect target references from a configuration node."""
+    if isinstance(config, list):
+        for item in config:
+            _walk(item, targets)
+        return
+
+    if not isinstance(config, dict):
+        return
+
+    for key in _REFERENCE_KEYS:
+        if key in config:
+            getattr(targets, f"{key}s").update(_collect_ids(config[key]))
+
+    for key, value in config.items():
+        if key in _EXCLUDED_KEYS:
+            continue
+        _walk(value, targets)
+
+
+def extract_targets_from_config(config: Any) -> ExtractedTargets:
+    """Extract area, device, floor, and label references from a raw config.
+
+    Walks the entire configuration structure, covering targets nested in
+    any script step type (including ``repeat``), triggers, conditions, and
+    ``wait_for_trigger`` blocks alike.
+    """
+    targets = ExtractedTargets()
+    _walk(config, targets)
+    return targets

--- a/tests/test_reference_extraction.py
+++ b/tests/test_reference_extraction.py
@@ -1,0 +1,173 @@
+"""Tests for target reference extraction from raw configurations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.spook.reference_extraction import extract_targets_from_config
+
+
+def test_repeat_nested_targets_are_found() -> None:
+    """Test targets inside repeat sequences are collected.
+
+    Home Assistant's built-in reference walkers miss ``repeat`` entirely;
+    this walker is the compensation.
+    """
+    config = {
+        "actions": [
+            {
+                "repeat": {
+                    "count": 3,
+                    "sequence": [
+                        {
+                            "action": "light.turn_on",
+                            "target": {"area_id": "attic"},
+                        },
+                        {
+                            "wait_for_trigger": [
+                                {
+                                    "trigger": "state",
+                                    "entity_id": "binary_sensor.motion",
+                                },
+                            ],
+                            "timeout": 10,
+                        },
+                    ],
+                    "until": [
+                        {
+                            "condition": "device",
+                            "device_id": "abcdef0123456789abcdef0123456789",
+                            "domain": "light",
+                            "type": "is_on",
+                        },
+                    ],
+                },
+            },
+        ],
+    }
+
+    targets = extract_targets_from_config(config)
+
+    assert targets.area_ids == {"attic"}
+    assert targets.device_ids == {"abcdef0123456789abcdef0123456789"}
+
+
+def test_targets_in_triggers_conditions_and_actions() -> None:
+    """Test target blocks are collected from every automation section."""
+    config = {
+        "triggers": [
+            {
+                "trigger": "light.turned_on",
+                "target": {"floor_id": "upstairs", "label_id": ["security"]},
+            },
+        ],
+        "conditions": [
+            {
+                "condition": "device",
+                "device_id": "1234567890abcdef1234567890abcdef",
+                "domain": "light",
+                "type": "is_on",
+            },
+        ],
+        "actions": [
+            {
+                "choose": [
+                    {
+                        "conditions": [],
+                        "sequence": [
+                            {
+                                "action": "light.turn_off",
+                                "target": {
+                                    "area_id": ["kitchen", "hallway"],
+                                },
+                            },
+                        ],
+                    },
+                ],
+                "default": [
+                    {
+                        "action": "light.turn_off",
+                        "data": {"area_id": "garage"},
+                    },
+                ],
+            },
+        ],
+    }
+
+    targets = extract_targets_from_config(config)
+
+    assert targets.area_ids == {"kitchen", "hallway", "garage"}
+    assert targets.device_ids == {"1234567890abcdef1234567890abcdef"}
+    assert targets.floor_ids == {"upstairs"}
+    assert targets.label_ids == {"security"}
+
+
+def test_event_data_and_variables_are_excluded() -> None:
+    """Test payload subtrees are not mistaken for references.
+
+    An ``area_id`` inside ``event_data`` filters incoming events, and
+    variables only become references where they are used.
+    """
+    config = {
+        "triggers": [
+            {
+                "trigger": "event",
+                "event_type": "custom_event",
+                "event_data": {"device_id": "payload", "area_id": "payload"},
+            },
+        ],
+        "variables": {"area_id": "not_a_reference"},
+        "actions": [
+            {
+                "event": "outgoing_event",
+                "event_data_template": {"label_id": "payload"},
+            },
+        ],
+    }
+
+    targets = extract_targets_from_config(config)
+
+    assert targets.area_ids == set()
+    assert targets.device_ids == set()
+    assert targets.label_ids == set()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "{{ my_area }}",
+        "all",
+        "none",
+        "",
+        42,
+        None,
+        {"nested": "dict"},
+    ],
+)
+def test_unresolvable_values_are_skipped(value: Any) -> None:
+    """Test templated, constant, and non-string values are not collected."""
+    config = {"actions": [{"target": {"area_id": value}}]}
+
+    assert extract_targets_from_config(config).area_ids == set()
+
+
+def test_mixed_list_keeps_plain_ids_only() -> None:
+    """Test lists keep plain IDs while skipping unresolvable entries."""
+    config = {
+        "target": {"area_id": ["kitchen", "{{ dynamic }}", "none", 5]},
+    }
+
+    assert extract_targets_from_config(config).area_ids == {"kitchen"}
+
+
+@pytest.mark.parametrize("config", [None, [], {}, "just a string", 42])
+def test_empty_or_scalar_configs_yield_nothing(config: Any) -> None:
+    """Test degenerate configurations produce no references."""
+    targets = extract_targets_from_config(config)
+
+    assert not targets.area_ids
+    assert not targets.device_ids
+    assert not targets.floor_ids
+    assert not targets.label_ids


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Groundwork for the unknown reference repairs. Home Assistant's built-in `referenced_areas`/`referenced_devices`/`referenced_floors`/`referenced_labels` walkers only know a fixed set of script step types, and notably miss `repeat` entirely: a `target: {area_id: ...}` inside a repeat sequence, or a device condition in `until:`/`while:`, is invisible to them (an upstream core fix is filed and pending, but Spook supports releases without it).

This adds `reference_extraction.py`: a generic recursive walker over raw automation and script configurations that collects `area_id`, `device_id`, `floor_id`, and `label_id` references into an `ExtractedTargets` result. Walking every container blindly is exactly what covers repeat sequences, `wait_for_trigger` blocks, choose branches, and new-style trigger/condition `target:` blocks without needing to know step types.

False positive guards, since these ID shapes are weak slugs: `event_data`, `event_data_template`, `variables`, and `trigger_variables` subtrees are excluded (payloads and definitions, not references), templated values are skipped (unresolvable statically), and the `all`/`none` match constants are ignored. Entity references intentionally stay with the existing, more specialized extraction machinery.

The module is not wired into any repair yet; the automation and script repairs adopt it in follow-up PRs, unioning its results with Home Assistant's built-in extraction (never replacing it, as the module docstring states).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Stale area/floor/label/device references hiding inside `repeat` blocks are currently undetectable. Small, reviewable steps: the walker lands first with its tests, the repair wiring follows.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Sixteen new unit tests cover the repeat-nested case (target in the sequence plus a device condition in `until:`), all three automation sections, the payload exclusions, templated/constant/non-string values, mixed lists, and degenerate configs. Full suite passes (548 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.