### PR TITLE
Detect empty floors and offer to remove them

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/empty_floors.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/empty_floors.py
@@ -1,0 +1,67 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.automation import automations_with_floor
+from homeassistant.components.script import scripts_with_floor
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.helpers import (
+    area_registry as ar,
+    floor_registry as fr,
+)
+from homeassistant.util import dt as dt_util
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+# Give a freshly created floor time to get areas assigned before nagging.
+_MINIMUM_AGE = timedelta(days=1)
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds floors that hold no areas and are used nowhere.
+
+    A floor exists to group areas. One with no areas, and no automation or
+    script targeting it, is dead weight. Surfaced as tidiness, with a fix
+    flow to remove it.
+    """
+
+    domain = "homeassistant"
+    repair = "empty_floors"
+    inspect_events = {
+        EVENT_HOMEASSISTANT_STARTED,
+        fr.EVENT_FLOOR_REGISTRY_UPDATED,
+        ar.EVENT_AREA_REGISTRY_UPDATED,
+    }
+    inspect_on_reload = True
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        floor_registry = fr.async_get(self.hass)
+        area_registry = ar.async_get(self.hass)
+
+        cutoff = dt_util.utcnow() - _MINIMUM_AGE
+        for floor in floor_registry.async_list_floors():
+            self.possible_issue_ids.add(floor.floor_id)
+
+            if floor.created_at > cutoff:
+                # Just created; leave time to assign areas.
+                continue
+            if ar.async_entries_for_floor(area_registry, floor.floor_id):
+                continue
+            if automations_with_floor(self.hass, floor.floor_id):
+                continue
+            if scripts_with_floor(self.hass, floor.floor_id):
+                continue
+
+            self.async_create_issue(
+                issue_id=floor.floor_id,
+                is_fixable=True,
+                data={"empty_floor_id": floor.floor_id, "floor": floor.name},
+                translation_placeholders={"floor": floor.name},
+            )

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
     entity_registry as er,
+    floor_registry as fr,
     issue_registry as ir,
 )
 from homeassistant.helpers.debounce import Debouncer
@@ -591,42 +592,45 @@ class StaleAccessTokenFixFlow(RepairsFlow):
         )
 
 
-class EmptyAreaFixFlow(RepairsFlow):
-    """Handler for an empty area: remove it, or keep it and stop nagging.
+class _RemoveOrIgnoreFixFlow(RepairsFlow):
+    """Base for an empty registry thing: remove it, or keep and stop nagging.
 
-    An empty area is tidiness, not breakage, so keeping it is a valid
-    choice. A fixable issue cannot be dismissed from the repairs UI, so the
-    flow offers an explicit "keep it" option that ignores the issue instead.
+    Empty registry things (areas, floors) are tidiness, not breakage, so
+    keeping one is a valid choice. A fixable issue cannot be dismissed from
+    the repairs UI, so the flow offers an explicit "keep it" option that
+    ignores the issue instead. Subclasses set ``_key`` (the placeholder and
+    ``empty_<thing>_id`` data key stem) and implement ``_remove``.
     """
+
+    #: Placeholder key and ``empty_<key>_id`` data-key stem (e.g. "area").
+    _key: str
 
     async def async_step_init(
         self,
         _: dict[str, str] | None = None,
     ) -> FlowResult:
-        """Offer to remove the area or keep and ignore it."""
+        """Offer to remove the thing or keep and ignore it."""
         return self.async_show_menu(
             step_id="init",
             menu_options=["remove", "ignore"],
-            description_placeholders=self._area_placeholders,
+            description_placeholders={
+                self._key: str((self.data or {}).get(self._key, "")),
+            },
         )
 
     async def async_step_remove(
         self,
         _: dict[str, str] | None = None,
     ) -> FlowResult:
-        """Remove the area, if it still exists."""
-        registry = ar.async_get(self.hass)
-        area_id = str((self.data or {}).get("empty_area_id", ""))
-        # The area may already be gone if removed elsewhere meanwhile.
-        if registry.async_get_area(area_id):
-            registry.async_delete(area_id)
+        """Remove the thing, if it still exists."""
+        self._remove(str((self.data or {}).get(f"empty_{self._key}_id", "")))
         return self.async_create_entry(data={})
 
     async def async_step_ignore(
         self,
         _: dict[str, str] | None = None,
     ) -> FlowResult:
-        """Keep the area and ignore the issue.
+        """Keep the thing and ignore the issue.
 
         Aborting (rather than creating an entry) keeps the issue so the
         ignore sticks; a completed fix flow would delete it and it would
@@ -635,10 +639,38 @@ class EmptyAreaFixFlow(RepairsFlow):
         ir.async_ignore_issue(self.hass, DOMAIN, self.issue_id, ignore=True)
         return self.async_abort(reason="issue_ignored")
 
-    @property
-    def _area_placeholders(self) -> dict[str, str]:
-        """Return the menu placeholders naming the area."""
-        return {"area": str((self.data or {}).get("area", ""))}
+    @callback
+    def _remove(self, thing_id: str) -> None:
+        """Remove the thing by id. Implemented by subclasses."""
+        raise NotImplementedError
+
+
+class EmptyAreaFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for an empty area: remove it, or keep it and stop nagging."""
+
+    _key = "area"
+
+    @callback
+    def _remove(self, thing_id: str) -> None:
+        """Remove the area, if it still exists."""
+        registry = ar.async_get(self.hass)
+        # The area may already be gone if removed elsewhere meanwhile.
+        if registry.async_get_area(thing_id):
+            registry.async_delete(thing_id)
+
+
+class EmptyFloorFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for an empty floor: remove it, or keep it and stop nagging."""
+
+    _key = "floor"
+
+    @callback
+    def _remove(self, thing_id: str) -> None:
+        """Remove the floor, if it still exists."""
+        registry = fr.async_get(self.hass)
+        # The floor may already be gone if removed elsewhere meanwhile.
+        if registry.async_get_floor(thing_id):
+            registry.async_delete(thing_id)
 
 
 async def async_create_fix_flow(
@@ -656,4 +688,6 @@ async def async_create_fix_flow(
         return StaleAccessTokenFixFlow(str(token_id), placeholders)
     if data and data.get("empty_area_id"):
         return EmptyAreaFixFlow()
+    if data and data.get("empty_floor_id"):
+        return EmptyFloorFixFlow()
     return ConfirmRepairFlow()

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -286,6 +286,24 @@
         }
       }
     },
+    "empty_floors": {
+      "title": "Empty floor: {floor}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Empty floor: {floor}",
+            "description": "The floor {floor} has no areas, and no automation or script targeting it.\n\nRemove it, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Remove this empty floor",
+              "ignore": "Keep it, stop telling me"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this floor from now on."
+        }
+      }
+    },
     "energy_unknown_references": {
       "description": "Spook has found a ghost in your energy dashboard 👻\n\nThe energy dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nThis usually happens when an entity used in the energy configuration was renamed or removed. To fix this error, open Settings > Dashboards > Energy and update or remove these entities.\n\nSpook 👻 Your homie.",
       "title": "Unknown entities used in the energy dashboard"

--- a/tests/ectoplasms/homeassistant/repairs/test_empty_floors.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_empty_floors.py
@@ -1,0 +1,151 @@
+"""Tests for the empty floors repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import area_registry as ar, floor_registry as fr
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs import empty_floors
+from custom_components.spook.ectoplasms.homeassistant.repairs.empty_floors import (
+    SpookRepair,
+)
+from custom_components.spook.repairs import EmptyFloorFixFlow, async_create_fix_flow
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+    import pytest
+
+# Comfortably past the creation grace period.
+_AGED = timedelta(days=2)
+
+
+def _issue_id(floor_id: str) -> str:
+    """Return the registry issue id for a floor."""
+    return f"empty_floors_{floor_id}"
+
+
+def _flow_for(hass: HomeAssistant, floor_id: str, floor_name: str) -> EmptyFloorFixFlow:
+    """Build an empty-floor fix flow as the framework would wire it up."""
+    flow = EmptyFloorFixFlow()
+    flow.hass = hass
+    flow.issue_id = _issue_id(floor_id)
+    flow.data = {"empty_floor_id": floor_id, "floor": floor_name}
+    return flow
+
+
+async def test_empty_floor_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an aged floor with no areas and no references is reported."""
+    floor = fr.async_get(hass).async_create("Attic")
+    freezer.tick(_AGED)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(floor.floor_id))
+    assert issue
+    assert issue.is_fixable
+    assert issue.translation_placeholders == {"floor": "Attic"}
+    assert issue.data == {"empty_floor_id": floor.floor_id, "floor": "Attic"}
+
+
+async def test_recently_created_floor_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a just-created floor is left alone during its grace period."""
+    floor = fr.async_get(hass).async_create("Brand New")
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(floor.floor_id)) is None
+
+
+async def test_floor_with_area_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a floor that holds an area is left alone."""
+    floor = fr.async_get(hass).async_create("Ground")
+    area = ar.async_get(hass).async_create("Kitchen")
+    ar.async_get(hass).async_update(area.id, floor_id=floor.floor_id)
+    freezer.tick(_AGED)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(floor.floor_id)) is None
+
+
+async def test_floor_referenced_by_automation_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an empty floor targeted by an automation is left alone."""
+    floor = fr.async_get(hass).async_create("First")
+    freezer.tick(_AGED)
+    monkeypatch.setattr(
+        empty_floors,
+        "automations_with_floor",
+        lambda _hass, fid: ["automation.lights"] if fid == floor.floor_id else [],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(floor.floor_id)) is None
+
+
+async def test_fix_flow_remove_option_removes_floor(
+    hass: HomeAssistant,
+) -> None:
+    """Test the remove menu option deletes the floor."""
+    floor = fr.async_get(hass).async_create("Attic")
+
+    flow = await async_create_fix_flow(
+        hass,
+        _issue_id(floor.floor_id),
+        {"empty_floor_id": floor.floor_id, "floor": "Attic"},
+    )
+    assert isinstance(flow, EmptyFloorFixFlow)
+    flow.hass = hass
+    flow.data = {"empty_floor_id": floor.floor_id, "floor": "Attic"}
+
+    menu = await flow.async_step_init()
+    assert menu["type"] == FlowResultType.MENU
+    assert fr.async_get(hass).async_get_floor(floor.floor_id) is not None
+
+    result = await flow.async_step_remove()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert fr.async_get(hass).async_get_floor(floor.floor_id) is None
+
+
+async def test_fix_flow_ignore_option_dismisses_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the keep menu option ignores the issue and keeps the floor."""
+    floor = fr.async_get(hass).async_create("First")
+    freezer.tick(_AGED)
+    await SpookRepair(hass).async_inspect()
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(floor.floor_id))
+
+    flow = _flow_for(hass, floor.floor_id, "First")
+    result = await flow.async_step_ignore()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert fr.async_get(hass).async_get_floor(floor.floor_id) is not None
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(floor.floor_id))
+    assert issue is not None
+    assert issue.dismissed_version is not None


### PR DESCRIPTION
## Description

Adds a Spook repair that surfaces empty floors: a floor with no areas, and no automation or script targeting it. A floor exists to group areas, so an empty one is leftover clutter.

Each empty floor gets its own fixable issue with the same Remove / Keep menu as the empty areas repair:

- **Remove this empty floor** removes the floor from the registry.
- **Keep it, stop telling me** ignores the issue and leaves the floor alone (a fixable issue cannot be dismissed from the repairs UI, so the flow ignores it explicitly and aborts, which makes the ignore stick across inspections).

A freshly created floor gets a one-day grace period before it can be flagged, so creating a floor and assigning areas to it later does not trigger an instant repair. References are checked with `automations_with_floor` / `scripts_with_floor`, so a floor you deliberately target is left alone.

Since this is the second Remove / Keep menu flow (after empty areas), the shared menu, ignore-via-abort, and remove-or-keep logic move into a small `_RemoveOrIgnoreFixFlow` base. `EmptyAreaFixFlow` and the new `EmptyFloorFixFlow` each just set a key and implement the actual removal. No behaviour change for empty areas.

This is the second slice of the "empty registry things" corner. Unused labels are the remaining piece and will follow in a separate PR.

## Motivation and Context

Empty floors are maintenance debt nobody surfaces today. Spook is the tool for exactly this kind of tidiness.

## How has this been tested?

- Detection of an aged empty floor, and non-detection of the false-positive twins: a floor holding an area, and an empty floor referenced by an automation.
- The one-day creation grace: a just-created floor is not flagged.
- The fix flow: the remove option deletes the floor, and the keep option ignores the issue while leaving the floor in place.
- Full suite green (651 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
