### PR TITLE
Detect unknown trigger types in automations

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_trigger_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_trigger_references.py
@@ -1,0 +1,64 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import automation
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import trigger as trigger_helper
+
+from ....platform_validation import async_filter_unknown_trigger_keys
+from ....reference_extraction import extract_platform_keys_from_config
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
+    """Spook repair tries to find unknown trigger types in automations.
+
+    An automation using a trigger from a removed integration fails
+    validation entirely and becomes unavailable; Home Assistant only
+    raises a generic issue for it. This repair names the exact trigger.
+    Unavailable automations are deliberately inspected: they are the
+    broken ones.
+    """
+
+    domain = automation.DOMAIN
+    repair = "automation_unknown_trigger_references"
+    inspect_events = {
+        automation.EVENT_AUTOMATION_RELOADED,
+        EVENT_COMPONENT_LOADED,
+    }
+    inspect_on_reload = True
+
+    entity_label = "automation"
+    reference_label = "triggers"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
+
+    async def async_activate(self) -> None:
+        """Activate the repair."""
+        await super().async_activate()
+
+        async def _async_platforms_registered(_platforms: set[str]) -> None:
+            """Re-inspect when new trigger platforms register."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            trigger_helper.async_subscribe_platform_events(
+                self.hass,
+                _async_platforms_registered,
+            ),
+        )
+
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown trigger keys used by ``entity``."""
+        if not (raw_config := getattr(entity, "raw_config", None)):
+            return set()
+
+        return await async_filter_unknown_trigger_keys(
+            self.hass,
+            extract_platform_keys_from_config(raw_config).trigger_keys,
+        )

--- a/custom_components/spook/platform_validation.py
+++ b/custom_components/spook/platform_validation.py
@@ -1,0 +1,105 @@
+"""Spook - Your homie. Validation of trigger and condition platform keys.
+
+Triggers and conditions are pluggable: integrations provide them and keys
+like ``samsung_tv.turned_on`` resolve to an integration at load time. When
+that integration is gone, the automation fails validation and Home
+Assistant only raises a generic issue. These helpers determine which keys
+cannot be provided by any available integration.
+
+A key is only reported as unknown when its integration does not exist at
+all, or exists but ships no trigger/condition platform. Integrations that
+exist but are not loaded yet are never reported.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+# The alias tables and registries are internal Home Assistant details;
+# the nightly canary and the tests guard these imports.
+from homeassistant.helpers.condition import (
+    _PLATFORM_ALIASES as _CONDITION_PLATFORM_ALIASES,
+    CONDITIONS,
+)
+from homeassistant.helpers.trigger import (
+    _PLATFORM_ALIASES as _TRIGGER_PLATFORM_ALIASES,
+    TRIGGERS,
+)
+from homeassistant.loader import IntegrationNotFound, async_get_integration
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.util.hass_dict import HassKey
+
+
+async def _async_filter_unknown_keys(
+    hass: HomeAssistant,
+    *,
+    keys: Iterable[str],
+    registry_key: HassKey[dict[str, str]],
+    aliases: Mapping[str | None, str | None],
+    platform_file: str,
+) -> set[str]:
+    """Return the platform keys that no available integration can provide."""
+    registered: dict[str, str] = hass.data.get(registry_key) or {}
+    registered_domains = set(registered.values())
+
+    unknown = set()
+    for key in keys:
+        if not key or not isinstance(key, str) or key in registered:
+            continue
+
+        domain = key.partition(".")[0]
+        if "." not in key:
+            # Aliases only apply to bare keys; ``None`` marks a built-in.
+            domain = aliases.get(domain, domain)  # type: ignore[assignment]
+            if domain is None:
+                continue
+
+        # The integration registered its platform; whether this specific
+        # key exists on it is validated by Home Assistant itself.
+        if domain in registered_domains:
+            continue
+
+        try:
+            integration = await async_get_integration(hass, domain)
+        except IntegrationNotFound:
+            unknown.add(key)
+            continue
+
+        # The integration exists but is not loaded (so nothing registered
+        # yet); only report when it cannot provide this platform at all.
+        if not integration.platforms_exists((platform_file,)):
+            unknown.add(key)
+
+    return unknown
+
+
+async def async_filter_unknown_trigger_keys(
+    hass: HomeAssistant,
+    keys: Iterable[str],
+) -> set[str]:
+    """Return the trigger keys that no available integration can provide."""
+    return await _async_filter_unknown_keys(
+        hass,
+        keys=keys,
+        registry_key=TRIGGERS,
+        aliases=_TRIGGER_PLATFORM_ALIASES,
+        platform_file="trigger",
+    )
+
+
+async def async_filter_unknown_condition_keys(
+    hass: HomeAssistant,
+    keys: Iterable[str],
+) -> set[str]:
+    """Return the condition keys that no available integration can provide."""
+    return await _async_filter_unknown_keys(
+        hass,
+        keys=keys,
+        registry_key=CONDITIONS,
+        aliases=_CONDITION_PLATFORM_ALIASES,
+        platform_file="condition",
+    )

--- a/custom_components/spook/platform_validation.py
+++ b/custom_components/spook/platform_validation.py
@@ -46,6 +46,9 @@ async def _async_filter_unknown_keys(
     registered: dict[str, str] = hass.data.get(registry_key) or {}
     registered_domains = set(registered.values())
 
+    # Keys often share a domain; resolve each integration only once.
+    domain_can_provide: dict[str, bool] = {}
+
     unknown = set()
     for key in keys:
         if not key or not isinstance(key, str) or key in registered:
@@ -63,15 +66,18 @@ async def _async_filter_unknown_keys(
         if domain in registered_domains:
             continue
 
-        try:
-            integration = await async_get_integration(hass, domain)
-        except IntegrationNotFound:
-            unknown.add(key)
-            continue
+        if (can_provide := domain_can_provide.get(domain)) is None:
+            try:
+                integration = await async_get_integration(hass, domain)
+            except IntegrationNotFound:
+                can_provide = False
+            else:
+                # The integration exists but is not loaded (so nothing is
+                # registered yet); trust it when it ships this platform.
+                can_provide = bool(integration.platforms_exists((platform_file,)))
+            domain_can_provide[domain] = can_provide
 
-        # The integration exists but is not loaded (so nothing registered
-        # yet); only report when it cannot provide this platform at all.
-        if not integration.platforms_exists((platform_file,)):
+        if not can_provide:
             unknown.add(key)
 
     return unknown

--- a/custom_components/spook/platform_validation.py
+++ b/custom_components/spook/platform_validation.py
@@ -34,6 +34,37 @@ if TYPE_CHECKING:
     from homeassistant.util.hass_dict import HassKey
 
 
+def _resolve_domain(
+    key: str,
+    aliases: Mapping[str | None, str | None],
+) -> str | None:
+    """Return the integration domain for a platform key.
+
+    Aliases only apply to bare keys; ``None`` marks a built-in.
+    """
+    domain = key.partition(".")[0]
+    if "." not in key:
+        return aliases.get(domain, domain)
+    return domain
+
+
+async def _async_domain_can_provide(
+    hass: HomeAssistant,
+    domain: str,
+    platform_file: str,
+) -> bool:
+    """Return whether the integration for ``domain`` can provide the platform.
+
+    An existing but not yet loaded integration has nothing registered;
+    it is trusted when it ships the platform file at all.
+    """
+    try:
+        integration = await async_get_integration(hass, domain)
+    except IntegrationNotFound:
+        return False
+    return bool(integration.platforms_exists((platform_file,)))
+
+
 async def _async_filter_unknown_keys(
     hass: HomeAssistant,
     *,
@@ -54,27 +85,15 @@ async def _async_filter_unknown_keys(
         if not key or not isinstance(key, str) or key in registered:
             continue
 
-        domain = key.partition(".")[0]
-        if "." not in key:
-            # Aliases only apply to bare keys; ``None`` marks a built-in.
-            domain = aliases.get(domain, domain)  # type: ignore[assignment]
-            if domain is None:
-                continue
+        domain = _resolve_domain(key, aliases)
 
-        # The integration registered its platform; whether this specific
-        # key exists on it is validated by Home Assistant itself.
-        if domain in registered_domains:
+        # ``None`` is a built-in. A registered domain is trusted; whether
+        # this specific key exists on it is validated by Home Assistant.
+        if domain is None or domain in registered_domains:
             continue
 
         if (can_provide := domain_can_provide.get(domain)) is None:
-            try:
-                integration = await async_get_integration(hass, domain)
-            except IntegrationNotFound:
-                can_provide = False
-            else:
-                # The integration exists but is not loaded (so nothing is
-                # registered yet); trust it when it ships this platform.
-                can_provide = bool(integration.platforms_exists((platform_file,)))
+            can_provide = await _async_domain_can_provide(hass, domain, platform_file)
             domain_can_provide[domain] = can_provide
 
         if not can_provide:

--- a/custom_components/spook/reference_extraction.py
+++ b/custom_components/spook/reference_extraction.py
@@ -104,3 +104,64 @@ def extract_targets_from_config(config: Any) -> ExtractedTargets:
     targets = ExtractedTargets()
     _walk(config, targets)
     return targets
+
+
+# Additional keys whose subtree carries payload or opaque data when
+# extracting trigger and condition platform keys. Service data can hold
+# keys like ``platform`` or ``condition`` (a weather condition, for
+# example), and blueprint inputs are free-form.
+_PLATFORM_KEY_EXCLUDED_KEYS = _EXCLUDED_KEYS | frozenset(
+    {
+        "data",
+        "data_template",
+        "service_data",
+        "use_blueprint",
+    },
+)
+
+
+@dataclass
+class ExtractedPlatformKeys:
+    """Trigger and condition platform keys extracted from a raw config."""
+
+    trigger_keys: set[str] = field(default_factory=set)
+    condition_keys: set[str] = field(default_factory=set)
+
+
+def _walk_platform_keys(config: Any, found: ExtractedPlatformKeys) -> None:
+    """Recursively collect trigger and condition platform keys."""
+    if isinstance(config, list):
+        for item in config:
+            _walk_platform_keys(item, found)
+        return
+
+    if not isinstance(config, dict):
+        return
+
+    if isinstance(condition := config.get("condition"), str):
+        found.condition_keys.add(condition)
+    else:
+        # Only collect trigger keys outside condition configurations: the
+        # trigger condition carries trigger IDs (not platform keys) in its
+        # own ``trigger`` field.
+        for key in ("trigger", "platform"):
+            if isinstance(trigger := config.get(key), str):
+                found.trigger_keys.add(trigger)
+                break
+
+    for key, value in config.items():
+        if key in _PLATFORM_KEY_EXCLUDED_KEYS:
+            continue
+        _walk_platform_keys(value, found)
+
+
+def extract_platform_keys_from_config(config: Any) -> ExtractedPlatformKeys:
+    """Extract trigger and condition platform keys from a raw config.
+
+    Collects the type of every trigger (``platform:``/``trigger:``) and
+    condition (``condition:``) used anywhere in the configuration,
+    including ``wait_for_trigger`` blocks and nested sequences.
+    """
+    found = ExtractedPlatformKeys()
+    _walk_platform_keys(config, found)
+    return found

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -302,8 +302,10 @@ class AbstractSpookEntityComponentUnknownReferencesRepair(AbstractSpookRepair, A
 
     #: Entity class representing an unavailable/broken instance. Entities of
     #: this type are still tracked in ``possible_issue_ids`` but skipped during
-    #: issue creation.
-    unavailable_entity_class: type
+    #: issue creation. ``None`` inspects every entity, including unavailable
+    #: ones; repairs that diagnose *why* an entity is broken need exactly
+    #: those.
+    unavailable_entity_class: type | None = None
 
     #: Translation placeholder key holding the entity's display name (e.g.
     #: ``"automation"`` or ``"script"``).
@@ -368,7 +370,9 @@ class AbstractSpookEntityComponentUnknownReferencesRepair(AbstractSpookRepair, A
 
             self.possible_issue_ids.add(entity.entity_id)
 
-            if isinstance(entity, self.unavailable_entity_class):
+            unavailable_class = self.unavailable_entity_class
+            # pylint: disable-next=isinstance-second-argument-not-valid-type
+            if unavailable_class is not None and isinstance(entity, unavailable_class):
                 continue
 
             if not self._should_inspect_entity(entity):

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -256,6 +256,10 @@
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following actions, which are unknown to Home Assistant:\n\n{services}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing actions.\n\nSpook 👻 Your homie.",
       "title": "Unknown actions used in: {automation}"
     },
+    "automation_unknown_trigger_references": {
+      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation uses the following triggers, which cannot be provided by any integration available to Home Assistant:\n\n{triggers}\n\n\n\nThis often happens when the integration providing a trigger was removed. To fix this error, [edit the automation]({edit}) and remove the use of these unavailable triggers, or restore the integration providing them.\n\nSpook 👻 Your homie.",
+      "title": "Unknown triggers used in: {automation}"
+    },
     "group_unknown_members": {
       "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Unknown group members in: {group}"
@@ -279,6 +283,17 @@
     "proximity_unknown_zone": {
       "description": "Spook has found a ghost in your proximity configuration 👻\n\nWhile floating around, Spook crossed path with the following proximity configuration:\n\n{name}\n\nThis configuration is based on a zone that is unknown to Home Assistant:\n\n`{zone}`\n\n\n\nTo fix this error, as you can't change the zone of a proximity configuration, the only option is to remove this specific proximity integration instance.\n\nSpook 👻 Your homie.",
       "title": "Unknown zone: {zone}"
+    },
+    "restart_required": {
+      "title": "Restart required",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Restart required",
+            "description": "In order for Spook 👻 to finish setting up, Home Assistant needs to be restarted.\n\nSelect submit to restart Home Assistant now."
+          }
+        }
+      }
     },
     "scene_unknown_entity_references": {
       "description": "Spook has found a ghost in your scenes 👻\n\nWhile floating around, Spook crossed path with the following scene:\n\n[{scene}]({edit})\n\nThis scene references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the scene]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
@@ -312,10 +327,6 @@
       "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Unknown source: {helper}"
     },
-    "utility_meter_unknown_source": {
-      "description": "Spook has found a ghost in your utility meter helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
-      "title": "Unknown source: {helper}"
-    },
     "trend_unknown_source": {
       "description": "Spook has found a ghost in your trend helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Unknown source: {helper}"
@@ -331,16 +342,9 @@
       },
       "title": "{title}"
     },
-    "restart_required": {
-      "title": "Restart required",
-      "fix_flow": {
-        "step": {
-          "confirm_restart": {
-            "title": "Restart required",
-            "description": "In order for Spook 👻 to finish setting up, Home Assistant needs to be restarted.\n\nSelect submit to restart Home Assistant now."
-          }
-        }
-      }
+    "utility_meter_unknown_source": {
+      "description": "Spook has found a ghost in your utility meter helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
+      "title": "Unknown source: {helper}"
     }
   },
   "services": {

--- a/tests/ectoplasms/automation/repairs/test_unknown_trigger_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_trigger_references.py
@@ -1,0 +1,78 @@
+"""Tests for the automation unknown trigger references repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.setup import async_setup_component
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.automation.repairs.unknown_trigger_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def test_broken_automation_gets_a_specific_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an automation with an unavailable trigger is named precisely.
+
+    An automation using a trigger from a removed integration fails
+    validation and becomes unavailable; the repair must inspect it
+    anyway and name the offending trigger.
+    """
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "id": "haunted",
+                    "alias": "Haunted",
+                    "triggers": [{"trigger": "ghost_integration.appeared"}],
+                    "actions": [{"action": "light.turn_on"}],
+                },
+                {
+                    "id": "healthy",
+                    "alias": "Healthy",
+                    "triggers": [
+                        {"trigger": "state", "entity_id": "binary_sensor.motion"},
+                    ],
+                    "actions": [{"action": "light.turn_on"}],
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    # The broken automation failed validation and is unavailable.
+    state = hass.states.get("automation.haunted")
+    assert state
+    assert state.state == "unavailable"
+
+    repair = SpookRepair(hass)
+    await repair.async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "automation_unknown_trigger_references_automation.haunted",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert (
+        issue.translation_placeholders["triggers"] == "- `ghost_integration.appeared`"
+    )
+
+    assert (
+        issue_registry.async_get_issue(
+            DOMAIN,
+            "automation_unknown_trigger_references_automation.healthy",
+        )
+        is None
+    )

--- a/tests/test_platform_validation.py
+++ b/tests/test_platform_validation.py
@@ -1,0 +1,77 @@
+"""Tests for trigger and condition platform key validation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.trigger import TRIGGERS
+
+from custom_components.spook.platform_validation import (
+    async_filter_unknown_condition_keys,
+    async_filter_unknown_trigger_keys,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def test_builtin_and_alias_keys_are_known(hass: HomeAssistant) -> None:
+    """Test built-in trigger and condition keys never report unknown."""
+    assert (
+        await async_filter_unknown_trigger_keys(
+            hass,
+            {"state", "event", "time", "time_pattern", "numeric_state", "device"},
+        )
+        == set()
+    )
+    assert (
+        await async_filter_unknown_condition_keys(
+            hass,
+            {"and", "or", "not", "state", "template", "time", "trigger", "device"},
+        )
+        == set()
+    )
+
+
+async def test_unknown_integration_is_reported(hass: HomeAssistant) -> None:
+    """Test keys from nonexistent integrations are reported."""
+    assert await async_filter_unknown_trigger_keys(
+        hass,
+        {"ghost_integration.appeared", "state"},
+    ) == {"ghost_integration.appeared"}
+
+
+async def test_integration_without_triggers_is_reported(hass: HomeAssistant) -> None:
+    """Test keys from integrations without a trigger platform are reported.
+
+    Spook itself exists as an integration but ships no trigger platform.
+    """
+    assert await async_filter_unknown_trigger_keys(hass, {"spook.boo"}) == {
+        "spook.boo",
+    }
+
+
+async def test_registered_platform_keys_are_known(hass: HomeAssistant) -> None:
+    """Test registered trigger keys and domains never report unknown."""
+    hass.data[TRIGGERS] = {"ghost_integration.appeared": "ghost_integration"}
+
+    assert (
+        await async_filter_unknown_trigger_keys(
+            hass,
+            # The second key is unregistered, but its domain has a
+            # registered platform; key-level validation is Home
+            # Assistant's job.
+            {"ghost_integration.appeared", "ghost_integration.vanished"},
+        )
+        == set()
+    )
+
+
+async def test_existing_unloaded_integration_is_not_reported(
+    hass: HomeAssistant,
+) -> None:
+    """Test integrations with trigger support are trusted when not loaded."""
+    assert (
+        await async_filter_unknown_trigger_keys(hass, {"sun", "template", "mqtt"})
+        == set()
+    )

--- a/tests/test_platform_validation.py
+++ b/tests/test_platform_validation.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.helpers.trigger import TRIGGERS
 
+from custom_components.spook import platform_validation
 from custom_components.spook.platform_validation import (
     async_filter_unknown_condition_keys,
     async_filter_unknown_trigger_keys,
@@ -13,6 +14,7 @@ from custom_components.spook.platform_validation import (
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    import pytest
 
 
 async def test_builtin_and_alias_keys_are_known(hass: HomeAssistant) -> None:
@@ -75,3 +77,37 @@ async def test_existing_unloaded_integration_is_not_reported(
         await async_filter_unknown_trigger_keys(hass, {"sun", "template", "mqtt"})
         == set()
     )
+
+
+async def test_shared_domains_are_resolved_once(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test keys sharing a domain resolve their integration only once."""
+    calls: list[str] = []
+    original = platform_validation.async_get_integration
+
+    async def _counting_get_integration(
+        hass_: HomeAssistant,
+        domain: str,
+    ) -> object:
+        calls.append(domain)
+        return await original(hass_, domain)
+
+    monkeypatch.setattr(
+        platform_validation,
+        "async_get_integration",
+        _counting_get_integration,
+    )
+
+    unknown = await async_filter_unknown_trigger_keys(
+        hass,
+        {"ghost_integration.a", "ghost_integration.b", "ghost_integration.c"},
+    )
+
+    assert unknown == {
+        "ghost_integration.a",
+        "ghost_integration.b",
+        "ghost_integration.c",
+    }
+    assert calls == ["ghost_integration"]

--- a/tests/test_reference_extraction.py
+++ b/tests/test_reference_extraction.py
@@ -6,7 +6,10 @@ from typing import Any
 
 import pytest
 
-from custom_components.spook.reference_extraction import extract_targets_from_config
+from custom_components.spook.reference_extraction import (
+    extract_platform_keys_from_config,
+    extract_targets_from_config,
+)
 
 
 def test_repeat_nested_targets_are_found() -> None:
@@ -171,3 +174,68 @@ def test_empty_or_scalar_configs_yield_nothing(config: Any) -> None:
     assert not targets.device_ids
     assert not targets.floor_ids
     assert not targets.label_ids
+
+
+def test_platform_keys_from_all_sections() -> None:
+    """Test trigger and condition keys are collected everywhere."""
+    config = {
+        "triggers": [
+            {"trigger": "state", "entity_id": "light.kitchen"},
+            {"platform": "samsung_tv.turned_on"},
+        ],
+        "conditions": [
+            {
+                "condition": "or",
+                "conditions": [{"condition": "sun", "after": "sunset"}],
+            },
+        ],
+        "actions": [
+            {
+                "repeat": {
+                    "count": 2,
+                    "sequence": [
+                        {
+                            "wait_for_trigger": [{"trigger": "ghost.appeared"}],
+                        },
+                        {"condition": "template", "value_template": "{{ true }}"},
+                    ],
+                },
+            },
+        ],
+    }
+
+    keys = extract_platform_keys_from_config(config)
+
+    assert keys.trigger_keys == {"state", "samsung_tv.turned_on", "ghost.appeared"}
+    assert keys.condition_keys == {"or", "sun", "template"}
+
+
+def test_platform_keys_skip_payloads_and_trigger_condition_ids() -> None:
+    """Test payload data and trigger condition IDs are not platform keys.
+
+    Service data can hold ``platform`` or ``condition`` keys (a weather
+    condition, for example), and the trigger *condition* references
+    trigger IDs, not platforms, in its ``trigger`` field.
+    """
+    config = {
+        "triggers": [
+            {
+                "trigger": "event",
+                "event_type": "x",
+                "event_data": {"platform": "payload"},
+            },
+        ],
+        "conditions": [{"condition": "trigger", "trigger": "my_trigger_id"}],
+        "actions": [
+            {
+                "action": "weather.set",
+                "data": {"condition": "sunny", "platform": "payload"},
+            },
+        ],
+        "use_blueprint": {"input": {"condition": "free-form"}},
+    }
+
+    keys = extract_platform_keys_from_config(config)
+
+    assert keys.trigger_keys == {"event"}
+    assert keys.condition_keys == {"trigger"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Triggers are pluggable now: keys like `samsung_tv.turned_on` resolve to an integration at automation load time. When that integration is removed, the automation fails validation, becomes unavailable, and Home Assistant only raises a generic "could not be validated" issue. Worse, unavailable automations report no references at all, so until now they were invisible to every Spook repair, exactly the automations that need attention most.

This adds `automation_unknown_trigger_references`, naming the precise trigger that no available integration can provide. The pieces:

- `platform_validation.py` (new): validates trigger keys against the runtime trigger registry, Home Assistant's alias tables (built-ins like `state` map to the `homeassistant` integration, `device` to `device_automation`), and the integration loader. Conservative on purpose: a key is only reported when its integration does not exist at all, or exists but ships no trigger platform. Integrations that exist but are not loaded, and unregistered subtypes of registered platforms, are trusted (validating those is Home Assistant's job).
- Trigger/condition key extraction in `reference_extraction.py`, walking the raw configuration with false-positive guards: service `data` payloads are excluded (a weather `condition: sunny` is not a platform key), blueprint inputs are excluded, and the trigger *condition*'s `trigger:` field is recognized as trigger IDs, not platforms.
- The shared repair base class now allows `unavailable_entity_class = None`, meaning unavailable entities are inspected too. This repair deliberately does so: the broken automations are the point.
- The repair re-inspects when new trigger platforms register (`async_subscribe_platform_events`), on automation reloads, and on component loads. Condition and script variants follow on this same infrastructure in follow-up PRs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

"Automation could not be validated" tells a user something broke; this repair tells them *what* broke and where to fix it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Extraction tests cover all config sections plus the payload and trigger-ID false-positive guards. Validation tests cover built-in aliases, nonexistent integrations, integrations without trigger support (Spook itself serves as the fixture), registered platforms, and unloaded-but-capable integrations (`sun`, `template`, `mqtt`). The end-to-end test sets up a real automation with `trigger: ghost_integration.appeared` through `async_setup_component`, verifies it became unavailable, and asserts the repair creates an issue naming exactly that trigger while a healthy sibling automation stays clean. Full suite passes (568 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
