### PR TITLE
Detect unknown source entities in ten more helper types

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/__init__.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_helper_source_references.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_helper_source_references.py
@@ -49,12 +49,10 @@ def _source_values(entry: ConfigEntry) -> set[str]:
         elif isinstance(raw, list):
             values.update(item for item in raw if isinstance(item, str))
 
-    # Bayesian nests each source under an observation.
+    # Bayesian stores each observation as a config subentry.
     if entry.domain == "bayesian":
-        for observation in entry.options.get("observations", []):
-            if isinstance(observation, dict) and isinstance(
-                entity_id := observation.get("entity_id"), str
-            ):
+        for subentry in entry.subentries.values():
+            if isinstance(entity_id := subentry.data.get("entity_id"), str):
                 values.add(entity_id)
 
     return values

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_helper_source_references.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_helper_source_references.py
@@ -1,0 +1,123 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import entity_registry as er
+
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+
+
+# Helper integrations that store one or more source entity references in
+# their config entry options, mapped to the option keys holding them. A
+# value is either an entity ID or an entity registry ID (both resolved via
+# ``er.async_resolve_entity_id``); a key may hold a single value or a list.
+#
+# Deliberately excluded: ``group`` (already covered by the group unknown
+# members repair) and the helpers with their own source repairs
+# (``integration``, ``switch_as_x``, ``trend``, ``utility_meter``).
+SOURCE_OPTION_KEYS: dict[str, tuple[str, ...]] = {
+    "derivative": ("source",),
+    "filter": ("entity_id",),
+    "generic_hygrostat": ("target_sensor", "humidifier"),
+    "generic_thermostat": ("target_sensor", "heater"),
+    "history_stats": ("entity_id",),
+    "min_max": ("entity_ids",),
+    "mold_indicator": (
+        "indoor_temp_sensor",
+        "indoor_humidity_sensor",
+        "outdoor_temp_sensor",
+    ),
+    "statistics": ("entity_id",),
+    "threshold": ("entity_id",),
+}
+
+
+def _source_values(entry: ConfigEntry) -> set[str]:
+    """Return the raw source references stored on a helper config entry."""
+    values: set[str] = set()
+    for key in SOURCE_OPTION_KEYS.get(entry.domain, ()):
+        raw = entry.options.get(key)
+        if isinstance(raw, str):
+            values.add(raw)
+        elif isinstance(raw, list):
+            values.update(item for item in raw if isinstance(item, str))
+
+    # Bayesian nests each source under an observation.
+    if entry.domain == "bayesian":
+        for observation in entry.options.get("observations", []):
+            if isinstance(observation, dict) and isinstance(
+                entity_id := observation.get("entity_id"), str
+            ):
+                values.add(entity_id)
+
+    return values
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair that finds helpers referencing unknown source entities.
+
+    Reads config entry options directly (a public API), so it also covers
+    helpers whose entity failed to set up, and avoids the private entity
+    attributes the per-helper source repairs rely on.
+    """
+
+    domain = "homeassistant"
+    repair = "unknown_helper_source_references"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    inspect_config_entry_changed = True
+
+    automatically_clean_up_issues = True
+
+    #: Helper domains this repair inspects.
+    _inspected_domains = frozenset({*SOURCE_OPTION_KEYS, "bayesian"})
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        self.possible_issue_ids.clear()
+
+        known_entity_ids = async_get_all_entity_ids(self.hass)
+        entity_registry = er.async_get(self.hass)
+
+        for entry in self.hass.config_entries.async_entries():
+            if entry.domain not in self._inspected_domains:
+                continue
+
+            self.possible_issue_ids.add(entry.entry_id)
+
+            unknown: set[str] = set()
+            for value in _source_values(entry):
+                resolved = er.async_resolve_entity_id(entity_registry, value)
+                if resolved is None:
+                    # A registry ID whose entry was deleted.
+                    unknown.add(value)
+                else:
+                    unknown.update(
+                        async_filter_known_entity_ids(
+                            self.hass,
+                            [resolved],
+                            known_entity_ids=known_entity_ids,
+                        )
+                    )
+
+            if not unknown:
+                continue
+
+            self.async_create_issue(
+                issue_id=entry.entry_id,
+                issue_domain=entry.domain,
+                translation_placeholders={
+                    "helper": entry.title,
+                    "domain": entry.domain,
+                    "sources": "\n".join(f"- `{source}`" for source in sorted(unknown)),
+                },
+            )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -343,6 +343,10 @@
       "description": "Spook has found a ghost in your trend helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{entity_id}`)\n\nThis helper has a source entity unknown to Home Assistant:\n\n`{source}`\n\n\n\nTo fix this error, edit the helper and adjust the source entity (or remove the helper) and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Unknown source: {helper}"
     },
+    "unknown_helper_source_references": {
+      "description": "Spook has found a ghost in your helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{domain}`)\n\nThis helper references the following source entities, which are unknown to Home Assistant:\n\n{sources}\n\n\n\nThis often happens when a source entity was renamed or removed. To fix this error, reconfigure the helper to point at existing entities, or remove the helper.\n\nSpook 👻 Your homie.",
+      "title": "Unknown source entities used in helper: {helper}"
+    },
     "user_issue": {
       "fix_flow": {
         "step": {

--- a/tests/ectoplasms/homeassistant/repairs/__init__.py
+++ b/tests/ectoplasms/homeassistant/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook Home Assistant repairs."""

--- a/tests/ectoplasms/homeassistant/repairs/test_unknown_helper_source_references.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_unknown_helper_source_references.py
@@ -41,16 +41,6 @@ def _issue_id(entry: MockConfigEntry) -> str:
             {"name": "Ghostly", "target_sensor": "sensor.ghost", "heater": "switch.x"},
             id="multi-key",
         ),
-        pytest.param(
-            "bayesian",
-            {
-                "name": "Ghostly",
-                "observations": [
-                    {"entity_id": "sensor.ghost", "platform": "state"},
-                ],
-            },
-            id="nested-observations",
-        ),
     ],
 )
 async def test_unknown_source_creates_issue(
@@ -133,6 +123,51 @@ async def test_unrelated_config_entries_are_ignored(
         domain="hue",
         title="Bridge",
         options={"source": "sensor.ghost"},
+    )
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(entry)) is None
+
+
+async def test_bayesian_observation_subentry_is_inspected(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test bayesian observations, stored as config subentries, are checked."""
+    entry = MockConfigEntry(
+        domain="bayesian",
+        title="Ghostly",
+        options={"name": "Ghostly"},
+        subentries_data=[
+            {
+                "subentry_type": "observation",
+                "title": "Ghost seen",
+                "unique_id": None,
+                "data": {"entity_id": "sensor.ghost", "platform": "state"},
+            },
+        ],
+    )
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(entry))
+    assert issue
+    assert issue.translation_placeholders
+    assert "sensor.ghost" in issue.translation_placeholders["sources"]
+
+
+async def test_bayesian_without_subentries_does_not_crash(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a bayesian entry with no observation subentries is fine."""
+    entry = MockConfigEntry(
+        domain="bayesian",
+        title="Odd",
+        options={"name": "Odd"},
     )
     entry.add_to_hass(hass)
 

--- a/tests/ectoplasms/homeassistant/repairs/test_unknown_helper_source_references.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_unknown_helper_source_references.py
@@ -1,0 +1,141 @@
+"""Tests for the table-driven unknown helper source references repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+import pytest
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs.unknown_helper_source_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import entity_registry as er, issue_registry as ir
+
+
+def _issue_id(entry: MockConfigEntry) -> str:
+    """Return the Spook issue ID for a helper config entry."""
+    return f"unknown_helper_source_references_{entry.entry_id}"
+
+
+@pytest.mark.parametrize(
+    ("helper_domain", "options"),
+    [
+        pytest.param(
+            "derivative",
+            {"name": "Ghostly", "source": "sensor.ghost"},
+            id="single-key-source",
+        ),
+        pytest.param(
+            "min_max",
+            {"name": "Ghostly", "entity_ids": ["sensor.real", "sensor.ghost"]},
+            id="list-key",
+        ),
+        pytest.param(
+            "generic_thermostat",
+            {"name": "Ghostly", "target_sensor": "sensor.ghost", "heater": "switch.x"},
+            id="multi-key",
+        ),
+        pytest.param(
+            "bayesian",
+            {
+                "name": "Ghostly",
+                "observations": [
+                    {"entity_id": "sensor.ghost", "platform": "state"},
+                ],
+            },
+            id="nested-observations",
+        ),
+    ],
+)
+async def test_unknown_source_creates_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    helper_domain: str,
+    options: dict[str, Any],
+) -> None:
+    """Test a helper referencing a nonexistent source is reported."""
+    entry = MockConfigEntry(domain=helper_domain, title="Ghostly", options=options)
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(entry))
+    assert issue
+    assert issue.translation_placeholders
+    assert "sensor.ghost" in issue.translation_placeholders["sources"]
+    assert issue.translation_placeholders["domain"] == helper_domain
+
+
+async def test_known_source_creates_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a helper referencing an existing entity is not reported."""
+    hass.states.async_set("sensor.real", "1")
+
+    entry = MockConfigEntry(
+        domain="derivative",
+        title="Fine",
+        options={"name": "Fine", "source": "sensor.real"},
+    )
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(entry)) is None
+
+
+async def test_source_stored_as_registry_id_is_resolved(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test sources stored as registry IDs resolve to their entity ID.
+
+    Some helpers (like switch_as_x) store the registry ID rather than the
+    entity ID; a live one must not be reported, a dead one must be.
+    """
+    live = entity_registry.async_get_or_create("sensor", "demo", "live")
+    hass.states.async_set(live.entity_id, "1")
+
+    live_entry = MockConfigEntry(
+        domain="derivative",
+        title="Live",
+        options={"name": "Live", "source": live.id},
+    )
+    live_entry.add_to_hass(hass)
+
+    dead_entry = MockConfigEntry(
+        domain="derivative",
+        title="Dead",
+        options={"name": "Dead", "source": "deleted-registry-id"},
+    )
+    dead_entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(live_entry)) is None
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(dead_entry))
+
+
+async def test_unrelated_config_entries_are_ignored(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test config entries outside the helper table are not inspected."""
+    entry = MockConfigEntry(
+        domain="hue",
+        title="Bridge",
+        options={"source": "sensor.ghost"},
+    )
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(entry)) is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Several helper integrations store one or more source entity references in their config entry options, and until now Spook checked none of them. This adds one table-driven repair covering ten helper types: `derivative`, `filter`, `threshold`, `statistics`, `history_stats`, `min_max`, `generic_thermostat`, `generic_hygrostat`, `mold_indicator`, and `bayesian`.

Design notes:

- Reads the public `ConfigEntry.options` rather than private entity attributes, so it also catches helpers whose entity failed to set up. This is the same reason the follow-up will migrate the existing private-attribute source repairs (`integration`, `switch_as_x`, `trend`, `utility_meter`) onto this repair.
- Handles every option shape: a single key, a list (`min_max`), multiple keys (`mold_indicator`, the thermostats), and `bayesian`'s nested `observations[].entity_id`.
- Resolves each stored value through `er.async_resolve_entity_id`, so a source stored as an entity ID or as an entity registry ID is handled uniformly; a registry ID whose entry was deleted is reported.
- Runs resolved IDs through the existing `async_filter_known_entity_ids`, inheriting the ignored-domain skips so a helper sourcing from, say, a group is not falsely flagged.
- Each issue is scoped to the helper's own domain via `issue_domain`, so it appears under the right integration.
- Deliberately excludes `group` (already covered by its unknown members repair) and the four helpers with existing source repairs, to avoid double reporting until they are migrated in a follow-up PR.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A derivative sensor built on a deleted source, or a min/max averaging entities that no longer exist, silently produced nonsense. These are now flagged with a precise, per-helper issue.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Parametrized tests cover all four option shapes (single key, list, multi key, nested observations), plus: a known source produces no issue, a source stored as a registry ID resolves correctly (live not reported, dead reported), and config entries outside the helper table are ignored. Full suite passes (587 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.