### PR TITLE
Detect and revoke forgotten long-lived access tokens

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/stale_access_tokens.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/stale_access_tokens.py
@@ -1,0 +1,62 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.auth.models import TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.util import dt as dt_util
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+# Long-lived access tokens do not expire on their own. One with no activity
+# for this long is almost certainly forgotten. The window is generous so a
+# token used by an infrequently-run script is not flagged.
+_STALE_AFTER = timedelta(days=180)
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds long-lived access tokens that look forgotten.
+
+    A long-lived access token never expires; one that has not been used in
+    a long time is a standing credential worth reviewing. Each stale token
+    gets its own fixable issue, so Spook can revoke it on request.
+    """
+
+    domain = "homeassistant"
+    repair = "stale_access_tokens"
+    # Staleness is driven by the passage of time, not by an event. Catch up
+    # once Home Assistant has started, then re-check once a day.
+    inspect_events = {EVENT_HOMEASSISTANT_STARTED}
+    inspect_interval = timedelta(days=1)
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        cutoff = dt_util.utcnow() - _STALE_AFTER
+        for user in await self.hass.auth.async_get_users():
+            if user.system_generated:
+                continue
+            for token in user.refresh_tokens.values():
+                self.possible_issue_ids.add(token.id)
+                if token.token_type != TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN:
+                    continue
+                last_activity = token.last_used_at or token.created_at
+                if last_activity >= cutoff:
+                    continue
+
+                placeholders = {
+                    "token": token.client_name or "Unnamed token",
+                    "owner": user.name or "Unknown user",
+                    "last_active": last_activity.date().isoformat(),
+                }
+                self.async_create_issue(
+                    issue_id=token.id,
+                    is_fixable=True,
+                    data={"stale_access_token_id": token.id, **placeholders},
+                    translation_placeholders=placeholders,
+                )

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -26,6 +26,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_component import DATA_INSTANCES
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.async_ import create_eager_task
 
 from .const import DOMAIN, LOGGER
@@ -33,6 +34,7 @@ from .entity_suggestions import async_describe_unknown_entities
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Mapping
+    from datetime import datetime, timedelta
     from types import ModuleType
 
     from homeassistant.data_entry_flow import FlowResult
@@ -142,6 +144,11 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
     inspect_config_entry_changed: bool | str = False
     inspect_on_reload: bool | str = False
 
+    #: Re-run the inspection on this fixed interval, on top of any event
+    #: triggers. Needed by repairs whose findings change with the passage of
+    #: time alone (e.g. something going stale), not in response to an event.
+    inspect_interval: timedelta | None = None
+
     automatically_clean_up_issues: bool = False
     possible_issue_ids: set[str]
 
@@ -217,16 +224,28 @@ class AbstractSpookRepair(AbstractSpookRepairBase):
         # Spook says: Bounce!
         await self.inspect_debouncer.async_call()
 
-        if self.inspect_events is None:
-            return
-
         async def _async_call_inspect_debouncer(_: Event) -> None:
             # Trigger an inspection when an event is received from the event bus.
             await self.inspect_debouncer.async_call()
 
-        for event in self.inspect_events:
+        if self.inspect_events is not None:
+            for event in self.inspect_events:
+                self._event_subs.add(
+                    self.hass.bus.async_listen(event, _async_call_inspect_debouncer),
+                )
+
+        if self.inspect_interval is not None:
+
+            async def _async_call_inspect_debouncer_interval(_: datetime) -> None:
+                # Trigger an inspection when the interval timer fires.
+                await self.inspect_debouncer.async_call()
+
             self._event_subs.add(
-                self.hass.bus.async_listen(event, _async_call_inspect_debouncer),
+                async_track_time_interval(
+                    self.hass,
+                    _async_call_inspect_debouncer_interval,
+                    self.inspect_interval,
+                ),
             )
 
         if self.inspect_on_reload:
@@ -536,12 +555,53 @@ class RestartRequiredFixFlow(RepairsFlow):
         return self.async_show_form(step_id="confirm_restart")
 
 
+class StaleAccessTokenFixFlow(RepairsFlow):
+    """Handler for a repairs issue flow that revokes a stale access token."""
+
+    def __init__(
+        self,
+        token_id: str,
+        placeholders: dict[str, str],
+    ) -> None:
+        """Initialize the flow with the token to revoke."""
+        self._token_id = token_id
+        self._placeholders = placeholders
+
+    async def async_step_init(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Handle asking confirmation of the revoke."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self,
+        user_input: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Handle the confirm of the token revoke."""
+        if user_input is not None:
+            # The token may already be gone if revoked elsewhere meanwhile.
+            if token := self.hass.auth.async_get_refresh_token(self._token_id):
+                self.hass.auth.async_remove_refresh_token(token)
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders=self._placeholders,
+        )
+
+
 async def async_create_fix_flow(
     _hass: HomeAssistant,
     issue_id: str,
-    _data: dict[str, str | int | float | None] | None,
+    data: dict[str, str | int | float | None] | None,
 ) -> RepairsFlow:
     """Create flow."""
     if issue_id == "restart_required":
         return RestartRequiredFixFlow()
+    if data and (token_id := data.get("stale_access_token_id")):
+        placeholders = {
+            key: str(data.get(key, "")) for key in ("token", "owner", "last_active")
+        }
+        return StaleAccessTokenFixFlow(str(token_id), placeholders)
     return ConfirmRepairFlow()

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -351,6 +351,17 @@
       "description": "Spook has found a ghost in your scripts 👻\n\nWhile floating around, Spook crossed path with the following script:\n\n[{script}]({edit}) (`{entity_id}`)\n\nThis script uses the following triggers, which cannot be provided by any integration available to Home Assistant:\n\n{triggers}\n\n\n\nThis often happens when the integration providing a trigger was removed. To fix this error, [edit the script]({edit}) and remove the use of these unavailable triggers, or restore the integration providing them.\n\nSpook 👻 Your homie.",
       "title": "Unknown triggers used in: {script}"
     },
+    "stale_access_tokens": {
+      "title": "Long-lived access token looks forgotten: {token}",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Revoke this long-lived access token?",
+            "description": "The long-lived access token `{token}` (owner: {owner}) has not been used since {last_active}.\n\nSelect submit to revoke it now. Anything still using this token will stop working until it gets a new one.\n\nSpook 👻 Your homie."
+          }
+        }
+      }
+    },
     "template_unknown_entity_references": {
       "description": "Spook has found a ghost in your template helpers 👻\n\nWhile floating around, Spook crossed path with the following template helper:\n\n{helper}\n\nIts templates reference the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nThis often happens when an entity was renamed or removed. To fix this error, reconfigure the template helper to reference existing entities.\n\nSpook 👻 Your homie.",
       "title": "Unknown entities used in template helper: {helper}"

--- a/tests/ectoplasms/homeassistant/repairs/test_stale_access_tokens.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_stale_access_tokens.py
@@ -1,0 +1,241 @@
+"""Tests for the stale long-lived access tokens repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from homeassistant.auth.models import (
+    TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
+    TOKEN_TYPE_NORMAL,
+)
+from homeassistant.util import dt as dt_util
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs.stale_access_tokens import (
+    SpookRepair,
+)
+from custom_components.spook.repairs import (
+    StaleAccessTokenFixFlow,
+    async_create_fix_flow,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+    import pytest
+
+_REPAIR = "stale_access_tokens"
+
+
+def _issue_id(token_id: str) -> str:
+    """Return the registry issue id for a token."""
+    return f"{_REPAIR}_{token_id}"
+
+
+def _token(
+    token_id: str,
+    token_type: str,
+    days_ago: int,
+    name: str = "Script",
+    *,
+    used: bool = True,
+) -> SimpleNamespace:
+    """Return a fake refresh token.
+
+    With ``used=False`` the token has never been used (``last_used_at`` is
+    ``None``), so the repair must fall back to ``created_at``.
+    """
+    when = dt_util.utcnow() - timedelta(days=days_ago)
+    return SimpleNamespace(
+        id=token_id,
+        token_type=token_type,
+        client_name=name,
+        created_at=when,
+        last_used_at=when if used else None,
+    )
+
+
+def _set_users(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    users: list[SimpleNamespace],
+) -> None:
+    """Make the repair see the given users."""
+
+    async def _async_get_users() -> list[SimpleNamespace]:
+        return users
+
+    monkeypatch.setattr(hass.auth, "async_get_users", _async_get_users)
+
+
+async def test_stale_token_creates_fixable_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a long-unused long-lived token gets its own fixable issue."""
+    user = SimpleNamespace(
+        system_generated=False,
+        name="Frenck",
+        refresh_tokens={
+            "a": _token("stale", TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN, 400, "Old"),
+            "b": _token("fresh", TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN, 10, "Fresh"),
+            "c": _token("normal", TOKEN_TYPE_NORMAL, 400, "Browser"),
+        },
+    )
+    _set_users(hass, monkeypatch, [user])
+
+    await SpookRepair(hass).async_inspect()
+
+    # Only the stale long-lived token gets an issue.
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id("fresh")) is None
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id("normal")) is None
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id("stale"))
+    assert issue
+    assert issue.is_fixable
+    assert issue.data == {
+        "stale_access_token_id": "stale",
+        "token": "Old",
+        "owner": "Frenck",
+        "last_active": issue.translation_placeholders["last_active"],
+    }
+
+
+async def test_system_user_tokens_are_ignored(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test tokens of system-generated users are not reported."""
+    user = SimpleNamespace(
+        system_generated=True,
+        name="Supervisor",
+        refresh_tokens={
+            "a": _token("sys", TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN, 400, "System"),
+        },
+    )
+    _set_users(hass, monkeypatch, [user])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id("sys")) is None
+
+
+async def test_only_fresh_tokens_create_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test recently used long-lived tokens produce no issue."""
+    user = SimpleNamespace(
+        system_generated=False,
+        name="Frenck",
+        refresh_tokens={
+            "a": _token("active", TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN, 5, "Active"),
+        },
+    )
+    _set_users(hass, monkeypatch, [user])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id("active")) is None
+
+
+async def test_never_used_token_falls_back_to_created_at(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a never-used long-lived token is judged by its creation date."""
+    created = dt_util.utcnow() - timedelta(days=400)
+    user = SimpleNamespace(
+        system_generated=False,
+        name="Frenck",
+        refresh_tokens={
+            "a": _token(
+                "never",
+                TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
+                400,
+                "Never used",
+                used=False,
+            ),
+        },
+    )
+    _set_users(hass, monkeypatch, [user])
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id("never"))
+    assert issue
+    assert issue.translation_placeholders
+    # Last active falls back to the creation date.
+    assert issue.translation_placeholders["last_active"] == created.date().isoformat()
+
+
+async def test_fix_flow_revokes_token(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test confirming the fix flow revokes the token."""
+    token = _token("stale", TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN, 400, "Old")
+    removed: list[object] = []
+
+    monkeypatch.setattr(
+        hass.auth,
+        "async_get_refresh_token",
+        lambda ref: token if ref == "stale" else None,
+    )
+    monkeypatch.setattr(
+        hass.auth,
+        "async_remove_refresh_token",
+        removed.append,
+    )
+
+    flow = await async_create_fix_flow(
+        hass,
+        _issue_id("stale"),
+        {
+            "stale_access_token_id": "stale",
+            "token": "Old",
+            "owner": "Frenck",
+            "last_active": "2025-01-01",
+        },
+    )
+    assert isinstance(flow, StaleAccessTokenFixFlow)
+    flow.hass = hass
+
+    # The form is shown first, no token removed yet.
+    await flow.async_step_init()
+    assert not removed
+
+    # Confirming revokes the token.
+    await flow.async_step_confirm({})
+    assert removed == [token]
+
+
+async def test_fix_flow_survives_already_revoked_token(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test confirming a token that is already gone does not blow up."""
+    removed: list[object] = []
+    monkeypatch.setattr(
+        hass.auth,
+        "async_get_refresh_token",
+        lambda _token_id: None,
+    )
+    monkeypatch.setattr(
+        hass.auth,
+        "async_remove_refresh_token",
+        removed.append,
+    )
+
+    flow = StaleAccessTokenFixFlow("gone", {})
+    flow.hass = hass
+
+    await flow.async_step_confirm({})
+    assert not removed

--- a/tests/test_repairs_cleanup.py
+++ b/tests/test_repairs_cleanup.py
@@ -4,7 +4,10 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
+
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -13,11 +16,13 @@ from custom_components.spook.const import DOMAIN
 from custom_components.spook.repairs import AbstractSpookRepair, AbstractSpookRepairBase
 import pytest
 
-EXPECTED_UNSUBSCRIBE_COUNT = 3
+EXPECTED_UNSUBSCRIBE_COUNT = 4
+EXPECTED_INTERVAL_INSPECTIONS = 2
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from freezegun.api import FrozenDateTimeFactory
     from homeassistant.config_entries import ConfigEntry, ConfigEntryChange
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import issue_registry as ir
@@ -48,6 +53,7 @@ class MockRepair(AbstractSpookRepair):
     inspect_events = {"mock_event"}
     inspect_config_entry_changed = True
     inspect_on_reload = True
+    inspect_interval = timedelta(days=1)
 
     inspections = 0
 
@@ -125,6 +131,61 @@ async def test_deactivate_unsubscribes_all_activation_listeners(
 
     assert len(unsubscribed) == 1
     assert not repair._event_subs
+
+
+class MockIntervalRepair(AbstractSpookRepair):
+    """Mock repair that re-inspects on a fixed interval alone."""
+
+    domain = "mock"
+    repair = "mock_repair"
+    inspect_interval = timedelta(days=1)
+
+    inspections = 0
+
+    async def async_inspect(self) -> None:
+        """Inspect the repair."""
+        self.inspections += 1
+
+
+async def _flush_debouncer(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Advance past the inspection debouncer cooldown and let it fire."""
+    freezer.tick(timedelta(seconds=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+async def test_inspect_interval_reinspects_over_time(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an interval-only repair re-inspects as time passes."""
+    repair = MockIntervalRepair(hass)
+    await repair.async_activate()
+
+    # A single timer subscription, no events wired.
+    assert len(repair._event_subs) == 1
+
+    # The initial activation bounce runs one inspection.
+    await _flush_debouncer(hass, freezer)
+    assert repair.inspections == 1
+
+    # A day later the interval fires another inspection.
+    freezer.tick(timedelta(days=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    await _flush_debouncer(hass, freezer)
+    assert repair.inspections == EXPECTED_INTERVAL_INSPECTIONS
+
+    # After deactivation the timer no longer fires.
+    await repair.async_deactivate()
+    freezer.tick(timedelta(days=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    await _flush_debouncer(hass, freezer)
+    assert repair.inspections == EXPECTED_INTERVAL_INSPECTIONS
 
 
 async def test_repair_manager_removes_issues_on_unload(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Description

Adds a new Spook repair that flags long-lived access tokens that look forgotten, and offers to revoke them straight from the repair.

A long-lived access token never expires on its own, so an old one that no integration uses anymore is a standing credential nobody is watching. Spook now checks every non-system user's long-lived access tokens and, for any that have not been used in 180 days, raises a repair issue naming the token (its label, the owner, and when it was last active). No secret is exposed: only the token name you gave it, never the bearer token.

Each stale token gets its own fixable issue. Selecting fix asks for confirmation and then revokes that token via `hass.auth.async_remove_refresh_token`. You can still manage it yourself under profile > Security > Long-lived access tokens instead.

Staleness is driven by time, not by an event, so this repair needs a new trigger shape. This PR adds a reusable `inspect_interval` to the repair base (wired through `async_track_time_interval`, cancelled on deactivate like every other trigger). The token repair inspects once after Home Assistant has started, then re-checks once a day. While in there, the `inspect_events is None` early return in `async_activate` was fixed so an interval-only or reload-only repair wires up correctly.

## Motivation and Context

Forgotten long-lived access tokens are a real security hygiene problem: they never expire, they are easy to create and forget, and a leaked one stays valid forever. Spook is the maintenance tool, so pointing them out (and cleaning them up) fits right in.

## How has this been tested?

- New unit tests for the repair: stale token raises a fixable issue with the right data, fresh and normal tokens are ignored, system-user tokens are ignored, the fix flow revokes the token, and the fix flow survives an already-revoked token.
- New base test proving `inspect_interval` re-inspects as time passes and stops firing after deactivate, plus the deactivate-unsubscribes test now covers the interval sub too.
- Full suite green (632 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
