### PR TITLE
Stop reporting devices split by Home Assistant Core 2026.8 as unknown

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -216,7 +216,20 @@ def async_filter_known_area_ids(
 def async_get_all_device_ids(hass: HomeAssistant) -> set[str]:
     """Return all device IDs, known to Home Assistant."""
     device_registry = dr.async_get(hass)
-    return {device.id for device in device_registry.devices.values()}
+    device_ids = {device.id for device in device_registry.devices.values()}
+
+    # Home Assistant Core 2026.8 split devices that belonged to multiple config
+    # entries into one device per config entry. The pre-split device ID is no
+    # longer registered, but it still resolves to those new devices, so anything
+    # targeting it keeps working. Those IDs are known, just not enumerated.
+    # Can be removed when Core drops composite devices in 2027.8.
+    get_composite_splits: Callable[[], Mapping[str, Any]] | None = getattr(
+        device_registry.devices, "get_composite_splits", None
+    )
+    if get_composite_splits is not None:
+        device_ids.update(get_composite_splits().keys())
+
+    return device_ids
 
 
 @callback

--- a/tests/ectoplasms/automation/repairs/test_unknown_device_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_device_references.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from custom_components.spook.ectoplasms.automation.repairs.unknown_device_references import (
     SpookRepair,
 )
@@ -14,6 +16,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import device_registry as dr
+    import pytest
 
 
 class MockAutomationEntity:
@@ -68,5 +72,47 @@ async def test_event_trigger_data_device_id_in_plural_triggers_is_not_reported_u
     )
     repair = SpookRepair(hass)
     repair._known_device_ids = set()
+
+    assert await repair._async_compute_unknown_references(entity) == set()
+
+
+async def test_pre_split_device_id_is_not_reported_unknown(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a device ID from before the Core 2026.8 device split is not unknown.
+
+    A device that belonged to multiple config entries was split into one device
+    per entry. Its original ID is gone from the registry, but Home Assistant
+    still resolves it to the new devices, so the automation keeps working.
+    """
+    entry = MockConfigEntry(domain="test", title="Test")
+    entry.add_to_hass(hass)
+    split = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("test", "split-device")},
+    )
+    # Stubbed so this test also runs on cores that predate the device split.
+    monkeypatch.setattr(
+        device_registry.devices,
+        "get_composite_splits",
+        lambda: {"pre-split-id": [split]},
+        raising=False,
+    )
+
+    entity = MockAutomationEntity(
+        raw_config={
+            "actions": [
+                {
+                    "action": "light.turn_on",
+                    "target": {"device_id": "pre-split-id"},
+                },
+            ],
+        },
+        referenced_devices={"pre-split-id"},
+    )
+    repair = SpookRepair(hass)
+    await repair._async_setup_inspection()
 
     assert await repair._async_compute_unknown_references(entity) == set()

--- a/tests/test_entity_filtering.py
+++ b/tests/test_entity_filtering.py
@@ -4,15 +4,23 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant.helpers import config_validation as cv
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+)
 
 from custom_components.spook.entity_filtering import (
+    async_filter_known_device_ids,
     async_filter_known_services,
     async_find_services_in_sequence,
+    async_get_all_device_ids,
 )
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    import pytest
 
 
 def test_find_services_skips_disabled_nested_steps() -> None:
@@ -85,3 +93,51 @@ async def test_templated_action_names_are_not_reported_unknown(
     found = async_find_services_in_sequence(sequence)
 
     assert async_filter_known_services(hass, services=found) == {"notify.ghost"}
+
+
+def test_registered_device_ids_are_known(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test registered devices are known and made-up IDs are not."""
+    entry = MockConfigEntry(domain="test", title="Test")
+    entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("test", "device")},
+    )
+
+    assert device.id in async_get_all_device_ids(hass)
+    assert async_filter_known_device_ids(
+        hass,
+        device_ids={device.id, "not-a-device"},
+    ) == {"not-a-device"}
+
+
+def test_composite_device_ids_are_known(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test pre-split device IDs are not reported as unknown.
+
+    Home Assistant Core 2026.8 split devices spanning multiple config entries
+    into one device per entry. The pre-split ID is gone from the registry, but
+    still resolves, so automations targeting it keep working.
+    """
+    entry = MockConfigEntry(domain="test", title="Test")
+    entry.add_to_hass(hass)
+    split = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("test", "split-device")},
+    )
+    # Stubbed so the test also runs on cores that predate the device split.
+    monkeypatch.setattr(
+        device_registry.devices,
+        "get_composite_splits",
+        lambda: {"pre-split-id": [split]},
+        raising=False,
+    )
+
+    assert "pre-split-id" in async_get_all_device_ids(hass)
+    assert async_filter_known_device_ids(hass, device_ids={"pre-split-id"}) == set()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Spook built its set of known device IDs by enumerating the device registry. Home Assistant Core 2026.8 splits a device that belonged to multiple config entries into one device per config entry, and the pre-split device is deliberately invisible to that enumeration. It is synthesized on demand instead, so anything targeting the old ID keeps working.

Result: Spook flagged every automation and script referencing such a device as referencing devices "which are unknown to Home Assistant", and told people to remove references that were perfectly fine.

This treats those pre-split IDs as known, guarded so Spook keeps working on Home Assistant Core versions that predate the split. Issues Spook already created clean themselves up on the next inspection, so nobody has to dismiss anything by hand.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The device registry rework landed in Home Assistant Core 2026.8 (see the [developer blog post](https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/)) and Spook started shouting about ghosts that were never there. People concluded the Core change had broken their automations, which it had not. That confusion is on Spook, and it needs to stop.

For the record, the only device reference case that genuinely stopped working is an event trigger matching on `event_data.device_id`. Spook has never reported that one, and Home Assistant Core is adding detection for it in the event trigger validator.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Added coverage at both levels: the shared `async_get_all_device_ids` / `async_filter_known_device_ids` helpers, and the automation device reference repair end to end. Both stub the Core lookup so the tests also run against the Home Assistant version this repository currently pins, which predates the device split.

Full suite passes (712 tests), ruff and pylint clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
