### PR TITLE
Detect unknown entities referenced in template helpers

### DIFF
--- a/custom_components/spook/ectoplasms/template/__init__.py
+++ b/custom_components/spook/ectoplasms/template/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/template/repairs/__init__.py
+++ b/custom_components/spook/ectoplasms/template/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/template/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/template/repairs/unknown_entity_references.py
@@ -1,0 +1,88 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_STATE_CHANGED
+from homeassistant.core import Event, callback
+from homeassistant.helpers import entity_registry as er
+
+from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....repairs import AbstractSpookRepair
+from ....template_extraction import async_extract_entities_from_config
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds unknown entities referenced in template helpers.
+
+    Template helper config entries store their templates in the entry
+    options; a template referencing a removed entity resolves to
+    ``unknown`` and is otherwise silent.
+    """
+
+    domain = "template"
+    repair = "template_unknown_entity_references"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    inspect_config_entry_changed = "template"
+    inspect_on_reload = "template"
+    automatically_clean_up_issues = True
+
+    async def async_activate(self) -> None:
+        """Activate the repair."""
+        await super().async_activate()
+
+        @callback
+        def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
+            """Return if a state entity was added or removed."""
+            return (
+                event_data.get("old_state") is None
+                or event_data.get("new_state") is None
+            )
+
+        @callback
+        def _async_call_inspect_debouncer(_: Event) -> None:
+            """Trigger an inspection when a state entity is added or removed."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            self.hass.bus.async_listen(
+                EVENT_STATE_CHANGED,
+                _async_call_inspect_debouncer,
+                event_filter=_state_entity_changed,
+            ),
+        )
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        known_entity_ids = async_get_all_entity_ids(self.hass, include_all_none=True)
+
+        for entry in self.hass.config_entries.async_entries(self.domain):
+            self.possible_issue_ids.add(entry.entry_id)
+
+            referenced = await async_extract_entities_from_config(
+                self.hass, dict(entry.options)
+            )
+            if unknown_entities := async_filter_known_entity_ids(
+                self.hass,
+                referenced,
+                known_entity_ids=known_entity_ids,
+            ):
+                self.async_create_issue(
+                    issue_id=entry.entry_id,
+                    translation_placeholders={
+                        "entities": "\n".join(
+                            f"- `{entity_id}`" for entity_id in sorted(unknown_entities)
+                        ),
+                        "helper": entry.title,
+                    },
+                )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -335,6 +335,10 @@
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script uses the following triggers, which cannot be provided by any integration available to Home Assistant:\n\n{triggers}\n\n\n\nThis often happens when the integration providing a trigger was removed. To fix this error, [edit the script]({edit}) and remove the use of these unavailable triggers, or restore the integration providing them.\n\nSpook 👻 Your homie.",
       "title": "Unknown triggers used in: {script}"
     },
+    "template_unknown_entity_references": {
+      "description": "Spook has found a ghost in your template helpers 👻\n\nWhile floating around, Spook crossed path with the following template helper:\n\n{helper}\n\nIts templates reference the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nThis often happens when an entity was renamed or removed. To fix this error, reconfigure the template helper to reference existing entities.\n\nSpook 👻 Your homie.",
+      "title": "Unknown entities used in template helper: {helper}"
+    },
     "unknown_helper_source_references": {
       "description": "Spook has found a ghost in your helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{domain}`)\n\nThis helper references the following source entities, which are unknown to Home Assistant:\n\n{sources}\n\n\n\nThis often happens when a source entity was renamed or removed. To fix this error, reconfigure the helper to point at existing entities, or remove the helper.\n\nSpook 👻 Your homie.",
       "title": "Unknown source entities used in helper: {helper}"

--- a/tests/ectoplasms/template/__init__.py
+++ b/tests/ectoplasms/template/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook template ectoplasm."""

--- a/tests/ectoplasms/template/repairs/__init__.py
+++ b/tests/ectoplasms/template/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook template repairs."""

--- a/tests/ectoplasms/template/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/template/repairs/test_unknown_entity_references.py
@@ -1,0 +1,76 @@
+"""Tests for the template helper unknown entity references repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.template.repairs.unknown_entity_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def test_unknown_entity_in_template_creates_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a template helper referencing a nonexistent entity is reported."""
+    entry = MockConfigEntry(
+        domain="template",
+        title="Ghostly sensor",
+        options={
+            "name": "Ghostly sensor",
+            "template_type": "sensor",
+            "state": "{{ states('sensor.ghost') | float + 1 }}",
+            "availability": "{{ has_value('binary_sensor.also_ghost') }}",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN,
+        f"template_unknown_entity_references_{entry.entry_id}",
+    )
+    assert issue
+    assert issue.translation_placeholders
+    assert issue.translation_placeholders["entities"] == (
+        "- `binary_sensor.also_ghost`\n- `sensor.ghost`"
+    )
+
+
+async def test_known_entities_create_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a template helper referencing existing entities is not reported."""
+    hass.states.async_set("sensor.real", "1")
+
+    entry = MockConfigEntry(
+        domain="template",
+        title="Fine sensor",
+        options={
+            "name": "Fine sensor",
+            "template_type": "sensor",
+            "state": "{{ states('sensor.real') | float + 1 }}",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(
+            DOMAIN,
+            f"template_unknown_entity_references_{entry.entry_id}",
+        )
+        is None
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `template` ectoplasm with a `template_unknown_entity_references` repair, the first check of template helpers, which were entirely unscanned. Template helper config entries store their templates in the entry options; a template referencing a removed entity resolves to `unknown` and is otherwise silent.

The repair reads each `template` config entry's options, extracts entity references with the existing template extraction (the same one the automation and script entity repairs use), filters against known entities, and raises a per-helper issue. It re-inspects on config entry changes, reloads, component load, and entity add/remove.

Scope: this covers config-entry template helpers, the publicly accessible case. YAML `template:` entities and trigger-based template sensors keep their config internal after setup and need a different access path; they are left for a follow-up.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A template sensor whose state or availability template watches a renamed or deleted entity just goes stale forever with no indication. Now it is reported.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

A template helper whose `state` and `availability` templates reference two nonexistent entities produces an issue naming both (sorted); an all-real-entities helper produces nothing. The extraction itself is already covered by the existing template extraction tests. Full suite passes (588 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.