### PR TITLE
Enrich unknown entity issues across all repairs

### DIFF
--- a/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
+++ b/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPl
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 
@@ -58,8 +59,8 @@ class SpookRepair(AbstractSpookRepair):
                     self.async_create_issue(
                         issue_id=entity.entity_id,
                         translation_placeholders={
-                            "entities": "\n".join(
-                                f"- `{entity_id}`" for entity_id in unknown_entities
+                            "entities": async_describe_unknown_entities(
+                                self.hass, sorted(unknown_entities)
                             ),
                             "group": entity.name,
                             "entity_id": entity.entity_id,

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import entity_registry as er
 from ....const import LOGGER
 from ....dashboard_extraction import extract_entities_from_dashboard_node
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -105,8 +106,8 @@ class SpookRepair(AbstractSpookRepair):
                 self.async_create_issue(
                     issue_id=url_path,
                     translation_placeholders={
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in sorted(unknown_entities)
+                        "entities": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                         "dashboard": title,
                         "edit": f"/{url_path}/{first_view_path}?edit=1",

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -52,8 +53,8 @@ class SpookRepair(AbstractSpookRepair):
                     issue_id=entry_id,
                     translation_placeholders={
                         "name": coordinator.name,
-                        "zones": "\n".join(
-                            f"- `{entity_id}`" for entity_id in unknown_entities
+                        "zones": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                     },
                 )

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -52,8 +53,8 @@ class SpookRepair(AbstractSpookRepair):
                     issue_id=entry_id,
                     translation_placeholders={
                         "name": coordinator.name,
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in unknown_entities
+                        "entities": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                     },
                 )

--- a/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -60,8 +61,8 @@ class SpookRepair(AbstractSpookRepair):
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in unknown_entities
+                        "entities": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                         "scene": entity.name,
                         "entity_id": entity.entity_id,

--- a/custom_components/spook/ectoplasms/template/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/template/repairs/unknown_entity_references.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 from ....template_extraction import async_extract_entities_from_config
 
@@ -80,8 +81,8 @@ class SpookRepair(AbstractSpookRepair):
                 self.async_create_issue(
                     issue_id=entry.entry_id,
                     translation_placeholders={
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in sorted(unknown_entities)
+                        "entities": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                         "helper": entry.title,
                     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Follow-up to #1368. The remaining repairs that build their own entity placeholder now use the shared `async_describe_unknown_entities` helper instead of an inline bullet join: Lovelace, scene, template helpers, group members, and both proximity repairs (tracked entities and ignored zones).

Every unknown-entity issue across Spook now carries the same context: `` (deleted on <date>, was provided by `<integration>`) `` or `` (did you mean `<entity>`?) ``, not just automations and scripts. Mechanical one-line swap per repair plus the import; no behavior change beyond the enriched text.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Consistency: the enrichment that landed for automation and script entity issues is just as useful on dashboards, scenes, groups, template helpers, and proximity, so all of them get it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The enrichment engine is covered by its own tests (#1368). Each repair's existing tests continue to pass: with no deleted entry or close match, the helper produces the same plain bullets as before, so the placeholder assertions are unchanged. Full suite passes (593 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.