### PR TITLE
Detect orphaned long-term statistics

### DIFF
--- a/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
+++ b/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM, EntityPl
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 
@@ -58,8 +59,8 @@ class SpookRepair(AbstractSpookRepair):
                     self.async_create_issue(
                         issue_id=entity.entity_id,
                         translation_placeholders={
-                            "entities": "\n".join(
-                                f"- `{entity_id}`" for entity_id in unknown_entities
+                            "entities": async_describe_unknown_entities(
+                                self.hass, sorted(unknown_entities)
                             ),
                             "group": entity.name,
                             "entity_id": entity.entity_id,

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import entity_registry as er
 from ....const import LOGGER
 from ....dashboard_extraction import extract_entities_from_dashboard_node
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -105,8 +106,8 @@ class SpookRepair(AbstractSpookRepair):
                 self.async_create_issue(
                     issue_id=url_path,
                     translation_placeholders={
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in sorted(unknown_entities)
+                        "entities": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                         "dashboard": title,
                         "edit": f"/{url_path}/{first_view_path}?edit=1",

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -52,8 +53,8 @@ class SpookRepair(AbstractSpookRepair):
                     issue_id=entry_id,
                     translation_placeholders={
                         "name": coordinator.name,
-                        "zones": "\n".join(
-                            f"- `{entity_id}`" for entity_id in unknown_entities
+                        "zones": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                     },
                 )

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -52,8 +53,8 @@ class SpookRepair(AbstractSpookRepair):
                     issue_id=entry_id,
                     translation_placeholders={
                         "name": coordinator.name,
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in unknown_entities
+                        "entities": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                     },
                 )

--- a/custom_components/spook/ectoplasms/recorder/repairs/__init__.py
+++ b/custom_components/spook/ectoplasms/recorder/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/recorder/repairs/orphaned_statistics.py
+++ b/custom_components/spook/ectoplasms/recorder/repairs/orphaned_statistics.py
@@ -1,0 +1,64 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from homeassistant.components.recorder.statistics import validate_statistics
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.recorder import DATA_INSTANCE, get_instance
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+# The recorder validation issue type for a statistic ID that has recorded
+# statistics but no matching sensor state at all: a genuine orphan. Other
+# issue types (unit or state-class changes, intentionally excluded
+# entities) are either handled by Home Assistant itself or expected.
+_ORPHAN_ISSUE_TYPE = "no_state"
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds long-term statistics without a matching entity.
+
+    Removing a sensor leaves its recorded statistics behind; Home
+    Assistant keeps them but never points them out. This surfaces them so
+    they can be cleaned up (Developer Tools > Statistics, or the
+    ``recorder.clear_statistics`` action).
+    """
+
+    domain = "recorder"
+    repair = "orphaned_statistics"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        if DATA_INSTANCE not in self.hass.data:
+            return  # Recorder is not set up.
+
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        self.possible_issue_ids.add(self.repair)
+
+        validation = await get_instance(self.hass).async_add_executor_job(
+            validate_statistics,
+            self.hass,
+        )
+        orphaned = sorted(
+            statistic_id
+            for statistic_id, issues in validation.items()
+            if any(issue.type == _ORPHAN_ISSUE_TYPE for issue in issues)
+        )
+
+        if orphaned:
+            self.async_create_issue(
+                issue_id=self.repair,
+                translation_placeholders={
+                    "statistics": "\n".join(
+                        f"- `{statistic_id}`" for statistic_id in orphaned
+                    ),
+                },
+            )

--- a/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/scene/repairs/unknown_entity_references.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -60,8 +61,8 @@ class SpookRepair(AbstractSpookRepair):
                 self.async_create_issue(
                     issue_id=entity.entity_id,
                     translation_placeholders={
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in unknown_entities
+                        "entities": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                         "scene": entity.name,
                         "entity_id": entity.entity_id,

--- a/custom_components/spook/ectoplasms/template/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/template/repairs/unknown_entity_references.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 from ....template_extraction import async_extract_entities_from_config
 
@@ -80,8 +81,8 @@ class SpookRepair(AbstractSpookRepair):
                 self.async_create_issue(
                     issue_id=entry.entry_id,
                     translation_placeholders={
-                        "entities": "\n".join(
-                            f"- `{entity_id}`" for entity_id in sorted(unknown_entities)
+                        "entities": async_describe_unknown_entities(
+                            self.hass, sorted(unknown_entities)
                         ),
                         "helper": entry.title,
                     },

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -276,6 +276,10 @@
       "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n[{dashboard}]({edit})\n\nThis dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
       "title": "Unknown entities used in: {dashboard}"
     },
+    "orphaned_statistics": {
+      "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Developer Tools > Statistics and fix them there, or remove them using the `recorder.clear_statistics` action.\n\nSpook 👻 Your homie.",
+      "title": "Orphaned long-term statistics found"
+    },
     "proximity_unknown_ignored_zones": {
       "description": "Spook has found a ghost in your proximity configuration 👻\n\nWhile floating around, Spook crossed path with the following proximity configuration:\n\n{name}\n\nThis configuration is ignoring zones that are unknown to Home Assistant:\n\n{zones}\n\n\n\nTo fix this error, edit the configuration and remove this/these zones.\n\nSpook 👻 Your homie.",
       "title": "Unknown ignored zones: {name}"

--- a/tests/ectoplasms/recorder/repairs/__init__.py
+++ b/tests/ectoplasms/recorder/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook recorder repairs."""

--- a/tests/ectoplasms/recorder/repairs/test_orphaned_statistics.py
+++ b/tests/ectoplasms/recorder/repairs/test_orphaned_statistics.py
@@ -1,0 +1,88 @@
+"""Tests for the orphaned long-term statistics repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.helpers.recorder import DATA_INSTANCE
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.recorder.repairs import orphaned_statistics
+from custom_components.spook.ectoplasms.recorder.repairs.orphaned_statistics import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+    import pytest
+
+_ISSUE_ID = "orphaned_statistics_orphaned_statistics"
+
+
+def _install_fake_recorder(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    validation: dict[str, list[Any]],
+) -> None:
+    """Install a fake recorder instance returning the given validation."""
+
+    async def _async_add_executor_job(_func: Any, *_args: Any) -> Any:
+        return validation
+
+    hass.data[DATA_INSTANCE] = SimpleNamespace(
+        async_add_executor_job=_async_add_executor_job,
+    )
+    monkeypatch.setattr(orphaned_statistics, "validate_statistics", lambda _hass: None)
+
+
+async def test_orphaned_statistics_create_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test statistics with a no_state issue are reported."""
+    validation = {
+        "sensor.ghost": [SimpleNamespace(type="no_state")],
+        "sensor.excluded": [SimpleNamespace(type="entity_no_longer_recorded")],
+        "sensor.fine": [],
+    }
+    _install_fake_recorder(hass, monkeypatch, validation)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders
+    # Only the no_state orphan is reported, not excluded or fine statistics.
+    assert issue.translation_placeholders["statistics"] == "- `sensor.ghost`"
+
+
+async def test_no_orphans_create_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test only non-orphan issue types produce no issue."""
+    validation = {
+        "sensor.excluded": [SimpleNamespace(type="entity_no_longer_recorded")]
+    }
+    _install_fake_recorder(hass, monkeypatch, validation)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_recorder_not_set_up_is_a_no_op(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the repair does nothing when the recorder is not set up."""
+    hass.data.pop(DATA_INSTANCE, None)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds an `orphaned_statistics` repair in the recorder ectoplasm. It runs Home Assistant's own `validate_statistics` in the recorder executor and surfaces the `no_state` orphans: long-term statistics kept for a sensor that no longer exists. Home Assistant keeps these indefinitely and only raises repairs for unit and state-class changes, so this is new coverage.

False-positive care: the `no_state` issue type fires only for a sensor statistic ID with no current sensor state at all. An unavailable or restored-but-broken sensor still has a state object, so it is not flagged. Only `no_state` is reported; `entity_no_longer_recorded` and `entity_not_recorded` are deliberately skipped because they usually mean an intentional recorder exclusion. When the recorder is not set up, the repair is a no-op. A single aggregate issue lists the orphans and auto-cleans when none remain, pointing at Developer Tools > Statistics and the `recorder.clear_statistics` action.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removing a sensor silently leaves its statistics behind forever; nothing points them out. First of the new maintenance corners, and it establishes the recorder statistics-metadata access that a later dashboard statistic-reference check can reuse.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tests use a fake recorder instance and a stubbed validation result: a mixed result reports only the `no_state` orphan (not excluded or fine statistics), non-orphan issue types produce nothing, and a missing recorder is a no-op. Full suite passes (599 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.