### PR TITLE
Detect and prune missing members in min/max helpers

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/min_max_unknown_sources.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/min_max_unknown_sources.py
@@ -1,0 +1,87 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import entity_registry as er
+
+from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_suggestions import async_describe_unknown_entities
+from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+# The min/max helper stores its members under this option key, as entity
+# registry IDs or entity IDs (both resolved via ``er.async_resolve_entity_id``).
+_ENTITY_IDS = "entity_ids"
+
+
+def async_unknown_members(hass: HomeAssistant, entry: ConfigEntry) -> set[str]:
+    """Return the raw member references of a min/max helper that are gone."""
+    entity_registry = er.async_get(hass)
+    known_entity_ids = async_get_all_entity_ids(hass)
+
+    unknown: set[str] = set()
+    for value in entry.options.get(_ENTITY_IDS) or []:
+        if not isinstance(value, str):
+            continue
+        resolved = er.async_resolve_entity_id(entity_registry, value)
+        if resolved is None:
+            # A registry ID whose entry was deleted.
+            unknown.add(value)
+        elif async_filter_known_entity_ids(
+            hass, [resolved], known_entity_ids=known_entity_ids
+        ):
+            unknown.add(value)
+    return unknown
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds min/max helpers with members that no longer exist.
+
+    Reads the config entry options directly (a public API). The missing
+    members can be pruned, keeping the helper working on the ones that
+    remain, so the issue is fixable.
+    """
+
+    domain = "homeassistant"
+    repair = "min_max_unknown_sources"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    inspect_config_entry_changed = "min_max"
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        self.possible_issue_ids.clear()
+
+        for entry in self.hass.config_entries.async_entries("min_max"):
+            self.possible_issue_ids.add(entry.entry_id)
+
+            if not (unknown := async_unknown_members(self.hass, entry)):
+                continue
+
+            self.async_create_issue(
+                issue_id=entry.entry_id,
+                issue_domain=entry.domain,
+                is_fixable=True,
+                data={
+                    "min_max_config_entry_id": entry.entry_id,
+                    "helper": entry.title,
+                    "sources": async_describe_unknown_entities(
+                        self.hass, sorted(unknown)
+                    ),
+                },
+                translation_placeholders={
+                    "helper": entry.title,
+                    "sources": async_describe_unknown_entities(
+                        self.hass, sorted(unknown)
+                    ),
+                },
+            )

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_helper_source_references.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_helper_source_references.py
@@ -19,8 +19,9 @@ if TYPE_CHECKING:
 # value is either an entity ID or an entity registry ID (both resolved via
 # ``er.async_resolve_entity_id``); a key may hold a single value or a list.
 #
-# Deliberately excluded: ``group`` (already covered by the group unknown
-# members repair).
+# Deliberately excluded: ``group`` (covered by the group unknown members
+# repair) and ``min_max`` (covered by the min_max unknown sources repair,
+# which can prune the missing members).
 SOURCE_OPTION_KEYS: dict[str, tuple[str, ...]] = {
     "derivative": ("source",),
     "filter": ("entity_id",),
@@ -28,7 +29,6 @@ SOURCE_OPTION_KEYS: dict[str, tuple[str, ...]] = {
     "generic_thermostat": ("target_sensor", "heater"),
     "history_stats": ("entity_id",),
     "integration": ("source",),
-    "min_max": ("entity_ids",),
     "mold_indicator": (
         "indoor_temp_sensor",
         "indoor_humidity_sensor",

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -36,6 +36,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.async_ import create_eager_task
 
 from .const import DOMAIN, LOGGER
+from .entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from .entity_suggestions import async_describe_unknown_entities
 
 if TYPE_CHECKING:
@@ -51,6 +52,10 @@ if TYPE_CHECKING:
 # entities; inspections are CPU-bound and must not stall the loop on
 # large installations.
 INSPECTION_YIELD_INTERVAL = 50
+
+# A min/max helper needs at least this many members to function; Spook must
+# not prune it below this.
+_MIN_MAX_MINIMUM_MEMBERS = 2
 
 
 class AbstractSpookRepairBase(ABC):
@@ -838,6 +843,55 @@ class GroupUnknownMembersFixFlow(_RemoveOrIgnoreFixFlow):
         return self.async_create_entry(data={})
 
 
+class MinMaxUnknownSourcesFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for a min/max helper's missing members.
+
+    Prunes the members that no longer exist from the helper's config entry,
+    keeping the ones that remain, so the helper carries on working.
+    """
+
+    _key = "helper"
+    _id_key = "min_max_config_entry_id"
+
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Name the helper and its missing members in the menu step."""
+        data = self.data or {}
+        return {
+            "helper": str(data.get("helper", "")),
+            "sources": str(data.get("sources", "")),
+        }
+
+    async def async_step_remove(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Remove the members that no longer exist from the helper."""
+        entry_id = str((self.data or {}).get("min_max_config_entry_id", ""))
+        entry = self.hass.config_entries.async_get_entry(entry_id)
+        if entry is not None:
+            entity_registry = er.async_get(self.hass)
+            known_entity_ids = async_get_all_entity_ids(self.hass)
+            members = list(entry.options.get("entity_ids") or [])
+            remaining = [
+                value
+                for value in members
+                if (resolved := er.async_resolve_entity_id(entity_registry, value))
+                is not None
+                and not async_filter_known_entity_ids(
+                    self.hass, [resolved], known_entity_ids=known_entity_ids
+                )
+            ]
+            if remaining != members:
+                if len(remaining) < _MIN_MAX_MINIMUM_MEMBERS:
+                    # A min/max helper needs at least two members; pruning
+                    # would leave too few and break it. Let the user decide.
+                    return self.async_abort(reason="too_few_members")
+                self.hass.config_entries.async_update_entry(
+                    entry, options={**entry.options, "entity_ids": remaining}
+                )
+        return self.async_create_entry(data={})
+
+
 # Remove-or-ignore fix flows, keyed by the data field that identifies their
 # leftover registry thing.
 _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
@@ -848,6 +902,7 @@ _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
     "unused_blueprint_path": UnusedBlueprintFixFlow,
     "person_entity_id": PersonUnknownDeviceTrackerFixFlow,
     "group_entity_id": GroupUnknownMembersFixFlow,
+    "min_max_config_entry_id": MinMaxUnknownSourcesFixFlow,
 }
 
 

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -345,6 +345,27 @@
       "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n[{dashboard}]({edit})\n\nThis dashboard references the following entities, which are unknown to Home Assistant:\n\n{entities}\n\n\n\nTo fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing entities.\n\nSpook 👻 Your homie.",
       "title": "Unknown entities used in: {dashboard}"
     },
+    "min_max_unknown_sources": {
+      "title": "Unknown members used in min/max helper: {helper}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Unknown members used in min/max helper: {helper}",
+            "description": "Spook has found a ghost in your helpers 👻\n\nThe min/max helper {helper} combines the following members, which are unknown to Home Assistant:\n\n{sources}\n\nRemove them so the helper carries on with the members that remain, or keep them and Spook will stop pointing them out.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Remove these members",
+              "manage": "Let me fix it myself",
+              "ignore": "Keep them, stop telling me"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this helper from now on.",
+          "manage": "You can manage this helper yourself on the [Helpers page](/config/helpers).",
+          "too_few_members": "A min/max helper needs at least two members, so removing the missing ones would leave too few. Reconfigure or remove the helper yourself on the [Helpers page](/config/helpers)."
+        }
+      }
+    },
     "orphaned_statistics": {
       "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Developer Tools > Statistics and fix them there, or remove them using the `recorder.clear_statistics` action.\n\nSpook 👻 Your homie.",
       "title": "Orphaned long-term statistics found"

--- a/tests/ectoplasms/homeassistant/repairs/test_min_max_unknown_sources.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_min_max_unknown_sources.py
@@ -1,0 +1,130 @@
+"""Tests for the min/max unknown sources repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.homeassistant.repairs.min_max_unknown_sources import (
+    SpookRepair,
+)
+from custom_components.spook.repairs import (
+    MinMaxUnknownSourcesFixFlow,
+    async_create_fix_flow,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+def _entry(hass: HomeAssistant, members: list[str]) -> MockConfigEntry:
+    """Add a min/max helper config entry with the given members."""
+    entry = MockConfigEntry(
+        domain="min_max",
+        title="Combined",
+        options={"entity_ids": members, "type": "max"},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _issue_id(entry: MockConfigEntry) -> str:
+    """Return the registry issue id for a helper entry."""
+    return f"min_max_unknown_sources_{entry.entry_id}"
+
+
+async def test_unknown_member_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a min/max helper with a missing member is reported as fixable."""
+    hass.states.async_set("sensor.known", "1")
+    entry = _entry(hass, ["sensor.known", "sensor.gone"])
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(entry))
+    assert issue
+    assert issue.is_fixable
+    assert issue.data
+    assert issue.data["min_max_config_entry_id"] == entry.entry_id
+    assert "sensor.gone" in issue.data["sources"]
+    assert "sensor.known" not in issue.data["sources"]
+
+
+async def test_deleted_registry_member_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a registry ID whose entry is gone is reported."""
+    entry = _entry(hass, ["01JGONEREGISTRYIDXXXXXXXXX"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(entry))
+
+
+async def test_all_known_members_create_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a helper whose members all exist is left alone."""
+    hass.states.async_set("sensor.known", "1")
+    entry = _entry(hass, ["sensor.known"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(entry)) is None
+
+
+async def test_fix_flow_remove_prunes_members(
+    hass: HomeAssistant,
+) -> None:
+    """Test the remove option drops the missing members from the helper."""
+    hass.states.async_set("sensor.known", "1")
+    hass.states.async_set("sensor.two", "2")
+    entry = _entry(hass, ["sensor.known", "sensor.two", "sensor.gone"])
+
+    flow = await async_create_fix_flow(
+        hass,
+        _issue_id(entry),
+        {
+            "min_max_config_entry_id": entry.entry_id,
+            "helper": "Combined",
+            "sources": "x",
+        },
+    )
+    assert isinstance(flow, MinMaxUnknownSourcesFixFlow)
+    flow.hass = hass
+    flow.data = {"min_max_config_entry_id": entry.entry_id}
+
+    result = await flow.async_step_remove()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options["entity_ids"] == ["sensor.known", "sensor.two"]
+
+
+async def test_fix_flow_remove_keeps_minimum_members(
+    hass: HomeAssistant,
+) -> None:
+    """Test pruning that would leave fewer than two members is refused."""
+    hass.states.async_set("sensor.known", "1")
+    entry = _entry(hass, ["sensor.known", "sensor.gone"])
+
+    flow = MinMaxUnknownSourcesFixFlow()
+    flow.hass = hass
+    flow.issue_id = _issue_id(entry)
+    flow.data = {"min_max_config_entry_id": entry.entry_id}
+
+    result = await flow.async_step_remove()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "too_few_members"
+    # The helper is left untouched.
+    assert entry.options["entity_ids"] == ["sensor.known", "sensor.gone"]

--- a/tests/ectoplasms/homeassistant/repairs/test_unknown_helper_source_references.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_unknown_helper_source_references.py
@@ -32,11 +32,6 @@ def _issue_id(entry: MockConfigEntry) -> str:
             id="single-key-source",
         ),
         pytest.param(
-            "min_max",
-            {"name": "Ghostly", "entity_ids": ["sensor.real", "sensor.ghost"]},
-            id="list-key",
-        ),
-        pytest.param(
             "generic_thermostat",
             {"name": "Ghostly", "target_sensor": "sensor.ghost", "heater": "switch.x"},
             id="multi-key",


### PR DESCRIPTION
## Description

Continues applying the actionable fix pattern to UI-managed helpers, this time to min/max helpers.

A min/max helper combines several member entities. When one is renamed or removed, the helper keeps referencing a member that no longer exists. This splits min/max out of the generic unknown helper source references repair into its own repair, so it can offer to clean it up.

Selecting the issue opens a menu:

- **Remove these members** prunes the members that no longer exist from the helper's config entry, resolving the registry IDs the min/max selector stores and recomputing which are gone at fix time, so a member that came back is kept. The helper carries on working with the members that remain. It never deletes the helper.
- **Let me fix it myself** takes you to the Helpers page.
- **Keep them, stop telling me** ignores the issue.

The other helpers in the generic repair (derivative, filter, statistics, and so on) are single-source: a missing source means the helper is broken, and pruning would leave it with nothing, so those stay as their informational notice rather than being auto-removed. min/max is the one member-list helper (alongside group) where pruning is the right, safe fix.

## Motivation and Context

Groups got this treatment already; min/max is the other common UI helper that ends up with dangling members. Spook already found these; now it can prune them for you or take you to the right place.

## How has this been tested?

- Detection of a min/max helper with a missing member (reported as fixable), a member stored as a deleted registry ID, and non-detection when all members exist.
- The remove option prunes the missing members from the config entry, keeping the ones that remain.
- Removed the now-moved min/max case from the generic helper repair's tests.
- Full suite green (696 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
