### PR TITLE
Detect customizations for non-existing entities

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_customized_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_customized_entities.py
@@ -1,0 +1,61 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from homeassistant.const import EVENT_CORE_CONFIG_UPDATE, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core_config import DATA_CUSTOMIZE
+from homeassistant.helpers import entity_registry as er
+
+from ....const import LOGGER
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
+from ....repairs import AbstractSpookRepair
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds customize entries for entities that do not exist.
+
+    The `customize:` section can pin attributes on a specific entity. When
+    that entity is renamed or removed, the customization becomes a dangling
+    reference doing nothing. Only exact entity keys are checked; glob and
+    domain customizations are patterns, not references.
+    """
+
+    domain = "homeassistant"
+    repair = "unknown_customized_entities"
+    inspect_events = {
+        EVENT_HOMEASSISTANT_STARTED,
+        EVENT_CORE_CONFIG_UPDATE,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        self.possible_issue_ids.add(self.repair)
+
+        if not (customize := self.hass.data.get(DATA_CUSTOMIZE)):
+            return  # No customizations at all.
+
+        # `_exact` holds the per-entity customizations, keyed by entity ID.
+        # Glob and domain customizations live separately and are patterns.
+        # pylint: disable-next=protected-access
+        exact = customize._exact  # noqa: SLF001
+        if not exact:
+            return
+
+        if unknown := async_filter_known_entity_ids(
+            self.hass,
+            entity_ids=list(exact),
+            known_entity_ids=async_get_all_entity_ids(self.hass),
+        ):
+            self.async_create_issue(
+                issue_id=self.repair,
+                translation_placeholders={
+                    "entities": async_describe_unknown_entities(
+                        self.hass, sorted(unknown)
+                    ),
+                },
+            )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -402,6 +402,10 @@
       "description": "Spook has found a ghost in your template helpers 👻\n\nWhile floating around, Spook crossed path with the following template helper:\n\n{helper}\n\nIts templates reference the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nThis often happens when an entity was renamed or removed. To fix this error, reconfigure the template helper to reference existing entities.\n\nSpook 👻 Your homie.",
       "title": "Unknown entities used in template helper: {helper}"
     },
+    "unknown_customized_entities": {
+      "description": "Spook has found a ghost in your customizations 👻\n\nThe `customize:` section pins attributes on the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nThis often happens when an entity was renamed or removed while its customization stayed behind. To fix this error, edit the `customize:` section in your configuration and remove these entities.\n\nSpook 👻 Your homie.",
+      "title": "Unknown entities in your customizations"
+    },
     "unknown_helper_source_references": {
       "description": "Spook has found a ghost in your helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{domain}`)\n\nThis helper references the following source entities, which are unknown to Home Assistant:\n\n{sources}\n\n\n\nThis often happens when a source entity was renamed or removed. To fix this error, reconfigure the helper to point at existing entities, or remove the helper.\n\nSpook 👻 Your homie.",
       "title": "Unknown source entities used in helper: {helper}"

--- a/tests/ectoplasms/homeassistant/repairs/test_unknown_customized_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_unknown_customized_entities.py
@@ -1,0 +1,68 @@
+"""Tests for the unknown customized entities repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.core_config import DATA_CUSTOMIZE
+from homeassistant.helpers.entity_values import EntityValues
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs.unknown_customized_entities import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+_ISSUE_ID = "unknown_customized_entities_unknown_customized_entities"
+
+
+async def test_unknown_customized_entity_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a customize entry for a non-existing entity is reported."""
+    hass.states.async_set("light.known", "on")
+    hass.data[DATA_CUSTOMIZE] = EntityValues(
+        exact={
+            "light.gone": {"icon": "mdi:ghost"},
+            "light.known": {"icon": "mdi:lightbulb"},
+        }
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders
+    entities = issue.translation_placeholders["entities"]
+    assert "light.gone" in entities
+    assert "light.known" not in entities
+
+
+async def test_known_customized_entity_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a customize entry for an existing entity is left alone."""
+    hass.states.async_set("light.known", "on")
+    hass.data[DATA_CUSTOMIZE] = EntityValues(exact={"light.known": {"icon": "x"}})
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_no_customizations_create_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an empty customize section produces no issue."""
+    hass.data[DATA_CUSTOMIZE] = EntityValues()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None


### PR DESCRIPTION
## Description

Adds a Spook repair that surfaces `customize:` entries pinning attributes on entities that no longer exist. When an entity is renamed or removed while its customization stays behind, the customization becomes a dangling reference that does nothing.

Only exact entity keys are checked. Glob (`customize_glob:`) and domain (`customize_domain:`) customizations are patterns, not references, so they are left alone. Exact keys are read from the core customize store (`hass.data[DATA_CUSTOMIZE]`) and checked against the entities known to Home Assistant (registry and current states), so a state-only entity still counts as existing.

The issue is informational: customizations live in `configuration.yaml`, which Spook cannot edit, so the issue is dismissable and its text points at the `customize:` section to clean up by hand.

This is one of the small reference checks. Note: the alert and notify-group checks from the same group are not practical to build (the alert integration is frozen and does not retain its watched entity on the entity after setup, and the legacy notify group exposes no clean handle to its member services), so they are intentionally left out.

## Motivation and Context

A customization pinned on a removed entity is dead configuration nobody surfaces today. Spook is the tool for exactly this kind of tidiness.

## How has this been tested?

- Detection of a customize entry for a non-existing entity, and non-detection of a customize entry for an existing entity.
- No issue when there are no customizations.
- Full suite green (685 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
