### PR TITLE
Add actions to expose entities to voice assistants

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/__init__.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/__init__.py
@@ -1,1 +1,56 @@
 """Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+# Home Assistant keeps the exposure settings, and the list of assistants that
+# have them, in this module. There is no public helper for either.
+from homeassistant.components.homeassistant.exposed_entities import (
+    KNOWN_ASSISTANTS,
+    async_expose_entity,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+CONF_ASSISTANTS = "assistants"
+
+EXPOSURE_SERVICE_SCHEMA = {
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(CONF_ASSISTANTS): vol.All(cv.ensure_list, [vol.In(KNOWN_ASSISTANTS)]),
+}
+
+
+def async_set_voice_assistant_exposure(
+    hass: HomeAssistant,
+    call: ServiceCall,
+    *,
+    should_expose: bool,
+) -> None:
+    """Set whether entities are exposed to the given voice assistants.
+
+    Shared by the expose and unexpose actions, which differ only in what they
+    set it to.
+    """
+    entity_registry = er.async_get(hass)
+
+    # Checked up front, so an unknown entity halfway down the list does not
+    # leave the ones before it already changed, with nothing saying which.
+    entity_ids = call.data[ATTR_ENTITY_ID]
+    for entity_id in entity_ids:
+        if (
+            hass.states.get(entity_id) is None
+            and entity_registry.async_get(entity_id) is None
+        ):
+            msg = f"Unknown entity: {entity_id}"
+            raise HomeAssistantError(msg)
+
+    for entity_id in entity_ids:
+        for assistant in call.data[CONF_ASSISTANTS]:
+            async_expose_entity(hass, assistant, entity_id, should_expose=should_expose)

--- a/custom_components/spook/ectoplasms/homeassistant/services/expose_entity.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/expose_entity.py
@@ -1,0 +1,25 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.homeassistant import DOMAIN
+
+from ....services import AbstractSpookAdminService
+from . import EXPOSURE_SERVICE_SCHEMA, async_set_voice_assistant_exposure
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant Core integration service to expose an entity."""
+
+    domain = DOMAIN
+    service = "expose_entity"
+    schema = EXPOSURE_SERVICE_SCHEMA
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        async_set_voice_assistant_exposure(self.hass, call, should_expose=True)

--- a/custom_components/spook/ectoplasms/homeassistant/services/unexpose_entity.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/unexpose_entity.py
@@ -1,0 +1,25 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.homeassistant import DOMAIN
+
+from ....services import AbstractSpookAdminService
+from . import EXPOSURE_SERVICE_SCHEMA, async_set_voice_assistant_exposure
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant Core integration service to stop exposing an entity."""
+
+    domain = DOMAIN
+    service = "unexpose_entity"
+    schema = EXPOSURE_SERVICE_SCHEMA
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        async_set_voice_assistant_exposure(self.hass, call, should_expose=False)

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -302,6 +302,33 @@ homeassistant_enable_entity:
         entity:
           multiple: true
 
+homeassistant_expose_entity:
+  name: Expose an entity to assistants 👻
+  description: >-
+    Exposes an entity (or entities) to voice assistants.
+  fields:
+    entity_id:
+      name: Entity
+      description: The entity/entities to expose.
+      required: true
+      selector:
+        entity:
+          multiple: true
+    assistants:
+      name: Assistants
+      description: The assistant(s) to apply this to.
+      required: true
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Alexa
+              value: cloud.alexa
+            - label: Google Assistant
+              value: cloud.google_assistant
+            - label: Assist
+              value: conversation
+
 homeassistant_hide_entity:
   name: Hide an entity 👻
   description: >-
@@ -333,6 +360,33 @@ homeassistant_rename_entity:
       required: true
       selector:
         text:
+
+homeassistant_unexpose_entity:
+  name: Stop exposing an entity to assistants 👻
+  description: >-
+    Stops exposing an entity (or entities) to voice assistants.
+  fields:
+    entity_id:
+      name: Entity
+      description: The entity/entities to stop exposing.
+      required: true
+      selector:
+        entity:
+          multiple: true
+    assistants:
+      name: Assistants
+      description: The assistant(s) to apply this to.
+      required: true
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Alexa
+              value: cloud.alexa
+            - label: Google Assistant
+              value: cloud.google_assistant
+            - label: Assist
+              value: conversation
 
 homeassistant_unhide_entity:
   name: Unhide an entity 👻

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -816,6 +816,20 @@
         }
       }
     },
+    "homeassistant_expose_entity": {
+      "name": "Expose an entity to assistants",
+      "description": "Exposes an entity (or entities) to voice assistants.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity/entities to expose."
+        },
+        "assistants": {
+          "name": "Assistants",
+          "description": "The assistant(s) to apply this to."
+        }
+      }
+    },
     "homeassistant_hide_entity": {
       "name": "Hide an entity",
       "description": "Hides an entity (or entities) on the fly.",
@@ -837,6 +851,20 @@
         "name": {
           "name": "Name",
           "description": "The new name for the entity/entities."
+        }
+      }
+    },
+    "homeassistant_unexpose_entity": {
+      "name": "Stop exposing an entity to assistants",
+      "description": "Stops exposing an entity (or entities) to voice assistants.",
+      "fields": {
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity/entities to stop exposing."
+        },
+        "assistants": {
+          "name": "Assistants",
+          "description": "The assistant(s) to apply this to."
         }
       }
     },

--- a/tests/ectoplasms/homeassistant/services/test_voice_assistant_exposure.py
+++ b/tests/ectoplasms/homeassistant/services/test_voice_assistant_exposure.py
@@ -1,0 +1,145 @@
+"""Tests for the homeassistant expose_entity and unexpose_entity services."""
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.components.homeassistant.exposed_entities import (
+    async_get_entity_settings,
+    async_should_expose,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from custom_components.spook.ectoplasms.homeassistant.services import (
+    expose_entity,
+    unexpose_entity,
+)
+
+if TYPE_CHECKING:
+    from tests.common import MockUser
+
+_ASSIST = "conversation"
+_ALEXA = "cloud.alexa"
+_GOOGLE = "cloud.google_assistant"
+
+
+@pytest.fixture
+async def exposure_services(hass: HomeAssistant) -> None:
+    """Register the Spook exposure services."""
+    # The exposure settings live in the homeassistant integration's storage.
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    expose_entity.SpookService(hass).async_register()
+    unexpose_entity.SpookService(hass).async_register()
+
+
+@pytest.fixture
+def light(hass: HomeAssistant) -> str:
+    """Return a registered light entity."""
+    return (
+        er.async_get(hass)
+        .async_get_or_create("light", "test", "lamp", suggested_object_id="lamp")
+        .entity_id
+    )
+
+
+async def _call(
+    hass: HomeAssistant,
+    user: MockUser,
+    service: str,
+    entity_id: str | list[str],
+    assistants: list[str],
+) -> None:
+    """Call one of the exposure services as an admin."""
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        {"entity_id": entity_id, "assistants": assistants},
+        blocking=True,
+        context=Context(user_id=user.id),
+    )
+
+
+@pytest.mark.usefixtures("exposure_services")
+async def test_expose_sets_exposure_for_the_named_assistant(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    light: str,
+) -> None:
+    """Test exposing to one assistant leaves the others alone."""
+    await _call(hass, hass_admin_user, "expose_entity", light, [_ASSIST])
+
+    assert async_should_expose(hass, _ASSIST, light) is True
+    # Untouched assistants keep whatever default they had.
+    assert _ALEXA not in async_get_entity_settings(hass, light)
+
+
+@pytest.mark.usefixtures("exposure_services")
+async def test_expose_accepts_several_assistants(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    light: str,
+) -> None:
+    """Test every named assistant is set."""
+    await _call(
+        hass, hass_admin_user, "expose_entity", light, [_ASSIST, _ALEXA, _GOOGLE]
+    )
+
+    assert all(
+        async_should_expose(hass, assistant, light) is True
+        for assistant in (_ASSIST, _ALEXA, _GOOGLE)
+    )
+
+
+@pytest.mark.usefixtures("exposure_services")
+async def test_unexpose_turns_it_back_off(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    light: str,
+) -> None:
+    """Test the exposure is removed again."""
+    await _call(hass, hass_admin_user, "expose_entity", light, [_ASSIST])
+    assert async_should_expose(hass, _ASSIST, light) is True
+
+    await _call(hass, hass_admin_user, "unexpose_entity", light, [_ASSIST])
+
+    assert async_should_expose(hass, _ASSIST, light) is False
+
+
+@pytest.mark.usefixtures("exposure_services")
+async def test_an_unknown_entity_changes_nothing(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    light: str,
+) -> None:
+    """Test one bad entity leaves the good ones untouched.
+
+    Checking while applying would expose the entities listed ahead of the
+    bad one and then raise, with nothing saying which got through.
+    """
+    with pytest.raises(HomeAssistantError, match=re.escape("light.nope")):
+        await _call(
+            hass, hass_admin_user, "expose_entity", [light, "light.nope"], [_ASSIST]
+        )
+
+    assert _ASSIST not in async_get_entity_settings(hass, light)
+
+
+@pytest.mark.usefixtures("exposure_services")
+async def test_an_unknown_assistant_is_refused(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    light: str,
+) -> None:
+    """Test only assistants Home Assistant knows about are accepted."""
+    with pytest.raises(vol.Invalid):
+        await _call(hass, hass_admin_user, "expose_entity", light, ["cloud.siri"])

--- a/tests/ectoplasms/homeassistant/services/test_voice_assistant_exposure.py
+++ b/tests/ectoplasms/homeassistant/services/test_voice_assistant_exposure.py
@@ -143,3 +143,27 @@ async def test_an_unknown_assistant_is_refused(
     """Test only assistants Home Assistant knows about are accepted."""
     with pytest.raises(vol.Invalid):
         await _call(hass, hass_admin_user, "expose_entity", light, ["cloud.siri"])
+
+
+@pytest.mark.usefixtures("exposure_services")
+async def test_an_entity_without_a_registry_entry_is_accepted(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test a YAML entity with no registry entry can still be exposed.
+
+    An entity that exists only in the state machine has no registry entry to
+    hang options on, and Home Assistant keeps its exposure somewhere else.
+    Requiring a registry entry would refuse it, which is why the check looks
+    at both.
+    """
+    hass.states.async_set("light.yaml_only", "on")
+    assert er.async_get(hass).async_get("light.yaml_only") is None
+
+    await _call(hass, hass_admin_user, "expose_entity", "light.yaml_only", [_ASSIST])
+
+    assert async_should_expose(hass, _ASSIST, "light.yaml_only") is True
+
+    await _call(hass, hass_admin_user, "unexpose_entity", "light.yaml_only", [_ASSIST])
+
+    assert async_should_expose(hass, _ASSIST, "light.yaml_only") is False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds `homeassistant.expose_entity` and `homeassistant.unexpose_entity`, admin actions that set whether entities are exposed to Assist, Google Assistant and Alexa.

Home Assistant offers this per entity in the UI under **Voice assistants**. As actions it can be handed to a script, or applied to a pile of entities at once.

Second of three splits out of #1328. Three things differ from the version there:

**The `CLOUD_NEVER_EXPOSED_ENTITIES` check is gone, because the constant is gone.** Home Assistant has no such list any more and no replacement for it, so that import fails outright on a current install. This is not a style call, the original does not load.

**Every entity is checked before any of them is exposed.** Checking while applying would change the entities ahead of a bad one and then raise, leaving the caller with no idea which got through.

**The shared half lives in the services package**, alongside the `input_number` helper that sits there for the same reason. My first attempt kept two flat files each with their own copy, matching how `hide_entity` and `unhide_entity` read, but at this length pylint calls it `duplicate-code` and it is right. The split reads better anyway: each action is now its own name and its own boolean, and the behaviour is described once.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of #1328, alongside #1441 which splits out `sensor.set_display_precision`.

The third piece, `input_number` `cycle`, is not a rebase but a rewrite: #1407 moved those services onto the public API, while that diff reaches into `entity._current_value` and `entity._maximum`, which no longer exist. It also needs a decision on what wrapping means when the amount overshoots the range, so it is coming separately.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Five tests in `tests/ectoplasms/homeassistant/services/test_voice_assistant_exposure.py`: exposing to one assistant leaves the others untouched, several assistants at once, unexposing turns it back off, one bad entity changes nothing, and an assistant Home Assistant does not know is refused by the schema.

Mutation tested:

```
check while applying         -> test_an_unknown_entity_changes_nothing fails
unexpose sets True instead   -> test_unexpose_turns_it_back_off fails
```

Full suite: `799 passed`. `ruff check`, `ruff format --check` and `pylint` (10.00/10) clean over both `custom_components` and `tests`. `tests/test_service_translations.py` covers descriptor and translation parity for both new actions.

The `services.yaml` and `en.json` entries sit in the `homeassistant_` run, so this does not touch the same region as #1441 and the two do not conflict.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
