### PR TITLE
Set repairs up when loaded on a running Home Assistant

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -25,8 +25,6 @@ from .services import SpookServiceManager
 from .setup_helpers import async_forward_setup_entry
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import Event, HomeAssistant
 
@@ -87,18 +85,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Who you gonna call? SpookRepairManager!
     repairs = SpookRepairManager(hass)
 
-    _ghost_busters_unsub: Callable[[], None] | None = None
-
-    async def _ghost_busters(_: Event) -> None:
+    async def _ghost_busters(_: Event | None = None) -> None:
         """Send them in, time for some ghost chasing."""
         await repairs.async_setup()
         entry.async_on_unload(repairs.async_on_unload)
 
-    # Wait until Home Assistant is started, before doing repairs
-    _ghost_busters_unsub = async_listen_once_tracked(
-        hass, EVENT_HOMEASSISTANT_STARTED, _ghost_busters
-    )
-    entry.async_on_unload(_ghost_busters_unsub)
+    if hass.state == CoreState.running:
+        # Home Assistant is already up, so the started event has been and gone.
+        # This is the reload path, and setting up for the first time on a
+        # running instance. Waiting for an event that cannot fire again would
+        # leave every repair check dead until a core restart, silently.
+        await _ghost_busters()
+    else:
+        # Otherwise wait for a settled instance, so repairs do not inspect a
+        # half-loaded Home Assistant and report things that are still coming.
+        entry.async_on_unload(
+            async_listen_once_tracked(hass, EVENT_HOMEASSISTANT_STARTED, _ghost_busters)
+        )
 
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -65,6 +65,23 @@ class _NoopSpookRepairManager:
         """Unload no repairs."""
 
 
+class _RecordingSpookRepairManager:
+    """Repair manager that records whether it was set up."""
+
+    setups = 0
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the recording repair manager."""
+        self.hass = hass
+
+    async def async_setup(self) -> None:
+        """Record that repairs were set up."""
+        type(self).setups += 1
+
+    async def async_on_unload(self) -> None:
+        """Unload no repairs."""
+
+
 def _sub_integration_names() -> set[str]:
     """Return bundled Spook sub-integration names."""
     return {
@@ -296,3 +313,75 @@ async def test_setup_entry_restart_required_paths(
     assert issue.severity is ir.IssueSeverity.WARNING
     assert issue.translation_key == "restart_required"
     await original_async_stop()
+
+
+async def test_repairs_are_set_up_when_loaded_after_start(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test repairs still start when the entry loads after Home Assistant did.
+
+    Reloading the config entry, or setting Spook up for the first time on a
+    running instance, re-runs async_setup_entry long after
+    EVENT_HOMEASSISTANT_STARTED has fired. Waiting for that event alone leaves
+    every repair check dead until a core restart, with nothing in the log.
+    """
+
+    async def async_forward_no_platforms(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+    ) -> None:
+        """Forward no ectoplasm setup."""
+
+    monkeypatch.setattr(spook, "PLATFORMS", [])
+    monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_noop)
+    monkeypatch.setattr(spook, "async_forward_setup_entry", async_forward_no_platforms)
+    monkeypatch.setattr(spook, "SpookServiceManager", _NoopSpookServiceManager)
+    monkeypatch.setattr(spook, "SpookRepairManager", _RecordingSpookRepairManager)
+    monkeypatch.setattr(_RecordingSpookRepairManager, "setups", 0)
+
+    hass.set_state(CoreState.running)
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _RecordingSpookRepairManager.setups == 1
+
+
+async def test_repairs_are_set_up_once_when_loaded_before_start(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the normal boot path still sets repairs up exactly once."""
+
+    async def async_forward_no_platforms(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+    ) -> None:
+        """Forward no ectoplasm setup."""
+
+    monkeypatch.setattr(spook, "PLATFORMS", [])
+    monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_noop)
+    monkeypatch.setattr(spook, "async_forward_setup_entry", async_forward_no_platforms)
+    monkeypatch.setattr(spook, "SpookServiceManager", _NoopSpookServiceManager)
+    monkeypatch.setattr(spook, "SpookRepairManager", _RecordingSpookRepairManager)
+    monkeypatch.setattr(_RecordingSpookRepairManager, "setups", 0)
+
+    hass.set_state(CoreState.not_running)
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Nothing yet, repairs deliberately wait for a settled instance.
+    assert _RecordingSpookRepairManager.setups == 0
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert _RecordingSpookRepairManager.setups == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`repairs.async_setup()` had a single call site: inside a `listen_once` handler for `EVENT_HOMEASSISTANT_STARTED`.

Reloading the config entry re-runs `async_setup_entry`, which registers that listener again, for an event that has already fired and cannot fire again. So the handler never runs, and every repair check stays dead until a Home Assistant core restart. No inspections, no new issues, and no cleanup of stale ones either. Nothing above debug level in the log to explain it.

The same applies when Spook is set up for the first time on an instance that is already running.

This sets repairs up straight away when Home Assistant is already up, and keeps waiting for the started event otherwise. That wait is deliberate and stays: it is what stops repairs inspecting a half-loaded instance during boot and reporting things that are still on their way.

Also removes a `_ghost_busters_unsub` variable that was assigned and then only ever read once on the next line, and the `Callable` import that existed for its annotation.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1410.

Worth flagging for triage: this may account for part of #1408, where a user deleted the flagged automations and was still being warned an hour later. If repairs are dead after a reload, the cleanup pass never runs either. #1411 describes a separate cause for stale issues, so that one still needs its own fix.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two tests in `tests/test_setup.py`, one per path, so neither can regress unnoticed:

- `test_repairs_are_set_up_when_loaded_after_start`: entry loads with `CoreState.running`, repairs are set up.
- `test_repairs_are_set_up_once_when_loaded_before_start`: entry loads with `CoreState.not_running`, nothing happens until `EVENT_HOMEASSISTANT_STARTED`, then exactly one setup.

The first fails without the change:

```
tests/test_setup.py::test_repairs_are_set_up_when_loaded_after_start FAILED
1 failed, 9 passed
```

With it, the full suite: `761 passed`, `ruff check` clean, `ruff format --check` clean, `pylint` 10.00/10.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
