### PR TITLE
Detect stale targets nested in repeat steps in automations

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_area_references.py
@@ -8,6 +8,7 @@ from homeassistant.components import automation
 from homeassistant.helpers import area_registry as ar
 
 from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
+from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
@@ -38,8 +39,15 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown area IDs referenced by ``entity``."""
+        area_ids = set(entity.referenced_areas)
+
+        # Also walk the raw configuration; the built-in extraction misses
+        # references nested in some step types, like repeat sequences.
+        if raw_config := getattr(entity, "raw_config", None):
+            area_ids.update(extract_targets_from_config(raw_config).area_ids)
+
         return async_filter_known_area_ids(
             self.hass,
-            area_ids=entity.referenced_areas,
+            area_ids=area_ids,
             known_area_ids=self._known_area_ids,
         )

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -8,6 +8,7 @@ from homeassistant.components import automation
 from homeassistant.helpers import device_registry as dr
 
 from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
+from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 
@@ -72,6 +73,11 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
         device_ids = set(entity.referenced_devices)
 
         if hasattr(entity, "raw_config") and entity.raw_config:
+            # Also walk the raw configuration; the built-in extraction misses
+            # references nested in some step types, like repeat sequences.
+            # The walker never collects from event trigger payloads, so the
+            # subtraction below only affects built-in extraction results.
+            device_ids.update(extract_targets_from_config(entity.raw_config).device_ids)
             device_ids.difference_update(
                 extract_event_data_device_ids_from_trigger_config(
                     entity.raw_config.get("trigger")

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_floor_references.py
@@ -8,6 +8,7 @@ from homeassistant.components import automation
 from homeassistant.helpers import floor_registry as fr
 
 from ....entity_filtering import async_filter_known_floor_ids, async_get_all_floor_ids
+from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
@@ -37,8 +38,15 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown floor IDs referenced by ``entity``."""
+        floor_ids = set(entity.referenced_floors)
+
+        # Also walk the raw configuration; the built-in extraction misses
+        # references nested in some step types, like repeat sequences.
+        if raw_config := getattr(entity, "raw_config", None):
+            floor_ids.update(extract_targets_from_config(raw_config).floor_ids)
+
         return async_filter_known_floor_ids(
             self.hass,
-            floor_ids=entity.referenced_floors,
+            floor_ids=floor_ids,
             known_floor_ids=self._known_floor_ids,
         )

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_label_references.py
@@ -8,6 +8,7 @@ from homeassistant.components import automation
 from homeassistant.helpers import label_registry as lr
 
 from ....entity_filtering import async_filter_known_label_ids, async_get_all_label_ids
+from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
@@ -37,8 +38,15 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown label IDs referenced by ``entity``."""
+        label_ids = set(entity.referenced_labels)
+
+        # Also walk the raw configuration; the built-in extraction misses
+        # references nested in some step types, like repeat sequences.
+        if raw_config := getattr(entity, "raw_config", None):
+            label_ids.update(extract_targets_from_config(raw_config).label_ids)
+
         return async_filter_known_label_ids(
             self.hass,
-            label_ids=entity.referenced_labels,
+            label_ids=label_ids,
             known_label_ids=self._known_label_ids,
         )

--- a/tests/ectoplasms/automation/repairs/test_repeat_nested_targets.py
+++ b/tests/ectoplasms/automation/repairs/test_repeat_nested_targets.py
@@ -1,0 +1,68 @@
+"""Tests for target references nested in repeat sequences.
+
+Home Assistant's built-in ``referenced_*`` extraction misses ``repeat``
+step types entirely; the automation reference repairs compensate by also
+walking the raw configuration.
+"""
+
+# pylint: disable=wrong-import-order,protected-access
+# ruff: noqa: SLF001
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _raw_config_with_repeat_nested(key: str, value: str) -> dict:
+    """Return an automation config with a target nested in a repeat."""
+    return {
+        "actions": [
+            {
+                "repeat": {
+                    "count": 2,
+                    "sequence": [
+                        {
+                            "action": "light.turn_on",
+                            "target": {key: value},
+                        },
+                    ],
+                },
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("reference_type", "ghost_id"),
+    [
+        pytest.param("area", "ghost_area", id="area"),
+        pytest.param("device", "abcdef0123456789abcdef0123456789", id="device"),
+        pytest.param("floor", "ghost_floor", id="floor"),
+        pytest.param("label", "ghost_label", id="label"),
+    ],
+)
+async def test_repeat_nested_reference_is_detected(
+    hass: HomeAssistant,
+    reference_type: str,
+    ghost_id: str,
+) -> None:
+    """Test a stale target inside a repeat sequence is reported."""
+    module = importlib.import_module(
+        "custom_components.spook.ectoplasms.automation.repairs."
+        f"unknown_{reference_type}_references",
+    )
+    repair = module.SpookRepair(hass)
+    setattr(repair, f"_known_{reference_type}_ids", {"known"})
+
+    entity = SimpleNamespace(
+        raw_config=_raw_config_with_repeat_nested(f"{reference_type}_id", ghost_id),
+        **{f"referenced_{reference_type}s": set()},
+    )
+
+    assert await repair._async_compute_unknown_references(entity) == {ghost_id}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The automation unknown area/device/floor/label reference repairs rely on Home Assistant's built-in `referenced_*` extraction, which misses references nested in `repeat` steps entirely (an upstream core fix is filed and pending). A `target: {area_id: ...}` inside a repeat sequence, or a device condition in `until:`/`while:`, was invisible to Spook.

Each of the four repairs now also walks the automation's raw configuration with the target reference walker from #1354 and unions the results with the built-in extraction before filtering against the known IDs. The device repair applies the union before its existing event-trigger payload subtraction; the ordering is safe because the walker never collects from event payloads, so the subtraction only affects the built-in extraction's contribution.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

"Repeat until the light in this area turns on" style automations silently kept nagging deleted areas without Spook noticing. Now they get reported like any other stale reference.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

A parametrized regression test covers all four reference types, each planting a stale target inside a repeat sequence while the built-in extraction returns nothing (the exact real-world blind spot). All four tests fail without the wiring and pass with it. Full suite passes (552 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.