### PR TITLE
Fix some minor typos

### DIFF
--- a/custom_components/spook/ectoplasms/cloud/switch.py
+++ b/custom_components/spook/ectoplasms/cloud/switch.py
@@ -108,7 +108,7 @@ async def async_setup_entry(
 
 
 class HomeAssistantCloudSpookSwitchEntity(HomeAssistantCloudSpookEntity, SwitchEntity):
-    """Spook switch providig Home Asistant Cloud controls."""
+    """Spook switch providing Home Assistant Cloud controls."""
 
     entity_description: HomeAssistantCloudSpookSwitchEntityDescription
 

--- a/custom_components/spook/ectoplasms/homeassistant/button.py
+++ b/custom_components/spook/ectoplasms/homeassistant/button.py
@@ -78,7 +78,7 @@ async def async_setup_entry(
 
 
 class HomeAssistantSpookButtonEntity(HomeAssistantSpookEntity, ButtonEntity):
-    """Spook button providig Home Asistant actions."""
+    """Spook button providing Home Assistant actions."""
 
     entity_description: HomeAssistantSpookButtonEntityDescription
 

--- a/custom_components/spook/ectoplasms/homeassistant/sensor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/sensor.py
@@ -599,7 +599,7 @@ async def async_setup_entry(
 
 
 class HomeAssistantSpookSensorEntity(HomeAssistantSpookEntity, SensorEntity):
-    """Spook sensor providig Home Asistant information."""
+    """Spook sensor providing Home Assistant information."""
 
     entity_description: HomeAssistantSpookSensorEntityDescription
     _unsub_debouncer: Callable[[], None] | None = None

--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -9,7 +9,7 @@ date: 2024-02-10T15:58:22+01:00
 ---
 
 ```{image} https://brands.home-assistant.io/automation/logo.png
-:alt: The Home Asistant automation icon
+:alt: The Home Assistant automation icon
 :width: 250px
 :align: center
 ```


### PR DESCRIPTION
## Description

Corrects `Home Asistant` and `providig` typos in automation documentation and Home Assistant entity docstrings.

## Motivation and Context

These user-facing and developer-facing strings contain spelling errors.

## How has this been tested?

- Ran `git diff --check`.
- Searched the repository for `Home Asistant` and `providig`; no occurrences remain.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.