### PR TITLE
Add an action to set a sensor's display precision

### DIFF
--- a/custom_components/spook/ectoplasms/sensor/__init__.py
+++ b/custom_components/spook/ectoplasms/sensor/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/sensor/services/__init__.py
+++ b/custom_components/spook/ectoplasms/sensor/services/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/sensor/services/set_display_precision.py
+++ b/custom_components/spook/ectoplasms/sensor/services/set_display_precision.py
@@ -1,0 +1,61 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import split_entity_id
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_DISPLAY_PRECISION = "display_precision"
+
+
+class SpookService(AbstractSpookAdminService):
+    """Sensor service to set how many decimals a sensor shows.
+
+    Home Assistant offers this per entity in the UI only. This is the same
+    setting, so it can be applied to a pile of sensors at once.
+    """
+
+    domain = DOMAIN
+    service = "set_display_precision"
+    schema = {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+        vol.Required(CONF_DISPLAY_PRECISION): vol.All(
+            vol.Coerce(int), vol.Range(min=0)
+        ),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        entity_registry = er.async_get(self.hass)
+
+        # Resolve every entity before changing any of them. An unknown one
+        # halfway down the list would otherwise leave the sensors before it
+        # already updated, with nothing saying which.
+        entries = []
+        for entity_id in call.data[ATTR_ENTITY_ID]:
+            entry = entity_registry.async_get(entity_id)
+            if entry is None or split_entity_id(entity_id)[0] != DOMAIN:
+                msg = f"Unknown sensor entity: {entity_id}"
+                raise HomeAssistantError(msg)
+            entries.append(entry)
+
+        display_precision = call.data[CONF_DISPLAY_PRECISION]
+        for entry in entries:
+            # Merged, so a custom unit or any other sensor option survives.
+            options = dict(entry.options.get(DOMAIN, {}))
+            options[CONF_DISPLAY_PRECISION] = display_precision
+            entity_registry.async_update_entity_options(
+                entry.entity_id, DOMAIN, options
+            )

--- a/custom_components/spook/ectoplasms/sensor/services/set_display_precision.py
+++ b/custom_components/spook/ectoplasms/sensor/services/set_display_precision.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 
 CONF_DISPLAY_PRECISION = "display_precision"
 
+# The frontend hands this to Intl.NumberFormat as maximumFractionDigits, which
+# ECMA-402 caps at 100 and which throws outside that range. A sensor that
+# cannot be rendered is a worse outcome than a rejected action call.
+MAX_DISPLAY_PRECISION = 100
+
 
 class SpookService(AbstractSpookAdminService):
     """Sensor service to set how many decimals a sensor shows.
@@ -32,7 +37,7 @@ class SpookService(AbstractSpookAdminService):
     schema = {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Required(CONF_DISPLAY_PRECISION): vol.All(
-            vol.Coerce(int), vol.Range(min=0)
+            vol.Coerce(int), vol.Range(min=0, max=MAX_DISPLAY_PRECISION)
         ),
     }
 

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -1229,6 +1229,7 @@ sensor_set_display_precision:
       selector:
         number:
           min: 0
+          max: 100
           mode: box
 
 timer_set_duration:

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -1209,6 +1209,28 @@ repairs_unignore_all:
   description: >-
     Unignore all issues currently raised in Home Assistant Repairs.
 
+sensor_set_display_precision:
+  name: Set display precision 👻
+  description: >-
+    Sets the number of decimals shown for one or more sensors.
+  fields:
+    entity_id:
+      name: Entity
+      description: The sensor entity/entities to update.
+      required: true
+      selector:
+        entity:
+          multiple: true
+          domain: sensor
+    display_precision:
+      name: Display precision
+      description: The number of decimals to show for the sensor.
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box
+
 timer_set_duration:
   name: Set duration 👻
   description: >-

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1356,6 +1356,20 @@
       "name": "Unignore all issues",
       "description": "Unignore all issues currently raised in Home Assistant Repairs."
     },
+    "sensor_set_display_precision": {
+      "name": "Set display precision",
+      "description": "Sets the number of decimals shown for one or more sensors.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "The sensor entity/entities to update."
+        },
+        "display_precision": {
+          "name": "Display precision",
+          "description": "The number of decimals to show for the sensor."
+        }
+      }
+    },
     "timer_set_duration": {
       "name": "Set duration",
       "description": "Set duration for an existing timer.",

--- a/tests/ectoplasms/sensor/__init__.py
+++ b/tests/ectoplasms/sensor/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook sensor ectoplasm."""

--- a/tests/ectoplasms/sensor/services/__init__.py
+++ b/tests/ectoplasms/sensor/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for sensor services."""

--- a/tests/ectoplasms/sensor/services/test_set_display_precision.py
+++ b/tests/ectoplasms/sensor/services/test_set_display_precision.py
@@ -1,0 +1,169 @@
+"""Tests for the sensor set_display_precision service."""
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.spook.ectoplasms.sensor.services import set_display_precision
+
+if TYPE_CHECKING:
+    from tests.common import MockUser
+
+_PRECISION = 2
+_OTHER_PRECISION = 3
+
+
+@pytest.fixture
+def display_precision_service(hass: HomeAssistant) -> None:
+    """Register the Spook set_display_precision service."""
+    hass.config.components.add(DOMAIN)
+    set_display_precision.SpookService(hass).async_register()
+
+
+@pytest.fixture
+def sensors(hass: HomeAssistant) -> list[str]:
+    """Return two registered sensor entities."""
+    entity_registry = er.async_get(hass)
+    return [
+        entity_registry.async_get_or_create(
+            DOMAIN, "test", unique_id, suggested_object_id=unique_id
+        ).entity_id
+        for unique_id in ("power", "energy")
+    ]
+
+
+def _precision(hass: HomeAssistant, entity_id: str) -> int | None:
+    """Return the stored display precision for an entity."""
+    entry = er.async_get(hass).async_get(entity_id)
+    return entry.options.get(DOMAIN, {}).get("display_precision")
+
+
+async def _call(
+    hass: HomeAssistant,
+    user: MockUser,
+    entity_id: str | list[str],
+    precision: int,
+) -> None:
+    """Call the service as an admin."""
+    await hass.services.async_call(
+        DOMAIN,
+        "set_display_precision",
+        {"entity_id": entity_id, "display_precision": precision},
+        blocking=True,
+        context=Context(user_id=user.id),
+    )
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_sets_the_display_precision(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    sensors: list[str],
+) -> None:
+    """Test the display precision is stored on the entity."""
+    assert _precision(hass, sensors[0]) is None
+
+    await _call(hass, hass_admin_user, sensors[0], _PRECISION)
+
+    assert _precision(hass, sensors[0]) == _PRECISION
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_zero_decimals_is_a_valid_choice(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    sensors: list[str],
+) -> None:
+    """Test asking for no decimals is stored rather than treated as unset."""
+    await _call(hass, hass_admin_user, sensors[0], 0)
+
+    assert _precision(hass, sensors[0]) == 0
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_applies_to_every_entity_given(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    sensors: list[str],
+) -> None:
+    """Test a list of sensors is all updated."""
+    await _call(hass, hass_admin_user, sensors, _OTHER_PRECISION)
+
+    assert all(_precision(hass, entity_id) == _OTHER_PRECISION for entity_id in sensors)
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_other_sensor_options_survive(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    sensors: list[str],
+) -> None:
+    """Test an existing sensor option is not dropped.
+
+    The options are stored as one mapping per domain, so writing the whole
+    thing back would take a custom unit with it.
+    """
+    entity_registry = er.async_get(hass)
+    entity_registry.async_update_entity_options(
+        sensors[0], DOMAIN, {"unit_of_measurement": "kW"}
+    )
+
+    await _call(hass, hass_admin_user, sensors[0], 1)
+
+    options = entity_registry.async_get(sensors[0]).options[DOMAIN]
+    assert options["display_precision"] == 1
+    assert options["unit_of_measurement"] == "kW"
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_an_unknown_entity_changes_nothing(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    sensors: list[str],
+) -> None:
+    """Test one bad entity leaves the good ones untouched.
+
+    Validating while applying would update the sensors listed before the bad
+    one and then raise, with nothing telling the user which got through.
+    """
+    with pytest.raises(HomeAssistantError, match=re.escape("sensor.nope")):
+        await _call(hass, hass_admin_user, [sensors[0], "sensor.nope"], 4)
+
+    assert _precision(hass, sensors[0]) is None
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_a_non_sensor_entity_is_refused(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test an entity from another domain is refused."""
+    er.async_get(hass).async_get_or_create(
+        "light", "test", "lamp", suggested_object_id="lamp"
+    )
+
+    with pytest.raises(HomeAssistantError, match=re.escape("light.lamp")):
+        await _call(hass, hass_admin_user, "light.lamp", _PRECISION)
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_a_negative_precision_is_refused(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    sensors: list[str],
+) -> None:
+    """Test a negative number of decimals is rejected by the schema."""
+    with pytest.raises(vol.Invalid):
+        await _call(hass, hass_admin_user, sensors[0], -1)
+
+    assert _precision(hass, sensors[0]) is None

--- a/tests/ectoplasms/sensor/services/test_set_display_precision.py
+++ b/tests/ectoplasms/sensor/services/test_set_display_precision.py
@@ -15,6 +15,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.spook.ectoplasms.sensor.services import set_display_precision
+from custom_components.spook.ectoplasms.sensor.services.set_display_precision import (
+    MAX_DISPLAY_PRECISION,
+)
 
 if TYPE_CHECKING:
     from tests.common import MockUser
@@ -167,3 +170,34 @@ async def test_a_negative_precision_is_refused(
         await _call(hass, hass_admin_user, sensors[0], -1)
 
     assert _precision(hass, sensors[0]) is None
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_an_unrenderable_precision_is_refused(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    sensors: list[str],
+) -> None:
+    """Test a precision the frontend cannot render is refused.
+
+    The number reaches Intl.NumberFormat as maximumFractionDigits, which
+    ECMA-402 caps at 100. Above that the sensor stops rendering, which is a
+    worse outcome than a rejected call, and it would be stored in the registry
+    waiting for someone to find it.
+    """
+    with pytest.raises(vol.Invalid):
+        await _call(hass, hass_admin_user, sensors[0], 1000)
+
+    assert _precision(hass, sensors[0]) is None
+
+
+@pytest.mark.usefixtures("display_precision_service")
+async def test_the_highest_renderable_precision_is_allowed(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    sensors: list[str],
+) -> None:
+    """Test the cap itself is still accepted."""
+    await _call(hass, hass_admin_user, sensors[0], 100)
+
+    assert _precision(hass, sensors[0]) == MAX_DISPLAY_PRECISION


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds `sensor.set_display_precision`, an admin action that stores the number of decimals a sensor shows in the entity registry.

Home Assistant already offers this setting, but per entity in the UI, one at a time. As an action it can be pointed at a pile of sensors at once, or driven from a script.

This is the first of three splits out of #1328, which bundles three unrelated features into one branch. Two things differ from the version there:

**Every entity is resolved before any of them is changed.** Validating while applying would update the sensors listed ahead of a bad one and then raise, leaving the caller with no idea which of them got through.

**The existing sensor options are merged rather than replaced.** Options are stored as one mapping per domain, so writing the whole thing back would take a custom `unit_of_measurement` on the same entity with it.

The registry key is the one core reads. `SensorEntity._display_precision_or_none` looks in `registry_entry.options["sensor"]` and prefers `display_precision` over the integration's `suggested_display_precision`, so this is the user override rather than a competing value.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of #1328.

The rest of that branch splits as:

- `homeassistant.expose_entity` / `unexpose_entity`, which also lands clean.
- `input_number` `cycle`, which needs rewriting rather than rebasing: #1407 moved both services onto the public API (`native_step`, `native_value_as_float`, `native_max_value`, `async_set_native_value`), while that diff reaches into `entity._current_value` and `entity._maximum`, which no longer exist. It also carries a design question about what wrapping means when the amount overshoots the range, which deserves its own conversation.

Worth recording from that review: CodeRabbit flagged the missing non-negative validation on `amount` as critical, on the grounds that a negative amount could set a value above the maximum. Home Assistant rejects it first:

```
Invalid value for input_number.test: -3.0 (range 0.0 - 10.0)
```

So that one is a nicer error message rather than a correctness hole.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Seven tests in `tests/ectoplasms/sensor/services/test_set_display_precision.py`: it sets the precision, zero decimals is a real choice rather than unset, a list is fully applied, other sensor options survive, one bad entity changes nothing, another domain is refused, and a negative precision is refused by the schema.

Mutation tested, one test each, since three of those pin behaviour that is easy to regress silently:

```
validate while applying          -> test_an_unknown_entity_changes_nothing fails
overwrite options instead of merging -> test_other_sensor_options_survive fails
drop the domain check            -> test_a_non_sensor_entity_is_refused fails
```

Full suite: `801 passed`. `ruff check`, `ruff format --check` and `pylint` (10.00/10) clean over both `custom_components` and `tests`. `tests/test_service_translations.py` covers the descriptor and translation parity for the new action.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
