### PR TITLE
Detect dashboard resources pointing at missing files

### DIFF
--- a/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
@@ -1,0 +1,78 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from homeassistant.components.lovelace import DOMAIN
+from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+# Local resource URL prefixes that map to a file on disk. External URLs
+# (http/https) and integration-served paths cannot be verified and are
+# skipped.
+_LOCAL_PREFIX = "/local/"
+_HACS_PREFIX = "/hacsfiles/"
+
+
+def _local_path(hass: HomeAssistant, url: str) -> Path | None:
+    """Return the on-disk path a local resource URL maps to, if any."""
+    url = url.split("?", 1)[0]
+    if url.startswith(_LOCAL_PREFIX):
+        return Path(hass.config.path("www", url[len(_LOCAL_PREFIX) :]))
+    if url.startswith(_HACS_PREFIX):
+        return Path(hass.config.path("www", "community", url[len(_HACS_PREFIX) :]))
+    return None
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds dashboard resources pointing at missing files.
+
+    A dashboard resource served from ``/local/`` or ``/hacsfiles/`` whose
+    file was removed (often after uninstalling a custom card) silently
+    fails to load in the browser.
+    """
+
+    domain = DOMAIN
+    repair = "lovelace_missing_resources"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        EVENT_LOVELACE_UPDATED,
+    }
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        self.possible_issue_ids.add(self.repair)
+
+        if (resources := self.hass.data[DOMAIN].resources) is None:
+            return
+
+        to_check: dict[str, Path] = {}
+        for item in resources.async_items() or []:
+            if (url := item.get("url")) and (
+                path := _local_path(self.hass, url)
+            ) is not None:
+                to_check[url] = path
+
+        missing = await self.hass.async_add_executor_job(self._find_missing, to_check)
+        if missing:
+            self.async_create_issue(
+                issue_id=self.repair,
+                translation_placeholders={
+                    "resources": "\n".join(f"- `{url}`" for url in sorted(missing)),
+                },
+            )
+
+    @staticmethod
+    def _find_missing(to_check: dict[str, Path]) -> set[str]:
+        """Return the URLs whose mapped file does not exist."""
+        return {url for url, path in to_check.items() if not path.exists()}

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -268,6 +268,10 @@
       "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Unknown group members in: {group}"
     },
+    "lovelace_missing_resources": {
+      "description": "Spook has found a ghost in your dashboards 👻\n\nThe following dashboard resources point at files that do not exist:\n\n{resources}\n\n\n\nThis usually happens when a custom card or its files were removed but the resource stayed behind. To fix this error, open Settings > Dashboards > Resources and remove or correct these resources.\n\nSpook 👻 Your homie.",
+      "title": "Dashboard resources point at missing files"
+    },
     "lovelace_unknown_area_references": {
       "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n{dashboard}\n\nThis dashboard references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nThis often happens when an area was renamed or removed. To fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
       "title": "Unknown areas used in dashboard: {dashboard}"

--- a/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
@@ -1,0 +1,90 @@
+"""Tests for the Lovelace missing resources repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.lovelace.repairs.missing_resources import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+_ISSUE_ID = "lovelace_missing_resources_lovelace_missing_resources"
+
+
+def _make_www_file(hass: HomeAssistant, name: str) -> None:
+    """Create a file under the config ``www`` directory."""
+    www = Path(hass.config.path("www"))
+    www.mkdir(parents=True, exist_ok=True)
+    (www / name).write_text("// here", encoding="utf-8")
+
+
+def _set_resources(hass: HomeAssistant, urls: list[str]) -> None:
+    """Install a fake resource collection with the given URLs."""
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=SimpleNamespace(
+            async_items=lambda: [{"url": url, "type": "module"} for url in urls],
+        ),
+    )
+
+
+async def test_missing_local_resource_creates_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a local resource whose file is gone is reported."""
+    await hass.async_add_executor_job(_make_www_file, hass, "present.js")
+
+    _set_resources(
+        hass,
+        [
+            "/local/present.js?v=1",
+            "/local/gone.js",
+            "/hacsfiles/removed-card/card.js",
+            "https://cdn.example.com/external.js",
+        ],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders
+    # Present local file and external URL are not reported; the two missing
+    # local files are.
+    assert issue.translation_placeholders["resources"] == (
+        "- `/hacsfiles/removed-card/card.js`\n- `/local/gone.js`"
+    )
+
+
+async def test_all_present_creates_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test present and external-only resources produce no issue."""
+    await hass.async_add_executor_job(_make_www_file, hass, "here.js")
+
+    _set_resources(hass, ["/local/here.js", "https://cdn.example.com/x.js"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_no_resource_collection_is_a_no_op(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a missing resource collection does not error."""
+    hass.data["lovelace"] = SimpleNamespace(resources=None)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `lovelace_missing_resources` repair. For each dashboard resource served from `/local/` or `/hacsfiles/`, it maps the URL to its on-disk path (`www/` and `www/community/` respectively, query strings stripped) and checks whether the file exists, in the executor. Missing files are listed in one aggregate issue pointing at Settings > Dashboards > Resources.

Only the two filesystem-backed prefixes are checked; external `http(s)` URLs and integration-served paths cannot be resolved to a file and are skipped, so the only thing reported is a genuinely dangling local resource. A missing or not-yet-loaded resource collection is a no-op.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removing a custom card (or its files) while leaving the dashboard resource behind causes the browser to silently fail to load it, with no indication in Home Assistant. This is a very common post-uninstall breakage.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tests create a real file under the config `www` directory and stub the resource collection: a mix of a present local file, two missing local files (`/local/` and `/hacsfiles/`), and an external URL reports only the two missing ones; an all-present-plus-external set reports nothing; a null collection is a no-op. Full suite passes (604 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.