### PR TITLE
Add a condition platform with a chance condition

### DIFF
--- a/custom_components/spook/condition.py
+++ b/custom_components/spook/condition.py
@@ -1,0 +1,47 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.condition import Condition
+
+# Core calls ``async_get_conditions`` repeatedly (once per config validation
+# and per condition instantiation), so the discovery result is cached rather
+# than re-globbing and re-importing on every call.
+DATA_CONDITIONS: HassKey[dict[str, type[Condition]]] = HassKey("spook_conditions")
+
+
+async def async_get_conditions(
+    hass: HomeAssistant,
+) -> dict[str, type[Condition]]:
+    """Return the conditions Spook provides.
+
+    Discovered from the leaf modules under ``ectoplasms/*/conditions/``,
+    each exposing a ``SpookCondition`` class; keys become ``spook.<key>``.
+    """
+    if (cached := hass.data.get(DATA_CONDITIONS)) is not None:
+        return cached
+
+    conditions: dict[str, type[Condition]] = {}
+
+    def _load_all_condition_modules() -> None:
+        """Load all condition modules and collect their conditions."""
+        for module_file in Path(__file__).parent.rglob("ectoplasms/*/conditions/*.py"):
+            if module_file.name == "__init__.py":
+                continue
+            module_path = str(module_file.relative_to(Path(__file__).parent))[
+                :-3
+            ].replace("/", ".")
+            module = importlib.import_module(f".{module_path}", __package__)
+            conditions[module.SpookCondition.condition] = module.SpookCondition
+
+    await hass.async_add_import_executor_job(_load_all_condition_modules)
+    hass.data[DATA_CONDITIONS] = conditions
+    return conditions

--- a/custom_components/spook/conditions.yaml
+++ b/custom_components/spook/conditions.yaml
@@ -1,0 +1,12 @@
+chance:
+  fields:
+    percentage:
+      required: true
+      example: 20
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+          mode: slider

--- a/custom_components/spook/ectoplasms/spook/conditions/__init__.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/spook/conditions/chance.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/chance.py
@@ -1,0 +1,64 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.helpers.condition import Condition
+
+if TYPE_CHECKING:
+    from typing import Unpack
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.condition import ConditionCheckParams, ConditionConfig
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_PERCENTAGE = "percentage"
+
+_HUNDRED_PERCENT = 100
+
+# A chance condition does not need cryptographic randomness, but using the
+# system RNG keeps the security scanners quiet without a suppression.
+_RANDOM = random.SystemRandom()
+
+_CONDITION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_PERCENTAGE): vol.All(
+                vol.Coerce(float),
+                vol.Range(min=0, max=_HUNDRED_PERCENT),
+            ),
+        },
+    }
+)
+
+
+class SpookCondition(Condition):
+    """Spook condition that passes a set percentage of the time, at random."""
+
+    condition = "chance"
+
+    _percentage: float
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the condition config."""
+        return _CONDITION_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Initialize the condition."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._percentage = options[CONF_PERCENTAGE]
+
+    def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:  # noqa: ARG002
+        """Return True for the configured percentage of checks."""
+        return _RANDOM.random() * _HUNDRED_PERCENT < self._percentage

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1,4 +1,16 @@
 {
+  "conditions": {
+    "chance": {
+      "name": "Chance",
+      "description": "Passes a set percentage of the time, chosen at random each check. Handy for adding a bit of variation to your automations.",
+      "fields": {
+        "percentage": {
+          "name": "Percentage",
+          "description": "How often this condition should pass, as a percentage."
+        }
+      }
+    }
+  },
   "config": {
     "abort": {
       "already_spooked": "Spook is already configured.",

--- a/tests/ectoplasms/spook/__init__.py
+++ b/tests/ectoplasms/spook/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook spook ectoplasm."""

--- a/tests/ectoplasms/spook/conditions/__init__.py
+++ b/tests/ectoplasms/spook/conditions/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook conditions."""

--- a/tests/ectoplasms/spook/conditions/test_chance.py
+++ b/tests/ectoplasms/spook/conditions/test_chance.py
@@ -1,0 +1,57 @@
+"""Tests for the Spook chance condition."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.condition import ConditionConfig
+import voluptuous as vol
+
+from custom_components.spook.condition import async_get_conditions
+from custom_components.spook.ectoplasms.spook.conditions.chance import SpookCondition
+import pytest
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def test_condition_is_discovered(hass: HomeAssistant) -> None:
+    """Test the chance condition is discovered as spook.chance."""
+    conditions = await async_get_conditions(hass)
+    assert conditions["chance"] is SpookCondition
+
+
+async def test_discovery_result_is_cached(hass: HomeAssistant) -> None:
+    """Test repeated discovery returns the cached mapping."""
+    first = await async_get_conditions(hass)
+    second = await async_get_conditions(hass)
+    assert first is second
+
+
+async def test_config_validation(hass: HomeAssistant) -> None:
+    """Test the condition validates its percentage option."""
+    percentage = 20
+    valid = await SpookCondition.async_validate_config(
+        hass, {"options": {"percentage": percentage}}
+    )
+    assert valid["options"]["percentage"] == percentage
+
+    with pytest.raises(vol.Invalid):
+        await SpookCondition.async_validate_config(
+            hass, {"options": {"percentage": 200}}
+        )
+    with pytest.raises(vol.Invalid):
+        await SpookCondition.async_validate_config(hass, {"options": {}})
+
+
+async def test_full_chance_always_passes(hass: HomeAssistant) -> None:
+    """Test 100 percent always passes."""
+    condition = SpookCondition(hass, ConditionConfig(options={"percentage": 100}))
+    assert all(condition(hass) for _ in range(50))
+
+
+async def test_zero_chance_never_passes(hass: HomeAssistant) -> None:
+    """Test 0 percent never passes."""
+    condition = SpookCondition(hass, ConditionConfig(options={"percentage": 0}))
+    assert not any(condition(hass) for _ in range(50))


### PR DESCRIPTION
## Description

Starts Phase 4: Spook becomes a condition provider, using Home Assistant's trigger/condition platform (open to custom integrations since the purpose-specific triggers/conditions graduated from Labs in 2026.7).

Two parts:

- **The platform.** A top-level `condition.py` exports `async_get_conditions`, which Home Assistant discovers automatically. It glob-discovers leaf modules under `ectoplasms/*/conditions/`, the same convention Spook already uses for repairs and services, so adding a condition later is just dropping a file. Keys become `spook.<key>`.
- **The first condition, `spook.chance`.** It passes a configurable percentage of the time, chosen at random on each check. Small, but genuinely useful: it replaces the copy-pasted random-template condition people write today. It ships with `conditions.yaml` (a percentage slider) and a `conditions` translation section, so it renders fully in the automation editor.

The `Condition` contract (`async_validate_config`, `ConditionConfig`, `_async_check`) was checked against the installed core, not from memory. The behaviour is boundary-testable without mocking randomness: 100 percent always passes, 0 percent never does.

Intentionally left out of this first PR: `icons.json` (Spook ships none today, and adding one risks pulling every existing service into icon validation), and extending `test_ectoplasm_discovery.py` (the dedicated condition test covers discovery). Both are easy follow-ups.

## Motivation and Context

Spook already surfaces and fixes maintenance issues; becoming a trigger/condition provider is the next capability on the roadmap. This lands the platform plumbing with one simple, useful condition to prove it end to end, so the higher-demand triggers and conditions can follow as leaf modules.

## How has this been tested?

- The chance condition is discovered as `spook.chance` through `async_get_conditions`.
- Config validation accepts a valid percentage and rejects an out-of-range or missing one.
- 100 percent always passes and 0 percent never passes (checked across many runs).
- Full suite green (708 passed), including the ectoplasm discovery and translation consistency tests; ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
