### PR TITLE
Detect unknown condition types in automations

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_condition_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_condition_references.py
@@ -1,0 +1,64 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import automation
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import condition as condition_helper
+
+from ....platform_validation import async_filter_unknown_condition_keys
+from ....reference_extraction import extract_platform_keys_from_config
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
+    """Spook repair tries to find unknown condition types in automations.
+
+    An automation using a condition from a removed integration fails
+    validation entirely and becomes unavailable; Home Assistant only
+    raises a generic issue for it. This repair names the exact condition.
+    Unavailable automations are deliberately inspected: they are the
+    broken ones.
+    """
+
+    domain = automation.DOMAIN
+    repair = "automation_unknown_condition_references"
+    inspect_events = {
+        automation.EVENT_AUTOMATION_RELOADED,
+        EVENT_COMPONENT_LOADED,
+    }
+    inspect_on_reload = True
+
+    entity_label = "automation"
+    reference_label = "conditions"
+    edit_url_pattern = "/config/automation/edit/{unique_id}"
+
+    async def async_activate(self) -> None:
+        """Activate the repair."""
+        await super().async_activate()
+
+        async def _async_platforms_registered(_platforms: set[str]) -> None:
+            """Re-inspect when new condition platforms register."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            condition_helper.async_subscribe_platform_events(
+                self.hass,
+                _async_platforms_registered,
+            ),
+        )
+
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown condition keys used by ``entity``."""
+        if not (raw_config := getattr(entity, "raw_config", None)):
+            return set()
+
+        return await async_filter_unknown_condition_keys(
+            self.hass,
+            extract_platform_keys_from_config(raw_config).condition_keys,
+        )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -236,6 +236,10 @@
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
       "title": "Unknown areas used in: {automation}"
     },
+    "automation_unknown_condition_references": {
+      "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation uses the following conditions, which cannot be provided by any integration available to Home Assistant:\n\n{conditions}\n\n\n\nThis often happens when the integration providing a condition was removed. To fix this error, [edit the automation]({edit}) and remove the use of these unavailable conditions, or restore the integration providing them.\n\nSpook 👻 Your homie.",
+      "title": "Unknown conditions used in: {automation}"
+    },
     "automation_unknown_device_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Your homie.",
       "title": "Unknown devices used in: {automation}"

--- a/tests/ectoplasms/automation/repairs/test_unknown_condition_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_condition_references.py
@@ -1,0 +1,87 @@
+"""Tests for the automation unknown condition references repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.setup import async_setup_component
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.automation.repairs.unknown_condition_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def test_broken_automation_gets_a_specific_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an automation with an unavailable condition is named precisely.
+
+    An automation using a condition from a removed integration fails
+    validation and becomes unavailable; the repair must inspect it
+    anyway and name the offending condition.
+    """
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "id": "haunted",
+                    "alias": "Haunted",
+                    "triggers": [
+                        {"trigger": "state", "entity_id": "binary_sensor.motion"},
+                    ],
+                    "conditions": [
+                        {"condition": "ghost_integration.is_haunted"},
+                    ],
+                    "actions": [{"action": "light.turn_on"}],
+                },
+                {
+                    "id": "healthy",
+                    "alias": "Healthy",
+                    "triggers": [
+                        {"trigger": "state", "entity_id": "binary_sensor.motion"},
+                    ],
+                    "conditions": [
+                        {"condition": "state", "entity_id": "sun.sun", "state": "x"},
+                    ],
+                    "actions": [{"action": "light.turn_on"}],
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    # The broken automation failed validation and is unavailable.
+    state = hass.states.get("automation.haunted")
+    assert state
+    assert state.state == "unavailable"
+
+    repair = SpookRepair(hass)
+    await repair.async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "automation_unknown_condition_references_automation.haunted",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert (
+        issue.translation_placeholders["conditions"]
+        == "- `ghost_integration.is_haunted`"
+    )
+
+    assert (
+        issue_registry.async_get_issue(
+            DOMAIN,
+            "automation_unknown_condition_references_automation.healthy",
+        )
+        is None
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The condition counterpart of #1357. Conditions are pluggable like triggers; an automation using a condition from a removed integration fails validation, becomes unavailable, and Home Assistant only raises a generic issue. This adds `automation_unknown_condition_references`, naming the precise condition that no available integration can provide.

Thin by design: the key extraction, the conservative validation (registry, alias tables, integration loader, per-domain memoization), and the unavailable-entity inspection all landed with #1357. This PR adds the repair itself (re-inspecting when new condition platforms register), its translation, and its end-to-end test.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Same as #1357, for conditions: "automation could not be validated" becomes "this exact condition no longer exists, here is the edit link".

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The end-to-end test sets up a real automation with `condition: ghost_integration.is_haunted` through `async_setup_component`, verifies it became unavailable, and asserts the repair creates an issue naming exactly that condition while a healthy sibling using a built-in `state` condition stays clean. Extraction and validation behavior is covered by the test suites that landed with #1357. Full suite passes (572 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.