### PR TITLE
Detect unknown area references in dashboards

### DIFF
--- a/custom_components/spook/dashboard_extraction.py
+++ b/custom_components/spook/dashboard_extraction.py
@@ -76,3 +76,47 @@ def extract_entities_from_dashboard_node(node: Any) -> set[str]:
     entities: set[str] = set()
     _walk(node, entities)
     return entities
+
+
+# Keys whose value holds one or more area references. ``area`` is the area
+# card and area view strategy; ``area_id`` is a service-call area target.
+_AREA_REFERENCE_KEYS = frozenset({"area", "area_id"})
+
+
+def _collect_plain(value: Any, out: set[str]) -> None:
+    """Collect plain string IDs from a key's string or list value."""
+    if isinstance(value, str):
+        out.add(value)
+    elif isinstance(value, list):
+        out.update(item for item in value if isinstance(item, str))
+
+
+def _walk_areas(node: Any, areas: set[str]) -> None:
+    """Recursively collect area references from a configuration node."""
+    if isinstance(node, list):
+        for item in node:
+            _walk_areas(item, areas)
+        return
+
+    if not isinstance(node, dict):
+        return
+
+    for key in _AREA_REFERENCE_KEYS:
+        if key in node:
+            _collect_plain(node[key], areas)
+
+    # The areas dashboard strategy lists area IDs to hide or order.
+    if isinstance(areas_display := node.get("areas_display"), dict):
+        for sub_key in ("hidden", "order"):
+            _collect_plain(areas_display.get(sub_key), areas)
+
+    for value in node.values():
+        if isinstance(value, (dict, list)):
+            _walk_areas(value, areas)
+
+
+def extract_areas_from_dashboard_node(node: Any) -> set[str]:
+    """Return the area references found anywhere in a dashboard node."""
+    areas: set[str] = set()
+    _walk_areas(node, areas)
+    return areas

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_area_references.py
@@ -1,0 +1,97 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.lovelace import DOMAIN
+from homeassistant.components.lovelace.const import ConfigNotFound
+from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
+from homeassistant.core import callback
+from homeassistant.helpers import area_registry as ar
+
+from ....const import LOGGER
+from ....dashboard_extraction import extract_areas_from_dashboard_node
+from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
+from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from homeassistant.components.lovelace.dashboard import (
+        LovelaceStorage,
+        LovelaceYAML,
+    )
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair tries to find unknown referenced areas in dashboards."""
+
+    domain = DOMAIN
+    repair = "lovelace_unknown_area_references"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        EVENT_LOVELACE_UPDATED,
+        ar.EVENT_AREA_REGISTRY_UPDATED,
+    }
+    inspect_config_entry_changed = True
+    inspect_on_reload = True
+    automatically_clean_up_issues = True
+
+    _dashboards: dict[str, LovelaceStorage | LovelaceYAML]
+
+    async def async_activate(self) -> None:
+        """Handle the activating a repair."""
+        self._dashboards = self.hass.data["lovelace"].dashboards
+        await super().async_activate()
+
+    async def async_inspect(self) -> None:
+        """Trigger a inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        known_area_ids = async_get_all_area_ids(self.hass)
+
+        for dashboard in self._dashboards.values():
+            url_path = dashboard.url_path or "lovelace"
+            self.possible_issue_ids.add(url_path)
+            try:
+                config = await dashboard.async_load(force=False)
+            except ConfigNotFound:
+                LOGGER.debug("Config for dashboard %s not found, skipping", url_path)
+                continue
+
+            extracted_areas = self.__async_extract_areas(config)
+            if unknown_areas := async_filter_known_area_ids(
+                self.hass,
+                area_ids=set(extracted_areas),
+                known_area_ids=known_area_ids,
+            ):
+                first_view_path = next(
+                    path
+                    for area_id, path in extracted_areas.items()
+                    if area_id in unknown_areas
+                )
+                title = "Overview"
+                if dashboard.config:
+                    title = dashboard.config.get("title", url_path)
+                self.async_create_issue(
+                    issue_id=url_path,
+                    translation_placeholders={
+                        "areas": "\n".join(
+                            f"- `{area_id}`" for area_id in sorted(unknown_areas)
+                        ),
+                        "dashboard": title,
+                        "edit": f"/{url_path}/{first_view_path}?edit=1",
+                    },
+                )
+
+    @callback
+    def __async_extract_areas(self, config: dict[str, Any]) -> dict[str, int | str]:
+        """Extract areas from a dashboard config, keyed by their view path."""
+        areas: dict[str, int | str] = {}
+        if isinstance(config, dict) and (views := config.get("views")):
+            for view_index, view in enumerate(views):
+                if not isinstance(view, dict):
+                    continue
+                view_path: int | str = view.get("path") or view_index
+                for area_id in extract_areas_from_dashboard_node(view):
+                    areas.setdefault(area_id, view_path)
+        return areas

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -268,6 +268,10 @@
       "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Unknown group members in: {group}"
     },
+    "lovelace_unknown_area_references": {
+      "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n{dashboard}\n\nThis dashboard references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nThis often happens when an area was renamed or removed. To fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
+      "title": "Unknown areas used in dashboard: {dashboard}"
+    },
     "lovelace_unknown_entity_references": {
       "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n[{dashboard}]({edit})\n\nThis dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
       "title": "Unknown entities used in: {dashboard}"

--- a/tests/ectoplasms/lovelace/repairs/test_unknown_area_references.py
+++ b/tests/ectoplasms/lovelace/repairs/test_unknown_area_references.py
@@ -1,0 +1,111 @@
+"""Tests for the Lovelace unknown area references repair."""
+
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.lovelace.repairs.unknown_area_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import area_registry as ar, issue_registry as ir
+
+
+def _extract(repair: SpookRepair, config: dict[str, Any]) -> dict[str, int | str]:
+    """Call the name-mangled dashboard-level area extractor."""
+    return repair._SpookRepair__async_extract_areas(config)  # noqa: SLF001  # type: ignore[attr-defined]
+
+
+def test_extract_areas_keeps_first_view_path(hass: HomeAssistant) -> None:
+    """Test each area is mapped to the first view it appears in."""
+    repair = SpookRepair(hass)
+    config = {
+        "views": [
+            {"path": "home", "cards": [{"type": "area", "area": "kitchen"}]},
+            {"path": "second", "cards": [{"type": "area", "area": "kitchen"}]},
+        ],
+    }
+
+    assert _extract(repair, config) == {"kitchen": "home"}
+
+
+async def test_unknown_area_creates_issue(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a dashboard referencing a nonexistent area is reported."""
+    known = area_registry.async_create("Living Room")
+
+    async def async_load(*, force: bool) -> dict[str, Any]:
+        """Return the dashboard config."""
+        del force
+        return {
+            "views": [
+                {
+                    "path": "home",
+                    "cards": [
+                        {"type": "area", "area": known.id},
+                        {"type": "area", "area": "ghost_area"},
+                    ],
+                },
+            ],
+        }
+
+    repair = SpookRepair(hass)
+    repair._dashboards = {  # noqa: SLF001
+        "lovelace": SimpleNamespace(
+            url_path="lovelace",
+            config={"title": "Overview"},
+            async_load=async_load,
+        ),
+    }
+
+    await repair.async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        "lovelace_unknown_area_references_lovelace",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert issue.translation_placeholders["areas"] == "- `ghost_area`"
+    assert issue.translation_placeholders["edit"] == "/lovelace/home?edit=1"
+
+
+async def test_known_areas_create_no_issue(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a dashboard referencing only existing areas is not reported."""
+    known = area_registry.async_create("Kitchen")
+
+    async def async_load(*, force: bool) -> dict[str, Any]:
+        """Return the dashboard config."""
+        del force
+        return {"views": [{"cards": [{"type": "area", "area": known.id}]}]}
+
+    repair = SpookRepair(hass)
+    repair._dashboards = {  # noqa: SLF001
+        "lovelace": SimpleNamespace(
+            url_path="lovelace",
+            config=None,
+            async_load=async_load,
+        ),
+    }
+
+    await repair.async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(
+            DOMAIN,
+            "lovelace_unknown_area_references_lovelace",
+        )
+        is None
+    )

--- a/tests/test_dashboard_extraction.py
+++ b/tests/test_dashboard_extraction.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from custom_components.spook.dashboard_extraction import (
+    extract_areas_from_dashboard_node,
     extract_entities_from_dashboard_node,
 )
 
@@ -178,3 +179,48 @@ def test_non_reference_keys_and_sources_are_ignored() -> None:
 def test_degenerate_nodes_yield_nothing(node: Any) -> None:
     """Test scalar, empty, and malformed nodes produce no references."""
     assert extract_entities_from_dashboard_node(node) == set()
+
+
+def test_area_references_from_cards_and_strategy() -> None:
+    """Test area references are collected from area cards and strategies."""
+    config = {
+        "views": [
+            {
+                "strategy": {
+                    "type": "areas",
+                    "areas_display": {
+                        "hidden": ["attic"],
+                        "order": ["kitchen", "hallway"],
+                    },
+                },
+            },
+            {
+                "cards": [
+                    {"type": "area", "area": "living_room"},
+                    {
+                        "type": "button",
+                        "tap_action": {
+                            "action": "perform-action",
+                            "target": {"area_id": ["garage", "shed"]},
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+    assert extract_areas_from_dashboard_node(config) == {
+        "attic",
+        "kitchen",
+        "hallway",
+        "living_room",
+        "garage",
+        "shed",
+    }
+
+
+def test_area_extraction_ignores_unrelated_keys() -> None:
+    """Test non-area keys are not collected as area references."""
+    config = {"type": "entity", "entity": "sensor.x", "name": "kitchen"}
+
+    assert extract_areas_from_dashboard_node(config) == set()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `lovelace_unknown_area_references` repair. Renaming or removing an area silently breaks area cards (`area:`) and the areas dashboard strategy, and nothing surfaced that until now.

- Extends the dashboard walker with `extract_areas_from_dashboard_node`, collecting `area`, `area_id` (service-call area targets), and the areas strategy's `areas_display.hidden`/`order` lists.
- The repair mirrors the entity references repair's dashboard loading and per-view path bookkeeping (for the edit link), but validates against the area registry and re-inspects on `EVENT_AREA_REGISTRY_UPDATED`.

Note: this repair duplicates the entity repair's dashboard-loop boilerplate. Kept separate on purpose (a shared `AbstractSpookLovelaceReferencesRepair` base earns its keep once a third reference type, floor or label, is added); flagged here as a tracked future cleanup rather than left silent.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Area renames are common and their effect on dashboards is invisible; this makes it a clear, actionable repair.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Walker tests cover area extraction from area cards, action targets, and the areas strategy, plus a not-collected negative. Repair tests cover the view-path mapping, a ghost-area dashboard producing an issue against the real area registry (asserting the edit URL and area placeholder), and an all-known-areas dashboard producing nothing. Full suite passes (578 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.