### PR TITLE
Detect registered entities that no longer exist

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
@@ -1,0 +1,72 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_RESTORED, EVENT_COMPONENT_LOADED, STATE_UNAVAILABLE
+from homeassistant.helpers import entity_registry as er
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds registered entities that no longer exist.
+
+    A registry entry whose integration loaded but never provided the
+    entity this session gets a restored ``unavailable`` state. Grouped per
+    config entry, and only for config entries that finished loading, so a
+    slow or retrying integration is never mistaken for a dead entity.
+    """
+
+    domain = "homeassistant"
+    repair = "dead_entities"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    inspect_config_entry_changed = True
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        entity_registry = er.async_get(self.hass)
+
+        dead_by_entry: dict[str, list[str]] = defaultdict(list)
+        for state in self.hass.states.async_all():
+            if state.state != STATE_UNAVAILABLE or not state.attributes.get(
+                ATTR_RESTORED
+            ):
+                continue
+            entry = entity_registry.async_get(state.entity_id)
+            if entry is None or entry.config_entry_id is None:
+                # Only config-entry-backed entities can be confirmed dead by
+                # cross-checking their config entry's load state.
+                continue
+            dead_by_entry[entry.config_entry_id].append(state.entity_id)
+
+        for entry_id, entity_ids in dead_by_entry.items():
+            config_entry = self.hass.config_entries.async_get_entry(entry_id)
+            if (
+                config_entry is None
+                or config_entry.state is not ConfigEntryState.LOADED
+            ):
+                # The integration is gone or still (re)loading; its entities
+                # may still appear, so this is not a dead-entity signal.
+                continue
+
+            self.possible_issue_ids.add(entry_id)
+            self.async_create_issue(
+                issue_id=entry_id,
+                issue_domain=config_entry.domain,
+                translation_placeholders={
+                    "integration": config_entry.title,
+                    "entities": "\n".join(
+                        f"- `{entity_id}`" for entity_id in sorted(entity_ids)
+                    ),
+                },
+            )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -264,6 +264,10 @@
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation uses the following triggers, which cannot be provided by any integration available to Home Assistant:\n\n{triggers}\n\n\n\nThis often happens when the integration providing a trigger was removed. To fix this error, [edit the automation]({edit}) and remove the use of these unavailable triggers, or restore the integration providing them.\n\nSpook 👻 Your homie.",
       "title": "Unknown triggers used in: {automation}"
     },
+    "dead_entities": {
+      "description": "Spook has found a ghost in your entities 👻\n\nThe {integration} integration finished setting up, but the following entities it registered never appeared, so they no longer exist:\n\n{entities}\n\n\n\nThis usually happens when a device or its entities were removed at the source but their registry entries stayed behind. To fix this error, remove these entities from the entity registry if you no longer need them.\n\nSpook 👻 Your homie.",
+      "title": "Non-existing entities registered by: {integration}"
+    },
     "energy_unknown_references": {
       "description": "Spook has found a ghost in your energy dashboard 👻\n\nThe energy dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nThis usually happens when an entity used in the energy configuration was renamed or removed. To fix this error, open Settings > Dashboards > Energy and update or remove these entities.\n\nSpook 👻 Your homie.",
       "title": "Unknown entities used in the energy dashboard"

--- a/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
@@ -83,7 +83,7 @@ async def test_live_entity_is_not_reported(
     )
 
 
-async def test_restored_entity_of_unloaded_entry_is_not_reported(
+async def test_restored_entity_of_retrying_entry_is_not_reported(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     issue_registry: ir.IssueRegistry,

--- a/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
@@ -1,0 +1,106 @@
+"""Tests for the dead entities repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_RESTORED, STATE_UNAVAILABLE
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs.dead_entities import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import entity_registry as er, issue_registry as ir
+
+
+def _loaded_entry(hass: HomeAssistant, title: str = "Hue") -> MockConfigEntry:
+    """Add a loaded config entry to hass."""
+    entry = MockConfigEntry(domain="derivative", title=title)
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    return entry
+
+
+def _register_restored(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    entry: MockConfigEntry | None,
+    object_id: str,
+) -> str:
+    """Register an entity with a restored unavailable state."""
+    reg = entity_registry.async_get_or_create(
+        "sensor",
+        "hue",
+        object_id,
+        config_entry=entry,
+    )
+    hass.states.async_set(reg.entity_id, STATE_UNAVAILABLE, {ATTR_RESTORED: True})
+    return reg.entity_id
+
+
+async def test_dead_entity_of_loaded_entry_is_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a restored entity of a loaded entry is reported."""
+    entry = _loaded_entry(hass)
+    dead = _register_restored(hass, entity_registry, entry, "dead")
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+    assert issue
+    assert issue.translation_placeholders
+    assert issue.translation_placeholders["entities"] == f"- `{dead}`"
+    assert issue.translation_placeholders["integration"] == "Hue"
+
+
+async def test_live_entity_is_not_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an entity with a real state is not reported."""
+    entry = _loaded_entry(hass)
+    reg = entity_registry.async_get_or_create(
+        "sensor", "hue", "live", config_entry=entry
+    )
+    hass.states.async_set(reg.entity_id, "21")
+
+    await SpookRepair(hass).async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+        is None
+    )
+
+
+async def test_restored_entity_of_unloaded_entry_is_not_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a restored entity of a retrying entry is not reported.
+
+    A config entry that has not finished loading may still provide the
+    entity, so it must not be flagged as dead.
+    """
+    entry = MockConfigEntry(domain="derivative", title="Hue")
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY)
+    _register_restored(hass, entity_registry, entry, "maybe")
+
+    await SpookRepair(hass).async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+        is None
+    )

--- a/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
@@ -104,3 +104,24 @@ async def test_restored_entity_of_unloaded_entry_is_not_reported(
         issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
         is None
     )
+
+
+async def test_restored_entity_without_config_entry_is_not_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a restored entity with no config entry is not reported.
+
+    Without a config entry its load state cannot be confirmed, so it is
+    deliberately left alone.
+    """
+    _register_restored(hass, entity_registry, None, "yamlish")
+
+    await SpookRepair(hass).async_inspect()
+
+    assert not any(
+        issue_id.startswith("dead_entities_")
+        for domain, issue_id in issue_registry.issues
+        if domain == DOMAIN
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `dead_entities` repair that finds registry entities which no longer exist. When a registered entity's platform never provides a state during a session, Home Assistant writes a synthetic `unavailable` state with the `restored: True` attribute. That is the "ghost forever" signal this repair keys on. Results are grouped per config entry, one issue per integration listing its dead entities.

The false-positive control is the important part: an entity is only reported when its config entry is in `ConfigEntryState.LOADED`, meaning the integration finished setting up but this entity never appeared. A retrying, errored, or unloaded config entry is skipped, since its entities may still show up. Entities without a config entry (YAML or hub-backed) are also skipped, because their load state cannot be confirmed. Live entities are naturally excluded.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Entities left in the registry after a device is removed at the source linger as permanently unavailable ghosts, and people build template sensors today just to spot them. This is one of the most requested maintenance gaps.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tests cover a restored entity of a loaded config entry being reported with its integration title, a live entity not being reported, and a restored entity of a `SETUP_RETRY` entry not being reported (the transient guard). Full suite passes (609 tests), ruff, pylint (10.00/10), and all prek hooks pass.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.