### PR TITLE
Detect empty areas and offer to remove them

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/empty_areas.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/empty_areas.py
@@ -1,0 +1,74 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.automation import automations_with_area
+from homeassistant.components.script import scripts_with_area
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+)
+from homeassistant.util import dt as dt_util
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+# Give a freshly created area time to be filled before nagging about it.
+# Creating an area and assigning devices to it is not instantaneous.
+_MINIMUM_AGE = timedelta(days=1)
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds areas that hold nothing and are used nowhere.
+
+    An area with no devices, no entities, and no automation or script
+    targeting it is dead weight. Surfaced as tidiness, with a fix flow to
+    remove it. References are checked so an area deliberately targeted by
+    an automation or script is left alone.
+    """
+
+    domain = "homeassistant"
+    repair = "empty_areas"
+    inspect_events = {
+        EVENT_HOMEASSISTANT_STARTED,
+        ar.EVENT_AREA_REGISTRY_UPDATED,
+        dr.EVENT_DEVICE_REGISTRY_UPDATED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    inspect_on_reload = True
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        area_registry = ar.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+
+        cutoff = dt_util.utcnow() - _MINIMUM_AGE
+        for area in area_registry.async_list_areas():
+            self.possible_issue_ids.add(area.id)
+
+            if area.created_at > cutoff:
+                # Just created; leave time to assign devices and entities.
+                continue
+            if dr.async_entries_for_area(device_registry, area.id):
+                continue
+            if er.async_entries_for_area(entity_registry, area.id):
+                continue
+            if automations_with_area(self.hass, area.id):
+                continue
+            if scripts_with_area(self.hass, area.id):
+                continue
+
+            self.async_create_issue(
+                issue_id=area.id,
+                is_fixable=True,
+                data={"empty_area_id": area.id, "area": area.name},
+                translation_placeholders={"area": area.name},
+            )

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -591,6 +591,56 @@ class StaleAccessTokenFixFlow(RepairsFlow):
         )
 
 
+class EmptyAreaFixFlow(RepairsFlow):
+    """Handler for an empty area: remove it, or keep it and stop nagging.
+
+    An empty area is tidiness, not breakage, so keeping it is a valid
+    choice. A fixable issue cannot be dismissed from the repairs UI, so the
+    flow offers an explicit "keep it" option that ignores the issue instead.
+    """
+
+    async def async_step_init(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Offer to remove the area or keep and ignore it."""
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=["remove", "ignore"],
+            description_placeholders=self._area_placeholders,
+        )
+
+    async def async_step_remove(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Remove the area, if it still exists."""
+        registry = ar.async_get(self.hass)
+        area_id = str((self.data or {}).get("empty_area_id", ""))
+        # The area may already be gone if removed elsewhere meanwhile.
+        if registry.async_get_area(area_id):
+            registry.async_delete(area_id)
+        return self.async_create_entry(data={})
+
+    async def async_step_ignore(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Keep the area and ignore the issue.
+
+        Aborting (rather than creating an entry) keeps the issue so the
+        ignore sticks; a completed fix flow would delete it and it would
+        just come back on the next inspection.
+        """
+        ir.async_ignore_issue(self.hass, DOMAIN, self.issue_id, ignore=True)
+        return self.async_abort(reason="issue_ignored")
+
+    @property
+    def _area_placeholders(self) -> dict[str, str]:
+        """Return the menu placeholders naming the area."""
+        return {"area": str((self.data or {}).get("area", ""))}
+
+
 async def async_create_fix_flow(
     _hass: HomeAssistant,
     issue_id: str,
@@ -604,4 +654,6 @@ async def async_create_fix_flow(
             key: str(data.get(key, "")) for key in ("token", "owner", "last_active")
         }
         return StaleAccessTokenFixFlow(str(token_id), placeholders)
+    if data and data.get("empty_area_id"):
+        return EmptyAreaFixFlow()
     return ConfirmRepairFlow()

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -268,6 +268,24 @@
       "description": "Spook has found a ghost in your entities 👻\n\nThe {integration} integration finished setting up, but the following entities it registered never appeared, so they no longer exist:\n\n{entities}\n\n\n\nThis usually happens when a device or its entities were removed at the source but their registry entries stayed behind. To fix this error, remove these entities from the entity registry if you no longer need them.\n\nSpook 👻 Your homie.",
       "title": "Non-existing entities registered by: {integration}"
     },
+    "empty_areas": {
+      "title": "Empty area: {area}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Empty area: {area}",
+            "description": "The area {area} has no devices, no entities, and no automation or script targeting it.\n\nRemove it, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Remove this empty area",
+              "ignore": "Keep it, stop telling me"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this area from now on."
+        }
+      }
+    },
     "energy_unknown_references": {
       "description": "Spook has found a ghost in your energy dashboard 👻\n\nThe energy dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nThis usually happens when an entity used in the energy configuration was renamed or removed. To fix this error, open Settings > Dashboards > Energy and update or remove these entities.\n\nSpook 👻 Your homie.",
       "title": "Unknown entities used in the energy dashboard"

--- a/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
@@ -1,0 +1,202 @@
+"""Tests for the empty areas repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs import empty_areas
+from custom_components.spook.ectoplasms.homeassistant.repairs.empty_areas import (
+    SpookRepair,
+)
+from custom_components.spook.repairs import EmptyAreaFixFlow, async_create_fix_flow
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import (
+        area_registry as ar,
+        device_registry as dr,
+        entity_registry as er,
+        issue_registry as ir,
+    )
+    import pytest
+
+# Comfortably past the creation grace period.
+_AGED = timedelta(days=2)
+
+
+def _issue_id(area_id: str) -> str:
+    """Return the registry issue id for an area."""
+    return f"empty_areas_{area_id}"
+
+
+async def test_empty_area_is_reported(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an aged area with nothing in it and no references is reported."""
+    area = area_registry.async_create("Ghost Room")
+    freezer.tick(_AGED)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(area.id))
+    assert issue
+    assert issue.is_fixable
+    assert issue.translation_placeholders == {"area": "Ghost Room"}
+    assert issue.data == {"empty_area_id": area.id, "area": "Ghost Room"}
+
+
+async def test_recently_created_area_is_not_reported(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a just-created area is left alone during its grace period."""
+    area = area_registry.async_create("Brand New")
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id)) is None
+
+
+async def test_area_with_entity_is_not_reported(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an area that holds an entity is left alone."""
+    area = area_registry.async_create("Living Room")
+    entry = entity_registry.async_get_or_create("light", "hue", "ceiling")
+    entity_registry.async_update_entity(entry.entity_id, area_id=area.id)
+    freezer.tick(_AGED)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id)) is None
+
+
+async def test_area_with_device_is_not_reported(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an area that holds a device is left alone."""
+    area = area_registry.async_create("Kitchen")
+    entry = MockConfigEntry(domain="derivative")
+    entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("hue", "bridge")},
+    )
+    device_registry.async_update_device(device.id, area_id=area.id)
+    freezer.tick(_AGED)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id)) is None
+
+
+async def test_area_referenced_by_automation_is_not_reported(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an empty area targeted by an automation is left alone."""
+    area = area_registry.async_create("Hallway")
+    freezer.tick(_AGED)
+    monkeypatch.setattr(
+        empty_areas,
+        "automations_with_area",
+        lambda _hass, area_id: ["automation.lights"] if area_id == area.id else [],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id)) is None
+
+
+def _flow_for(hass: HomeAssistant, area_id: str, area_name: str) -> EmptyAreaFixFlow:
+    """Build an empty-area fix flow as the framework would wire it up."""
+    flow = EmptyAreaFixFlow()
+    flow.hass = hass
+    flow.issue_id = _issue_id(area_id)
+    flow.data = {"empty_area_id": area_id, "area": area_name}
+    return flow
+
+
+async def test_fix_flow_remove_option_removes_area(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test the remove menu option deletes the area."""
+    area = area_registry.async_create("Ghost Room")
+
+    flow = await async_create_fix_flow(
+        hass,
+        _issue_id(area.id),
+        {"empty_area_id": area.id, "area": "Ghost Room"},
+    )
+    assert isinstance(flow, EmptyAreaFixFlow)
+    flow.hass = hass
+    flow.data = {"empty_area_id": area.id, "area": "Ghost Room"}
+
+    # The menu is shown first, area still present.
+    menu = await flow.async_step_init()
+    assert menu["type"] == FlowResultType.MENU
+    assert area_registry.async_get_area(area.id) is not None
+
+    # Choosing remove deletes the area.
+    result = await flow.async_step_remove()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert area_registry.async_get_area(area.id) is None
+
+
+async def test_fix_flow_ignore_option_dismisses_issue(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the keep menu option ignores the issue and keeps the area."""
+    area = area_registry.async_create("Hallway")
+    freezer.tick(_AGED)
+    await SpookRepair(hass).async_inspect()
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id))
+
+    flow = _flow_for(hass, area.id, "Hallway")
+    result = await flow.async_step_ignore()
+
+    assert result["type"] == FlowResultType.ABORT
+    # Area stays, issue stays but is now ignored.
+    assert area_registry.async_get_area(area.id) is not None
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(area.id))
+    assert issue is not None
+    assert issue.dismissed_version is not None
+
+
+async def test_fix_flow_remove_survives_already_removed_area(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test removing an area that is already gone does not blow up."""
+    flow = _flow_for(hass, "gone", "Gone")
+
+    result = await flow.async_step_remove()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert area_registry.async_get_area("gone") is None


### PR DESCRIPTION
## Description

Adds a new Spook repair that surfaces empty areas: an area with no devices, no entities, and no automation or script targeting it. These pile up after you move devices around or delete things, and nothing in Home Assistant points them out.

Each empty area gets its own fixable issue. Selecting it opens a small menu:

- **Remove this empty area** removes the area from the registry.
- **Keep it, stop telling me** ignores the issue and leaves the area alone.

The keep option matters here. A fixable repair issue cannot be dismissed from the repairs UI (the frontend routes fixable issues straight to the fix flow, which has no ignore button). An empty area is tidiness, not breakage, so keeping one is a perfectly valid choice. The menu's keep option calls `async_ignore_issue` and aborts the flow, so the issue stays put but ignored, and it does not come back on the next inspection.

To avoid nagging while you are still setting things up, a freshly created area gets a one-day grace period before it can be flagged. Areas that predate the created-at timestamp (migrated as epoch) are handled normally.

References are checked with `automations_with_area` / `scripts_with_area`, so an empty area you deliberately target from an automation or script is left alone.

This is the first slice of the "empty registry things" corner. Empty floors and unused labels are deliberately left for follow-up PRs, since their false-positive surfaces (dashboards, templates) differ.

## Motivation and Context

Empty areas are maintenance debt nobody surfaces today. Spook is the tool for exactly this kind of tidiness.

## How has this been tested?

- Detection of an aged empty area, and non-detection of the false-positive twins: an area holding an entity, an area holding a device, and an empty area referenced by an automation.
- The one-day creation grace: a just-created area is not flagged.
- The fix flow: the remove option deletes the area, the keep option ignores the issue while leaving the area in place, and remove copes with an area that is already gone.
- Full suite green (643 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
