### PR TITLE
Report missing scenes instead of ignoring every scene

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -16,6 +16,8 @@ from homeassistant.const import (
     CONF_REPEAT,
     CONF_SEQUENCE,
     CONF_SERVICE,
+    CONF_SERVICE_DATA,
+    CONF_SERVICE_DATA_TEMPLATE,
     CONF_THEN,
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
@@ -163,6 +165,7 @@ def async_setup_all_entity_ids_cache_invalidation(
         unsub_component_loaded()
         unsub_state_changed()
         cache.entity_ids = None
+        cache.created_scene_ids = None
         cache.unsubscribe = None  # Mark as unsubscribed
 
     cache.unsubscribe = _unsubscribe_listeners
@@ -190,7 +193,9 @@ def _find_created_scene_ids(config: Any) -> set[str]:
         return scene_ids
 
     if config.get("action", config.get(CONF_SERVICE)) in _SCENE_CREATE_ACTIONS:
-        data = config.get("data")
+        # This walks raw configuration, where the legacy `data_template` key
+        # has not been folded into `data` yet. Home Assistant still accepts it.
+        data = config.get(CONF_SERVICE_DATA, config.get(CONF_SERVICE_DATA_TEMPLATE))
         if isinstance(data, dict):
             scene_id = data.get(_CONF_SCENE_ID)
             # A templated scene_id cannot be resolved, so it is left alone and

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
-from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
+from homeassistant.components import automation, script
 from homeassistant.const import (
     CONF_CHOOSE,
     CONF_DEFAULT,
@@ -67,6 +66,12 @@ IGNORED_ENTITY_DOMAINS = (
 # `scene.create` builds a scene at runtime, named after its `scene_id`.
 _SCENE_CREATE_ACTIONS = ("scene.create",)
 _CONF_SCENE_ID = "scene_id"
+
+# Placeholders Home Assistant keeps for configurations it could not validate.
+_UNAVAILABLE_ENTITY_CLASSES = (
+    automation.UnavailableAutomationEntity,
+    script.UnavailableScriptEntity,
+)
 
 # Home Assistant's legacy time_date platform can create these entity IDs without
 # entity-registry entries. Treat them as known so references to configured
@@ -194,9 +199,18 @@ def _find_created_scene_ids(config: Any) -> set[str]:
 
     if config.get("action", config.get(CONF_SERVICE)) in _SCENE_CREATE_ACTIONS:
         # This walks raw configuration, where the legacy `data_template` key
-        # has not been folded into `data` yet. Home Assistant still accepts it.
-        data = config.get(CONF_SERVICE_DATA, config.get(CONF_SERVICE_DATA_TEMPLATE))
-        if isinstance(data, dict):
+        # has not been folded into `data` yet. Home Assistant accepts both and
+        # merges them, so read both rather than preferring one.
+        data = {
+            key: value
+            for payload in (
+                config.get(CONF_SERVICE_DATA),
+                config.get(CONF_SERVICE_DATA_TEMPLATE),
+            )
+            if isinstance(payload, dict)
+            for key, value in payload.items()
+        }
+        if data:
             scene_id = data.get(_CONF_SCENE_ID)
             # A templated scene_id cannot be resolved, so it is left alone and
             # the scene it builds stays reportable.
@@ -224,10 +238,15 @@ def async_get_created_scene_ids(hass: HomeAssistant) -> set[str]:
     if (scene_ids := cache.created_scene_ids) is None:
         scene_ids = set()
         instances = hass.data.get(DATA_INSTANCES, {})
-        for domain in (AUTOMATION_DOMAIN, SCRIPT_DOMAIN):
+        for domain in (automation.DOMAIN, script.DOMAIN):
             if (entity_component := instances.get(domain)) is None:
                 continue
             for entity in entity_component.entities:
+                if isinstance(entity, _UNAVAILABLE_ENTITY_CLASSES):
+                    # Kept around for a configuration Home Assistant rejected.
+                    # It cannot run, so it creates nothing.
+                    continue
+
                 if (raw_config := getattr(entity, "raw_config", None)) is not None:
                     scene_ids |= _find_created_scene_ids(raw_config)
         cache.created_scene_ids = scene_ids

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
+from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
 from homeassistant.const import (
     CONF_CHOOSE,
     CONF_DEFAULT,
@@ -20,6 +22,7 @@ from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_HOMEASSISTANT_START,
     EVENT_STATE_CHANGED,
+    Platform,
 )
 from homeassistant.core import (
     callback,
@@ -33,6 +36,7 @@ from homeassistant.helpers import (
     floor_registry as fr,
     label_registry as lr,
 )
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util.hass_dict import HassKey
 
 from .const import LOGGER
@@ -44,13 +48,23 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 
-# Entity domains to ignore when filtering unknown entities
+# Entity domains to ignore when filtering unknown entities. These can be
+# created on the fly by an action, so a reference to one that does not exist
+# yet is not necessarily broken.
+#
+# Scenes used to be in here for the same reason. They are not any more: a
+# scene created by an action is found by scanning for `scene.create` instead,
+# which reports the genuinely missing ones rather than none of them. The same
+# treatment is possible for `group.set` and `device_tracker.see`.
 IGNORED_ENTITY_DOMAINS = (
     "device_tracker.",
     "group.",
     "persistent_notification.",
-    "scene.",
 )
+
+# `scene.create` builds a scene at runtime, named after its `scene_id`.
+_SCENE_CREATE_ACTIONS = ("scene.create",)
+_CONF_SCENE_ID = "scene_id"
 
 # Home Assistant's legacy time_date platform can create these entity IDs without
 # entity-registry entries. Treat them as known so references to configured
@@ -72,6 +86,7 @@ class EntityIDsCache:
     """Per Home Assistant instance cache of all known entity IDs."""
 
     entity_ids: set[str] | None = None
+    created_scene_ids: set[str] | None = None
     unsubscribe: Callable[[], None] | None = None
 
 
@@ -110,6 +125,7 @@ def async_setup_all_entity_ids_cache_invalidation(
         """Clear the cached set of all entity IDs."""
         LOGGER.debug("Clearing all_entity_ids cache.")
         cache.entity_ids = None
+        cache.created_scene_ids = None
 
     @callback
     def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
@@ -153,6 +169,70 @@ def async_setup_all_entity_ids_cache_invalidation(
     return _unsubscribe_listeners
 
 
+def _find_created_scene_ids(config: Any) -> set[str]:
+    """Find scene IDs a configuration creates, at any nesting depth.
+
+    Walks arbitrary nesting rather than the script grammar, because a
+    ``scene.create`` step is recognizable on its own and can sit inside any
+    branch, repeat or parallel block.
+    """
+    scene_ids: set[str] = set()
+
+    if isinstance(config, list):
+        for item in config:
+            scene_ids |= _find_created_scene_ids(item)
+        return scene_ids
+
+    if not isinstance(config, dict):
+        return scene_ids
+
+    if config.get(CONF_ENABLED) is False:
+        return scene_ids
+
+    if config.get("action", config.get(CONF_SERVICE)) in _SCENE_CREATE_ACTIONS:
+        data = config.get("data")
+        if isinstance(data, dict):
+            scene_id = data.get(_CONF_SCENE_ID)
+            # A templated scene_id cannot be resolved, so it is left alone and
+            # the scene it builds stays reportable.
+            if isinstance(scene_id, str) and scene_id:
+                scene_ids.add(f"{Platform.SCENE}.{scene_id}")
+
+    for value in config.values():
+        if isinstance(value, (dict, list)):
+            scene_ids |= _find_created_scene_ids(value)
+
+    return scene_ids
+
+
+@callback
+def async_get_created_scene_ids(hass: HomeAssistant) -> set[str]:
+    """Return scene entity IDs that configured actions create at runtime.
+
+    ``scene.create`` builds a scene while an automation or script runs, so
+    nothing in the registry knows about it until then, and after a restart it
+    is gone again until the action runs once more. Referencing one is not a
+    broken reference, so collect them and treat them as known.
+    """
+    cache = _async_get_cache(hass)
+
+    if (scene_ids := cache.created_scene_ids) is None:
+        scene_ids = set()
+        instances = hass.data.get(DATA_INSTANCES, {})
+        for domain in (AUTOMATION_DOMAIN, SCRIPT_DOMAIN):
+            if (entity_component := instances.get(domain)) is None:
+                continue
+            for entity in entity_component.entities:
+                if (raw_config := getattr(entity, "raw_config", None)) is not None:
+                    scene_ids |= _find_created_scene_ids(raw_config)
+        cache.created_scene_ids = scene_ids
+        LOGGER.debug(
+            "Spook found %s scenes created by configured actions", len(scene_ids)
+        )
+
+    return scene_ids.copy()
+
+
 @callback
 def async_get_all_entity_ids(
     hass: HomeAssistant, *, include_all_none: bool = False
@@ -173,6 +253,7 @@ def async_get_all_entity_ids(
         combined_entity_ids = entity_ids_from_registry.union(
             entity_ids_from_states,
             KNOWN_TIME_DATE_ENTITY_IDS,
+            async_get_created_scene_ids(hass),
         )
 
         # Filter out ignored domains

--- a/tests/ectoplasms/automation/repairs/test_unknown_scene_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_scene_references.py
@@ -1,0 +1,164 @@
+"""Tests for scene references in automations.
+
+Scenes were ignored wholesale, because `scene.create` builds them while an
+automation runs and nothing knows about them beforehand. These pin the
+narrower rule: a scene some configured action creates is known, any other
+missing scene is reported.
+"""
+
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import automation
+from homeassistant.setup import async_setup_component
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def _inspect(hass: HomeAssistant, actions: list[dict]) -> None:
+    """Set up an automation with the given actions and inspect it."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            "automation": [
+                {
+                    "alias": "Scene test",
+                    "triggers": [{"trigger": "event", "event_type": "poke"}],
+                    "actions": actions,
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+    await SpookRepair(hass)._async_inspect_with_cleanup()
+
+
+def _reported(issue_registry: ir.IssueRegistry) -> str | None:
+    """Return the reported entities for the test automation, if any."""
+    issue = issue_registry.async_get_issue(
+        DOMAIN, "automation_unknown_entity_references_automation.scene_test"
+    )
+    return issue.translation_placeholders["entities"] if issue else None
+
+
+async def test_missing_scene_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a scene that does not exist is reported."""
+    await _inspect(
+        hass,
+        [{"action": "scene.turn_on", "target": {"entity_id": "scene.deleted"}}],
+    )
+
+    assert "scene.deleted" in (_reported(issue_registry) or "")
+
+
+async def test_existing_scene_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a scene that exists is left alone."""
+    hass.states.async_set("scene.movie_night", "scening")
+
+    await _inspect(
+        hass,
+        [{"action": "scene.turn_on", "target": {"entity_id": "scene.movie_night"}}],
+    )
+
+    assert _reported(issue_registry) is None
+
+
+async def test_scene_created_by_an_action_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a scene the same automation creates is treated as known.
+
+    This is the snapshot-then-restore pattern, and the reason scenes were
+    ignored in the first place.
+    """
+    hass.states.async_set("light.hall", "on")
+
+    await _inspect(
+        hass,
+        [
+            {
+                "action": "scene.create",
+                "data": {"scene_id": "before", "snapshot_entities": ["light.hall"]},
+            },
+            {"action": "scene.turn_on", "target": {"entity_id": "scene.before"}},
+        ],
+    )
+
+    assert _reported(issue_registry) is None
+
+
+async def test_scene_created_in_a_nested_block_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a scene.create inside a branch still counts."""
+    hass.states.async_set("light.hall", "on")
+
+    await _inspect(
+        hass,
+        [
+            {
+                "if": [
+                    {"condition": "state", "entity_id": "light.hall", "state": "on"}
+                ],
+                "then": [
+                    {
+                        "action": "scene.create",
+                        "data": {
+                            "scene_id": "nested",
+                            "snapshot_entities": ["light.hall"],
+                        },
+                    },
+                ],
+            },
+            {"action": "scene.turn_on", "target": {"entity_id": "scene.nested"}},
+        ],
+    )
+
+    assert _reported(issue_registry) is None
+
+
+async def test_templated_scene_id_is_still_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a templated scene_id does not silence the scene it names.
+
+    Spook cannot know what the template renders to, so the safe answer is to
+    keep reporting rather than assume a match.
+    """
+    hass.states.async_set("light.hall", "on")
+
+    await _inspect(
+        hass,
+        [
+            {
+                "action": "scene.create",
+                "data": {
+                    "scene_id": "{{ 'dynamic' }}",
+                    "snapshot_entities": ["light.hall"],
+                },
+            },
+            {"action": "scene.turn_on", "target": {"entity_id": "scene.dynamic"}},
+        ],
+    )
+
+    assert "scene.dynamic" in (_reported(issue_registry) or "")

--- a/tests/ectoplasms/automation/repairs/test_unknown_scene_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_scene_references.py
@@ -230,3 +230,80 @@ async def test_scene_created_by_a_script_is_not_reported(
     )
 
     assert _reported(issue_registry) is None
+
+
+async def test_scene_id_in_either_payload_key_counts(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test both payload keys are read, not just whichever comes first.
+
+    A step can carry `data` and `data_template` at once, with the scene_id in
+    either. Home Assistant merges them, so preferring one key loses the other.
+    """
+    hass.states.async_set("light.hall", "on")
+
+    await _inspect(
+        hass,
+        [
+            {
+                "service": "scene.create",
+                "data": {"snapshot_entities": ["light.hall"]},
+                "data_template": {"scene_id": "split"},
+            },
+            {"action": "scene.turn_on", "target": {"entity_id": "scene.split"}},
+        ],
+    )
+
+    assert _reported(issue_registry) is None
+
+
+async def test_scene_created_by_a_broken_automation_is_still_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a configuration Home Assistant rejected does not vouch for a scene.
+
+    Home Assistant keeps a placeholder entity for an automation it could not
+    validate, and that placeholder still carries the raw configuration. It can
+    never run, so the scene it would have created does not exist.
+    """
+    hass.states.async_set("light.hall", "on")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            "automation": [
+                {
+                    # No triggers key, so validation fails and Home Assistant
+                    # keeps an unavailable placeholder for it.
+                    "alias": "Broken",
+                    "actions": [
+                        {
+                            "action": "scene.create",
+                            "data": {
+                                "scene_id": "never_made",
+                                "snapshot_entities": ["light.hall"],
+                            },
+                        },
+                    ],
+                },
+                {
+                    "alias": "Scene test",
+                    "triggers": [{"trigger": "event", "event_type": "poke"}],
+                    "actions": [
+                        {
+                            "action": "scene.turn_on",
+                            "target": {"entity_id": "scene.never_made"},
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass)._async_inspect_with_cleanup()
+
+    assert "scene.never_made" in (_reported(issue_registry) or "")

--- a/tests/ectoplasms/automation/repairs/test_unknown_scene_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_scene_references.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant.components import automation
+from homeassistant.components import automation, script
 from homeassistant.setup import async_setup_component
 
 from custom_components.spook.const import DOMAIN
@@ -162,3 +162,71 @@ async def test_templated_scene_id_is_still_reported(
     )
 
     assert "scene.dynamic" in (_reported(issue_registry) or "")
+
+
+async def test_scene_created_with_legacy_data_template_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the legacy `data_template` form is read too.
+
+    Raw configuration has not had `data_template` folded into `data` yet, and
+    Home Assistant still accepts it, so a scene created that way has to count.
+    """
+    hass.states.async_set("light.hall", "on")
+
+    await _inspect(
+        hass,
+        [
+            {
+                "service": "scene.create",
+                "data_template": {
+                    "scene_id": "legacy",
+                    "snapshot_entities": ["light.hall"],
+                },
+            },
+            {"action": "scene.turn_on", "target": {"entity_id": "scene.legacy"}},
+        ],
+    )
+
+    assert _reported(issue_registry) is None
+
+
+async def test_scene_created_by_a_script_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a scene a script creates counts for an automation that uses it.
+
+    Scripts are scanned as well as automations, because the snapshot and the
+    restore do not have to live in the same place.
+    """
+    hass.states.async_set("light.hall", "on")
+
+    assert await async_setup_component(
+        hass,
+        script.DOMAIN,
+        {
+            "script": {
+                "snapshotter": {
+                    "sequence": [
+                        {
+                            "action": "scene.create",
+                            "data": {
+                                "scene_id": "from_script",
+                                "snapshot_entities": ["light.hall"],
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+    )
+    await hass.async_block_till_done()
+
+    await _inspect(
+        hass,
+        [{"action": "scene.turn_on", "target": {"entity_id": "scene.from_script"}}],
+    )
+
+    assert _reported(issue_registry) is None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -223,7 +223,6 @@ async def test_filter_template_entities_ignores_ignored_domains(
     unknown = await async_filter_known_entity_ids_with_templates(
         hass,
         {
-            "{{ states('scene.goodnight') }}",
             "{{ states('group.family') }}",
             "{{ states('device_tracker.phone') }}",
             "persistent_notification.update",
@@ -233,6 +232,24 @@ async def test_filter_template_entities_ignores_ignored_domains(
     )
 
     assert unknown == {"light.missing"}
+
+
+async def test_filter_template_entities_reports_missing_scenes(
+    hass: HomeAssistant,
+) -> None:
+    """Test scenes are checked rather than ignored wholesale.
+
+    Scenes used to sit in the ignored domains because `scene.create` builds
+    them at runtime. Those are found by scanning configurations now, so a
+    scene nothing creates is a genuinely missing one.
+    """
+    unknown = await async_filter_known_entity_ids_with_templates(
+        hass,
+        {"{{ states('scene.goodnight') }}"},
+        known_entity_ids=set(),
+    )
+
+    assert unknown == {"scene.goodnight"}
 
 
 async def test_extract_entities_from_config_reuses_known_services(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Scenes have been in `IGNORED_ENTITY_DOMAINS` since early 2024, with this reasoning:

> Filter out scenes, groups & device_tracker entities. Those can be created on the fly with services, which we currently cannot detect yet. Let's prevent some false positives.

That guard applies on both sides. Scenes are stripped out of the known entity IDs *and* out of the references being checked, so no scene reference is ever inspected and a deleted scene stays invisible.

The "cannot detect yet" part is no longer true. Spook walks action configuration now, so the exact case the guard worried about is detectable: `scene.create` names the scene it builds through its `scene_id`. So collect those from automations and scripts, treat them as known, and let every other missing scene be reported.

A templated `scene_id` cannot be resolved, so the scene it builds stays reportable. Same direction as #1400 took for disabled steps: err towards saying too much rather than calling a broken reference harmless.

`group.` and `device_tracker.` stay ignored. `group.set` and `device_tracker.see` can get exactly the same treatment, but that belongs in its own change.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1412.

Reproduced first, with the config from the issue. Home Assistant reports the missing scene, Spook drops it on the floor:

```
referenced_entities: ['light.exists', 'scene.does_not_exist']
reported:            None
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

New `tests/ectoplasms/automation/repairs/test_unknown_scene_references.py`, five cases: a missing scene is reported, an existing one is not, a scene created by `scene.create` in the same config is not, the same nested inside an `if`/`then` is not, and a templated `scene_id` does not silence the scene it names.

Both halves are mutation tested, since this is the kind of change that can pass for the wrong reason:

```
put "scene." back in IGNORED_ENTITY_DOMAINS  -> the missing-scene tests fail
remove the scene.create scan                 -> the exemption tests fail
```

`tests/test_util.py::test_filter_template_entities_ignores_ignored_domains` asserted that scenes are ignored, so it loses its scene case and gains a sibling asserting the opposite.

Full suite: `767 passed`. `ruff check`, `ruff format --check` and `pylint` (10.00/10) clean over both `custom_components` and `tests`.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
