### PR TITLE
Count timers, counters and groups

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/sensor.py
+++ b/custom_components/spook/ectoplasms/homeassistant/sensor.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import (
     automation,
+    counter,
+    group,
     input_boolean,
     input_button,
     input_datetime,
@@ -17,6 +19,7 @@ from homeassistant.components import (
     person,
     script,
     sun,
+    timer,
     zone,
 )
 from homeassistant.components.sensor import (
@@ -166,6 +169,16 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
         value_fn=lambda hass: len(hass.states.async_entity_ids(Platform.CLIMATE)),
     ),
     HomeAssistantSpookSensorEntityDescription(
+        key=counter.DOMAIN,
+        translation_key="homeassistant_counter",
+        entity_id="sensor.counters",
+        icon="mdi:counter",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.TOTAL,
+        update_events={EVENT_COMPONENT_LOADED, er.EVENT_ENTITY_REGISTRY_UPDATED},
+        value_fn=lambda hass: len(hass.states.async_entity_ids(counter.DOMAIN)),
+    ),
+    HomeAssistantSpookSensorEntityDescription(
         key=Platform.COVER,
         translation_key="homeassistant_cover",
         entity_id="sensor.covers",
@@ -236,6 +249,16 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL,
         update_events={EVENT_COMPONENT_LOADED, er.EVENT_ENTITY_REGISTRY_UPDATED},
         value_fn=lambda hass: len(hass.states.async_entity_ids(Platform.FAN)),
+    ),
+    HomeAssistantSpookSensorEntityDescription(
+        key=group.DOMAIN,
+        translation_key="homeassistant_group",
+        entity_id="sensor.groups",
+        icon="mdi:google-circles-communities",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.TOTAL,
+        update_events={EVENT_COMPONENT_LOADED, er.EVENT_ENTITY_REGISTRY_UPDATED},
+        value_fn=lambda hass: len(hass.states.async_entity_ids(group.DOMAIN)),
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.HUMIDIFIER,
@@ -513,6 +536,16 @@ SENSORS: tuple[HomeAssistantSpookSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL,
         update_events={EVENT_COMPONENT_LOADED, er.EVENT_ENTITY_REGISTRY_UPDATED},
         value_fn=lambda hass: len(hass.states.async_entity_ids(Platform.TIME)),
+    ),
+    HomeAssistantSpookSensorEntityDescription(
+        key=timer.DOMAIN,
+        translation_key="homeassistant_timer",
+        entity_id="sensor.timers",
+        icon="mdi:timer-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.TOTAL,
+        update_events={EVENT_COMPONENT_LOADED, er.EVENT_ENTITY_REGISTRY_UPDATED},
+        value_fn=lambda hass: len(hass.states.async_entity_ids(timer.DOMAIN)),
     ),
     HomeAssistantSpookSensorEntityDescription(
         key=Platform.TODO,

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -1,7 +1,15 @@
 {
   "domain": "spook",
   "name": "Spook",
-  "after_dependencies": ["blueprint", "cloud", "energy", "proximity", "timer"],
+  "after_dependencies": [
+    "blueprint",
+    "cloud",
+    "counter",
+    "energy",
+    "group",
+    "proximity",
+    "timer"
+  ],
   "codeowners": ["@frenck"],
   "config_flow": true,
   "dependencies": [

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -108,6 +108,9 @@
       "homeassistant_climate": {
         "name": "Climate"
       },
+      "homeassistant_counter": {
+        "name": "Counters"
+      },
       "homeassistant_cover": {
         "name": "Covers"
       },
@@ -131,6 +134,9 @@
       },
       "homeassistant_fan": {
         "name": "Fans"
+      },
+      "homeassistant_group": {
+        "name": "Groups"
       },
       "homeassistant_humidifier": {
         "name": "Humidifiers"
@@ -209,6 +215,9 @@
       },
       "homeassistant_time": {
         "name": "Times"
+      },
+      "homeassistant_timer": {
+        "name": "Timers"
       },
       "homeassistant_todo": {
         "name": "To-do lists"

--- a/tests/ectoplasms/homeassistant/test_sensor.py
+++ b/tests/ectoplasms/homeassistant/test_sensor.py
@@ -75,7 +75,7 @@ def test_every_sensor_has_a_translation() -> None:
     missing = [
         sensor.translation_key
         for sensor in SENSORS
-        if sensor.translation_key not in translations
+        if not translations.get(sensor.translation_key, {}).get("name")
     ]
 
     assert not missing

--- a/tests/ectoplasms/homeassistant/test_sensor.py
+++ b/tests/ectoplasms/homeassistant/test_sensor.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from homeassistant.components import automation, script
+from homeassistant.components import automation, counter, group, script, timer
 
 from custom_components.spook.ectoplasms.homeassistant.sensor import SENSORS
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+
+SPOOK_ROOT = Path(__file__).parents[3] / "custom_components" / "spook"
 
 
 def _value_for_sensor(hass: HomeAssistant, key: str) -> int | None:
@@ -31,3 +35,47 @@ async def test_automation_count_excludes_restored_entities(hass: HomeAssistant) 
     hass.states.async_set("automation.restored", "unavailable", {"restored": True})
 
     assert _value_for_sensor(hass, automation.DOMAIN) == 1
+
+
+async def test_counter_count(hass: HomeAssistant) -> None:
+    """Test counters are counted."""
+    counters = ("counter.animals_detected", "counter.doorbell_presses")
+    for entity_id in counters:
+        hass.states.async_set(entity_id, "0")
+
+    assert _value_for_sensor(hass, counter.DOMAIN) == len(counters)
+
+
+async def test_group_count(hass: HomeAssistant) -> None:
+    """Test groups are counted."""
+    hass.states.async_set("group.exterior_lights", "on")
+
+    assert _value_for_sensor(hass, group.DOMAIN) == 1
+
+
+async def test_timer_count(hass: HomeAssistant) -> None:
+    """Test timers are counted."""
+    timers = ("timer.kitchen_lighting", "timer.laundry")
+    for entity_id in timers:
+        hass.states.async_set(entity_id, "idle")
+
+    assert _value_for_sensor(hass, timer.DOMAIN) == len(timers)
+
+
+def test_every_sensor_has_a_translation() -> None:
+    """Test every sensor description has a name to show.
+
+    Without a translation the entity falls back to showing its key, which
+    nobody notices until it is on someone's dashboard.
+    """
+    translations = json.loads((SPOOK_ROOT / "translations" / "en.json").read_text())[
+        "entity"
+    ]["sensor"]
+
+    missing = [
+        sensor.translation_key
+        for sensor in SENSORS
+        if sensor.translation_key not in translations
+    ]
+
+    assert not missing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds the three missing counters on the Home Assistant device: `sensor.timers`, `sensor.counters` and `sensor.groups`. Nearly every other domain already had one, so anyone swapping a hand written template sensor for a Spook one found a hole where these should be.

While in there, a second thing: nothing checked that a sensor has a name to show. I removed a translation and the entire suite stayed green, which means the entity would quietly fall back to rendering its raw translation key on someone's dashboard. `test_every_sensor_has_a_translation` closes that.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1390.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Four new tests in `tests/ectoplasms/homeassistant/test_sensor.py`: one per new domain, plus the translation parity check.

Mutation tested, both directions:

```
remove the timer translation  -> test_every_sensor_has_a_translation fails
remove the timer sensor       -> test_timer_count fails
```

Full suite: `771 passed`. `ruff check`, `ruff format --check` and `pylint` (10.00/10) clean over both `custom_components` and `tests`.

Note on `en.json`: the diff is nine added lines and nothing else. My first attempt rewrote the file through `json.dumps`, which reordered the `repairs_*` keys and unescaped an emoji, so I redid it as a plain text insertion.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
