### PR TITLE
Add generic dashboard entity reference walker

### DIFF
--- a/custom_components/spook/dashboard_extraction.py
+++ b/custom_components/spook/dashboard_extraction.py
@@ -1,0 +1,78 @@
+"""Spook - Your homie. Entity reference extraction from dashboard configs.
+
+The Lovelace repair used to hand-walk a fixed set of known card shapes,
+missing references in custom cards and any structure it did not explicitly
+recurse into. This module walks a dashboard configuration generically: it
+recurses through every container and collects entity references from
+reference-shaped keys wherever they appear, so custom cards are covered
+for free.
+
+Only recognized keys are read; arbitrary strings are never collected. The
+downstream ``async_filter_known_entity_ids`` still validates every value,
+so a benign string under a recognized key is dropped rather than reported.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .entity_filtering import split_comma_separated_entity_ids
+
+# Keys whose value holds one or more entity references, anywhere in a
+# dashboard configuration. Values may be a single entity ID, a
+# comma-separated list, or a list of entity IDs; entity IDs nested inside
+# dicts (like entities-card rows) are reached by the recursion instead.
+_ENTITY_REFERENCE_KEYS = frozenset(
+    {
+        "badges",
+        "camera_image",
+        "entities",
+        "entity",
+        "entity_id",
+        "entity_ids",
+        "exclude_entities",
+        "favorite_entities",
+        "image_entity",
+        "include_entities",
+    },
+)
+
+
+def _collect_strings(value: Any, entities: set[str]) -> None:
+    """Collect entity IDs from a recognized key's string or list value."""
+    if isinstance(value, str):
+        entities.update(split_comma_separated_entity_ids(value))
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, str):
+                entities.update(split_comma_separated_entity_ids(item))
+
+
+def _walk(node: Any, entities: set[str]) -> None:
+    """Recursively collect entity references from a configuration node."""
+    if isinstance(node, list):
+        for item in node:
+            _walk(item, entities)
+        return
+
+    if not isinstance(node, dict):
+        return
+
+    for key in _ENTITY_REFERENCE_KEYS:
+        if key in node:
+            _collect_strings(node[key], entities)
+
+    for value in node.values():
+        if isinstance(value, (dict, list)):
+            _walk(value, entities)
+
+
+def extract_entities_from_dashboard_node(node: Any) -> set[str]:
+    """Return the entity references found anywhere in a dashboard node.
+
+    Accepts any part of a dashboard configuration (a whole config, a view,
+    a card) and returns every entity reference reachable from it.
+    """
+    entities: set[str] = set()
+    _walk(node, entities)
+    return entities

--- a/tests/test_dashboard_extraction.py
+++ b/tests/test_dashboard_extraction.py
@@ -1,0 +1,180 @@
+"""Tests for generic dashboard entity reference extraction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.spook.dashboard_extraction import (
+    extract_entities_from_dashboard_node,
+)
+
+
+def test_full_dashboard_walk() -> None:
+    """Test entities are collected from views, badges, cards, and sections."""
+    config = {
+        "views": [
+            {
+                "path": "home",
+                "badges": [
+                    "sensor.bare_badge",
+                    {"type": "entity", "entity": "sensor.dict_badge"},
+                ],
+                "cards": [
+                    {"type": "entity", "entity": "light.kitchen"},
+                    {
+                        "type": "entities",
+                        "entities": [
+                            "switch.a",
+                            {"entity": "switch.b", "name": "B"},
+                        ],
+                    },
+                ],
+                "sections": [
+                    {"cards": [{"type": "entity", "entity": "climate.hvac"}]},
+                ],
+            },
+        ],
+    }
+
+    assert extract_entities_from_dashboard_node(config) == {
+        "sensor.bare_badge",
+        "sensor.dict_badge",
+        "light.kitchen",
+        "switch.a",
+        "switch.b",
+        "climate.hvac",
+    }
+
+
+def test_actions_targets_and_service_data() -> None:
+    """Test entity references inside actions are collected."""
+    config = {
+        "type": "button",
+        "entity": "light.button",
+        "tap_action": {
+            "action": "perform-action",
+            "target": {"entity_id": ["light.a", "light.b"]},
+        },
+        "hold_action": {
+            "action": "call-service",
+            "service_data": {"entity_id": "switch.hold"},
+        },
+        "double_tap_action": {
+            "action": "perform-action",
+            "data": {"entity_id": "fan.double"},
+        },
+    }
+
+    assert extract_entities_from_dashboard_node(config) == {
+        "light.button",
+        "light.a",
+        "light.b",
+        "switch.hold",
+        "fan.double",
+    }
+
+
+def test_picture_elements_and_nested_stacks() -> None:
+    """Test deeply nested elements and stacked cards are reached."""
+    config = {
+        "type": "vertical-stack",
+        "cards": [
+            {
+                "type": "picture-elements",
+                "camera_image": "camera.front",
+                "image_entity": "image.map",
+                "elements": [
+                    {"type": "state-badge", "entity": "sensor.temp"},
+                    {
+                        "type": "conditional",
+                        "conditions": [{"entity": "binary_sensor.cond"}],
+                        "elements": [{"type": "icon", "entity": "light.nested"}],
+                    },
+                ],
+            },
+        ],
+    }
+
+    assert extract_entities_from_dashboard_node(config) == {
+        "camera.front",
+        "image.map",
+        "sensor.temp",
+        "binary_sensor.cond",
+        "light.nested",
+    }
+
+
+def test_custom_card_structure_is_covered() -> None:
+    """Test references in an unknown card structure are still found.
+
+    A generic walk reaches entity keys the old per-card walker never knew
+    about.
+    """
+    config = {
+        "type": "custom:my-fancy-card",
+        "header": {"widgets": [{"entity": "sensor.custom_nested"}]},
+        "extra": {"deeply": {"nested": {"entity_id": "switch.custom"}}},
+    }
+
+    assert extract_entities_from_dashboard_node(config) == {
+        "sensor.custom_nested",
+        "switch.custom",
+    }
+
+
+def test_markdown_and_area_card_keys() -> None:
+    """Test markdown entity_ids and area card exclude_entities are collected."""
+    config = {
+        "views": [
+            {
+                "cards": [
+                    {
+                        "type": "markdown",
+                        "entity_ids": ["sensor.md_a", "sensor.md_b"],
+                    },
+                    {
+                        "type": "area",
+                        "area": "living_room",
+                        "exclude_entities": ["light.excluded"],
+                    },
+                ],
+            },
+        ],
+    }
+
+    assert extract_entities_from_dashboard_node(config) == {
+        "sensor.md_a",
+        "sensor.md_b",
+        "light.excluded",
+    }
+
+
+def test_comma_separated_values_are_split() -> None:
+    """Test comma-separated entity IDs are split into individual references."""
+    config = {"entity_id": "light.a, light.b ,light.c"}
+
+    assert extract_entities_from_dashboard_node(config) == {
+        "light.a",
+        "light.b",
+        "light.c",
+    }
+
+
+def test_non_reference_keys_and_sources_are_ignored() -> None:
+    """Test unrelated keys and geo location sources are not collected."""
+    config = {
+        "type": "map",
+        "theme": "some-theme",
+        "title": "My Map",
+        "geo_location_sources": ["all", "nws"],
+    }
+
+    assert extract_entities_from_dashboard_node(config) == set()
+
+
+@pytest.mark.parametrize("node", [None, [], {}, "string", 42, {"entity": 5}])
+def test_degenerate_nodes_yield_nothing(node: Any) -> None:
+    """Test scalar, empty, and malformed nodes produce no references."""
+    assert extract_entities_from_dashboard_node(node) == set()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Groundwork for rewriting the Lovelace unknown entity references repair. The current repair hand-walks a fixed set of known card shapes, so it misses references in custom cards and any structure it does not explicitly recurse into.

This adds `dashboard_extraction.py`: a generic recursive walker that collects entity references from reference-shaped keys anywhere in a dashboard configuration. It recurses through every container and reads entity IDs from `entity`, `entity_id`, `entities`, `entity_ids`, `camera_image`, `image_entity`, `badges`, `exclude_entities`, `include_entities`, and `favorite_entities`. Entity IDs nested in dicts (entities-card rows, picture elements, action targets) are reached by the recursion; comma-separated values are split.

The walk is deliberately key-name driven and never collects arbitrary strings, so it stays false-positive safe. The downstream `async_filter_known_entity_ids` still validates every value, so a benign string under a recognized key is dropped rather than reported.

Not wired into the repair yet; that is the next PR, which replaces the repair's hand-rolled extraction and migrates its behavior-pinning tests onto this module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A custom card burying an `entity` key was invisible to the old walker. A generic walk reaches it, and covers new built-in card shapes without per-card maintenance.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Thirteen unit tests cover the full dashboard structure (views, badges, cards, sections), action targets/data/service_data, deeply nested picture-elements and stacks, a genuinely custom card structure, markdown `entity_ids`, area card keys, comma splitting, and the negatives (geo location sources and unrelated keys ignored, degenerate nodes). Full suite passes (593 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.