### PR TITLE
Detect unused blueprints and offer to remove them

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unused_blueprints.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unused_blueprints.py
@@ -1,0 +1,97 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.components import blueprint
+from homeassistant.components.automation import automations_with_blueprint
+from homeassistant.components.script import scripts_with_blueprint
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.util import dt as dt_util
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Give a freshly added or edited blueprint time to be put to use before
+# nagging about it. Judged by the blueprint file's modification time.
+_MINIMUM_AGE = timedelta(days=1)
+
+
+def _file_mtime(path: Path) -> float | None:
+    """Return the file's modification time, or None if it cannot be read."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds blueprints that no automation or script uses.
+
+    Blueprints pile up after you try one out and move on. A blueprint with
+    zero consumers is dead weight. Surfaced as tidiness, with a fix flow to
+    remove it. A blueprint whose file was added or changed within the grace
+    period is left alone, so importing one to use in a moment does not
+    trigger an instant repair.
+    """
+
+    domain = "homeassistant"
+    repair = "unused_blueprints"
+    inspect_events = {EVENT_HOMEASSISTANT_STARTED}
+    inspect_on_reload = True
+    inspect_interval = timedelta(days=1)
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        domain_blueprints: dict[str, blueprint.DomainBlueprints] = self.hass.data.get(
+            blueprint.DOMAIN, {}
+        )
+        cutoff = (dt_util.utcnow() - _MINIMUM_AGE).timestamp()
+        for domain, domain_blueprint in domain_blueprints.items():
+            # Only automations and scripts consume blueprints. A domain Spook
+            # cannot check is skipped, so it never guesses a blueprint unused.
+            if domain == "automation":
+                consumers = automations_with_blueprint
+            elif domain == "script":
+                consumers = scripts_with_blueprint
+            else:
+                continue
+
+            for path, item in (await domain_blueprint.async_get_blueprints()).items():
+                issue_id = f"{domain}:{path}"
+                self.possible_issue_ids.add(issue_id)
+
+                if not isinstance(item, blueprint.Blueprint):
+                    # Failed to load or missing; not a usage question.
+                    continue
+                if consumers(self.hass, path):
+                    continue
+
+                mtime = await self.hass.async_add_executor_job(
+                    _file_mtime, domain_blueprint.blueprint_folder / path
+                )
+                if mtime is None or mtime > cutoff:
+                    # File gone, or added/changed recently; give it time.
+                    continue
+
+                self.async_create_issue(
+                    issue_id=issue_id,
+                    is_fixable=True,
+                    data={
+                        "unused_blueprint_domain": domain,
+                        "unused_blueprint_path": path,
+                        "blueprint": item.name,
+                    },
+                    translation_placeholders={
+                        "blueprint": item.name,
+                        "domain": domain,
+                    },
+                )

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import asyncio
+from contextlib import suppress
 from dataclasses import dataclass, field
 import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, final
 
+from homeassistant.components import blueprint
 from homeassistant.components.homeassistant import SERVICE_HOMEASSISTANT_RESTART
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
 from homeassistant.config_entries import (
@@ -617,10 +619,12 @@ class _RemoveOrIgnoreFixFlow(RepairsFlow):
         return self.async_show_menu(
             step_id="init",
             menu_options=["remove", "ignore"],
-            description_placeholders={
-                self._key: str((self.data or {}).get(self._key, "")),
-            },
+            description_placeholders=self._menu_placeholders(),
         )
+
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Return the placeholders naming the thing in the menu step."""
+        return {self._key: str((self.data or {}).get(self._key, ""))}
 
     async def async_step_remove(
         self,
@@ -694,6 +698,52 @@ class UnusedLabelFixFlow(_RemoveOrIgnoreFixFlow):
             registry.async_delete(thing_id)
 
 
+class UnusedBlueprintFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for an unused blueprint: remove it, or keep it and stop nagging.
+
+    Blueprint removal deletes a file, so it overrides ``async_step_remove``
+    with the async removal instead of the synchronous ``_remove`` hook.
+    """
+
+    _key = "blueprint"
+    _id_key = "unused_blueprint_path"
+
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Name the blueprint and its domain in the menu step."""
+        data = self.data or {}
+        return {
+            "blueprint": str(data.get("blueprint", "")),
+            "domain": str(data.get("unused_blueprint_domain", "")),
+        }
+
+    async def async_step_remove(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Remove the blueprint file, if it still exists and is not in use."""
+        data = self.data or {}
+        domain = str(data.get("unused_blueprint_domain", ""))
+        path = str(data.get("unused_blueprint_path", ""))
+        domain_blueprints: dict[str, blueprint.DomainBlueprints] = self.hass.data.get(
+            blueprint.DOMAIN, {}
+        )
+        if domain_blueprint := domain_blueprints.get(domain):
+            # It may already be gone, or have gained a consumer meanwhile.
+            with suppress(FileNotFoundError, blueprint.BlueprintInUse):
+                await domain_blueprint.async_remove_blueprint(path)
+        return self.async_create_entry(data={})
+
+
+# Remove-or-ignore fix flows, keyed by the data field that identifies their
+# leftover registry thing.
+_REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
+    "empty_area_id": EmptyAreaFixFlow,
+    "empty_floor_id": EmptyFloorFixFlow,
+    "unused_label_id": UnusedLabelFixFlow,
+    "unused_blueprint_path": UnusedBlueprintFixFlow,
+}
+
+
 async def async_create_fix_flow(
     _hass: HomeAssistant,
     issue_id: str,
@@ -707,10 +757,8 @@ async def async_create_fix_flow(
             key: str(data.get(key, "")) for key in ("token", "owner", "last_active")
         }
         return StaleAccessTokenFixFlow(str(token_id), placeholders)
-    if data and data.get("empty_area_id"):
-        return EmptyAreaFixFlow()
-    if data and data.get("empty_floor_id"):
-        return EmptyFloorFixFlow()
-    if data and data.get("unused_label_id"):
-        return UnusedLabelFixFlow()
+    if data:
+        for key, flow in _REMOVE_OR_IGNORE_FLOWS.items():
+            if data.get(key):
+                return flow()
     return ConfirmRepairFlow()

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -406,6 +406,24 @@
       "description": "Spook has found a ghost in your helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{domain}`)\n\nThis helper references the following source entities, which are unknown to Home Assistant:\n\n{sources}\n\n\n\nThis often happens when a source entity was renamed or removed. To fix this error, reconfigure the helper to point at existing entities, or remove the helper.\n\nSpook 👻 Your homie.",
       "title": "Unknown source entities used in helper: {helper}"
     },
+    "unused_blueprints": {
+      "title": "Unused blueprint: {blueprint}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Unused blueprint: {blueprint}",
+            "description": "The blueprint {blueprint} is not used by any {domain}.\n\nRemove it, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Remove this unused blueprint",
+              "ignore": "Keep it, stop telling me"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this blueprint from now on."
+        }
+      }
+    },
     "unused_labels": {
       "title": "Unused label: {label}",
       "fix_flow": {

--- a/tests/ectoplasms/homeassistant/repairs/test_unused_blueprints.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_unused_blueprints.py
@@ -1,0 +1,217 @@
+"""Tests for the unused blueprints repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components import blueprint
+from homeassistant.components.blueprint import Blueprint
+from homeassistant.components.blueprint.errors import FailedToLoad
+from homeassistant.components.blueprint.schemas import BLUEPRINT_SCHEMA
+from homeassistant.data_entry_flow import FlowResultType
+import pytest
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs import unused_blueprints
+from custom_components.spook.ectoplasms.homeassistant.repairs.unused_blueprints import (
+    SpookRepair,
+)
+from custom_components.spook.repairs import (
+    UnusedBlueprintFixFlow,
+    async_create_fix_flow,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+_ISSUE_ID = "unused_blueprints_automation:motion.yaml"
+
+
+@pytest.fixture(autouse=True)
+def _aged_blueprints(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Treat every blueprint file as old, so the grace period never hides it."""
+    monkeypatch.setattr(unused_blueprints, "_file_mtime", lambda _path: 0.0)
+
+
+class _FakeDomainBlueprints:
+    """Minimal stand-in for a core DomainBlueprints."""
+
+    def __init__(self, blueprints: dict[str, Any]) -> None:
+        """Store the blueprints to hand out."""
+        self._blueprints = blueprints
+        self.removed: list[str] = []
+        self.blueprint_folder = Path("/nonexistent")
+
+    async def async_get_blueprints(self) -> dict[str, Any]:
+        """Return the blueprints."""
+        return self._blueprints
+
+    async def async_remove_blueprint(self, path: str) -> None:
+        """Record and drop the blueprint."""
+        self.removed.append(path)
+        self._blueprints.pop(path, None)
+
+
+def _blueprint(name: str = "Motion light") -> Blueprint:
+    """Build a minimal, valid automation blueprint."""
+    return Blueprint(
+        {"blueprint": {"name": name, "domain": "automation"}},
+        expected_domain="automation",
+        schema=BLUEPRINT_SCHEMA,
+    )
+
+
+def _install(hass: HomeAssistant, domain: str, blueprints: dict[str, Any]) -> None:
+    """Install fake domain blueprints into hass."""
+    hass.data[blueprint.DOMAIN] = {domain: _FakeDomainBlueprints(blueprints)}
+
+
+async def test_unused_blueprint_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a blueprint used by no automation is reported."""
+    _install(hass, "automation", {"motion.yaml": _blueprint()})
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.is_fixable
+    assert issue.translation_placeholders == {
+        "blueprint": "Motion light",
+        "domain": "automation",
+    }
+    assert issue.data == {
+        "unused_blueprint_domain": "automation",
+        "unused_blueprint_path": "motion.yaml",
+        "blueprint": "Motion light",
+    }
+
+
+async def test_recently_added_blueprint_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a blueprint whose file was just added is left alone."""
+    # A modification time in the future is comfortably within the grace.
+    monkeypatch.setattr(unused_blueprints, "_file_mtime", lambda _path: 9_999_999_999.0)
+    _install(hass, "automation", {"motion.yaml": _blueprint()})
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_used_blueprint_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a blueprint with a consumer is left alone."""
+    _install(hass, "automation", {"motion.yaml": _blueprint()})
+    monkeypatch.setattr(
+        unused_blueprints,
+        "automations_with_blueprint",
+        lambda _hass, path: ["automation.hall"] if path == "motion.yaml" else [],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_unloadable_blueprint_is_ignored(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a blueprint that failed to load is not reported."""
+    err = FailedToLoad("automation", "motion.yaml", FileNotFoundError())
+    _install(hass, "automation", {"motion.yaml": err})
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_blueprint_in_uncheckable_domain_is_ignored(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a blueprint in a domain Spook cannot check is left alone."""
+    _install(hass, "template", {"motion.yaml": _blueprint()})
+
+    await SpookRepair(hass).async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, "unused_blueprints_template:motion.yaml")
+        is None
+    )
+
+
+async def test_fix_flow_remove_option_removes_blueprint(
+    hass: HomeAssistant,
+) -> None:
+    """Test the remove menu option deletes the blueprint file."""
+    _install(hass, "automation", {"motion.yaml": _blueprint()})
+    fake = hass.data[blueprint.DOMAIN]["automation"]
+
+    flow = await async_create_fix_flow(
+        hass,
+        _ISSUE_ID,
+        {
+            "unused_blueprint_domain": "automation",
+            "unused_blueprint_path": "motion.yaml",
+            "blueprint": "Motion light",
+        },
+    )
+    assert isinstance(flow, UnusedBlueprintFixFlow)
+    flow.hass = hass
+    flow.data = {
+        "unused_blueprint_domain": "automation",
+        "unused_blueprint_path": "motion.yaml",
+        "blueprint": "Motion light",
+    }
+
+    menu = await flow.async_step_init()
+    assert menu["type"] == FlowResultType.MENU
+    # The menu names both the blueprint and its domain.
+    assert menu["description_placeholders"] == {
+        "blueprint": "Motion light",
+        "domain": "automation",
+    }
+
+    result = await flow.async_step_remove()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert fake.removed == ["motion.yaml"]
+
+
+async def test_fix_flow_ignore_option_dismisses_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the keep menu option ignores the issue and keeps the blueprint."""
+    _install(hass, "automation", {"motion.yaml": _blueprint()})
+    await SpookRepair(hass).async_inspect()
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+    flow = UnusedBlueprintFixFlow()
+    flow.hass = hass
+    flow.issue_id = _ISSUE_ID
+    flow.data = {
+        "unused_blueprint_domain": "automation",
+        "unused_blueprint_path": "motion.yaml",
+        "blueprint": "Motion light",
+    }
+    result = await flow.async_step_ignore()
+
+    assert result["type"] == FlowResultType.ABORT
+    fake = hass.data[blueprint.DOMAIN]["automation"]
+    assert fake.removed == []
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue is not None
+    assert issue.dismissed_version is not None


### PR DESCRIPTION
## Description

Adds a Spook repair that surfaces unused blueprints: a blueprint that no automation or script uses. Blueprints pile up after you try one out and move on, and nothing in Home Assistant points them out.

Each unused blueprint gets its own fixable issue with the same Remove / Keep menu as the empty areas, empty floors, and unused labels repairs:

- **Remove this unused blueprint** deletes the blueprint file.
- **Keep it, stop telling me** ignores the issue and leaves the blueprint alone.

Detection enumerates the per-domain `DomainBlueprints` from `hass.data`, and for the automation and script domains flags any blueprint with zero consumers (`automations_with_blueprint` / `scripts_with_blueprint`). A blueprint domain Spook cannot check for usage is skipped, and blueprints that failed to load or are missing are skipped too, so Spook never guesses a blueprint is unused when it cannot tell.

Like the empty areas, floors, and labels repairs, a freshly added blueprint gets a one-day grace period so importing one to use in a moment does not trigger an instant repair. Blueprints have no creation timestamp, so the grace is judged by the blueprint file's modification time (statted in the executor). The repair also inspects only on start, on reload, and once a day. Removal goes through core's `async_remove_blueprint`, which refuses to delete a blueprint that is in use.

The remove-or-keep fix flows are now selected from a small table, and the blueprint flow overrides the remove step because deleting a blueprint file is asynchronous and needs both the domain and the path.

This is the "unused blueprints" corner (3.6). It pairs with the planned blueprint update work later on.

## Motivation and Context

Unused blueprints are maintenance debt nobody surfaces today. Spook is the tool for exactly this kind of tidiness.

## How has this been tested?

- Detection of a blueprint with no consumers, and non-detection of the twins: a blueprint with a consumer, a blueprint that failed to load, and a blueprint in a domain Spook cannot check.
- The one-day grace: a blueprint whose file was just added is not flagged.
- The fix flow: the remove option deletes the blueprint, and the keep option ignores the issue while leaving the blueprint in place.
- Full suite green (670 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
