### PR TITLE
Detect stale targets nested in repeat steps in scripts

### DIFF
--- a/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_area_references.py
@@ -8,6 +8,7 @@ from homeassistant.components import script
 from homeassistant.helpers import area_registry as ar
 
 from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
+from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
@@ -35,8 +36,15 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown area IDs referenced by ``entity``."""
+        area_ids = set(entity.script.referenced_areas)
+
+        # Also walk the raw configuration; the built-in extraction misses
+        # references nested in some step types, like repeat sequences.
+        if raw_config := getattr(entity, "raw_config", None):
+            area_ids.update(extract_targets_from_config(raw_config).area_ids)
+
         return async_filter_known_area_ids(
             self.hass,
-            area_ids=entity.script.referenced_areas,
+            area_ids=area_ids,
             known_area_ids=self._known_area_ids,
         )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
@@ -8,6 +8,7 @@ from homeassistant.components import script
 from homeassistant.helpers import device_registry as dr
 
 from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
+from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
@@ -36,8 +37,15 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown device IDs referenced by ``entity``."""
+        device_ids = set(entity.script.referenced_devices)
+
+        # Also walk the raw configuration; the built-in extraction misses
+        # references nested in some step types, like repeat sequences.
+        if raw_config := getattr(entity, "raw_config", None):
+            device_ids.update(extract_targets_from_config(raw_config).device_ids)
+
         return async_filter_known_device_ids(
             self.hass,
-            device_ids=entity.script.referenced_devices,
+            device_ids=device_ids,
             known_device_ids=self._known_device_ids,
         )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_floor_references.py
@@ -8,6 +8,7 @@ from homeassistant.components import script
 from homeassistant.helpers import floor_registry as fr
 
 from ....entity_filtering import async_filter_known_floor_ids, async_get_all_floor_ids
+from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
@@ -35,8 +36,15 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown floor IDs referenced by ``entity``."""
+        floor_ids = set(entity.script.referenced_floors)
+
+        # Also walk the raw configuration; the built-in extraction misses
+        # references nested in some step types, like repeat sequences.
+        if raw_config := getattr(entity, "raw_config", None):
+            floor_ids.update(extract_targets_from_config(raw_config).floor_ids)
+
         return async_filter_known_floor_ids(
             self.hass,
-            floor_ids=entity.script.referenced_floors,
+            floor_ids=floor_ids,
             known_floor_ids=self._known_floor_ids,
         )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_label_references.py
@@ -8,6 +8,7 @@ from homeassistant.components import script
 from homeassistant.helpers import label_registry as lr
 
 from ....entity_filtering import async_filter_known_label_ids, async_get_all_label_ids
+from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 
 if TYPE_CHECKING:
@@ -35,8 +36,15 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
     async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
         """Return unknown label IDs referenced by ``entity``."""
+        label_ids = set(entity.script.referenced_labels)
+
+        # Also walk the raw configuration; the built-in extraction misses
+        # references nested in some step types, like repeat sequences.
+        if raw_config := getattr(entity, "raw_config", None):
+            label_ids.update(extract_targets_from_config(raw_config).label_ids)
+
         return async_filter_known_label_ids(
             self.hass,
-            label_ids=entity.script.referenced_labels,
+            label_ids=label_ids,
             known_label_ids=self._known_label_ids,
         )

--- a/tests/ectoplasms/script/repairs/test_repeat_nested_targets.py
+++ b/tests/ectoplasms/script/repairs/test_repeat_nested_targets.py
@@ -1,0 +1,68 @@
+"""Tests for target references nested in repeat sequences.
+
+Home Assistant's built-in ``referenced_*`` extraction misses ``repeat``
+step types entirely; the script reference repairs compensate by also
+walking the raw configuration.
+"""
+
+# pylint: disable=wrong-import-order,protected-access
+# ruff: noqa: SLF001
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _raw_config_with_repeat_nested(key: str, value: str) -> dict:
+    """Return a script config with a target nested in a repeat."""
+    return {
+        "sequence": [
+            {
+                "repeat": {
+                    "count": 2,
+                    "sequence": [
+                        {
+                            "action": "light.turn_on",
+                            "target": {key: value},
+                        },
+                    ],
+                },
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("reference_type", "ghost_id"),
+    [
+        pytest.param("area", "ghost_area", id="area"),
+        pytest.param("device", "abcdef0123456789abcdef0123456789", id="device"),
+        pytest.param("floor", "ghost_floor", id="floor"),
+        pytest.param("label", "ghost_label", id="label"),
+    ],
+)
+async def test_repeat_nested_reference_is_detected(
+    hass: HomeAssistant,
+    reference_type: str,
+    ghost_id: str,
+) -> None:
+    """Test a stale target inside a repeat sequence is reported."""
+    module = importlib.import_module(
+        "custom_components.spook.ectoplasms.script.repairs."
+        f"unknown_{reference_type}_references",
+    )
+    repair = module.SpookRepair(hass)
+    setattr(repair, f"_known_{reference_type}_ids", {"known"})
+
+    entity = SimpleNamespace(
+        raw_config=_raw_config_with_repeat_nested(f"{reference_type}_id", ghost_id),
+        script=SimpleNamespace(**{f"referenced_{reference_type}s": set()}),
+    )
+
+    assert await repair._async_compute_unknown_references(entity) == {ghost_id}

--- a/tests/ectoplasms/script/repairs/test_repeat_nested_targets.py
+++ b/tests/ectoplasms/script/repairs/test_repeat_nested_targets.py
@@ -13,10 +13,14 @@ import importlib
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+from homeassistant.setup import async_setup_component
+
+from custom_components.spook.const import DOMAIN
 import pytest
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
 
 
 def _raw_config_with_repeat_nested(key: str, value: str) -> dict:
@@ -66,3 +70,52 @@ async def test_repeat_nested_reference_is_detected(
     )
 
     assert await repair._async_compute_unknown_references(entity) == {ghost_id}
+
+
+async def test_repeat_nested_target_detected_on_real_script_entity(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test detection against a real script entity, end to end.
+
+    Pins that production ``ScriptEntity`` instances expose ``raw_config``;
+    a mock-only test could keep passing if that attribute ever went away.
+    """
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "spooky": {
+                    "sequence": [
+                        {
+                            "repeat": {
+                                "count": 2,
+                                "sequence": [
+                                    {
+                                        "action": "light.turn_on",
+                                        "target": {"area_id": "ghost_area"},
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+    )
+    await hass.async_block_till_done()
+
+    module = importlib.import_module(
+        "custom_components.spook.ectoplasms.script.repairs.unknown_area_references",
+    )
+    repair = module.SpookRepair(hass)
+    await repair.async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "script_unknown_area_references_script.spooky",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert issue.translation_placeholders["areas"] == "- `ghost_area`"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The script counterpart of #1355. The script unknown area/device/floor/label reference repairs rely on Home Assistant's built-in `referenced_*` extraction, which misses references nested in `repeat` steps entirely. Each of the four repairs now also walks the script's raw configuration with the target reference walker from #1354 and unions the results with the built-in extraction before filtering against the known IDs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Same blind spot as automations: a `target: {area_id: ...}` inside a repeat sequence, or a device condition in `until:`/`while:`, silently escaped detection. With this and #1355, repeat-nested stale references are covered on every Home Assistant release Spook supports, independent of the pending upstream core fix.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

A parametrized regression test covers all four reference types, each planting a stale target inside a repeat sequence while the built-in extraction returns nothing. All four tests fail without the wiring and pass with it. Full suite passes (556 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.