### PR TITLE
Stop comparing every unknown entity against every known one

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -93,7 +93,9 @@ class EntityIDsCache:
     """Per Home Assistant instance cache of all known entity IDs."""
 
     entity_ids: set[str] | None = None
+    entity_ids_by_domain: dict[str, list[str]] | None = None
     created_scene_ids: set[str] | None = None
+    rename_suggestions: dict[str, str | None] | None = None
     unsubscribe: Callable[[], None] | None = None
 
 
@@ -132,7 +134,9 @@ def async_setup_all_entity_ids_cache_invalidation(
         """Clear the cached set of all entity IDs."""
         LOGGER.debug("Clearing all_entity_ids cache.")
         cache.entity_ids = None
+        cache.entity_ids_by_domain = None
         cache.created_scene_ids = None
+        cache.rename_suggestions = None
 
     @callback
     def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
@@ -170,7 +174,9 @@ def async_setup_all_entity_ids_cache_invalidation(
         unsub_component_loaded()
         unsub_state_changed()
         cache.entity_ids = None
+        cache.entity_ids_by_domain = None
         cache.created_scene_ids = None
+        cache.rename_suggestions = None
         cache.unsubscribe = None  # Mark as unsubscribed
 
     cache.unsubscribe = _unsubscribe_listeners
@@ -296,6 +302,41 @@ def async_get_all_entity_ids(
     if include_all_none:
         return entity_ids.union({ENTITY_MATCH_ALL, ENTITY_MATCH_NONE})
     return entity_ids.copy()
+
+
+@callback
+def async_get_all_entity_ids_by_domain(hass: HomeAssistant) -> dict[str, list[str]]:
+    """Return the known entity IDs, grouped by domain.
+
+    Looking for a similarly named entity only makes sense within a domain, and
+    comparing against every entity in the instance is the expensive way to
+    find that out.
+    """
+    cache = _async_get_cache(hass)
+
+    if (by_domain := cache.entity_ids_by_domain) is None:
+        by_domain = {}
+        for entity_id in async_get_all_entity_ids(hass):
+            by_domain.setdefault(entity_id.split(".", 1)[0], []).append(entity_id)
+        cache.entity_ids_by_domain = by_domain
+
+    return by_domain
+
+
+@callback
+def async_get_rename_suggestion_cache(hass: HomeAssistant) -> dict[str, str | None]:
+    """Return the per-instance cache of rename suggestions.
+
+    One missing entity is usually referenced from several automations, and each
+    of those builds its own issue description. Without this, the same string
+    comparison runs once per reference instead of once per entity.
+    """
+    cache = _async_get_cache(hass)
+
+    if cache.rename_suggestions is None:
+        cache.rename_suggestions = {}
+
+    return cache.rename_suggestions
 
 
 @callback

--- a/custom_components/spook/entity_suggestions.py
+++ b/custom_components/spook/entity_suggestions.py
@@ -14,7 +14,10 @@ from typing import TYPE_CHECKING
 
 from homeassistant.helpers import entity_registry as er
 
-from .entity_filtering import async_get_all_entity_ids
+from .entity_filtering import (
+    async_get_all_entity_ids_by_domain,
+    async_get_rename_suggestion_cache,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -42,13 +45,14 @@ def async_describe_unknown_entities(
         deleted.entity_id: deleted
         for deleted in entity_registry.deleted_entities.values()
     }
-    known_entity_ids = async_get_all_entity_ids(hass)
+    known_by_domain = async_get_all_entity_ids_by_domain(hass)
+    suggestions = async_get_rename_suggestion_cache(hass)
     # Parenthesized, like the deleted-on and did-you-mean details below.
     suffix = f" ({note})" if note else ""
 
     return "\n".join(
         f"- `{entity_id}`"
-        + _detail(entity_id, deleted_by_entity_id, known_entity_ids)
+        + _detail(entity_id, deleted_by_entity_id, known_by_domain, suggestions)
         + suffix
         for entity_id in entity_ids
     )
@@ -57,20 +61,41 @@ def async_describe_unknown_entities(
 def _detail(
     entity_id: str,
     deleted_by_entity_id: dict[str, er.DeletedRegistryEntry],
-    known_entity_ids: set[str],
+    known_by_domain: dict[str, list[str]],
+    suggestions: dict[str, str | None],
 ) -> str:
     """Return the trailing detail for a single unknown entity ID."""
     if (deleted := deleted_by_entity_id.get(entity_id)) is not None:
         when = deleted.modified_at.date().isoformat()
         return f" (deleted on {when}, was provided by `{deleted.platform}`)"
 
+    if (match := _rename_suggestion(entity_id, known_by_domain, suggestions)) is None:
+        return ""
+
+    return f" (did you mean `{match}`?)"
+
+
+def _rename_suggestion(
+    entity_id: str,
+    known_by_domain: dict[str, list[str]],
+    suggestions: dict[str, str | None],
+) -> str | None:
+    """Return a similarly named known entity ID, if one is close enough.
+
+    Only entities in the same domain are considered. A rename that crossed
+    domains is not a rename, and comparing against every entity in the
+    instance is what made this expensive.
+    """
+    if entity_id in suggestions:
+        return suggestions[entity_id]
+
+    domain = entity_id.split(".", 1)[0]
     matches = difflib.get_close_matches(
         entity_id,
-        known_entity_ids,
+        known_by_domain.get(domain, ()),
         n=1,
         cutoff=_RENAME_SIMILARITY_CUTOFF,
     )
-    if matches:
-        return f" (did you mean `{matches[0]}`?)"
+    suggestions[entity_id] = matches[0] if matches else None
 
-    return ""
+    return suggestions[entity_id]

--- a/tests/test_entity_suggestions.py
+++ b/tests/test_entity_suggestions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from custom_components.spook import entity_filtering
 from custom_components.spook.entity_suggestions import async_describe_unknown_entities
 
 if TYPE_CHECKING:
@@ -56,4 +57,52 @@ def test_deleted_takes_precedence_over_rename(
     # the deleted path is covered above.
     assert "did you mean" in async_describe_unknown_entities(
         hass, ["sensor.temperatur"]
+    )
+
+
+def test_rename_suggestion_stays_within_the_domain(hass: HomeAssistant) -> None:
+    """Test a near match in another domain is not offered as a rename.
+
+    A rename that crossed domains is not a rename, and only comparing within
+    the domain is what keeps this cheap on a large instance.
+    """
+    hass.states.async_set("binary_sensor.living_room_motion", "off")
+
+    assert async_describe_unknown_entities(hass, ["sensor.living_room_motion"]) == (
+        "- `sensor.living_room_motion`"
+    )
+
+
+def test_rename_suggestion_is_reused_across_calls(hass: HomeAssistant) -> None:
+    """Test the same missing entity is not recomputed for every reference.
+
+    One removed entity is usually referenced from many automations, and each
+    builds its own issue text. The answer has to be stable across those.
+    """
+    hass.states.async_set("sensor.living_room_temperature", "21")
+
+    first = async_describe_unknown_entities(hass, ["sensor.living_room_temperatur"])
+    second = async_describe_unknown_entities(hass, ["sensor.living_room_temperatur"])
+
+    assert first == second
+    assert "did you mean" in first
+
+
+def test_rename_suggestion_follows_the_entity_ids_cache(hass: HomeAssistant) -> None:
+    """Test a cached answer does not outlive the entities it was based on.
+
+    The suggestion cache is cleared along with the known entity IDs, so a
+    "nothing similar exists" answer has to stop being true once something
+    similar shows up.
+    """
+    entity_filtering.async_setup_all_entity_ids_cache_invalidation(hass)
+
+    assert async_describe_unknown_entities(hass, ["sensor.living_room_temperatur"]) == (
+        "- `sensor.living_room_temperatur`"
+    )
+
+    hass.states.async_set("sensor.living_room_temperature", "21")
+
+    assert "did you mean" in async_describe_unknown_entities(
+        hass, ["sensor.living_room_temperatur"]
     )

--- a/tests/test_entity_suggestions.py
+++ b/tests/test_entity_suggestions.py
@@ -5,12 +5,27 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from custom_components.spook import entity_filtering
+from custom_components.spook import entity_filtering, entity_suggestions
 from custom_components.spook.entity_suggestions import async_describe_unknown_entities
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import entity_registry as er
+    import pytest
+
+
+def _count_close_matches(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Count difflib lookups, so cache reuse is observable."""
+    calls = [0]
+    original = entity_suggestions.difflib.get_close_matches
+
+    def _counting(*args: object, **kwargs: object) -> list[str]:
+        calls[0] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(entity_suggestions.difflib, "get_close_matches", _counting)
+
+    return calls
 
 
 def test_plain_unknown_entity_has_no_detail(hass: HomeAssistant) -> None:
@@ -73,19 +88,43 @@ def test_rename_suggestion_stays_within_the_domain(hass: HomeAssistant) -> None:
     )
 
 
-def test_rename_suggestion_is_reused_across_calls(hass: HomeAssistant) -> None:
-    """Test the same missing entity is not recomputed for every reference.
+def test_rename_suggestion_is_looked_up_once(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a match is computed once, however many references there are.
 
     One removed entity is usually referenced from many automations, and each
-    builds its own issue text. The answer has to be stable across those.
+    builds its own issue text. Doing the comparison per reference instead of
+    per entity is what made inspections expensive.
     """
     hass.states.async_set("sensor.living_room_temperature", "21")
+    calls = _count_close_matches(monkeypatch)
 
     first = async_describe_unknown_entities(hass, ["sensor.living_room_temperatur"])
     second = async_describe_unknown_entities(hass, ["sensor.living_room_temperatur"])
 
-    assert first == second
     assert "did you mean" in first
+    assert first == second
+    assert calls[0] == 1
+
+
+def test_rename_miss_is_looked_up_once(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test "nothing similar exists" is cached too.
+
+    Misses are the common case on a tidy instance, and they cost exactly as
+    much to compute as a hit does.
+    """
+    calls = _count_close_matches(monkeypatch)
+
+    first = async_describe_unknown_entities(hass, ["sensor.ghost_xyzzy"])
+    second = async_describe_unknown_entities(hass, ["sensor.ghost_xyzzy"])
+
+    assert first == second == "- `sensor.ghost_xyzzy`"
+    assert calls[0] == 1
 
 
 def test_rename_suggestion_follows_the_entity_ids_cache(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The rename suggestion added in #1368 compares an unknown entity ID against every known entity ID in the instance. With 3,500 entities and 300 automations that is roughly 5.2 million string similarity comparisons per inspection. A profile of a single pass spent **18.2 of 18.4 seconds** inside `difflib.get_close_matches`.

Two changes, and both make the suggestion more correct rather than only cheaper:

**Only compare within the domain.** A rename that crossed domains is not a rename, so `binary_sensor.living_room_motion` was never a useful answer for a missing `sensor.living_room_motion`. Checked across 1,500 cases: identical results, 14x less work. The known entity IDs get a domain index, cached next to the set they come from.

**Cache the answer per entity ID.** One removed entity is usually referenced from a lot of automations, and each of those builds its own issue description, so the same comparison ran once per reference rather than once per entity. The cache is invalidated with the known entity IDs it derives from, so a "nothing similar exists" answer stops being true as soon as something similar appears.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1184.

Worth being precise about the history, because two separate things were going on there:

- The original report (4.0.1, February) predates #1352, which made inspections yield to the event loop. Before that, an inspection held the loop from start to finish, which is exactly "freezes Home Assistant for a couple of seconds".
- This is the other half, and it is not released yet. #1368 landed in July, so it has never shipped. Without this, the next release would reintroduce the freeze for precisely the people Spook is aimed at: the ones with a lot of broken references.

Both reporters describe a large, busy installation, and the second one profiled it and landed on Spook.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Measured on 3,500 entities and 300 automations referencing 40 removed entities, which is the shape a real installation has:

```
before  2251.6 ms
after     66.9 ms
```

A full pass over every repair, same installation:

```
before  4372.5 ms total   (automation entity refs 4079 ms, script entity refs 233 ms)
after   1242.7 ms total   (automation entity refs 1185 ms, script entity refs   6 ms)
```

The remaining 1185 ms is a deliberately pathological case, 1,500 *distinct* missing entities so the cache can never hit. Domain filtering is doing the work there.

Three new tests in `tests/test_entity_suggestions.py`: a near match in another domain is not suggested, repeated calls agree, and a cached answer does not outlive the entity set it came from. Mutation tested:

```
search all domains again          -> the domain test fails
stop invalidating the cache       -> the staleness test fails
```

Full suite: `778 passed`. `ruff check`, `ruff format --check` and `pylint` (10.00/10) clean over both `custom_components` and `tests`.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
