### PR TITLE
Detect unused labels and offer to remove them

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unused_labels.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unused_labels.py
@@ -1,0 +1,77 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.components.automation import automations_with_label
+from homeassistant.components.script import scripts_with_label
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+    label_registry as lr,
+)
+from homeassistant.util import dt as dt_util
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+# Give a freshly created label time to be applied before nagging about it.
+_MINIMUM_AGE = timedelta(days=1)
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds labels that are not applied to anything.
+
+    A label that is on no entity, device, or area, and is not targeted by
+    any automation or script, is not doing anything. Surfaced as tidiness,
+    with a fix flow to remove it.
+    """
+
+    domain = "homeassistant"
+    repair = "unused_labels"
+    inspect_events = {
+        EVENT_HOMEASSISTANT_STARTED,
+        lr.EVENT_LABEL_REGISTRY_UPDATED,
+        ar.EVENT_AREA_REGISTRY_UPDATED,
+        dr.EVENT_DEVICE_REGISTRY_UPDATED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    inspect_on_reload = True
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        label_registry = lr.async_get(self.hass)
+        area_registry = ar.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+
+        cutoff = dt_util.utcnow() - _MINIMUM_AGE
+        for label in label_registry.async_list_labels():
+            self.possible_issue_ids.add(label.label_id)
+
+            if label.created_at > cutoff:
+                # Just created; leave time to apply it to something.
+                continue
+            if er.async_entries_for_label(entity_registry, label.label_id):
+                continue
+            if dr.async_entries_for_label(device_registry, label.label_id):
+                continue
+            if ar.async_entries_for_label(area_registry, label.label_id):
+                continue
+            if automations_with_label(self.hass, label.label_id):
+                continue
+            if scripts_with_label(self.hass, label.label_id):
+                continue
+
+            self.async_create_issue(
+                issue_id=label.label_id,
+                is_fixable=True,
+                data={"unused_label_id": label.label_id, "label": label.name},
+                translation_placeholders={"label": label.name},
+            )

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -23,6 +23,7 @@ from homeassistant.helpers import (
     entity_registry as er,
     floor_registry as fr,
     issue_registry as ir,
+    label_registry as lr,
 )
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -593,17 +594,20 @@ class StaleAccessTokenFixFlow(RepairsFlow):
 
 
 class _RemoveOrIgnoreFixFlow(RepairsFlow):
-    """Base for an empty registry thing: remove it, or keep and stop nagging.
+    """Base for a leftover registry thing: remove it, or keep and stop nagging.
 
-    Empty registry things (areas, floors) are tidiness, not breakage, so
-    keeping one is a valid choice. A fixable issue cannot be dismissed from
-    the repairs UI, so the flow offers an explicit "keep it" option that
-    ignores the issue instead. Subclasses set ``_key`` (the placeholder and
-    ``empty_<thing>_id`` data key stem) and implement ``_remove``.
+    Leftover registry things (empty areas, empty floors, unused labels) are
+    tidiness, not breakage, so keeping one is a valid choice. A fixable issue
+    cannot be dismissed from the repairs UI, so the flow offers an explicit
+    "keep it" option that ignores the issue instead. Subclasses set ``_key``
+    (the placeholder key), ``_id_key`` (the data key holding the id), and
+    implement ``_remove``.
     """
 
-    #: Placeholder key and ``empty_<key>_id`` data-key stem (e.g. "area").
+    #: Placeholder key naming the thing (e.g. "area").
     _key: str
+    #: Data key holding the thing's id (e.g. "empty_area_id").
+    _id_key: str
 
     async def async_step_init(
         self,
@@ -623,7 +627,7 @@ class _RemoveOrIgnoreFixFlow(RepairsFlow):
         _: dict[str, str] | None = None,
     ) -> FlowResult:
         """Remove the thing, if it still exists."""
-        self._remove(str((self.data or {}).get(f"empty_{self._key}_id", "")))
+        self._remove(str((self.data or {}).get(self._id_key, "")))
         return self.async_create_entry(data={})
 
     async def async_step_ignore(
@@ -649,6 +653,7 @@ class EmptyAreaFixFlow(_RemoveOrIgnoreFixFlow):
     """Handler for an empty area: remove it, or keep it and stop nagging."""
 
     _key = "area"
+    _id_key = "empty_area_id"
 
     @callback
     def _remove(self, thing_id: str) -> None:
@@ -663,6 +668,7 @@ class EmptyFloorFixFlow(_RemoveOrIgnoreFixFlow):
     """Handler for an empty floor: remove it, or keep it and stop nagging."""
 
     _key = "floor"
+    _id_key = "empty_floor_id"
 
     @callback
     def _remove(self, thing_id: str) -> None:
@@ -670,6 +676,21 @@ class EmptyFloorFixFlow(_RemoveOrIgnoreFixFlow):
         registry = fr.async_get(self.hass)
         # The floor may already be gone if removed elsewhere meanwhile.
         if registry.async_get_floor(thing_id):
+            registry.async_delete(thing_id)
+
+
+class UnusedLabelFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for an unused label: remove it, or keep it and stop nagging."""
+
+    _key = "label"
+    _id_key = "unused_label_id"
+
+    @callback
+    def _remove(self, thing_id: str) -> None:
+        """Remove the label, if it still exists."""
+        registry = lr.async_get(self.hass)
+        # The label may already be gone if removed elsewhere meanwhile.
+        if registry.async_get_label(thing_id):
             registry.async_delete(thing_id)
 
 
@@ -690,4 +711,6 @@ async def async_create_fix_flow(
         return EmptyAreaFixFlow()
     if data and data.get("empty_floor_id"):
         return EmptyFloorFixFlow()
+    if data and data.get("unused_label_id"):
+        return UnusedLabelFixFlow()
     return ConfirmRepairFlow()

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -406,6 +406,24 @@
       "description": "Spook has found a ghost in your helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{domain}`)\n\nThis helper references the following source entities, which are unknown to Home Assistant:\n\n{sources}\n\n\n\nThis often happens when a source entity was renamed or removed. To fix this error, reconfigure the helper to point at existing entities, or remove the helper.\n\nSpook 👻 Your homie.",
       "title": "Unknown source entities used in helper: {helper}"
     },
+    "unused_labels": {
+      "title": "Unused label: {label}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Unused label: {label}",
+            "description": "The label {label} is not applied to any entity, device, or area, and no automation or script targets it.\n\nRemove it, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Remove this unused label",
+              "ignore": "Keep it, stop telling me"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this label from now on."
+        }
+      }
+    },
     "user_issue": {
       "fix_flow": {
         "step": {

--- a/tests/ectoplasms/homeassistant/repairs/test_unused_labels.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_unused_labels.py
@@ -1,0 +1,194 @@
+"""Tests for the unused labels repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import (
+    area_registry as ar,
+    entity_registry as er,
+    label_registry as lr,
+)
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs import unused_labels
+from custom_components.spook.ectoplasms.homeassistant.repairs.unused_labels import (
+    SpookRepair,
+)
+from custom_components.spook.repairs import UnusedLabelFixFlow, async_create_fix_flow
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+    import pytest
+
+# Comfortably past the creation grace period.
+_AGED = timedelta(days=2)
+
+
+def _issue_id(label_id: str) -> str:
+    """Return the registry issue id for a label."""
+    return f"unused_labels_{label_id}"
+
+
+def _flow_for(
+    hass: HomeAssistant, label_id: str, label_name: str
+) -> UnusedLabelFixFlow:
+    """Build an unused-label fix flow as the framework would wire it up."""
+    flow = UnusedLabelFixFlow()
+    flow.hass = hass
+    flow.issue_id = _issue_id(label_id)
+    flow.data = {"unused_label_id": label_id, "label": label_name}
+    return flow
+
+
+async def test_unused_label_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an aged label applied to nothing is reported."""
+    label = lr.async_get(hass).async_create("Holiday")
+    freezer.tick(_AGED)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id))
+    assert issue
+    assert issue.is_fixable
+    assert issue.translation_placeholders == {"label": "Holiday"}
+    assert issue.data == {"unused_label_id": label.label_id, "label": "Holiday"}
+
+
+async def test_recently_created_label_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a just-created label is left alone during its grace period."""
+    label = lr.async_get(hass).async_create("Brand New")
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id)) is None
+
+
+async def test_label_on_entity_is_not_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a label applied to an entity is left alone."""
+    label = lr.async_get(hass).async_create("Tagged")
+    entry = entity_registry.async_get_or_create("light", "hue", "ceiling")
+    entity_registry.async_update_entity(entry.entity_id, labels={label.label_id})
+    freezer.tick(_AGED)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id)) is None
+
+
+async def test_label_on_area_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a label applied to an area is left alone."""
+    label = lr.async_get(hass).async_create("Zone")
+    area = ar.async_get(hass).async_create("Kitchen")
+    ar.async_get(hass).async_update(area.id, labels={label.label_id})
+    freezer.tick(_AGED)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id)) is None
+
+
+async def test_label_used_by_automation_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a label targeted by an automation is left alone."""
+    label = lr.async_get(hass).async_create("Targeted")
+    freezer.tick(_AGED)
+    monkeypatch.setattr(
+        unused_labels,
+        "automations_with_label",
+        lambda _hass, lid: ["automation.lights"] if lid == label.label_id else [],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id)) is None
+
+
+async def test_label_used_by_script_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a label targeted by a script is left alone."""
+    label = lr.async_get(hass).async_create("Targeted")
+    freezer.tick(_AGED)
+    monkeypatch.setattr(
+        unused_labels,
+        "scripts_with_label",
+        lambda _hass, lid: ["script.lights"] if lid == label.label_id else [],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id)) is None
+
+
+async def test_fix_flow_remove_option_removes_label(
+    hass: HomeAssistant,
+) -> None:
+    """Test the remove menu option deletes the label."""
+    label = lr.async_get(hass).async_create("Holiday")
+
+    flow = await async_create_fix_flow(
+        hass,
+        _issue_id(label.label_id),
+        {"unused_label_id": label.label_id, "label": "Holiday"},
+    )
+    assert isinstance(flow, UnusedLabelFixFlow)
+    flow.hass = hass
+    flow.data = {"unused_label_id": label.label_id, "label": "Holiday"}
+
+    menu = await flow.async_step_init()
+    assert menu["type"] == FlowResultType.MENU
+    assert lr.async_get(hass).async_get_label(label.label_id) is not None
+
+    result = await flow.async_step_remove()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert lr.async_get(hass).async_get_label(label.label_id) is None
+
+
+async def test_fix_flow_ignore_option_dismisses_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the keep menu option ignores the issue and keeps the label."""
+    label = lr.async_get(hass).async_create("Targeted")
+    freezer.tick(_AGED)
+    await SpookRepair(hass).async_inspect()
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id))
+
+    flow = _flow_for(hass, label.label_id, "Targeted")
+    result = await flow.async_step_ignore()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert lr.async_get(hass).async_get_label(label.label_id) is not None
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id))
+    assert issue is not None
+    assert issue.dismissed_version is not None


### PR DESCRIPTION
## Description

Adds a Spook repair that surfaces unused labels: a label that is not applied to any entity, device, or area, and is not targeted by any automation or script. It is just sitting there doing nothing.

Each unused label gets its own fixable issue with the same Remove / Keep menu as the empty areas and empty floors repairs:

- **Remove this unused label** removes the label from the registry.
- **Keep it, stop telling me** ignores the issue and leaves the label alone (a fixable issue cannot be dismissed from the repairs UI, so the flow ignores it explicitly and aborts, which makes the ignore stick across inspections).

A freshly created label gets a one-day grace period before it can be flagged, so creating a label and applying it later does not trigger an instant repair.

This is the third and final slice of the "empty registry things" corner, after empty areas and empty floors. The shared Remove / Keep menu flow base picks up a small `_id_key` field so the label flow can use its own data key; empty areas and floors are unchanged.

## Motivation and Context

Unused labels are maintenance debt nobody surfaces today. Spook is the tool for exactly this kind of tidiness.

## How has this been tested?

- Detection of an aged unused label, and non-detection of the twins: a label on an entity, a label on an area, and a label targeted by an automation.
- The one-day creation grace: a just-created label is not flagged.
- The fix flow: the remove option deletes the label, and the keep option ignores the issue while leaving the label in place.
- Full suite green (660 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
