### PR TITLE
Guard device enable/disable helpers against via_device_id cycles

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/device.py
@@ -12,28 +12,33 @@ def async_disable_device_and_parent_if_needed(
     device_id: str,
 ) -> None:
     """Disable a device and its parent when no enabled child devices remain."""
-    device = device_registry.async_get(device_id)
-    if device is None:
-        return
+    # A registry can contain via_device_id cycles (including self-references),
+    # so track visited devices to avoid walking the chain forever.
+    seen: set[str] = set()
+    current_id: str | None = device_id
+    while current_id is not None and current_id not in seen:
+        seen.add(current_id)
+        device = device_registry.async_get(current_id)
+        if device is None:
+            return
 
-    if device.disabled_by is None:
-        device_registry.async_update_device(
-            device_id=device_id,
-            disabled_by=dr.DeviceEntryDisabler.USER,
-        )
+        if device.disabled_by is None:
+            device_registry.async_update_device(
+                device_id=current_id,
+                disabled_by=dr.DeviceEntryDisabler.USER,
+            )
 
-    if device.via_device_id is None:
-        return
+        if device.via_device_id is None:
+            return
 
-    if all(
-        child.id == device_id or child.disabled_by is not None
-        for child in device_registry.devices.values()
-        if child.via_device_id == device.via_device_id
-    ):
-        async_disable_device_and_parent_if_needed(
-            device_registry,
-            device.via_device_id,
-        )
+        if not all(
+            child.id == current_id or child.disabled_by is not None
+            for child in device_registry.devices.values()
+            if child.via_device_id == device.via_device_id
+        ):
+            return
+
+        current_id = device.via_device_id
 
 
 @callback
@@ -42,14 +47,22 @@ def async_enable_device_and_parent(
     device_id: str,
 ) -> None:
     """Enable a device and its parent device chain."""
-    device = device_registry.async_get(device_id)
-    if device is None:
-        return
+    # A registry can contain via_device_id cycles (including self-references),
+    # so track visited devices to avoid walking the chain forever.
+    chain: list[str] = []
+    seen: set[str] = set()
+    current_id: str | None = device_id
+    while current_id is not None and current_id not in seen:
+        device = device_registry.async_get(current_id)
+        if device is None:
+            break
+        seen.add(current_id)
+        chain.append(current_id)
+        current_id = device.via_device_id
 
-    if device.via_device_id is not None:
-        async_enable_device_and_parent(device_registry, device.via_device_id)
-
-    device_registry.async_update_device(
-        device_id=device_id,
-        disabled_by=None,
-    )
+    # Enable parents before their children, like the previous recursive walk
+    for chain_device_id in reversed(chain):
+        device_registry.async_update_device(
+            device_id=chain_device_id,
+            disabled_by=None,
+        )

--- a/tests/ectoplasms/homeassistant/services/test_device.py
+++ b/tests/ectoplasms/homeassistant/services/test_device.py
@@ -249,3 +249,71 @@ async def test_enable_device_service_enables_parent_device(
 
     assert device_registry.async_get(child.id).disabled_by is None
     assert device_registry.async_get(parent.id).disabled_by is None
+
+
+@pytest.mark.usefixtures("device_services")
+async def test_enable_device_service_survives_via_device_self_reference(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test enabling a device whose via_device_id points at itself."""
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "self-referencing-device")},
+        disabled_by=DeviceEntryDisabler.USER,
+    )
+    device_registry.async_update_device(device_id=device.id, via_device_id=device.id)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "enable_device",
+        {"device_id": device.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert device_registry.async_get(device.id).disabled_by is None
+
+
+@pytest.mark.usefixtures("device_services")
+async def test_device_services_survive_via_device_cycle(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+) -> None:
+    """Test the device services on two devices forming a via_device cycle."""
+    first = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "cycle-first-device")},
+    )
+    second = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "cycle-second-device")},
+    )
+    device_registry.async_update_device(device_id=first.id, via_device_id=second.id)
+    device_registry.async_update_device(device_id=second.id, via_device_id=first.id)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "disable_device",
+        {"device_id": first.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert device_registry.async_get(first.id).disabled_by is DeviceEntryDisabler.USER
+    assert device_registry.async_get(second.id).disabled_by is DeviceEntryDisabler.USER
+
+    await hass.services.async_call(
+        DOMAIN,
+        "enable_device",
+        {"device_id": first.id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert device_registry.async_get(first.id).disabled_by is None
+    assert device_registry.async_get(second.id).disabled_by is None


### PR DESCRIPTION
## Description

`async_enable_device_and_parent()` and `async_disable_device_and_parent_if_needed()` recurse over `device.via_device_id` with no cycle protection. A registry containing a `via_device_id` cycle — including a device pointing at itself — makes them recurse until `RecursionError` (the traceback in #1396 shows the same frame repeated ~950 times), which breaks the **Enable device** action entirely.

Both helpers now walk the chain iteratively and stop as soon as they see an already-visited device. The enable helper still enables parents before their children, and the disable helper keeps its exact semantics (only disables a parent when no enabled child devices remain, and never overwrites an existing `disabled_by` reason).

## Motivation and Context

Fixes #1396 — regression report against v5.0.0 where enabling a device via the Spook action fails with `RecursionError: maximum recursion depth exceeded`.

## How has this been tested?

Two new tests in `tests/ectoplasms/homeassistant/services/test_device.py`:

- `test_enable_device_service_survives_via_device_self_reference`: a disabled device whose `via_device_id` points at itself is enabled without recursion.
- `test_device_services_survive_via_device_cycle`: two devices forming a `via_device_id` cycle can be disabled (both end up disabled) and re-enabled (both end up enabled) through the services.

Both pass, together with the existing device service tests. (`test_disable_device_service_preserves_parent_disabled_reason` fails on current `main` in my environment with and without this change — newer HA core ignores `disabled_by=CONFIG_ENTRY` at device creation — so it is unrelated.)

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
