### PR TITLE
Offer to clean up unknown members in groups

### DIFF
--- a/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
+++ b/custom_components/spook/ectoplasms/group/repairs/unknown_members.py
@@ -56,12 +56,19 @@ class SpookRepair(AbstractSpookRepair):
                 if unknown_entities := async_filter_known_entity_ids(
                     self.hass, entity_ids=members, known_entity_ids=known_entity_ids
                 ):
+                    described = async_describe_unknown_entities(
+                        self.hass, sorted(unknown_entities)
+                    )
                     self.async_create_issue(
                         issue_id=entity.entity_id,
+                        is_fixable=True,
+                        data={
+                            "group_entity_id": entity.entity_id,
+                            "group": entity.name,
+                            "entities": described,
+                        },
                         translation_placeholders={
-                            "entities": async_describe_unknown_entities(
-                                self.hass, sorted(unknown_entities)
-                            ),
+                            "entities": described,
                             "group": entity.name,
                             "entity_id": entity.entity_id,
                         },

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -18,6 +18,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigEntryChange,
 )
+from homeassistant.const import CONF_ENTITIES
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
@@ -785,6 +786,58 @@ class PersonUnknownDeviceTrackerFixFlow(_RemoveOrIgnoreFixFlow):
         return self.async_create_entry(data={})
 
 
+class GroupUnknownMembersFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for a group's unknown members.
+
+    Prunes the missing members from a UI-managed group's config entry. Only
+    config-entry groups can be edited; a YAML group cannot, so that is
+    reported instead.
+    """
+
+    _key = "group"
+    _id_key = "group_entity_id"
+
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Name the group and its missing members in the menu step."""
+        data = self.data or {}
+        return {
+            "group": str(data.get("group", "")),
+            "entity_id": str(data.get("group_entity_id", "")),
+            "entities": str(data.get("entities", "")),
+        }
+
+    async def async_step_remove(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Remove the members that no longer exist from the group."""
+        entity_id = str((self.data or {}).get("group_entity_id", ""))
+        entity_registry = er.async_get(self.hass)
+
+        entry_entity = entity_registry.async_get(entity_id)
+        if entry_entity is None or entry_entity.config_entry_id is None:
+            # A YAML group; its members live in configuration.yaml.
+            return self.async_abort(reason="not_editable")
+
+        # If the config entry itself is already gone, there is nothing left
+        # to prune; the group's own entity is gone too, so the issue clears
+        # on the next inspection. Completing the flow is the honest outcome.
+        entry = self.hass.config_entries.async_get_entry(entry_entity.config_entry_id)
+        if entry is not None:
+            members = list(entry.options.get(CONF_ENTITIES) or [])
+            remaining = [
+                member
+                for member in members
+                if entity_registry.async_get(member) is not None
+                or self.hass.states.get(member) is not None
+            ]
+            if remaining != members:
+                self.hass.config_entries.async_update_entry(
+                    entry, options={**entry.options, CONF_ENTITIES: remaining}
+                )
+        return self.async_create_entry(data={})
+
+
 # Remove-or-ignore fix flows, keyed by the data field that identifies their
 # leftover registry thing.
 _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
@@ -794,6 +847,7 @@ _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
     "unused_label_id": UnusedLabelFixFlow,
     "unused_blueprint_path": UnusedBlueprintFixFlow,
     "person_entity_id": PersonUnknownDeviceTrackerFixFlow,
+    "group_entity_id": GroupUnknownMembersFixFlow,
 }
 
 

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -313,8 +313,25 @@
       "title": "Unknown entities used in the energy dashboard"
     },
     "group_unknown_members": {
-      "description": "Spook has found a ghost in your groups 👻\n\nWhile floating around, Spook crossed path with the following group:\n\n{group} (`{entity_id}`)\n\nThis group has members, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, edit the group, remove the use of these non-existing entities and restart Home Assistant.\n\nSpook 👻 Your homie.",
-      "title": "Unknown group members in: {group}"
+      "title": "Unknown group members in: {group}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Unknown group members in: {group}",
+            "description": "Spook has found a ghost in your groups 👻\n\nThe group {group} (`{entity_id}`) has members that are unknown to Home Assistant:\n\n{entities}\n\nRemove them from the group, or keep them and Spook will stop pointing them out.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Remove these members",
+              "manage": "Let me fix it myself",
+              "ignore": "Keep them, stop telling me"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this group from now on.",
+          "not_editable": "This group is set up in YAML, so Spook cannot edit it. Update the group in your configuration instead.",
+          "manage": "You can manage this group yourself on the [Helpers page](/config/helpers)."
+        }
+      }
     },
     "lovelace_missing_resources": {
       "description": "Spook has found a ghost in your dashboards 👻\n\nThe following dashboard resources point at files that do not exist:\n\n{resources}\n\n\n\nThis usually happens when a custom card or its files were removed but the resource stayed behind. To fix this error, open Settings > Dashboards > Resources and remove or correct these resources.\n\nSpook 👻 Your homie.",

--- a/tests/ectoplasms/group/__init__.py
+++ b/tests/ectoplasms/group/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook group ectoplasm."""

--- a/tests/ectoplasms/group/repairs/__init__.py
+++ b/tests/ectoplasms/group/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook group repairs."""

--- a/tests/ectoplasms/group/repairs/test_unknown_members.py
+++ b/tests/ectoplasms/group/repairs/test_unknown_members.py
@@ -1,0 +1,122 @@
+"""Tests for the group unknown members repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.group.repairs.unknown_members import SpookRepair
+from custom_components.spook.repairs import (
+    GroupUnknownMembersFixFlow,
+    async_create_fix_flow,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import entity_registry as er, issue_registry as ir
+
+_ISSUE_ID = "group_unknown_members_light.living"
+
+
+def _install_group(hass: HomeAssistant, entity_id: str, members: list[str]) -> None:
+    """Install a fake UI group entity into the group entity platform."""
+    entity = SimpleNamespace(entity_id=entity_id, name="Living", _entity_ids=members)
+    hass.data[DATA_ENTITY_PLATFORM] = {
+        "group": [SimpleNamespace(domain="light", entities={entity_id: entity})]
+    }
+
+
+async def test_unknown_member_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a group with a missing member is reported as fixable."""
+    hass.states.async_set("light.known", "on")
+    _install_group(hass, "light.living", ["light.known", "light.gone"])
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.is_fixable
+    assert issue.data
+    assert issue.data["group_entity_id"] == "light.living"
+    assert "light.gone" in issue.data["entities"]
+    assert "light.known" not in issue.data["entities"]
+
+
+async def test_group_with_known_members_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a group whose members all exist is left alone."""
+    hass.states.async_set("light.known", "on")
+    _install_group(hass, "light.living", ["light.known"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_fix_flow_remove_prunes_ui_group(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the remove option drops missing members from a UI group."""
+    hass.states.async_set("light.known", "on")
+    entry = MockConfigEntry(
+        domain="group",
+        options={"entities": ["light.known", "light.gone"], "group_type": "light"},
+    )
+    entry.add_to_hass(hass)
+    reg = entity_registry.async_get_or_create(
+        "light", "group", "living", config_entry=entry
+    )
+
+    flow = await async_create_fix_flow(
+        hass,
+        f"group_unknown_members_{reg.entity_id}",
+        {"group_entity_id": reg.entity_id, "group": "Living", "entities": "x"},
+    )
+    assert isinstance(flow, GroupUnknownMembersFixFlow)
+    flow.hass = hass
+    flow.data = {"group_entity_id": reg.entity_id, "group": "Living", "entities": "x"}
+
+    # The menu names the group and its entity id.
+    menu = await flow.async_step_init()
+    assert menu["description_placeholders"] == {
+        "group": "Living",
+        "entity_id": reg.entity_id,
+        "entities": "x",
+    }
+
+    result = await flow.async_step_remove()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options["entities"] == ["light.known"]
+
+
+async def test_fix_flow_remove_yaml_group_aborts(
+    hass: HomeAssistant,
+) -> None:
+    """Test a YAML group (no config entry) reports it cannot be edited."""
+    flow = GroupUnknownMembersFixFlow()
+    flow.hass = hass
+    flow.issue_id = "group_unknown_members_light.yaml_group"
+    flow.data = {
+        "group_entity_id": "light.yaml_group",
+        "group": "YAML",
+        "entities": "x",
+    }
+
+    result = await flow.async_step_remove()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "not_editable"


### PR DESCRIPTION
## Description

Turns the group unknown members repair into an actionable one. It already spots groups (UI-managed light, switch, and other groups, as well as YAML groups) that still list members which no longer exist. Now it offers to clean them up.

Selecting the issue opens a menu:

- **Remove these members** drops the missing members from the group. For a UI-managed group it edits the group's config entry, keeping every member that still exists (recomputed at fix time, so a member that came back is kept), and the group reloads without the ghosts.
- **Let me fix it myself** takes you to the Helpers page.
- **Keep them, stop telling me** ignores the issue.

Only UI-managed (config entry) groups can be edited. A YAML group lives in `configuration.yaml`, so its remove option reports that and points you at your configuration instead, the same way the person device tracker repair does.

This reuses the shared remove-or-ignore fix flow base; the group flow only overrides the remove step. First application of the actionable fix pattern to a UI-managed helper.

## Motivation and Context

Spook already found these; now it can fix them for you, or take you to the right place. Groups are the most common UI helper that ends up with dangling members after an entity is renamed or removed.

## How has this been tested?

- Detection of a group with a missing member (reported as fixable), and non-detection of a group whose members all exist.
- The remove option prunes the missing members from a UI group's config entry.
- A YAML group aborts the remove with the cannot-edit message.
- Full suite green (691 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
