### PR TITLE
Offer a fix-it-myself link in repair fix flows

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -580,16 +580,27 @@ class _RemoveOrIgnoreFixFlow(RepairsFlow):
         self,
         _: dict[str, str] | None = None,
     ) -> FlowResult:
-        """Offer to remove the thing or keep and ignore it."""
+        """Offer to remove the thing, fix it yourself, or keep and ignore it."""
         return self.async_show_menu(
             step_id="init",
-            menu_options=["remove", "ignore"],
+            menu_options=["remove", "manage", "ignore"],
             description_placeholders=self._menu_placeholders(),
         )
 
     def _menu_placeholders(self) -> dict[str, str]:
         """Return the placeholders naming the thing in the menu step."""
         return {self._key: str((self.data or {}).get(self._key, ""))}
+
+    async def async_step_manage(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Point the user at where to fix it themselves.
+
+        Aborts rather than completing, so the issue stays until the user
+        actually resolves it. The abort message links to the right page.
+        """
+        return self.async_abort(reason="manage")
 
     async def async_step_remove(
         self,

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -277,12 +277,14 @@
             "description": "The area {area} has no devices, no entities, and no automation or script targeting it.\n\nRemove it, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
             "menu_options": {
               "remove": "Remove this empty area",
-              "ignore": "Keep it, stop telling me"
+              "ignore": "Keep it, stop telling me",
+              "manage": "Let me fix it myself"
             }
           }
         },
         "abort": {
-          "issue_ignored": "Spook will keep quiet about this area from now on."
+          "issue_ignored": "Spook will keep quiet about this area from now on.",
+          "manage": "You can manage this area yourself on the [Areas page](/config/areas/dashboard)."
         }
       }
     },
@@ -295,12 +297,14 @@
             "description": "The floor {floor} has no areas, and no automation or script targeting it.\n\nRemove it, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
             "menu_options": {
               "remove": "Remove this empty floor",
-              "ignore": "Keep it, stop telling me"
+              "ignore": "Keep it, stop telling me",
+              "manage": "Let me fix it myself"
             }
           }
         },
         "abort": {
-          "issue_ignored": "Spook will keep quiet about this floor from now on."
+          "issue_ignored": "Spook will keep quiet about this floor from now on.",
+          "manage": "You can manage this floor yourself on the [Areas page](/config/areas/dashboard)."
         }
       }
     },
@@ -337,13 +341,15 @@
             "description": "Spook has found a ghost in your people 👻\n\n{person} tracks the following device trackers, which are unknown to Home Assistant:\n\n{device_trackers}\n\nThis often happens when a device tracker was renamed or its integration was removed.\n\nRemove them from {person}, or keep them and Spook will stop pointing them out.\n\nSpook 👻 Your homie.",
             "menu_options": {
               "remove": "Remove these device trackers",
-              "ignore": "Keep them, stop telling me"
+              "ignore": "Keep them, stop telling me",
+              "manage": "Let me fix it myself"
             }
           }
         },
         "abort": {
           "issue_ignored": "Spook will keep quiet about this person from now on.",
-          "not_editable": "This person is set up in YAML, so Spook cannot edit it. Update the person in your configuration instead."
+          "not_editable": "This person is set up in YAML, so Spook cannot edit it. Update the person in your configuration instead.",
+          "manage": "You can manage this person yourself on the [People page](/config/person)."
         }
       }
     },
@@ -415,12 +421,14 @@
             "description": "The long-lived access token `{token}` (owner: {owner}) has not been used since {last_active}.\n\nRevoke it, or keep it and Spook will stop pointing it out. Revoking it stops anything still using this token from working until it gets a new one.\n\nSpook 👻 Your homie.",
             "menu_options": {
               "remove": "Revoke this token",
-              "ignore": "Keep it, stop telling me"
+              "ignore": "Keep it, stop telling me",
+              "manage": "Let me fix it myself"
             }
           }
         },
         "abort": {
-          "issue_ignored": "Spook will keep quiet about this token from now on."
+          "issue_ignored": "Spook will keep quiet about this token from now on.",
+          "manage": "You can manage long-lived access tokens yourself under [your profile's security settings](/profile/security)."
         }
       }
     },
@@ -445,12 +453,14 @@
             "description": "The blueprint {blueprint} is not used by any {domain}.\n\nRemove it, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
             "menu_options": {
               "remove": "Remove this unused blueprint",
-              "ignore": "Keep it, stop telling me"
+              "ignore": "Keep it, stop telling me",
+              "manage": "Let me fix it myself"
             }
           }
         },
         "abort": {
-          "issue_ignored": "Spook will keep quiet about this blueprint from now on."
+          "issue_ignored": "Spook will keep quiet about this blueprint from now on.",
+          "manage": "You can manage this blueprint yourself on the [Blueprints page](/config/blueprint/dashboard)."
         }
       }
     },
@@ -463,12 +473,14 @@
             "description": "The label {label} is not applied to any entity, device, or area, and no automation or script targets it.\n\nRemove it, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
             "menu_options": {
               "remove": "Remove this unused label",
-              "ignore": "Keep it, stop telling me"
+              "ignore": "Keep it, stop telling me",
+              "manage": "Let me fix it myself"
             }
           }
         },
         "abort": {
-          "issue_ignored": "Spook will keep quiet about this label from now on."
+          "issue_ignored": "Spook will keep quiet about this label from now on.",
+          "manage": "You can manage this label yourself on the [Labels page](/config/labels)."
         }
       }
     },

--- a/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
@@ -159,12 +159,28 @@ async def test_fix_flow_remove_option_removes_area(
     # The menu is shown first, area still present.
     menu = await flow.async_step_init()
     assert menu["type"] == FlowResultType.MENU
+    assert menu["menu_options"] == ["remove", "manage", "ignore"]
     assert area_registry.async_get_area(area.id) is not None
 
     # Choosing remove deletes the area.
     result = await flow.async_step_remove()
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert area_registry.async_get_area(area.id) is None
+
+
+async def test_fix_flow_manage_option_keeps_area(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test the fix-it-myself option aborts and leaves the area in place."""
+    area = area_registry.async_create("Ghost Room")
+
+    flow = _flow_for(hass, area.id, "Ghost Room")
+    result = await flow.async_step_manage()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "manage"
+    assert area_registry.async_get_area(area.id) is not None
 
 
 async def test_fix_flow_ignore_option_dismisses_issue(


### PR DESCRIPTION
## Description

Adds a third option to the fix flows that offer to clean something up. Until now those flows let you either have Spook fix it or ignore it. This adds a middle path: take me to the page and I will fix it myself.

The menu is now, for every remove-or-ignore fix flow:

- **Remove / Revoke** lets Spook do it (unchanged).
- **Let me fix it myself** points you at the right settings page and steps back.
- **Keep it, stop telling me** ignores the issue (unchanged).

The "fix it myself" option aborts the flow with a message linking to the relevant page, so the issue is not marked as resolved and stays until you actually handle it. This is one change on the shared `_RemoveOrIgnoreFixFlow` base, so all six flows using it pick it up at once: stale access tokens, empty areas, empty floors, unused labels, unused blueprints, and unknown device trackers on people.

Each issue links to its own page:

- Stale access token: your profile's security settings (`/profile/security`)
- Empty area and empty floor: the Areas page (`/config/areas/dashboard`)
- Unused label: the Labels page (`/config/labels`)
- Unused blueprint: the Blueprints page (`/config/blueprint/dashboard`)
- Unknown device trackers on a person: the People page (`/config/person`)

## Motivation and Context

Sometimes you do not want Spook to remove the thing for you, but you also do not want to dismiss the notice. You want to go fix it yourself. This gives that a first-class option and drops you on the right page.

## How has this been tested?

- The menu now offers `remove`, `manage`, and `ignore`.
- The fix-it-myself option aborts with the `manage` reason and leaves the thing in place.
- All existing remove and ignore paths are unchanged and still pass.
- Full suite green (687 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
