### PR TITLE
Offer to remove helpers whose source entities are gone

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_helper_source_references.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unknown_helper_source_references.py
@@ -113,12 +113,20 @@ class SpookRepair(AbstractSpookRepair):
             if not unknown:
                 continue
 
+            sources = "\n".join(f"- `{source}`" for source in sorted(unknown))
             self.async_create_issue(
                 issue_id=entry.entry_id,
                 issue_domain=entry.domain,
+                is_fixable=True,
+                data={
+                    "helper_config_entry_id": entry.entry_id,
+                    "helper": entry.title,
+                    "domain": entry.domain,
+                    "sources": sources,
+                },
                 translation_placeholders={
                     "helper": entry.title,
                     "domain": entry.domain,
-                    "sources": "\n".join(f"- `{source}`" for source in sorted(unknown)),
+                    "sources": sources,
                 },
             )

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -11,8 +11,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, final
 
 from homeassistant.components import blueprint
+from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.homeassistant import SERVICE_HOMEASSISTANT_RESTART
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.components.script import scripts_with_entity
 from homeassistant.config_entries import (
     SIGNAL_CONFIG_ENTRY_CHANGED,
     ConfigEntry,
@@ -40,7 +42,7 @@ from .entity_filtering import async_filter_known_entity_ids, async_get_all_entit
 from .entity_suggestions import async_describe_unknown_entities
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Mapping
+    from collections.abc import Callable, Coroutine, Mapping, Sized
     from datetime import datetime, timedelta
     from types import ModuleType
 
@@ -56,6 +58,11 @@ INSPECTION_YIELD_INTERVAL = 50
 # A min/max helper needs at least this many members to function; Spook must
 # not prune it below this.
 _MIN_MAX_MINIMUM_MEMBERS = 2
+
+
+def _plural(items: Sized) -> str:
+    """Return the plural suffix for a sized collection."""
+    return "" if len(items) == 1 else "s"
 
 
 class AbstractSpookRepairBase(ABC):
@@ -892,6 +899,63 @@ class MinMaxUnknownSourcesFixFlow(_RemoveOrIgnoreFixFlow):
         return self.async_create_entry(data={})
 
 
+class HelperUnknownSourcesFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for a helper whose source entities are gone.
+
+    A single-source helper whose source no longer exists is broken; there is
+    nothing to prune, so the fix is to remove the whole helper. Warns, up
+    front, when the helper is still used by automations or scripts, and is
+    honest that those become dangling references, which Spook itself will
+    then point out.
+    """
+
+    _key = "helper"
+    _id_key = "helper_config_entry_id"
+
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Name the helper, its missing sources, and where it is used."""
+        data = self.data or {}
+        return {
+            "helper": str(data.get("helper", "")),
+            "domain": str(data.get("domain", "")),
+            "sources": str(data.get("sources", "")),
+            "usage": self._usage_text(str(data.get("helper_config_entry_id", ""))),
+        }
+
+    def _usage_text(self, entry_id: str) -> str:
+        """Describe which automations and scripts still use the helper."""
+        entity_registry = er.async_get(self.hass)
+        automations: set[str] = set()
+        scripts: set[str] = set()
+        for entity in er.async_entries_for_config_entry(entity_registry, entry_id):
+            automations.update(automations_with_entity(self.hass, entity.entity_id))
+            scripts.update(scripts_with_entity(self.hass, entity.entity_id))
+
+        if not automations and not scripts:
+            return "It is not used by any automation or script."
+
+        parts: list[str] = []
+        if automations:
+            parts.append(f"{len(automations)} automation{_plural(automations)}")
+        if scripts:
+            parts.append(f"{len(scripts)} script{_plural(scripts)}")
+        return (
+            f"It is still used by {' and '.join(parts)}. Removing the helper "
+            "leaves them referencing a missing entity, which Spook will then "
+            "point out for you."
+        )
+
+    async def async_step_remove(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Remove the whole helper, if it still exists."""
+        entry_id = str((self.data or {}).get("helper_config_entry_id", ""))
+        if self.hass.config_entries.async_get_entry(entry_id) is not None:
+            await self.hass.config_entries.async_remove(entry_id)
+        return self.async_create_entry(data={})
+
+
 # Remove-or-ignore fix flows, keyed by the data field that identifies their
 # leftover registry thing.
 _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
@@ -903,6 +967,7 @@ _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
     "person_entity_id": PersonUnknownDeviceTrackerFixFlow,
     "group_entity_id": GroupUnknownMembersFixFlow,
     "min_max_config_entry_id": MinMaxUnknownSourcesFixFlow,
+    "helper_config_entry_id": HelperUnknownSourcesFixFlow,
 }
 
 

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -479,8 +479,24 @@
       "title": "Unknown entities in your customizations"
     },
     "unknown_helper_source_references": {
-      "description": "Spook has found a ghost in your helpers 👻\n\nWhile floating around, Spook crossed path with the following helper:\n\n{helper} (`{domain}`)\n\nThis helper references the following source entities, which are unknown to Home Assistant:\n\n{sources}\n\n\n\nThis often happens when a source entity was renamed or removed. To fix this error, reconfigure the helper to point at existing entities, or remove the helper.\n\nSpook 👻 Your homie.",
-      "title": "Unknown source entities used in helper: {helper}"
+      "title": "Unknown source entities used in helper: {helper}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Unknown source entities used in helper: {helper}",
+            "description": "Spook has found a ghost in your helpers 👻\n\nThe helper {helper} (`{domain}`) references the following source entities, which are unknown to Home Assistant:\n\n{sources}\n\nWithout its sources this helper cannot work. {usage}\n\nRemove the helper, or keep it and Spook will stop pointing it out.\n\nSpook 👻 Your homie.",
+            "menu_options": {
+              "remove": "Remove this helper",
+              "manage": "Let me fix it myself",
+              "ignore": "Keep it, stop telling me"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this helper from now on.",
+          "manage": "You can manage this helper yourself on the [Helpers page](/config/helpers)."
+        }
+      }
     },
     "unused_blueprints": {
       "title": "Unused blueprint: {blueprint}",

--- a/tests/ectoplasms/homeassistant/repairs/test_unknown_helper_source_references.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_unknown_helper_source_references.py
@@ -8,9 +8,14 @@ from typing import TYPE_CHECKING, Any
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import pytest
 
+from custom_components.spook import repairs
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.homeassistant.repairs.unknown_helper_source_references import (
     SpookRepair,
+)
+from custom_components.spook.repairs import (
+    HelperUnknownSourcesFixFlow,
+    async_create_fix_flow,
 )
 
 if TYPE_CHECKING:
@@ -169,3 +174,93 @@ async def test_bayesian_without_subentries_does_not_crash(
     await SpookRepair(hass).async_inspect()
 
     assert issue_registry.async_get_issue(DOMAIN, _issue_id(entry)) is None
+
+
+async def test_issue_is_fixable_with_config_entry_data(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the issue is fixable and carries the config entry id."""
+    entry = MockConfigEntry(
+        domain="derivative",
+        title="Ghostly",
+        options={"name": "Ghostly", "source": "sensor.ghost"},
+    )
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id(entry))
+    assert issue
+    assert issue.is_fixable
+    assert issue.data
+    assert issue.data["helper_config_entry_id"] == entry.entry_id
+
+
+async def test_fix_flow_remove_deletes_helper(
+    hass: HomeAssistant,
+) -> None:
+    """Test the remove option removes the whole helper config entry."""
+    entry = MockConfigEntry(
+        domain="derivative",
+        title="Ghostly",
+        options={"name": "Ghostly", "source": "sensor.ghost"},
+    )
+    entry.add_to_hass(hass)
+
+    flow = await async_create_fix_flow(
+        hass,
+        _issue_id(entry),
+        {"helper_config_entry_id": entry.entry_id, "helper": "Ghostly"},
+    )
+    assert isinstance(flow, HelperUnknownSourcesFixFlow)
+    flow.hass = hass
+    flow.data = {"helper_config_entry_id": entry.entry_id}
+
+    result = await flow.async_step_remove()
+
+    assert result["type"] == "create_entry"
+    assert hass.config_entries.async_get_entry(entry.entry_id) is None
+
+
+async def test_menu_warns_when_used_by_automation(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the menu warns, honestly, when the helper is still in use."""
+    entry = MockConfigEntry(domain="derivative", title="Ghostly")
+    entry.add_to_hass(hass)
+    reg = entity_registry.async_get_or_create(
+        "sensor", "derivative", "x", config_entry=entry
+    )
+    monkeypatch.setattr(
+        repairs,
+        "automations_with_entity",
+        lambda _hass, eid: ["automation.a"] if eid == reg.entity_id else [],
+    )
+
+    flow = HelperUnknownSourcesFixFlow()
+    flow.hass = hass
+    flow.data = {"helper_config_entry_id": entry.entry_id, "helper": "Ghostly"}
+
+    menu = await flow.async_step_init()
+    usage = menu["description_placeholders"]["usage"]
+    assert "1 automation" in usage
+    assert "Spook will then point out" in usage
+
+
+async def test_menu_reports_when_unused(
+    hass: HomeAssistant,
+) -> None:
+    """Test the menu states the helper is unused when it is."""
+    entry = MockConfigEntry(domain="derivative", title="Ghostly")
+    entry.add_to_hass(hass)
+
+    flow = HelperUnknownSourcesFixFlow()
+    flow.hass = hass
+    flow.data = {"helper_config_entry_id": entry.entry_id, "helper": "Ghostly"}
+
+    menu = await flow.async_step_init()
+    usage = menu["description_placeholders"]["usage"]
+    assert usage == "It is not used by any automation or script."


### PR DESCRIPTION
## Description

Completes the actionable fix pattern for UI-managed helpers, this time for the single-source ones.

The unknown helper source references repair already spots config-entry helpers (derivative, filter, statistics, threshold, trend, switch_as_x, utility_meter, integration, history_stats, generic_thermostat, generic_hygrostat, mold_indicator, bayesian) that reference a source entity which no longer exists. Unlike groups and min/max, these are single-source: without their source they cannot work, and there is nothing to prune. So the fix is to remove the whole helper.

Selecting the issue opens a menu:

- **Remove this helper** deletes the helper's config entry.
- **Let me fix it myself** takes you to the Helpers page.
- **Keep it, stop telling me** ignores the issue.

Before you remove it, the menu tells you, honestly, whether the helper is still used. It counts the automations and scripts that reference the helper's own entity and, when there are any, says so: removing the helper leaves them referencing a missing entity, which Spook will then point out for you (its automation and script reference repairs catch exactly that). When nothing uses it, it says so too. No hedging needed, because Spook cleans up the fallout.

This is the last of the UI-managed helper fix flows: groups and min/max prune their missing members, and the remaining single-source helpers offer removal.

## Motivation and Context

A helper whose source entity is gone is dead weight that only produces an unavailable entity. Spook already found these; now it can remove them for you, and is upfront about the knock-on references it will help you clean up next.

## How has this been tested?

- The issue is now fixable and carries the config entry id.
- The remove option deletes the helper config entry.
- The menu warns when the helper is still used by an automation, and states it is unused when it is not.
- Existing detection tests (single-key, multi-key, registry-ID sources, bayesian subentries) still pass.
- Full suite green (701 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
