### PR TITLE
Stop reporting action names as unknown entities

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -396,12 +396,47 @@ def async_filter_known_device_ids(
 
 
 @callback
+def async_drop_existing_action_names(
+    hass: HomeAssistant,
+    candidates: set[str],
+) -> set[str]:
+    """Return the candidates with existing action names removed.
+
+    An action name has the same shape as an entity ID, and some of them reach
+    a reference check as if they were one. A legacy notify group is the common
+    case: `notify.my_phone` is an action and no entity at all, and Home
+    Assistant reports it as a referenced entity when an automation uses it as
+    a legacy target. Scanning action payloads turns up the same thing, in
+    third-party actions that take a list of notifier names.
+
+    Nothing is dangling in either case, so an existing action is not an
+    unknown entity. Reporting it sends people looking for an entity that was
+    never supposed to exist.
+
+    Asks the registry per candidate rather than building the set of every
+    action in the instance, because this runs once per inspected item while
+    the candidates are only ever the handful that looked broken.
+    """
+    if not candidates:
+        return candidates
+
+    return {
+        candidate
+        for candidate in candidates
+        # Guarded: an exception here would abort the whole inspection, and not
+        # every caller has already checked the shape.
+        if "." not in candidate
+        or not hass.services.has_service(*candidate.split(".", 1))
+    }
+
+
+@callback
 def async_filter_known_entity_ids(
     hass: HomeAssistant,
     entity_ids: Iterable[str],
     known_entity_ids: set[str] | None = None,
 ) -> set[str]:
-    """Filter out known entity IDs.
+    """Filter out known entity IDs, and names that are actions.
 
     This callback version skips template processing. For template support,
     use async_filter_known_entity_ids_with_templates instead.
@@ -423,7 +458,7 @@ def async_filter_known_entity_ids(
             ):
                 result.add(entity_id)
 
-    return result
+    return async_drop_existing_action_names(hass, result)
 
 
 @callback

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.template import Template
 from .const import LOGGER
 from .entity_filtering import (
     IGNORED_ENTITY_DOMAINS,
+    async_drop_existing_action_names,
     async_get_all_entity_ids,
     async_get_all_services,
     split_comma_separated_entity_ids,
@@ -351,7 +352,8 @@ async def async_filter_known_entity_ids_with_templates(
     """Async version that can process templates to extract entity dependencies.
 
     This function processes both regular entity IDs and template strings,
-    extracting entity dependencies from templates using RenderInfo.
+    extracting entity dependencies from templates using RenderInfo. Names that
+    belong to an existing action are dropped, since those are not entities.
     """
     if known_entity_ids is None:
         known_entity_ids = async_get_all_entity_ids(hass)
@@ -390,7 +392,7 @@ async def async_filter_known_entity_ids_with_templates(
                     # Process as regular entity ID
                     unknown_entities.add(entity_id)
 
-    return unknown_entities
+    return async_drop_existing_action_names(hass, unknown_entities)
 
 
 def extract_template_strings_from_config(

--- a/tests/ectoplasms/automation/repairs/test_notify_action_names.py
+++ b/tests/ectoplasms/automation/repairs/test_notify_action_names.py
@@ -1,0 +1,174 @@
+"""Tests for action names reaching the entity reference check.
+
+An action name has the same shape as an entity ID. A legacy notify group is
+the common case: `notify.my_phone` is an action rather than an entity, and it
+arrives at the entity check through two different doors. Neither should
+produce a repair.
+"""
+
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components import automation
+from homeassistant.setup import async_setup_component
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def _inspect(hass: HomeAssistant, actions: list[dict]) -> None:
+    """Set up an automation with the given actions and inspect it."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            "automation": [
+                {
+                    "alias": "Notify router",
+                    "triggers": [{"trigger": "event", "event_type": "doorbell"}],
+                    "actions": actions,
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+    await SpookRepair(hass)._async_inspect_with_cleanup()
+
+
+def _reported(issue_registry: ir.IssueRegistry) -> str | None:
+    """Return the reported entities for the test automation, if any."""
+    issue = issue_registry.async_get_issue(
+        DOMAIN, "automation_unknown_entity_references_automation.notify_router"
+    )
+    return issue.translation_placeholders["entities"] if issue else None
+
+
+async def test_legacy_target_in_service_data_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a legacy notify group used as a target is left alone.
+
+    Home Assistant reads `data.entity_id` as a target and hands the name back
+    as a referenced entity, so this one does not even originate in Spook.
+    """
+    hass.services.async_register("notify", "my_phone", lambda _c: None)
+
+    await _inspect(
+        hass,
+        [
+            {
+                "service": "notify.notify",
+                "data": {"message": "Doorbell", "entity_id": "notify.my_phone"},
+            },
+        ],
+    )
+
+    assert _reported(issue_registry) is None
+
+
+async def test_notify_group_in_a_target_block_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a legacy notify group named in a target block is left alone."""
+    hass.services.async_register("notify", "all_phones", lambda _c: None)
+
+    await _inspect(
+        hass,
+        [
+            {
+                "action": "notify.send_message",
+                "target": {"entity_id": "notify.all_phones"},
+                "data": {"message": "Doorbell"},
+            },
+        ],
+    )
+
+    assert _reported(issue_registry) is None
+
+
+async def test_third_party_fan_out_payload_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test notifier names in a third-party action's payload are left alone.
+
+    A fan-out action takes a list of notifier names under a key of its own
+    choosing. Home Assistant sees nothing here; this arrives purely through
+    Spook scanning the payload.
+    """
+    hass.services.async_register("notify", "mobile_app_phone", lambda _c: None)
+    hass.services.async_register("notify", "old_tablet", lambda _c: None)
+
+    await _inspect(
+        hass,
+        [
+            {
+                "action": "notifier_hub.send",
+                "data": {
+                    "title": "Hello",
+                    "message": "World",
+                    "notify": ["notify.mobile_app_phone", "notify.old_tablet"],
+                },
+            },
+        ],
+    )
+
+    assert _reported(issue_registry) is None
+
+
+async def test_a_removed_entity_is_still_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the check still does its job alongside a notify group.
+
+    The point is dropping action names, not going quiet. A genuinely missing
+    entity in the same automation has to survive.
+    """
+    hass.services.async_register("notify", "my_phone", lambda _c: None)
+
+    await _inspect(
+        hass,
+        [
+            {
+                "action": "notify.send_message",
+                "target": {"entity_id": "notify.my_phone"},
+            },
+            {"action": "light.turn_on", "target": {"entity_id": "light.removed"}},
+        ],
+    )
+
+    reported = _reported(issue_registry) or ""
+    assert "light.removed" in reported
+    assert "notify.my_phone" not in reported
+
+
+async def test_a_removed_script_is_still_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an entity ID that doubles as an action name is not lost.
+
+    A script owns both `script.x` as an entity and `script.x` as an action, so
+    they appear and disappear together. Deleting one does not leave the other
+    behind to vouch for it.
+    """
+    hass.services.async_register("script", "turn_on", lambda _c: None)
+
+    await _inspect(
+        hass,
+        [{"action": "script.turn_on", "target": {"entity_id": "script.removed"}}],
+    )
+
+    assert "script.removed" in (_reported(issue_registry) or "")

--- a/tests/ectoplasms/template/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/template/repairs/test_unknown_entity_references.py
@@ -371,3 +371,42 @@ async def test_templated_enabled_counts_as_active(
     entities = issue.translation_placeholders["entities"]
     assert "light.gone" in entities
     assert "only referenced from disabled steps" not in entities
+
+
+async def test_notify_group_in_a_helper_action_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a legacy notify group called by a helper is not a missing entity.
+
+    Template helpers run actions too, so the same action name that trips the
+    automation check reaches this one as well.
+    """
+    hass.services.async_register("notify", "my_phone", lambda _call: None)
+
+    entry = MockConfigEntry(
+        domain="template",
+        title="Doorbell button",
+        options={
+            "name": "Doorbell button",
+            "template_type": "button",
+            "press": [
+                {
+                    "action": "notify.send_message",
+                    "target": {"entity_id": "notify.my_phone"},
+                    "data": {"message": "Doorbell"},
+                },
+            ],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(
+            DOMAIN,
+            f"template_unknown_entity_references_{entry.entry_id}",
+        )
+        is None
+    )

--- a/tests/test_entity_filtering.py
+++ b/tests/test_entity_filtering.py
@@ -12,7 +12,9 @@ from homeassistant.helpers import (
 )
 
 from custom_components.spook.entity_filtering import (
+    async_drop_existing_action_names,
     async_filter_known_device_ids,
+    async_filter_known_entity_ids,
     async_filter_known_services,
     async_find_services_in_sequence,
     async_get_all_device_ids,
@@ -141,3 +143,58 @@ def test_composite_device_ids_are_known(
 
     assert "pre-split-id" in async_get_all_device_ids(hass)
     assert async_filter_known_device_ids(hass, device_ids={"pre-split-id"}) == set()
+
+
+async def test_action_names_are_not_unknown_entities(hass: HomeAssistant) -> None:
+    """Test a name belonging to an existing action is not a missing entity.
+
+    A legacy notify group registers `notify.my_phone` as an action and no
+    entity at all, so a reference to it is not dangling. Reporting it sends
+    someone looking for an entity that was never meant to exist.
+    """
+    hass.services.async_register("notify", "my_phone", lambda _call: None)
+
+    unknown = async_filter_known_entity_ids(
+        hass,
+        {"notify.my_phone", "light.removed"},
+        known_entity_ids=set(),
+    )
+
+    assert unknown == {"light.removed"}
+
+
+async def test_action_names_are_only_looked_up_when_needed(
+    hass: HomeAssistant,
+) -> None:
+    """Test nothing is looked up when every reference is known.
+
+    Almost every inspection finds nothing wrong, and that case should not pay
+    for the action lookup at all.
+    """
+    hass.states.async_set("light.kept", "on")
+
+    assert (
+        async_filter_known_entity_ids(
+            hass,
+            {"light.kept"},
+            known_entity_ids={"light.kept"},
+        )
+        == set()
+    )
+
+
+async def test_a_malformed_candidate_does_not_abort_the_check(
+    hass: HomeAssistant,
+) -> None:
+    """Test a name without a domain is handled rather than raised on.
+
+    An exception here would take down the whole inspection, and not every
+    caller has already validated the shape of what it collected.
+    """
+    assert async_filter_known_entity_ids(
+        hass,
+        {"light.removed"},
+        known_entity_ids=set(),
+    ) == {"light.removed"}
+
+    assert async_drop_existing_action_names(hass, {"nodomain"}) == {"nodomain"}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -315,18 +315,17 @@ async def test_extract_entities_from_config_reuses_duplicate_template_results(
     assert calls == 1
 
 
-async def test_filter_plain_entity_ids_does_not_get_services(
-    hass: HomeAssistant,
+def _counting_services(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test plain entity filtering avoids service lookups."""
-    calls = 0
+    services: set[str],
+) -> list[int]:
+    """Count service lookups, so the cost of filtering is observable."""
+    calls = [0]
 
     def async_get_all_services(_: HomeAssistant) -> set[str]:
         """Return registered services."""
-        nonlocal calls
-        calls += 1
-        return {"light.turn_on"}
+        calls[0] += 1
+        return services
 
     monkeypatch.setattr(
         template_extraction,
@@ -334,12 +333,49 @@ async def test_filter_plain_entity_ids_does_not_get_services(
         async_get_all_services,
     )
 
+    return calls
+
+
+async def test_filter_plain_entity_ids_does_not_get_services_when_all_known(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a configuration with nothing wrong pays nothing for the check.
+
+    Action names are only subtracted from what survived the entity check, so
+    there is nothing to look up when everything is known. That is the case on
+    almost every inspection.
+    """
+    calls = _counting_services(monkeypatch, {"light.turn_on"})
+
+    assert (
+        await async_filter_known_entity_ids_with_templates(
+            hass,
+            {"sensor.known", "light.known"},
+            known_entity_ids={"sensor.known", "light.known"},
+        )
+        == set()
+    )
+    assert calls[0] == 0
+
+
+async def test_filter_plain_entity_ids_never_builds_the_service_set(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test findings are checked against the registry, not against a built set.
+
+    Enumerating every action in the instance costs more than the handful of
+    lookups actually needed, and this runs once per inspected item.
+    """
+    calls = _counting_services(monkeypatch, {"light.turn_on"})
+
     assert await async_filter_known_entity_ids_with_templates(
         hass,
-        {"sensor.missing", "light.unknown"},
+        {"sensor.missing", "light.unknown", "binary_sensor.gone"},
         known_entity_ids=set(),
-    ) == {"sensor.missing", "light.unknown"}
-    assert calls == 0
+    ) == {"sensor.missing", "light.unknown", "binary_sensor.gone"}
+    assert calls[0] == 0
 
 
 async def test_time_date_entities_are_known(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

An action name has the same shape as an entity ID. A legacy notify group is the case people keep hitting, because `notify.my_phone` is an action and no entity at all. Two different doors let one of those reach the entity reference check as if it were an entity, which is why this has been reported twice with different symptoms and neither open PR fixes both.

I measured where each one enters, for the same notify group, across five shapes:

| Shape | Home Assistant `referenced_entities` | Spook's own extractor |
|---|---|---|
| `action: notify.my_phone` | no | no |
| `service: notify.my_phone` | no | no |
| `data: {entity_id: notify.my_phone}` | **yes** | yes |
| `target: {entity_id: notify.my_phone}` | **yes** | yes |
| `notifier_hub.send`, `data: {notify: [...]}` | no | **yes** |

So there are two independent entry points:

- **#1331** arrives through Home Assistant. It reads `data.entity_id` and `target.entity_id` as targets and reports the name as a referenced entity. Spook is only believing what it was handed, which is why no amount of restraint in Spook's own scanning fixes it.
- **#1338** is Spook's own payload scanning finding notifier names under a key a third-party action chose for itself. Home Assistant sees nothing there.

Worth noting the first two rows: the action *name* is never read as an entity, by either. That matters for #1333, whose stated basis is that Home Assistant exposes action names through `referenced_entities`. For these shapes it does not, so subtracting called actions removes things that were never in the set.

**The fix.** The template path already subtracted known actions, inside the regex extraction. The plain entity ID path did not, and that asymmetry is the whole bug. Both filters now drop a candidate that names an existing action, which covers all nine repairs that use them rather than only the two that happened to get reported.

An existing action is not a dangling entity reference. Reporting it sends someone hunting for an entity that was never supposed to exist.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1331.
Fixes #1338.

Supersedes #1339, which suppresses notify-shaped strings inside `data`. That covers #1338 only: it misses both `entity_id` doors where Home Assistant is the source, and it drops template references as collateral.

Supersedes #1333, for the reason in the table above.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

New `tests/ectoplasms/automation/repairs/test_notify_action_names.py`, one per entry point plus the cases that must not change: a legacy target in service data, a notify group in a `target` block, a third-party fan-out payload, a removed entity in the same automation as a notify group, and a removed script.

Also a helper action case through the template repair, since template helpers run actions too, and direct tests of the filter itself.

Both wire-ups are mutation tested independently, because the first version of this had a change that no test exercised:

```
revert the plain filter          -> 2 tests fail
revert the template-aware filter -> 4 tests fail
```

**On the collision worth worrying about:** a script owns both `script.x` as an entity and `script.x` as an action, so dropping action names could in principle hide a deleted script. It cannot, because the two appear and vanish together, and `test_a_removed_script_is_still_reported` pins that.

**On cost**, since this runs on the same path #1439 just made fast. It asks the registry per candidate rather than building the set of every action in the instance, so there is nothing measurable either way, on 3,500 entities with 300 automations and 1,200 registered actions:

```
nothing wrong    21.6 ms -> 19.4 ms
with findings     68.0 ms -> 63.8 ms
```

Building the whole set instead cost +33 ms on the findings path, which is why it does not.

Full suite: `790 passed`. `ruff check`, `ruff format --check` and `pylint` (10.00/10) clean over both `custom_components` and `tests`.

**One honest limitation.** A reference to a legacy notify service that has genuinely been *removed* now goes quiet. Spook was calling it an unknown entity, which was the wrong label for it anyway, and the action reference repair will not catch it either since that one only inspects action names rather than targets. Small, and correctly labelled nothing rather than labelled wrongly, but it is a real blind spot and I would rather it be written down than discovered.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
