### PR TITLE
Detect unknown entities in the energy dashboard

### DIFF
--- a/custom_components/spook/ectoplasms/energy/__init__.py
+++ b/custom_components/spook/ectoplasms/energy/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/energy/repairs/__init__.py
+++ b/custom_components/spook/ectoplasms/energy/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/energy/repairs/unknown_references.py
+++ b/custom_components/spook/ectoplasms/energy/repairs/unknown_references.py
@@ -1,0 +1,66 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from homeassistant.components.energy.validate import async_validate
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import entity_registry as er
+
+from ....const import LOGGER
+from ....entity_suggestions import async_describe_unknown_entities
+from ....repairs import AbstractSpookRepair
+
+# The energy validation issue type raised when a referenced entity or
+# statistic has no state at all: it was removed. Other issue types
+# (unavailable, non-numeric, undefined statistics) are transient or are
+# configuration choices rather than stale references.
+_MISSING_ISSUE_TYPE = "entity_not_defined"
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds unknown entities referenced in the energy dashboard.
+
+    Home Assistant validates the energy preferences but only surfaces the
+    result inside the energy configuration panel; a removed entity left in
+    the energy dashboard otherwise goes unnoticed.
+    """
+
+    domain = "energy"
+    repair = "energy_unknown_references"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        if "energy" not in self.hass.config.components:
+            return  # Energy dashboard is not set up.
+
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        self.possible_issue_ids.add(self.repair)
+
+        validation = await async_validate(self.hass)
+        unknown: set[str] = set()
+        for issues_group in (
+            validation.energy_sources,
+            validation.device_consumption,
+            validation.device_consumption_water,
+        ):
+            for issues in issues_group:
+                if (issue := issues.issues.get(_MISSING_ISSUE_TYPE)) is not None:
+                    unknown.update(
+                        affected for affected, _detail in issue.affected_entities
+                    )
+
+        if unknown:
+            self.async_create_issue(
+                issue_id=self.repair,
+                translation_placeholders={
+                    "entities": async_describe_unknown_entities(
+                        self.hass, sorted(unknown)
+                    ),
+                },
+            )

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "spook",
   "name": "Spook",
-  "after_dependencies": ["blueprint", "cloud", "timer", "proximity"],
+  "after_dependencies": ["blueprint", "cloud", "energy", "proximity", "timer"],
   "codeowners": ["@frenck"],
   "config_flow": true,
   "dependencies": [

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -264,6 +264,10 @@
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation uses the following triggers, which cannot be provided by any integration available to Home Assistant:\n\n{triggers}\n\n\n\nThis often happens when the integration providing a trigger was removed. To fix this error, [edit the automation]({edit}) and remove the use of these unavailable triggers, or restore the integration providing them.\n\nSpook 👻 Your homie.",
       "title": "Unknown triggers used in: {automation}"
     },
+    "energy_unknown_references": {
+      "description": "Spook has found a ghost in your energy dashboard 👻\n\nThe energy dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nThis usually happens when an entity used in the energy configuration was renamed or removed. To fix this error, open Settings > Dashboards > Energy and update or remove these entities.\n\nSpook 👻 Your homie.",
+      "title": "Unknown entities used in the energy dashboard"
+    },
     "group_unknown_members": {
       "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Your homie.",
       "title": "Unknown group members in: {group}"

--- a/tests/ectoplasms/energy/__init__.py
+++ b/tests/ectoplasms/energy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook energy ectoplasm."""

--- a/tests/ectoplasms/energy/repairs/__init__.py
+++ b/tests/ectoplasms/energy/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook energy repairs."""

--- a/tests/ectoplasms/energy/repairs/test_unknown_references.py
+++ b/tests/ectoplasms/energy/repairs/test_unknown_references.py
@@ -1,0 +1,91 @@
+"""Tests for the energy dashboard unknown references repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.energy.validate import (
+    EnergyPreferencesValidation,
+    ValidationIssues,
+)
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.energy.repairs import unknown_references
+from custom_components.spook.ectoplasms.energy.repairs.unknown_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+    import pytest
+
+_ISSUE_ID = "energy_unknown_references_energy_unknown_references"
+
+
+def _install_validation(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    result: EnergyPreferencesValidation,
+) -> None:
+    """Make the repair see the given validation result with energy loaded."""
+    hass.config.components.add("energy")
+
+    async def _async_validate(_hass: HomeAssistant) -> EnergyPreferencesValidation:
+        return result
+
+    monkeypatch.setattr(unknown_references, "async_validate", _async_validate)
+
+
+async def test_missing_energy_entity_creates_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test an energy source referencing a removed entity is reported."""
+    result = EnergyPreferencesValidation()
+    source_issues = ValidationIssues()
+    source_issues.add_issue(hass, "entity_not_defined", "sensor.ghost_meter")
+    # A transient issue type must not be reported.
+    source_issues.add_issue(hass, "entity_unavailable", "sensor.flaky")
+    result.energy_sources.append(source_issues)
+
+    _install_validation(hass, monkeypatch, result)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders
+    assert "sensor.ghost_meter" in issue.translation_placeholders["entities"]
+    assert "sensor.flaky" not in issue.translation_placeholders["entities"]
+
+
+async def test_only_transient_issues_create_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test transient validation issues alone produce no repair issue."""
+    result = EnergyPreferencesValidation()
+    device_issues = ValidationIssues()
+    device_issues.add_issue(hass, "entity_unavailable", "sensor.flaky")
+    result.device_consumption.append(device_issues)
+
+    _install_validation(hass, monkeypatch, result)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_energy_not_set_up_is_a_no_op(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the repair does nothing when the energy dashboard is absent."""
+    # A fresh test instance has no energy component set up.
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds an `energy_unknown_references` repair. Home Assistant already validates the energy preferences, but only surfaces the result inside the energy configuration panel. This runs `energy.validate.async_validate` and reports the stale-reference issues: entities referenced by the energy dashboard (sources, device consumption, water consumption) that no longer exist. Reported entities go through the shared enrichment helper, so each shows the deleted-on/rename context.

False-positive care: only the `entity_not_defined` issue type is reported, which fires when the referenced entity has no state at all (removed); an unavailable entity still has a state and is not flagged. `entity_unavailable` (transient), `entity_state_non_numeric` and `recorder_untracked` (configuration choices), and `statistics_not_defined` (transient for a freshly configured source) are all skipped. When the energy dashboard is not set up, the repair is a no-op.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A sensor removed while still referenced by the energy dashboard silently produces gaps; the only existing signal is buried in the energy config panel. This makes it an actionable repair.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tests stub the validation result: an energy source with a removed entity is reported while a co-occurring transient `entity_unavailable` is not, transient-only validation produces nothing, and an absent energy dashboard is a no-op. Full suite passes (611 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.