### PR TITLE
Stop calling a helper API that Home Assistant is removing

### DIFF
--- a/custom_components/spook/integrations/spook_inverse/__init__.py
+++ b/custom_components/spook/integrations/spook_inverse/__init__.py
@@ -7,9 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.helper_integration import (
-    async_remove_helper_config_entry_from_source_device,
-)
+from homeassistant.helpers.helper_integration import async_remove_helper_devices
 
 from .config_flow import SpookInverseConfigFlowHandler
 from .const import CONF_HIDE_SOURCE
@@ -88,7 +86,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             )
         ):
             # Remove the spook_inverse config entry from the source device
-            async_remove_helper_config_entry_from_source_device(
+            async_remove_helper_devices(
                 hass,
                 helper_config_entry_id=config_entry.entry_id,
                 source_device_id=source_device_id,

--- a/tests/integrations/spook_inverse/test_init.py
+++ b/tests/integrations/spook_inverse/test_init.py
@@ -21,6 +21,7 @@ from custom_components.spook.integrations.spook_inverse.const import (
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    import pytest
 
 
 async def test_async_get_source_entity_device_id_resolves_entity_id(
@@ -172,3 +173,52 @@ async def test_async_remove_entry_preserves_user_hidden_source(
         entity_registry.async_get("switch.source").hidden_by
         is er.RegistryEntryHider.USER
     )
+
+
+async def test_async_migrate_entry_uses_no_deprecated_helper_api(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test migration does not call a Home Assistant API scheduled for removal.
+
+    Core logs a deprecation warning naming Spook's issue tracker, so a stale
+    call here sends users here to report a problem that is ours to fix.
+    """
+    source_entry = MockConfigEntry(domain="switch", title="Source")
+    source_entry.add_to_hass(hass)
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=source_entry.entry_id,
+        identifiers={("switch", "source-device")},
+    )
+    er.async_get(hass).async_get_or_create(
+        "switch",
+        "test",
+        "source",
+        suggested_object_id="source",
+        device_id=device.id,
+    )
+
+    migrated_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Inverse",
+        options={
+            CONF_ENTITY_ID: "switch.source",
+            CONF_HIDE_SOURCE: False,
+            "inverse_type": Platform.SWITCH,
+        },
+        version=1,
+        minor_version=1,
+    )
+    migrated_entry.add_to_hass(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=migrated_entry.entry_id,
+        identifiers={("switch", "source-device")},
+    )
+
+    assert await hass.config_entries.async_setup(migrated_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert migrated_entry.minor_version == MIGRATION_MINOR_VERSION
+    assert "deprecated function" not in caplog.text.lower()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

#1409 flagged two scheduled Home Assistant API removals. One is real, one is a scanner false positive. This fixes the real one.

**Real: `async_remove_helper_config_entry_from_source_device`, going in Core 2027.8.** It is a deprecated alias of `async_remove_helper_devices` and forwards the same two keyword arguments unchanged, so this is a straight swap with no behaviour change.

Not something to sit on until 2027, because the deprecation fires today and sends people here:

```
The deprecated function async_remove_helper_config_entry_from_source_device was
called from spook_inverse. It will be removed in HA Core 2027.8.0. Use
homeassistant.helpers.helper_integration.async_remove_helper_devices instead,
please create a bug report at https://github.com/frenck/spook/issues
```

Anyone migrating an inverse helper is being invited to open an issue about our homework.

**False positive: the 2026.11 statistics metadata.** The reporter suspected as much and they are right. Core only warns when the key is absent:

```python
if "mean_type" not in metadata and not _called_from_ws_api:
    report_usage(..., breaks_in_ha_version="2026.11", ...)
if "unit_class" not in metadata and not _called_from_ws_api:
```

`import_statistics.py` sets both unconditionally in the dict literal it passes, so neither check ever trips. #1294 already handled this and shipped in 5.0.0. The scanner matches on call arguments syntactically and cannot see into the metadata mapping. No change needed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1409.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Confirmed the warning is emitted before the change and gone after, by running the inverse migration tests with warning-level logging:

```
before: deprecation warnings: 1
after:  deprecation warnings: 0
```

`test_async_migrate_entry_uses_no_deprecated_helper_api` pins it: it runs the migration and asserts nothing logged a deprecated-function warning. Restoring the old call makes it fail, so it cannot quietly come back.

Full suite: `776 passed`. `ruff check`, `ruff format --check` and `pylint` (10.00/10) clean over both `custom_components` and `tests`.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
