### PR TITLE
Make the stale access token repair dismissable

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -559,42 +559,6 @@ class RestartRequiredFixFlow(RepairsFlow):
         return self.async_show_form(step_id="confirm_restart")
 
 
-class StaleAccessTokenFixFlow(RepairsFlow):
-    """Handler for a repairs issue flow that revokes a stale access token."""
-
-    def __init__(
-        self,
-        token_id: str,
-        placeholders: dict[str, str],
-    ) -> None:
-        """Initialize the flow with the token to revoke."""
-        self._token_id = token_id
-        self._placeholders = placeholders
-
-    async def async_step_init(
-        self,
-        _: dict[str, str] | None = None,
-    ) -> FlowResult:
-        """Handle asking confirmation of the revoke."""
-        return await self.async_step_confirm()
-
-    async def async_step_confirm(
-        self,
-        user_input: dict[str, str] | None = None,
-    ) -> FlowResult:
-        """Handle the confirm of the token revoke."""
-        if user_input is not None:
-            # The token may already be gone if revoked elsewhere meanwhile.
-            if token := self.hass.auth.async_get_refresh_token(self._token_id):
-                self.hass.auth.async_remove_refresh_token(token)
-            return self.async_create_entry(data={})
-
-        return self.async_show_form(
-            step_id="confirm",
-            description_placeholders=self._placeholders,
-        )
-
-
 class _RemoveOrIgnoreFixFlow(RepairsFlow):
     """Base for a leftover registry thing: remove it, or keep and stop nagging.
 
@@ -698,6 +662,31 @@ class UnusedLabelFixFlow(_RemoveOrIgnoreFixFlow):
             registry.async_delete(thing_id)
 
 
+class StaleAccessTokenFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for a stale access token: revoke it, or keep it and stop nagging.
+
+    A fixable issue cannot be dismissed from the repairs UI, so keeping a
+    token you still want is offered explicitly as the "keep it" option.
+    """
+
+    _key = "token"
+    _id_key = "stale_access_token_id"
+
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Name the token, owner, and last-used date in the menu step."""
+        data = self.data or {}
+        return {
+            key: str(data.get(key, "")) for key in ("token", "owner", "last_active")
+        }
+
+    @callback
+    def _remove(self, thing_id: str) -> None:
+        """Revoke the token, if it still exists."""
+        # The token may already be gone if revoked elsewhere meanwhile.
+        if token := self.hass.auth.async_get_refresh_token(thing_id):
+            self.hass.auth.async_remove_refresh_token(token)
+
+
 class UnusedBlueprintFixFlow(_RemoveOrIgnoreFixFlow):
     """Handler for an unused blueprint: remove it, or keep it and stop nagging.
 
@@ -737,6 +726,7 @@ class UnusedBlueprintFixFlow(_RemoveOrIgnoreFixFlow):
 # Remove-or-ignore fix flows, keyed by the data field that identifies their
 # leftover registry thing.
 _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
+    "stale_access_token_id": StaleAccessTokenFixFlow,
     "empty_area_id": EmptyAreaFixFlow,
     "empty_floor_id": EmptyFloorFixFlow,
     "unused_label_id": UnusedLabelFixFlow,
@@ -752,11 +742,6 @@ async def async_create_fix_flow(
     """Create flow."""
     if issue_id == "restart_required":
         return RestartRequiredFixFlow()
-    if data and (token_id := data.get("stale_access_token_id")):
-        placeholders = {
-            key: str(data.get(key, "")) for key in ("token", "owner", "last_active")
-        }
-        return StaleAccessTokenFixFlow(str(token_id), placeholders)
     if data:
         for key, flow in _REMOVE_OR_IGNORE_FLOWS.items():
             if data.get(key):

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -391,10 +391,17 @@
       "title": "Long-lived access token looks forgotten: {token}",
       "fix_flow": {
         "step": {
-          "confirm": {
-            "title": "Revoke this long-lived access token?",
-            "description": "The long-lived access token `{token}` (owner: {owner}) has not been used since {last_active}.\n\nSelect submit to revoke it now. Anything still using this token will stop working until it gets a new one.\n\nSpook 👻 Your homie."
+          "init": {
+            "title": "Long-lived access token looks forgotten: {token}",
+            "description": "The long-lived access token `{token}` (owner: {owner}) has not been used since {last_active}.\n\nRevoke it, or keep it and Spook will stop pointing it out. Revoking it stops anything still using this token from working until it gets a new one.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Revoke this token",
+              "ignore": "Keep it, stop telling me"
+            }
           }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this token from now on."
         }
       }
     },

--- a/tests/ectoplasms/homeassistant/repairs/test_stale_access_tokens.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_stale_access_tokens.py
@@ -176,11 +176,25 @@ async def test_never_used_token_falls_back_to_created_at(
     assert issue.translation_placeholders["last_active"] == created.date().isoformat()
 
 
-async def test_fix_flow_revokes_token(
+def _token_flow(hass: HomeAssistant, token_id: str) -> StaleAccessTokenFixFlow:
+    """Build a stale-token fix flow as the framework would wire it up."""
+    flow = StaleAccessTokenFixFlow()
+    flow.hass = hass
+    flow.issue_id = _issue_id(token_id)
+    flow.data = {
+        "stale_access_token_id": token_id,
+        "token": "Old",
+        "owner": "Frenck",
+        "last_active": "2025-01-01",
+    }
+    return flow
+
+
+async def test_fix_flow_remove_revokes_token(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test confirming the fix flow revokes the token."""
+    """Test the revoke menu option removes the token."""
     token = _token("stale", TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN, 400, "Old")
     removed: list[object] = []
 
@@ -189,11 +203,7 @@ async def test_fix_flow_revokes_token(
         "async_get_refresh_token",
         lambda ref: token if ref == "stale" else None,
     )
-    monkeypatch.setattr(
-        hass.auth,
-        "async_remove_refresh_token",
-        removed.append,
-    )
+    monkeypatch.setattr(hass.auth, "async_remove_refresh_token", removed.append)
 
     flow = await async_create_fix_flow(
         hass,
@@ -207,35 +217,56 @@ async def test_fix_flow_revokes_token(
     )
     assert isinstance(flow, StaleAccessTokenFixFlow)
     flow.hass = hass
+    flow.data = {"stale_access_token_id": "stale"}
 
-    # The form is shown first, no token removed yet.
-    await flow.async_step_init()
+    # The menu is shown first, no token removed yet.
+    menu = await flow.async_step_init()
+    assert menu["type"] == "menu"
     assert not removed
 
-    # Confirming revokes the token.
-    await flow.async_step_confirm({})
+    # Choosing revoke removes the token.
+    result = await flow.async_step_remove()
+    assert result["type"] == "create_entry"
     assert removed == [token]
 
 
-async def test_fix_flow_survives_already_revoked_token(
+async def test_fix_flow_remove_survives_already_revoked_token(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test confirming a token that is already gone does not blow up."""
+    """Test revoking a token that is already gone does not blow up."""
     removed: list[object] = []
-    monkeypatch.setattr(
-        hass.auth,
-        "async_get_refresh_token",
-        lambda _token_id: None,
-    )
-    monkeypatch.setattr(
-        hass.auth,
-        "async_remove_refresh_token",
-        removed.append,
-    )
+    monkeypatch.setattr(hass.auth, "async_get_refresh_token", lambda _ref: None)
+    monkeypatch.setattr(hass.auth, "async_remove_refresh_token", removed.append)
 
-    flow = StaleAccessTokenFixFlow("gone", {})
-    flow.hass = hass
+    flow = _token_flow(hass, "gone")
+    result = await flow.async_step_remove()
 
-    await flow.async_step_confirm({})
+    assert result["type"] == "create_entry"
     assert not removed
+
+
+async def test_fix_flow_ignore_option_dismisses_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the keep menu option ignores the issue and keeps the token."""
+    user = SimpleNamespace(
+        system_generated=False,
+        name="Frenck",
+        refresh_tokens={
+            "a": _token("stale", TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN, 400, "Old"),
+        },
+    )
+    _set_users(hass, monkeypatch, [user])
+    await SpookRepair(hass).async_inspect()
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id("stale"))
+
+    flow = _token_flow(hass, "stale")
+    result = await flow.async_step_ignore()
+
+    assert result["type"] == "abort"
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id("stale"))
+    assert issue is not None
+    assert issue.dismissed_version is not None


### PR DESCRIPTION
## Description

Makes the stale long-lived access token repair dismissable.

The repair is fixable, and Home Assistant sends a fixable issue straight to its fix flow, which has no ignore button. So a token you recognize and want to keep could not be dismissed: it kept nagging until revoked. This moves the token flow onto the shared remove-or-ignore menu the empty areas, floors, labels, and blueprints repairs already use.

Selecting the issue now opens a menu:

- **Revoke this token** revokes it (unchanged behaviour).
- **Keep it, stop telling me** ignores the issue and leaves the token in place. It ignores rather than resolves, so the dismissal sticks across inspections instead of the issue coming straight back.

No detection change; only the fix flow. The token flow becomes a small `_RemoveOrIgnoreFixFlow` subclass, and the fix-flow dispatcher folds the token into its lookup table.

## Motivation and Context

A fixable repair with no way to say "I know, leave it" is a poor fit for an advisory security-hygiene notice. Keeping a rarely-used token you actually rely on is a valid choice.

## How has this been tested?

- The revoke menu option revokes the token, and copes with a token that is already gone.
- The keep menu option ignores the issue while leaving the token in place (the issue stays but is marked ignored).
- Detection tests unchanged and still pass.
- Full suite green (671 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
