### PR TITLE
Detect unknown trigger and condition types in scripts

### DIFF
--- a/custom_components/spook/ectoplasms/script/repairs/unknown_condition_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_condition_references.py
@@ -1,0 +1,61 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import script
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import condition as condition_helper
+
+from ....platform_validation import async_filter_unknown_condition_keys
+from ....reference_extraction import extract_platform_keys_from_config
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
+    """Spook repair tries to find unknown condition types in scripts.
+
+    A script using a condition from a removed integration fails validation
+    entirely and becomes unavailable; Home Assistant only raises a
+    generic issue for it. This repair names the exact condition.
+    Unavailable scripts are deliberately inspected: they are the broken
+    ones.
+    """
+
+    domain = script.DOMAIN
+    repair = "script_unknown_condition_references"
+    inspect_events = {EVENT_COMPONENT_LOADED}
+    inspect_on_reload = True
+
+    entity_label = "script"
+    reference_label = "conditions"
+    edit_url_pattern = "/config/script/edit/{unique_id}"
+
+    async def async_activate(self) -> None:
+        """Activate the repair."""
+        await super().async_activate()
+
+        async def _async_platforms_registered(_platforms: set[str]) -> None:
+            """Re-inspect when new condition platforms register."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            condition_helper.async_subscribe_platform_events(
+                self.hass,
+                _async_platforms_registered,
+            ),
+        )
+
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown condition keys used by ``entity``."""
+        if not (raw_config := getattr(entity, "raw_config", None)):
+            return set()
+
+        return await async_filter_unknown_condition_keys(
+            self.hass,
+            extract_platform_keys_from_config(raw_config).condition_keys,
+        )

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_trigger_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_trigger_references.py
@@ -1,0 +1,61 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import script
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import trigger as trigger_helper
+
+from ....platform_validation import async_filter_unknown_trigger_keys
+from ....reference_extraction import extract_platform_keys_from_config
+from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
+    """Spook repair tries to find unknown trigger types in scripts.
+
+    A script using a trigger from a removed integration fails validation
+    entirely and becomes unavailable; Home Assistant only raises a
+    generic issue for it. This repair names the exact trigger.
+    Unavailable scripts are deliberately inspected: they are the broken
+    ones.
+    """
+
+    domain = script.DOMAIN
+    repair = "script_unknown_trigger_references"
+    inspect_events = {EVENT_COMPONENT_LOADED}
+    inspect_on_reload = True
+
+    entity_label = "script"
+    reference_label = "triggers"
+    edit_url_pattern = "/config/script/edit/{unique_id}"
+
+    async def async_activate(self) -> None:
+        """Activate the repair."""
+        await super().async_activate()
+
+        async def _async_platforms_registered(_platforms: set[str]) -> None:
+            """Re-inspect when new trigger platforms register."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            trigger_helper.async_subscribe_platform_events(
+                self.hass,
+                _async_platforms_registered,
+            ),
+        )
+
+    async def _async_compute_unknown_references(self, entity: Any) -> set[str]:
+        """Return unknown trigger keys used by ``entity``."""
+        if not (raw_config := getattr(entity, "raw_config", None)):
+            return set()
+
+        return await async_filter_unknown_trigger_keys(
+            self.hass,
+            extract_platform_keys_from_config(raw_config).trigger_keys,
+        )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -307,6 +307,10 @@
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
       "title": "Unknown areas used in: {script}"
     },
+    "script_unknown_condition_references": {
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script uses the following conditions, which cannot be provided by any integration available to Home Assistant:\n\n{conditions}\n\n\n\nThis often happens when the integration providing a condition was removed. To fix this error, [edit the script]({edit}) and remove the use of these unavailable conditions, or restore the integration providing them.\n\nSpook 👻 Your homie.",
+      "title": "Unknown conditions used in: {script}"
+    },
     "script_unknown_device_references": {
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following devices, which are unknown to Home Assistant:\n\n{devices}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing devices.\n\nSpook 👻 Your homie.",
       "title": "Unknown devices used in: {script}"
@@ -326,6 +330,10 @@
     "script_unknown_service_references": {
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script references the following actions, which are unknown to Home Assistant:\n\n{services}\n\n\n\nTo fix this error, [edit the script]({edit}) and remove the use of these non-existing actions.\n\nSpook 👻 Your homie.",
       "title": "Unknown actions used in: {script}"
+    },
+    "script_unknown_trigger_references": {
+      "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script uses the following triggers, which cannot be provided by any integration available to Home Assistant:\n\n{triggers}\n\n\n\nThis often happens when the integration providing a trigger was removed. To fix this error, [edit the script]({edit}) and remove the use of these unavailable triggers, or restore the integration providing them.\n\nSpook 👻 Your homie.",
+      "title": "Unknown triggers used in: {script}"
     },
     "switch_as_x_unknown_source": {
       "description": "Spook has found a ghost in your Switch as X helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source switch entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",

--- a/tests/ectoplasms/script/repairs/test_unknown_platform_references.py
+++ b/tests/ectoplasms/script/repairs/test_unknown_platform_references.py
@@ -1,0 +1,109 @@
+"""Tests for the script unknown trigger and condition references repairs."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.setup import async_setup_component
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.script.repairs import (
+    unknown_condition_references,
+    unknown_trigger_references,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def test_broken_scripts_get_specific_issues(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test scripts with unavailable trigger or condition types are named.
+
+    Scripts using triggers (via ``wait_for_trigger``) or conditions from
+    removed integrations fail validation and become unavailable; the
+    repairs must inspect them anyway and name the offending keys.
+    """
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "haunted_wait": {
+                    "sequence": [
+                        {
+                            "wait_for_trigger": [
+                                {"trigger": "ghost_integration.appeared"},
+                            ],
+                        },
+                    ],
+                },
+                "haunted_check": {
+                    "sequence": [
+                        {"condition": "ghost_integration.is_haunted"},
+                        {"action": "light.turn_on"},
+                    ],
+                },
+                "healthy": {
+                    "sequence": [
+                        {
+                            "condition": "state",
+                            "entity_id": "sun.sun",
+                            "state": "above_horizon",
+                        },
+                        {"action": "light.turn_on"},
+                    ],
+                },
+            },
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Both broken scripts failed validation and are unavailable.
+    for object_id in ("haunted_wait", "haunted_check"):
+        state = hass.states.get(f"script.{object_id}")
+        assert state
+        assert state.state == "unavailable"
+
+    trigger_repair = unknown_trigger_references.SpookRepair(hass)
+    await trigger_repair.async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "script_unknown_trigger_references_script.haunted_wait",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert (
+        issue.translation_placeholders["triggers"] == "- `ghost_integration.appeared`"
+    )
+
+    condition_repair = unknown_condition_references.SpookRepair(hass)
+    await condition_repair.async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "script_unknown_condition_references_script.haunted_check",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert (
+        issue.translation_placeholders["conditions"]
+        == "- `ghost_integration.is_haunted`"
+    )
+
+    for repair_name in (
+        "script_unknown_trigger_references",
+        "script_unknown_condition_references",
+    ):
+        assert (
+            issue_registry.async_get_issue(
+                DOMAIN,
+                f"{repair_name}_script.healthy",
+            )
+            is None
+        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The script counterparts of #1357 and #1358, completing the unknown platform type detection. Scripts use triggers through `wait_for_trigger` blocks and conditions as sequence steps; when the providing integration is removed, the script fails validation, becomes unavailable, and Home Assistant only raises a generic issue.

This adds `script_unknown_trigger_references` and `script_unknown_condition_references`, both thin mirrors of the automation pair: raw configuration inspection including unavailable scripts, the shared extraction and validation infrastructure from #1357, and re-inspection when new trigger or condition platforms register. Scripts have no dedicated reload event, so re-inspection additionally rides on the generic reload handling and component loads.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Completes the story started in #1357: every automation and script using a trigger or condition that no available integration can provide now gets a precise, actionable issue instead of a generic validation failure.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The end-to-end test sets up three real scripts through `async_setup_component`: one with a ghost trigger in `wait_for_trigger`, one with a ghost condition step, and a healthy one. Both broken scripts are verified unavailable and named precisely in their issues; the healthy script stays clean for both repairs. Full suite passes (577 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.