### PR TITLE
Detect stale device references in templates

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_device_references.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import device_registry as dr
 from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
 from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+from ....template_extraction import extract_device_ids_from_config
 
 
 def extract_event_data_device_ids_from_trigger_config(
@@ -88,6 +89,8 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
                     entity.raw_config.get("triggers")
                 )
             )
+            # Devices referenced via device_entities() in templates.
+            device_ids.update(extract_device_ids_from_config(entity.raw_config))
 
         return async_filter_known_device_ids(
             self.hass,

--- a/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
+++ b/custom_components/spook/ectoplasms/script/repairs/unknown_device_references.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import device_registry as dr
 from ....entity_filtering import async_filter_known_device_ids, async_get_all_device_ids
 from ....reference_extraction import extract_targets_from_config
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
+from ....template_extraction import extract_device_ids_from_config
 
 if TYPE_CHECKING:
     from typing import Any
@@ -43,6 +44,8 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
         # references nested in some step types, like repeat sequences.
         if raw_config := getattr(entity, "raw_config", None):
             device_ids.update(extract_targets_from_config(raw_config).device_ids)
+            # Devices referenced via device_entities() in templates.
+            device_ids.update(extract_device_ids_from_config(raw_config))
 
         return async_filter_known_device_ids(
             self.hass,

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -103,6 +103,14 @@ COMPILED_ENTITY_ID_TEMPLATE_PATTERNS = tuple(
 
 JINJA_COMMENT_PATTERN = re.compile(r"\{#.*?#\}", re.DOTALL)
 
+# The ``device_entities`` template function takes a device registry ID
+# directly (no name or entity resolution), so a quoted literal is
+# unambiguously a device reference.
+_DEVICE_ENTITIES_PATTERN = re.compile(
+    r"device_entities\s*\(\s*['\"]([^'\"]+)['\"]",
+    re.IGNORECASE,
+)
+
 
 def is_template_string(value: str) -> bool:
     """Check if a string looks like a Jinja2 template."""
@@ -437,3 +445,18 @@ async def async_extract_entities_from_config(
                 exc,  # Pass the exception for logging
             )
     return entities
+
+
+@lru_cache(maxsize=1024)
+def _extract_device_ids_from_template(template_str: str) -> frozenset[str]:
+    """Extract device IDs referenced via ``device_entities`` in a template."""
+    template_without_comments = _strip_jinja_comments(template_str)
+    return frozenset(_DEVICE_ENTITIES_PATTERN.findall(template_without_comments))
+
+
+def extract_device_ids_from_config(config: Any) -> set[str]:
+    """Extract device IDs referenced via ``device_entities`` in templates."""
+    device_ids: set[str] = set()
+    for template_str in extract_template_strings_from_config(config):
+        device_ids.update(_extract_device_ids_from_template(template_str))
+    return device_ids

--- a/tests/ectoplasms/automation/repairs/test_template_device_references.py
+++ b/tests/ectoplasms/automation/repairs/test_template_device_references.py
@@ -1,0 +1,57 @@
+"""Tests for device references via device_entities() in templates."""
+
+# pylint: disable=wrong-import-order,protected-access
+# ruff: noqa: SLF001
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from custom_components.spook.ectoplasms.automation.repairs.unknown_device_references import (
+    SpookRepair as AutomationSpookRepair,
+)
+from custom_components.spook.ectoplasms.script.repairs.unknown_device_references import (
+    SpookRepair as ScriptSpookRepair,
+)
+import pytest
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_RAW_CONFIG = {
+    "actions": [
+        {
+            "action": "light.turn_on",
+            "target": {"entity_id": "{{ device_entities('ghost_device') }}"},
+        },
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    ("repair_class", "entity_kwargs"),
+    [
+        pytest.param(
+            AutomationSpookRepair,
+            {"referenced_devices": set()},
+            id="automation",
+        ),
+        pytest.param(
+            ScriptSpookRepair,
+            {"script": SimpleNamespace(referenced_devices=set())},
+            id="script",
+        ),
+    ],
+)
+async def test_template_device_entities_reference_is_detected(
+    hass: HomeAssistant,
+    repair_class: type,
+    entity_kwargs: dict[str, Any],
+) -> None:
+    """Test a stale device_entities() device ID in a template is reported."""
+    repair = repair_class(hass)
+    repair._known_device_ids = {"known_device"}
+
+    entity = SimpleNamespace(raw_config=_RAW_CONFIG, **entity_kwargs)
+
+    assert await repair._async_compute_unknown_references(entity) == {"ghost_device"}

--- a/tests/test_reference_extraction.py
+++ b/tests/test_reference_extraction.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from custom_components.spook.template_extraction import extract_device_ids_from_config
 from custom_components.spook.reference_extraction import (
     extract_platform_keys_from_config,
     extract_targets_from_config,
@@ -239,3 +240,34 @@ def test_platform_keys_skip_payloads_and_trigger_condition_ids() -> None:
 
     assert keys.trigger_keys == {"event"}
     assert keys.condition_keys == {"trigger"}
+
+
+def test_device_ids_extracted_from_template_config() -> None:
+    """Test device_entities() device IDs are pulled from templated config."""
+    config = {
+        "actions": [
+            {
+                "action": "light.turn_on",
+                "target": {
+                    "entity_id": "{{ device_entities('abc123device') }}",
+                },
+            },
+            {
+                "action": "notify.notify",
+                "data": {
+                    "message": (
+                        '{{ device_entities("def456device") | length }} devices'
+                    ),
+                },
+            },
+        ],
+    }
+
+    assert extract_device_ids_from_config(config) == {"abc123device", "def456device"}
+
+
+def test_device_extraction_ignores_non_device_templates() -> None:
+    """Test templates without device_entities yield no device IDs."""
+    config = {"value_template": "{{ states('sensor.x') }}"}
+
+    assert extract_device_ids_from_config(config) == set()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Automation and script device reference repairs now also look at `device_entities('<device_id>')` calls in templates, so a template referencing a deleted device is flagged.

This is deliberately the only template registry function handled here. I verified the resolution semantics of all of them against the installed Home Assistant: `device_entities` passes its argument straight to `async_entries_for_device` with no name, alias, or cross-type resolution, so a quoted literal is unambiguously a device registry ID and safe to validate. The area/floor/label functions (`area_entities`, `floor_entities`, `label_entities`, and friends) all accept an ID *or* a name *or* an alias *or* even a device/entity ID, which is a real false-positive surface; validating their literals safely needs a large multi-registry union and is left for a careful follow-up (noted in the plan).

The extraction is an `lru_cache`d regex over template strings, matching the existing entity-extraction caching. In the automation repair it runs after the event-trigger payload device subtraction so ordering stays correct.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A template building a target from `device_entities()` of a removed device silently resolves to nothing; now it is reported like any other stale device reference.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Extraction tests cover two `device_entities` call forms and confirm non-device templates yield nothing. A parametrized repair test proves both the automation and script device repairs report a ghost `device_entities` ID end to end. Full suite passes (582 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.