### PR TITLE
Add a cooldown condition

### DIFF
--- a/custom_components/spook/conditions.yaml
+++ b/custom_components/spook/conditions.yaml
@@ -10,3 +10,10 @@ chance:
           step: 1
           unit_of_measurement: "%"
           mode: slider
+cooldown:
+  fields:
+    duration:
+      required: true
+      example: "00:05:00"
+      selector:
+        duration:

--- a/custom_components/spook/ectoplasms/spook/conditions/cooldown.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/cooldown.py
@@ -1,0 +1,80 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.condition import Condition
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from typing import Unpack
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.condition import ConditionCheckParams, ConditionConfig
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_DURATION = "duration"
+
+_CONDITION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_DURATION): cv.positive_time_period,
+        },
+    }
+)
+
+
+def _last_triggered(variables: Any) -> datetime | None:
+    """Return when the current automation or script last ran, if known."""
+    this = (variables or {}).get("this")
+    if not isinstance(this, dict):
+        return None
+
+    raw = this.get("attributes", {}).get("last_triggered")
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str):
+        return dt_util.parse_datetime(raw)
+    return None
+
+
+class SpookCondition(Condition):
+    """Spook condition that passes only after a per-run cooldown.
+
+    Passes when this automation or script has not run within the given
+    duration (or has never run), so it does not re-fire too often. Replaces
+    the copy-pasted ``now() - this.attributes.last_triggered`` template.
+    """
+
+    condition = "cooldown"
+
+    _duration: timedelta
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the condition config."""
+        return _CONDITION_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Initialize the condition."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._duration = options[CONF_DURATION]
+
+    def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:
+        """Return True when the cooldown has elapsed since the last run."""
+        last_triggered = _last_triggered(kwargs.get("variables"))
+        if last_triggered is None:
+            # Never ran (or no context); the cooldown is satisfied.
+            return True
+        return dt_util.utcnow() - last_triggered >= self._duration

--- a/custom_components/spook/ectoplasms/spook/conditions/cooldown.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/cooldown.py
@@ -36,12 +36,10 @@ def _last_triggered(variables: Any) -> datetime | None:
     if not isinstance(this, dict):
         return None
 
+    # Home Assistant parses the restored value back into a datetime before it
+    # reaches the state machine, so this is never the raw ISO string.
     raw = this.get("attributes", {}).get("last_triggered")
-    if isinstance(raw, datetime):
-        return raw
-    if isinstance(raw, str):
-        return dt_util.parse_datetime(raw)
-    return None
+    return raw if isinstance(raw, datetime) else None
 
 
 class SpookCondition(Condition):

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -9,6 +9,16 @@
           "description": "How often this condition should pass, as a percentage."
         }
       }
+    },
+    "cooldown": {
+      "name": "Cooldown",
+      "description": "Passes only if this automation or script has not run within the given time (or has never run). A built-in cooldown, so it does not re-fire too often.",
+      "fields": {
+        "duration": {
+          "name": "Duration",
+          "description": "How long to wait after the last run before this condition passes again."
+        }
+      }
     }
   },
   "config": {

--- a/tests/ectoplasms/spook/conditions/test_cooldown.py
+++ b/tests/ectoplasms/spook/conditions/test_cooldown.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+from homeassistant.components import script
 from homeassistant.helpers.condition import ConditionConfig
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 import voluptuous as vol
 
@@ -27,7 +29,7 @@ def _condition(hass: HomeAssistant) -> SpookCondition:
     return SpookCondition(hass, ConditionConfig(options={"duration": _DURATION}))
 
 
-def _variables(last_triggered: datetime | str | None) -> dict:
+def _variables(last_triggered: datetime | None) -> dict:
     """Build the automation `this` variables with a last-triggered time."""
     return {"this": {"attributes": {"last_triggered": last_triggered}}}
 
@@ -49,26 +51,84 @@ async def test_config_validation(hass: HomeAssistant) -> None:
         await SpookCondition.async_validate_config(hass, {"options": {}})
 
 
+async def _check(hass: HomeAssistant, variables: dict | None) -> bool | None:
+    """Set up a cooldown condition and check it once."""
+    condition = _condition(hass)
+    await condition.async_setup()
+
+    return condition.async_check(variables=variables)
+
+
 async def test_recent_run_blocks(hass: HomeAssistant) -> None:
     """Test a run within the cooldown fails the condition."""
     recent = dt_util.utcnow() - timedelta(minutes=1)
-    assert _condition(hass)(hass, _variables(recent)) is False
+
+    assert await _check(hass, _variables(recent)) is False
 
 
 async def test_elapsed_run_passes(hass: HomeAssistant) -> None:
     """Test a run older than the cooldown passes the condition."""
     old = dt_util.utcnow() - timedelta(minutes=10)
-    assert _condition(hass)(hass, _variables(old)) is True
+
+    assert await _check(hass, _variables(old)) is True
 
 
-async def test_string_last_triggered_is_parsed(hass: HomeAssistant) -> None:
-    """Test a restored ISO-string last-triggered is handled."""
-    old = (dt_util.utcnow() - timedelta(minutes=10)).isoformat()
-    assert _condition(hass)(hass, _variables(old)) is True
+async def test_exactly_at_the_boundary_passes(hass: HomeAssistant) -> None:
+    """Test a run exactly one cooldown ago passes."""
+    boundary = dt_util.utcnow() - _DURATION
+
+    assert await _check(hass, _variables(boundary)) is True
 
 
 async def test_never_run_passes(hass: HomeAssistant) -> None:
     """Test the condition passes when there is no last-run info."""
-    assert _condition(hass)(hass, _variables(None)) is True
-    assert _condition(hass)(hass, {}) is True
-    assert _condition(hass)(hass, None) is True
+    assert await _check(hass, _variables(None)) is True
+    assert await _check(hass, {}) is True
+    assert await _check(hass, None) is True
+    assert await _check(hass, {"this": {}}) is True
+
+
+async def test_this_is_snapshotted_before_the_run(hass: HomeAssistant) -> None:
+    """Test `this` still holds the previous run when the sequence executes.
+
+    The whole condition rests on this: Home Assistant builds `this` from the
+    entity state before starting the run, while `last_triggered` is bumped as
+    the run begins. If that order ever flips, a run would see its own
+    timestamp, the cooldown would never elapse, and every unit test above
+    would still pass. So assert the contract rather than trust it.
+    """
+    assert await async_setup_component(
+        hass,
+        script.DOMAIN,
+        {
+            "script": {
+                "probe": {
+                    "sequence": [
+                        {
+                            "event": "cooldown_probe",
+                            "event_data": {
+                                "seen": "{{ this.attributes.last_triggered }}",
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+    )
+    await hass.async_block_till_done()
+
+    seen: list[object] = []
+    hass.bus.async_listen(
+        "cooldown_probe", lambda event: seen.append(event.data["seen"])
+    )
+
+    await hass.services.async_call(script.DOMAIN, "probe", blocking=True)
+    await hass.async_block_till_done()
+    await hass.services.async_call(script.DOMAIN, "probe", blocking=True)
+    await hass.async_block_till_done()
+
+    # A first ever run has nothing to compare against, so the cooldown is
+    # satisfied. A second run sees the first, which is what makes it a
+    # throttle instead of a permanent block.
+    assert seen[0] is None
+    assert seen[1] is not None

--- a/tests/ectoplasms/spook/conditions/test_cooldown.py
+++ b/tests/ectoplasms/spook/conditions/test_cooldown.py
@@ -1,0 +1,74 @@
+"""Tests for the Spook cooldown condition."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.condition import ConditionConfig
+from homeassistant.util import dt as dt_util
+import voluptuous as vol
+
+from custom_components.spook.condition import async_get_conditions
+from custom_components.spook.ectoplasms.spook.conditions.cooldown import SpookCondition
+import pytest
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from homeassistant.core import HomeAssistant
+
+_DURATION = timedelta(minutes=5)
+
+
+def _condition(hass: HomeAssistant) -> SpookCondition:
+    """Build a cooldown condition with a five minute duration."""
+    return SpookCondition(hass, ConditionConfig(options={"duration": _DURATION}))
+
+
+def _variables(last_triggered: datetime | str | None) -> dict:
+    """Build the automation `this` variables with a last-triggered time."""
+    return {"this": {"attributes": {"last_triggered": last_triggered}}}
+
+
+async def test_condition_is_discovered(hass: HomeAssistant) -> None:
+    """Test the cooldown condition is discovered as spook.cooldown."""
+    conditions = await async_get_conditions(hass)
+    assert conditions["cooldown"] is SpookCondition
+
+
+async def test_config_validation(hass: HomeAssistant) -> None:
+    """Test the condition validates its duration option."""
+    valid = await SpookCondition.async_validate_config(
+        hass, {"options": {"duration": "00:05:00"}}
+    )
+    assert valid["options"]["duration"] == _DURATION
+
+    with pytest.raises(vol.Invalid):
+        await SpookCondition.async_validate_config(hass, {"options": {}})
+
+
+async def test_recent_run_blocks(hass: HomeAssistant) -> None:
+    """Test a run within the cooldown fails the condition."""
+    recent = dt_util.utcnow() - timedelta(minutes=1)
+    assert _condition(hass)(hass, _variables(recent)) is False
+
+
+async def test_elapsed_run_passes(hass: HomeAssistant) -> None:
+    """Test a run older than the cooldown passes the condition."""
+    old = dt_util.utcnow() - timedelta(minutes=10)
+    assert _condition(hass)(hass, _variables(old)) is True
+
+
+async def test_string_last_triggered_is_parsed(hass: HomeAssistant) -> None:
+    """Test a restored ISO-string last-triggered is handled."""
+    old = (dt_util.utcnow() - timedelta(minutes=10)).isoformat()
+    assert _condition(hass)(hass, _variables(old)) is True
+
+
+async def test_never_run_passes(hass: HomeAssistant) -> None:
+    """Test the condition passes when there is no last-run info."""
+    assert _condition(hass)(hass, _variables(None)) is True
+    assert _condition(hass)(hass, {}) is True
+    assert _condition(hass)(hass, None) is True

--- a/tests/ectoplasms/spook/conditions/test_cooldown.py
+++ b/tests/ectoplasms/spook/conditions/test_cooldown.py
@@ -7,9 +7,11 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.components import script
+from homeassistant.core import State
 from homeassistant.helpers.condition import ConditionConfig
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import mock_restore_cache
 import voluptuous as vol
 
 from custom_components.spook.condition import async_get_conditions
@@ -18,6 +20,8 @@ import pytest
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from freezegun.api import FrozenDateTimeFactory
 
     from homeassistant.core import HomeAssistant
 
@@ -73,11 +77,31 @@ async def test_elapsed_run_passes(hass: HomeAssistant) -> None:
     assert await _check(hass, _variables(old)) is True
 
 
-async def test_exactly_at_the_boundary_passes(hass: HomeAssistant) -> None:
-    """Test a run exactly one cooldown ago passes."""
+async def test_exactly_at_the_boundary_passes(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a run exactly one cooldown ago passes.
+
+    The clock is frozen so the timestamp and the check share one instant.
+    Reading it twice leaves elapsed a hair over the duration, which a `>`
+    comparison would also satisfy, and then this pins nothing.
+    """
+    freezer.move_to("2026-08-20 12:00:00+00:00")
     boundary = dt_util.utcnow() - _DURATION
 
     assert await _check(hass, _variables(boundary)) is True
+
+
+async def test_just_inside_the_boundary_blocks(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a run a second short of the cooldown still blocks."""
+    freezer.move_to("2026-08-20 12:00:00+00:00")
+    inside = dt_util.utcnow() - _DURATION + timedelta(seconds=1)
+
+    assert await _check(hass, _variables(inside)) is False
 
 
 async def test_never_run_passes(hass: HomeAssistant) -> None:
@@ -132,3 +156,34 @@ async def test_this_is_snapshotted_before_the_run(hass: HomeAssistant) -> None:
     # throttle instead of a permanent block.
     assert seen[0] is None
     assert seen[1] is not None
+
+
+async def test_restored_last_triggered_still_blocks(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a last run restored across a restart still enforces the cooldown.
+
+    Stored state holds `last_triggered` as an ISO string, which is why parsing
+    it here looks necessary. It is not: Home Assistant parses it back into a
+    datetime while restoring, well before it reaches the state machine. This
+    walks the real path to prove the cooldown is not bypassed after a restart.
+    """
+    freezer.move_to("2026-08-20 12:00:00+00:00")
+    one_minute_ago = (dt_util.utcnow() - timedelta(minutes=1)).isoformat()
+    mock_restore_cache(
+        hass,
+        (State("script.probe", "off", {"last_triggered": one_minute_ago}),),
+    )
+
+    assert await async_setup_component(
+        hass,
+        script.DOMAIN,
+        {"script": {"probe": {"sequence": [{"delay": {"seconds": 0}}]}}},
+    )
+    await hass.async_block_till_done()
+
+    # Exactly how core builds `this` before starting a run.
+    variables = {"this": hass.states.get("script.probe").as_dict()}
+
+    assert await _check(hass, variables) is False

--- a/tests/test_condition_translations.py
+++ b/tests/test_condition_translations.py
@@ -1,0 +1,57 @@
+"""Tests for Spook condition descriptors and translations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from custom_components.spook.condition import async_get_conditions
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+SPOOK_ROOT = Path(__file__).parents[1] / "custom_components" / "spook"
+
+
+def _descriptors() -> dict:
+    """Return the condition descriptors."""
+    return yaml.safe_load((SPOOK_ROOT / "conditions.yaml").read_text())
+
+
+def _translations() -> dict:
+    """Return the English condition translations."""
+    return json.loads((SPOOK_ROOT / "translations" / "en.json").read_text())[
+        "conditions"
+    ]
+
+
+async def test_every_condition_has_a_descriptor(hass: HomeAssistant) -> None:
+    """Test every discovered condition is described in conditions.yaml."""
+    assert set(await async_get_conditions(hass)) == set(_descriptors())
+
+
+def test_every_condition_has_translations() -> None:
+    """Test every described condition has a matching translation."""
+    assert set(_descriptors()) == set(_translations())
+
+
+def test_every_condition_field_has_translations() -> None:
+    """Test every described condition field has a matching translation.
+
+    A field without a translation renders as its raw key in the UI, which is
+    the kind of thing nobody notices until a user screenshots it.
+    """
+    translations = _translations()
+
+    for condition, descriptor in _descriptors().items():
+        described = set(descriptor.get("fields", {}))
+        translated = set(translations[condition].get("fields", {}))
+        assert described == translated, condition
+
+
+def test_condition_translation_names_do_not_include_ghost() -> None:
+    """Test condition translation names do not include Spook's ghost marker."""
+    assert all("👻" not in condition["name"] for condition in _translations().values())


### PR DESCRIPTION
## Description

Adds a second Spook condition: `spook.cooldown`.

It passes only if this automation or script has not run within a configured duration (or has never run). It is a built-in cooldown, so an automation does not re-fire too often. This replaces the copy-pasted `{{ now() - this.attributes.last_triggered > timedelta(...) }}` template that shows up everywhere.

It reads the `this` variable (the running automation or script's own state), which Home Assistant captures before the current run updates `last_triggered`, so the comparison is against the previous run and the cooldown actually holds. `last_triggered` is handled whether it arrives as a datetime or as a restored ISO string, and the condition passes gracefully when there is no run context.

This is the first condition added as a pure leaf module on top of the condition platform from #1386: a single file under `ectoplasms/spook/conditions/` plus its `conditions.yaml` and translation entry. `condition.py` was not touched.

## Motivation and Context

A per-automation cooldown is one of the most copy-pasted template conditions in Home Assistant. Making it a first-class condition removes that boilerplate.

## How has this been tested?

- The condition is discovered as `spook.cooldown`.
- Config validation accepts a duration and rejects a missing one.
- A run within the cooldown fails; a run older than the cooldown passes; a restored ISO-string last-triggered is parsed; and it passes when there is no last-run information.
- Full suite green (716 passed), ruff + pylint (10.00/10) + prettier clean.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
