### PR TITLE
Detect and clean up unknown device trackers on people

### DIFF
--- a/custom_components/spook/ectoplasms/person/repairs/__init__.py
+++ b/custom_components/spook/ectoplasms/person/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/person/repairs/unknown_device_trackers.py
+++ b/custom_components/spook/ectoplasms/person/repairs/unknown_device_trackers.py
@@ -1,0 +1,76 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import person
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import DATA_INSTANCES
+
+from ....const import LOGGER
+from ....entity_suggestions import async_describe_unknown_entities
+from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.entity_component import EntityComponent
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds device trackers a person points at that are gone.
+
+    A person tracks a set of device trackers. When one is renamed or its
+    integration is removed, the person keeps pointing at an entity that no
+    longer exists. Device trackers can be state-only, so both the entity
+    registry and the current states are checked before flagging one.
+    """
+
+    domain = person.DOMAIN
+    repair = "person_unknown_device_trackers"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    inspect_on_reload = True
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        component: EntityComponent[person.Person] | None
+        if not (component := self.hass.data.get(DATA_INSTANCES, {}).get(self.domain)):
+            return  # Person is not set up; nothing to do.
+
+        entity_registry = er.async_get(self.hass)
+        for person_entity in component.entities:
+            self.possible_issue_ids.add(person_entity.entity_id)
+
+            unknown = [
+                device_tracker
+                for device_tracker in person_entity.device_trackers
+                if entity_registry.async_get(device_tracker) is None
+                and self.hass.states.get(device_tracker) is None
+            ]
+            if not unknown:
+                continue
+
+            self.async_create_issue(
+                issue_id=person_entity.entity_id,
+                is_fixable=True,
+                data={
+                    "person_entity_id": person_entity.entity_id,
+                    "person": person_entity.name,
+                    "device_trackers": async_describe_unknown_entities(
+                        self.hass, sorted(unknown)
+                    ),
+                    "unknown_trackers": ",".join(sorted(unknown)),
+                },
+                translation_placeholders={"person": person_entity.name},
+            )
+            LOGGER.debug(
+                "Spook found unknown device trackers for %s: %s",
+                person_entity.entity_id,
+                ", ".join(sorted(unknown)),
+            )

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -19,6 +19,7 @@ from homeassistant.config_entries import (
     ConfigEntryChange,
 )
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
@@ -734,6 +735,56 @@ class UnusedBlueprintFixFlow(_RemoveOrIgnoreFixFlow):
         return self.async_create_entry(data={})
 
 
+class PersonUnknownDeviceTrackerFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for a person's unknown device trackers.
+
+    Offers to strip the unknown device trackers from the person, or to keep
+    them and ignore the issue. Removal reuses Spook's own
+    ``person.remove_device_tracker`` action, which only edits storage-backed
+    persons; a YAML person cannot be edited, so that is reported instead.
+    """
+
+    _key = "person"
+    _id_key = "person_entity_id"
+
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Name the person and the offending device trackers in the menu."""
+        data = self.data or {}
+        return {
+            "person": str(data.get("person", "")),
+            "device_trackers": str(data.get("device_trackers", "")),
+        }
+
+    async def async_step_remove(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Remove the still-unknown device trackers from the person."""
+        data = self.data or {}
+        entity_id = str(data.get("person_entity_id", ""))
+        candidates = [t for t in str(data.get("unknown_trackers", "")).split(",") if t]
+
+        entity_registry = er.async_get(self.hass)
+        unknown = [
+            tracker
+            for tracker in candidates
+            if entity_registry.async_get(tracker) is None
+            and self.hass.states.get(tracker) is None
+        ]
+        if unknown:
+            try:
+                await self.hass.services.async_call(
+                    "person",
+                    "remove_device_tracker",
+                    {"entity_id": entity_id, "device_tracker": unknown},
+                    blocking=True,
+                )
+            except HomeAssistantError:
+                # YAML persons are not editable; nothing Spook can remove.
+                return self.async_abort(reason="not_editable")
+        return self.async_create_entry(data={})
+
+
 # Remove-or-ignore fix flows, keyed by the data field that identifies their
 # leftover registry thing.
 _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
@@ -741,6 +792,7 @@ _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
     "empty_floor_id": EmptyFloorFixFlow,
     "unused_label_id": UnusedLabelFixFlow,
     "unused_blueprint_path": UnusedBlueprintFixFlow,
+    "person_entity_id": PersonUnknownDeviceTrackerFixFlow,
 }
 
 

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -328,6 +328,25 @@
       "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Developer Tools > Statistics and fix them there, or remove them using the `recorder.clear_statistics` action.\n\nSpook 👻 Your homie.",
       "title": "Orphaned long-term statistics found"
     },
+    "person_unknown_device_trackers": {
+      "title": "Unknown device trackers tracked by: {person}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Unknown device trackers tracked by: {person}",
+            "description": "Spook has found a ghost in your people 👻\n\n{person} tracks the following device trackers, which are unknown to Home Assistant:\n\n{device_trackers}\n\nThis often happens when a device tracker was renamed or its integration was removed.\n\nRemove them from {person}, or keep them and Spook will stop pointing them out.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Remove these device trackers",
+              "ignore": "Keep them, stop telling me"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this person from now on.",
+          "not_editable": "This person is set up in YAML, so Spook cannot edit it. Update the person in your configuration instead."
+        }
+      }
+    },
     "proximity_unknown_ignored_zones": {
       "description": "Spook has found a ghost in your proximity configuration 👻\n\nWhile floating around, Spook crossed path with the following proximity configuration:\n\n{name}\n\nThis configuration is ignoring zones that are unknown to Home Assistant:\n\n{zones}\n\n\n\nTo fix this error, edit the configuration and remove this/these zones.\n\nSpook 👻 Your homie.",
       "title": "Unknown ignored zones: {name}"

--- a/tests/ectoplasms/person/__init__.py
+++ b/tests/ectoplasms/person/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook person ectoplasm."""

--- a/tests/ectoplasms/person/repairs/__init__.py
+++ b/tests/ectoplasms/person/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook person repairs."""

--- a/tests/ectoplasms/person/repairs/test_unknown_device_trackers.py
+++ b/tests/ectoplasms/person/repairs/test_unknown_device_trackers.py
@@ -1,0 +1,191 @@
+"""Tests for the person unknown device trackers repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_component import DATA_INSTANCES
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.person.repairs.unknown_device_trackers import (
+    SpookRepair,
+)
+from custom_components.spook.repairs import (
+    PersonUnknownDeviceTrackerFixFlow,
+    async_create_fix_flow,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+    from homeassistant.helpers import entity_registry as er, issue_registry as ir
+
+_ISSUE_ID = "person_unknown_device_trackers_person.frenck"
+
+
+def _install_person(hass: HomeAssistant, device_trackers: list[str]) -> None:
+    """Install a fake person entity component into hass."""
+    person = SimpleNamespace(
+        entity_id="person.frenck",
+        name="Frenck",
+        device_trackers=device_trackers,
+    )
+    hass.data.setdefault(DATA_INSTANCES, {})["person"] = SimpleNamespace(
+        entities=[person]
+    )
+
+
+def _flow_for(
+    hass: HomeAssistant, unknown: list[str]
+) -> PersonUnknownDeviceTrackerFixFlow:
+    """Build a person fix flow as the framework would wire it up."""
+    flow = PersonUnknownDeviceTrackerFixFlow()
+    flow.hass = hass
+    flow.issue_id = _ISSUE_ID
+    flow.data = {
+        "person_entity_id": "person.frenck",
+        "person": "Frenck",
+        "device_trackers": "- `" + "`\n- `".join(unknown) + "`",
+        "unknown_trackers": ",".join(unknown),
+    }
+    return flow
+
+
+async def test_unknown_device_tracker_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a person tracking a non-existing device tracker is reported."""
+    hass.states.async_set("device_tracker.phone", "home")
+    _install_person(hass, ["device_tracker.gone", "device_tracker.phone"])
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.is_fixable
+    assert issue.translation_placeholders == {"person": "Frenck"}
+    assert issue.data == {
+        "person_entity_id": "person.frenck",
+        "person": "Frenck",
+        "device_trackers": "- `device_tracker.gone`",
+        "unknown_trackers": "device_tracker.gone",
+    }
+
+
+async def test_registered_device_tracker_is_not_flagged(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a device tracker known only to the registry is left alone."""
+    entry = entity_registry.async_get_or_create("device_tracker", "gps", "car")
+    _install_person(hass, [entry.entity_id])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_all_known_trackers_create_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a person with only existing device trackers is not reported."""
+    hass.states.async_set("device_tracker.phone", "home")
+    _install_person(hass, ["device_tracker.phone"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_no_person_component_does_nothing(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the repair is a no-op when person is not set up."""
+    await SpookRepair(hass).async_inspect()
+
+    assert not any(
+        issue_id.startswith("person_unknown_device_trackers_")
+        for domain, issue_id in issue_registry.issues
+        if domain == DOMAIN
+    )
+
+
+async def test_fix_flow_remove_calls_service(
+    hass: HomeAssistant,
+) -> None:
+    """Test the remove option strips the still-unknown trackers."""
+    calls: list[dict] = []
+
+    async def _handler(call: ServiceCall) -> None:
+        calls.append(call.data)
+
+    hass.services.async_register("person", "remove_device_tracker", _handler)
+
+    flow = await async_create_fix_flow(
+        hass,
+        _ISSUE_ID,
+        {
+            "person_entity_id": "person.frenck",
+            "person": "Frenck",
+            "device_trackers": "- `device_tracker.gone`",
+            "unknown_trackers": "device_tracker.gone",
+        },
+    )
+    assert isinstance(flow, PersonUnknownDeviceTrackerFixFlow)
+    flow.hass = hass
+    flow.data = {
+        "person_entity_id": "person.frenck",
+        "person": "Frenck",
+        "device_trackers": "- `device_tracker.gone`",
+        "unknown_trackers": "device_tracker.gone",
+    }
+
+    result = await flow.async_step_remove()
+
+    assert result["type"] == "create_entry"
+    assert calls == [
+        {"entity_id": "person.frenck", "device_tracker": ["device_tracker.gone"]}
+    ]
+
+
+async def test_fix_flow_remove_skips_now_known_tracker(
+    hass: HomeAssistant,
+) -> None:
+    """Test a tracker that came back is not removed."""
+    hass.states.async_set("device_tracker.gone", "home")
+    called = False
+
+    async def _handler(_call: ServiceCall) -> None:
+        nonlocal called
+        called = True
+
+    hass.services.async_register("person", "remove_device_tracker", _handler)
+
+    flow = _flow_for(hass, ["device_tracker.gone"])
+    result = await flow.async_step_remove()
+
+    assert result["type"] == "create_entry"
+    assert called is False
+
+
+async def test_fix_flow_remove_yaml_person_aborts(
+    hass: HomeAssistant,
+) -> None:
+    """Test a non-editable person reports it cannot be edited."""
+
+    async def _handler(_call: ServiceCall) -> None:
+        raise HomeAssistantError
+
+    hass.services.async_register("person", "remove_device_tracker", _handler)
+
+    flow = _flow_for(hass, ["device_tracker.gone"])
+    result = await flow.async_step_remove()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_editable"


### PR DESCRIPTION
## Description

Adds a Spook repair that surfaces device trackers a person points at that no longer exist. When a device tracker is renamed or its integration is removed, the person keeps referencing a gone entity, and nothing in Home Assistant points that out. Device trackers can be state-only, so both the entity registry and the current states are checked before flagging one.

Each affected person gets a fixable issue with a Remove / Keep menu:

- **Remove these device trackers** strips the still-unknown trackers from the person. It re-derives which of the flagged trackers are still unknown at fix time (so one that came back is left in place) and removes them through Spook's own `person.remove_device_tracker` action.
- **Keep them, stop telling me** ignores the issue and leaves the person untouched.

Only storage-backed persons can be edited. A YAML person cannot, so the remove step reports that instead of failing, and points the user at their configuration.

The remove-or-keep menu and ignore handling are reused from the shared fix-flow base; the person flow overrides only the remove step. `device_tracker` sits in Spook's ignored entity domains for the generic reference checks (state-only trackers are legitimate), so this repair checks the person configuration directly.

This is the first of the small reference checks (person device trackers).

## Motivation and Context

A person quietly tracking a removed device tracker is exactly the kind of stale reference Spook exists to surface, now with a one-select cleanup.

## How has this been tested?

- Detection of a person tracking a non-existing device tracker, and non-detection of the twins: a tracker known only to the registry, and a person whose trackers all exist.
- No-op when person is not set up.
- The fix flow: remove calls the action with the still-unknown trackers, skips a tracker that came back, and a non-editable (YAML) person aborts with a clear message.
- Full suite green (680 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
