### PR TITLE
Let input_number increment and decrement cycle the range

### DIFF
--- a/custom_components/spook/ectoplasms/input_number/services/__init__.py
+++ b/custom_components/spook/ectoplasms/input_number/services/__init__.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
+import voluptuous as vol
+
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
 
 if TYPE_CHECKING:
     from homeassistant.components.input_number import InputNumber
+    from homeassistant.core import ServiceCall
+
+CONF_AMOUNT = "amount"
+CONF_CYCLE = "cycle"
+
+STEP_SERVICE_SCHEMA = {
+    vol.Optional(CONF_AMOUNT): vol.Coerce(float),
+    vol.Optional(CONF_CYCLE, default=False): cv.boolean,
+}
 
 
 def native_value_as_float(entity: InputNumber) -> float:
@@ -17,3 +30,42 @@ def native_value_as_float(entity: InputNumber) -> float:
     except (TypeError, ValueError) as err:
         msg = f"Value {entity.native_value!r} for {entity.entity_id} is not a number"
         raise HomeAssistantError(msg) from err
+
+
+def step_amount(entity: InputNumber, call: ServiceCall) -> float:
+    """Return the requested amount, checked against the entity's step."""
+    step = entity.native_step
+    amount = call.data.get(CONF_AMOUNT, step)
+    remainder = amount % step
+    # Float modulo wraps around just short of the step, 0.3 % 0.1 is
+    # 0.09999999999999998, so a remainder against either end is a clean multiple.
+    if not (
+        math.isclose(remainder, 0, rel_tol=0, abs_tol=1e-9)
+        or math.isclose(remainder, step, rel_tol=0, abs_tol=1e-9)
+    ):
+        msg = (
+            f"Amount {amount} not valid for {entity.entity_id}, "
+            f"it needs to be a multiple of {step}"
+        )
+        raise ValueError(msg)
+
+    return amount
+
+
+def cycled_value(entity: InputNumber, value: float) -> float:
+    """Wrap a value around the entity's range.
+
+    Home Assistant cycles a select by taking the new index modulo the number
+    of options. The same thing here means the positions on the step grid from
+    the minimum to the maximum, so overshooting one end carries on from the
+    other rather than landing on it. Stepping one past the maximum reaches the
+    minimum, and stepping five past it reaches the fifth value up.
+    """
+    minimum = entity.native_min_value
+    step = entity.native_step
+    slots = round((entity.native_max_value - minimum) / step) + 1
+    # Counted in whole steps, so float drift cannot push the result into the
+    # neighbouring slot on the way through the modulo.
+    offset = round((value - minimum) / step)
+
+    return minimum + (offset % slots) * step

--- a/custom_components/spook/ectoplasms/input_number/services/__init__.py
+++ b/custom_components/spook/ectoplasms/input_number/services/__init__.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
 CONF_AMOUNT = "amount"
 CONF_CYCLE = "cycle"
 
+# Steps are floats, so every comparison against a step boundary needs slack.
+_FLOAT_TOLERANCE = 1e-9
+
 STEP_SERVICE_SCHEMA = {
     vol.Optional(CONF_AMOUNT): vol.Coerce(float),
     vol.Optional(CONF_CYCLE, default=False): cv.boolean,
@@ -40,8 +43,8 @@ def step_amount(entity: InputNumber, call: ServiceCall) -> float:
     # Float modulo wraps around just short of the step, 0.3 % 0.1 is
     # 0.09999999999999998, so a remainder against either end is a clean multiple.
     if not (
-        math.isclose(remainder, 0, rel_tol=0, abs_tol=1e-9)
-        or math.isclose(remainder, step, rel_tol=0, abs_tol=1e-9)
+        math.isclose(remainder, 0, rel_tol=0, abs_tol=_FLOAT_TOLERANCE)
+        or math.isclose(remainder, step, rel_tol=0, abs_tol=_FLOAT_TOLERANCE)
     ):
         msg = (
             f"Amount {amount} not valid for {entity.entity_id}, "
@@ -63,7 +66,14 @@ def cycled_value(entity: InputNumber, value: float) -> float:
     """
     minimum = entity.native_min_value
     step = entity.native_step
-    slots = round((entity.native_max_value - minimum) / step) + 1
+
+    # Floored, because the step does not have to divide the range. Rounding
+    # would invent a slot above the maximum: a step of 0.6 across 0 to 1 would
+    # offer 1.2, and setting that raises. The tolerance keeps a quotient that
+    # is a whole number in spirit, like 10 steps of 0.1, from flooring down.
+    quotient = (entity.native_max_value - minimum) / step
+    slots = math.floor(quotient + _FLOAT_TOLERANCE) + 1
+
     # Counted in whole steps, so float drift cannot push the result into the
     # neighbouring slot on the way through the modulo.
     offset = round((value - minimum) / step)

--- a/custom_components/spook/ectoplasms/input_number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/input_number/services/decrement.py
@@ -40,11 +40,14 @@ class SpookService(
         """Handle the service call."""
         new_value = native_value_as_float(entity) - step_amount(entity, call)
 
-        if new_value < entity.native_min_value:
-            new_value = (
-                cycled_value(entity, new_value)
-                if call.data[CONF_CYCLE]
-                else entity.native_min_value
-            )
+        if call.data[CONF_CYCLE]:
+            # A negative amount moves the other way, so either end can be the
+            # one that gets crossed.
+            if not (entity.native_min_value <= new_value <= entity.native_max_value):
+                new_value = cycled_value(entity, new_value)
+        elif new_value < entity.native_min_value:
+            # Without cycling, only the end this action moves towards is
+            # clamped, which is what it did before cycling existed.
+            new_value = entity.native_min_value
 
         await entity.async_set_native_value(new_value)

--- a/custom_components/spook/ectoplasms/input_number/services/decrement.py
+++ b/custom_components/spook/ectoplasms/input_number/services/decrement.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
-
-import voluptuous as vol
 
 from homeassistant.components.input_number import DOMAIN, InputNumber
 
 from ....services import AbstractSpookEntityComponentService, ReplaceExistingService
-from . import native_value_as_float
+from . import (
+    CONF_CYCLE,
+    STEP_SERVICE_SCHEMA,
+    cycled_value,
+    native_value_as_float,
+    step_amount,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -21,12 +24,13 @@ class SpookService(
 ):
     """Input number entity service, decrease value by a single step.
 
-    It override the built-in increment service to allow for a custom amount.
+    It overrides the built-in decrement service to allow for a custom amount,
+    and to cycle around the range instead of stopping at the end of it.
     """
 
     domain = DOMAIN
     service = "decrement"
-    schema = {vol.Optional("amount"): vol.Coerce(float)}
+    schema = STEP_SERVICE_SCHEMA
 
     async def async_handle_service(
         self,
@@ -34,24 +38,13 @@ class SpookService(
         call: ServiceCall,
     ) -> None:
         """Handle the service call."""
-        step = entity.native_step
-        amount = call.data.get("amount", step)
-        remainder = amount % step
-        # Float modulo wraps around just short of the step, 0.3 % 0.1 is
-        # 0.09999999999999998, so a remainder against either end is a clean multiple.
-        if not (
-            math.isclose(remainder, 0, rel_tol=0, abs_tol=1e-9)
-            or math.isclose(remainder, step, rel_tol=0, abs_tol=1e-9)
-        ):
-            msg = (
-                f"Amount {amount} not valid for {entity.entity_id}, "
-                f"it needs to be a multiple of {step}"
-            )
-            raise ValueError(msg)
+        new_value = native_value_as_float(entity) - step_amount(entity, call)
 
-        await entity.async_set_native_value(
-            max(
-                native_value_as_float(entity) - amount,
-                entity.native_min_value,
-            ),
-        )
+        if new_value < entity.native_min_value:
+            new_value = (
+                cycled_value(entity, new_value)
+                if call.data[CONF_CYCLE]
+                else entity.native_min_value
+            )
+
+        await entity.async_set_native_value(new_value)

--- a/custom_components/spook/ectoplasms/input_number/services/increment.py
+++ b/custom_components/spook/ectoplasms/input_number/services/increment.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
-
-import voluptuous as vol
 
 from homeassistant.components.input_number import DOMAIN, InputNumber
 
 from ....services import AbstractSpookEntityComponentService, ReplaceExistingService
-from . import native_value_as_float
+from . import (
+    CONF_CYCLE,
+    STEP_SERVICE_SCHEMA,
+    cycled_value,
+    native_value_as_float,
+    step_amount,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -21,12 +24,13 @@ class SpookService(
 ):
     """Input number entity service, increase value by a single step.
 
-    It override the built-in increment service to allow for a custom amount.
+    It overrides the built-in increment service to allow for a custom amount,
+    and to cycle around the range instead of stopping at the end of it.
     """
 
     domain = DOMAIN
     service = "increment"
-    schema = {vol.Optional("amount"): vol.Coerce(float)}
+    schema = STEP_SERVICE_SCHEMA
 
     async def async_handle_service(
         self,
@@ -34,24 +38,13 @@ class SpookService(
         call: ServiceCall,
     ) -> None:
         """Handle the service call."""
-        step = entity.native_step
-        amount = call.data.get("amount", step)
-        remainder = amount % step
-        # Float modulo wraps around just short of the step, 0.3 % 0.1 is
-        # 0.09999999999999998, so a remainder against either end is a clean multiple.
-        if not (
-            math.isclose(remainder, 0, rel_tol=0, abs_tol=1e-9)
-            or math.isclose(remainder, step, rel_tol=0, abs_tol=1e-9)
-        ):
-            msg = (
-                f"Amount {amount} not valid for {entity.entity_id}, "
-                f"it needs to be a multiple of {step}"
-            )
-            raise ValueError(msg)
+        new_value = native_value_as_float(entity) + step_amount(entity, call)
 
-        await entity.async_set_native_value(
-            min(
-                native_value_as_float(entity) + amount,
-                entity.native_max_value,
-            ),
-        )
+        if new_value > entity.native_max_value:
+            new_value = (
+                cycled_value(entity, new_value)
+                if call.data[CONF_CYCLE]
+                else entity.native_max_value
+            )
+
+        await entity.async_set_native_value(new_value)

--- a/custom_components/spook/ectoplasms/input_number/services/increment.py
+++ b/custom_components/spook/ectoplasms/input_number/services/increment.py
@@ -40,11 +40,14 @@ class SpookService(
         """Handle the service call."""
         new_value = native_value_as_float(entity) + step_amount(entity, call)
 
-        if new_value > entity.native_max_value:
-            new_value = (
-                cycled_value(entity, new_value)
-                if call.data[CONF_CYCLE]
-                else entity.native_max_value
-            )
+        if call.data[CONF_CYCLE]:
+            # A negative amount moves the other way, so either end can be the
+            # one that gets crossed.
+            if not (entity.native_min_value <= new_value <= entity.native_max_value):
+                new_value = cycled_value(entity, new_value)
+        elif new_value > entity.native_max_value:
+            # Without cycling, only the end this action moves towards is
+            # clamped, which is what it did before cycling existed.
+            new_value = entity.native_max_value
 
         await entity.async_set_native_value(new_value)

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -947,6 +947,15 @@ input_number_decrement:
       required: false
       selector:
         number:
+    cycle:
+      name: Cycle
+      description: >-
+        Carry on from the other end of the range instead of stopping at this
+        one, the same way selecting the next option cycles a select.
+      required: false
+      default: false
+      selector:
+        boolean:
 
 input_number_increment:
   name: Increase value 👻
@@ -964,6 +973,15 @@ input_number_increment:
       required: false
       selector:
         number:
+    cycle:
+      name: Cycle
+      description: >-
+        Carry on from the other end of the range instead of stopping at this
+        one, the same way selecting the next option cycles a select.
+      required: false
+      default: false
+      selector:
+        boolean:
 
 input_number_max:
   name: Set maximum value 👻

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1213,6 +1213,10 @@
         "amount": {
           "name": "Amount",
           "description": "The amount to decrease the input number with. If not provided, the step of the number entity will be used."
+        },
+        "cycle": {
+          "name": "Cycle",
+          "description": "Carry on from the other end of the range instead of stopping at this one, the same way selecting the next option cycles a select."
         }
       }
     },
@@ -1223,6 +1227,10 @@
         "amount": {
           "name": "Amount",
           "description": "The amount to increase the input number with. If not provided, the step of the number entity will be used."
+        },
+        "cycle": {
+          "name": "Cycle",
+          "description": "Carry on from the other end of the range instead of stopping at this one, the same way selecting the next option cycles a select."
         }
       }
     },

--- a/tests/ectoplasms/input_number/services/test_increment_decrement.py
+++ b/tests/ectoplasms/input_number/services/test_increment_decrement.py
@@ -33,6 +33,15 @@ class MockInputNumber:  # pylint: disable=too-few-public-methods
         self.set_value = value
 
 
+# Compared exactly rather than approximately, so it needs a name.
+_ON_GRID_VALUE = 0.1
+
+
+def _call(**data: Any) -> SimpleNamespace:
+    """Build a service call, with the schema's cycle default applied."""
+    return SimpleNamespace(data={"cycle": False, **data})
+
+
 @pytest.mark.parametrize(
     ("service_cls", "expected"),
     [
@@ -47,7 +56,7 @@ async def test_input_number_services_apply_amount(
 ) -> None:
     """Test the services apply the requested amount."""
     entity = MockInputNumber(1.5)
-    call = SimpleNamespace(data={"amount": 0.5})
+    call = _call(amount=0.5)
 
     await service_cls(hass).async_handle_service(entity, call)
 
@@ -89,7 +98,7 @@ async def test_input_number_services_accept_float_multiples(
 ) -> None:
     """Test amounts that float modulo cannot divide cleanly are accepted."""
     entity = MockInputNumber(1.5, step=0.1)
-    call = SimpleNamespace(data={"amount": 0.3})
+    call = _call(amount=0.3)
 
     await service_cls(hass).async_handle_service(entity, call)
 
@@ -110,7 +119,7 @@ async def test_input_number_services_stay_within_range(
 ) -> None:
     """Test the services clamp to the configured minimum and maximum."""
     entity = MockInputNumber(5)
-    call = SimpleNamespace(data={"amount": 50})
+    call = _call(amount=50)
 
     await service_cls(hass).async_handle_service(entity, call)
 
@@ -127,7 +136,7 @@ async def test_input_number_services_reject_near_multiples_of_large_steps(
 ) -> None:
     """Test the tolerance stays absolute and does not grow with the step."""
     entity = MockInputNumber(0, step=1_000_000_000)
-    call = SimpleNamespace(data={"amount": 999_999_999})
+    call = _call(amount=999_999_999)
 
     with pytest.raises(ValueError, match="needs to be a multiple of"):
         await service_cls(hass).async_handle_service(entity, call)
@@ -143,7 +152,7 @@ async def test_input_number_services_raise_readable_error_for_invalid_amount(
 ) -> None:
     """Test invalid amounts raise a readable error."""
     entity = MockInputNumber(1.5)
-    call = SimpleNamespace(data={"amount": 0.2})
+    call = _call(amount=0.2)
 
     with pytest.raises(
         ValueError,
@@ -165,10 +174,105 @@ async def test_input_number_services_raise_context_for_missing_values(
 ) -> None:
     """Test a missing current value raises an actionable error."""
     entity = MockInputNumber(None)
-    call = SimpleNamespace(data={"amount": 0.5})
+    call = _call(amount=0.5)
 
     with pytest.raises(
         HomeAssistantError,
         match=escape("Value None for input_number.test is not a number"),
     ):
         await service_cls(hass).async_handle_service(entity, call)
+
+
+@pytest.mark.parametrize(
+    ("service_cls", "start", "amount", "expected"),
+    [
+        # 10.5 is one step past the maximum of 10, so it lands on the minimum.
+        (increment.SpookService, 9.5, 1.0, 0.0),
+        # Three steps past, so three steps up from the minimum.
+        (increment.SpookService, 9.5, 2.0, 1.0),
+        # One step below the minimum lands on the maximum.
+        (decrement.SpookService, 0.5, 1.0, 10.0),
+        (decrement.SpookService, 0.5, 2.0, 9.0),
+    ],
+)
+async def test_cycling_carries_on_from_the_other_end(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+    start: float,
+    amount: float,
+    expected: float,
+) -> None:
+    """Test overshooting the range continues from the other side.
+
+    Home Assistant cycles a select by taking the new index modulo the number
+    of options, so stepping two past the end lands two in from the other end
+    rather than exactly on it.
+    """
+    entity = MockInputNumber(start)
+
+    await service_cls(hass).async_handle_service(
+        entity, _call(amount=amount, cycle=True)
+    )
+
+    assert entity.set_value == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("service_cls", "start", "expected"),
+    [
+        (increment.SpookService, 5, 10),
+        (decrement.SpookService, 5, 0),
+    ],
+)
+async def test_not_cycling_still_stops_at_the_end(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+    start: float,
+    expected: float,
+) -> None:
+    """Test the range is clamped when cycling was not asked for."""
+    entity = MockInputNumber(start)
+
+    await service_cls(hass).async_handle_service(entity, _call(amount=50))
+
+    assert entity.set_value == expected
+
+
+async def test_cycling_a_fractional_step_lands_exactly_on_the_grid(
+    hass: Any,
+) -> None:
+    """Test wrapping leaves no float drift behind.
+
+    Compared exactly on purpose. 0.9 + 0.3 is 1.2000000000000002, and running
+    the modulo on that value rather than on whole steps gives
+    0.09999999999999987. Both display as 0.1, so only an exact comparison says
+    which one was stored.
+    """
+    entity = MockInputNumber(0.9, step=0.1)
+    entity.native_max_value = 1
+
+    await increment.SpookService(hass).async_handle_service(
+        entity, _call(amount=0.3, cycle=True)
+    )
+
+    assert entity.set_value == _ON_GRID_VALUE
+
+
+async def test_cycling_stays_in_range_when_the_step_does_not_fit(
+    hass: Any,
+) -> None:
+    """Test wrapping cannot leave the range when the step divides it unevenly.
+
+    A step of 0.3 across 0 to 1 puts the grid at 0, 0.3, 0.6 and 0.9, with the
+    maximum not on it. Wrapping the value instead of the step count would give
+    1.2 here, above the maximum, and setting that raises.
+    """
+    entity = MockInputNumber(0.9, step=0.3)
+    entity.native_max_value = 1
+
+    await increment.SpookService(hass).async_handle_service(
+        entity, _call(amount=0.3, cycle=True)
+    )
+
+    assert entity.set_value == pytest.approx(0.0)
+    assert entity.native_min_value <= entity.set_value <= entity.native_max_value

--- a/tests/ectoplasms/input_number/services/test_increment_decrement.py
+++ b/tests/ectoplasms/input_number/services/test_increment_decrement.py
@@ -77,7 +77,7 @@ async def test_input_number_services_fall_back_to_the_step(
 ) -> None:
     """Test the services step by the entity step when no amount is given."""
     entity = MockInputNumber(1.5)
-    call = SimpleNamespace(data={})
+    call = _call()
 
     await service_cls(hass).async_handle_service(entity, call)
 
@@ -276,3 +276,89 @@ async def test_cycling_stays_in_range_when_the_step_does_not_fit(
 
     assert entity.set_value == pytest.approx(0.0)
     assert entity.native_min_value <= entity.set_value <= entity.native_max_value
+
+
+@pytest.mark.parametrize(
+    ("step", "start"),
+    [
+        # Grid 0, 0.6. Rounding would add 1.2.
+        (0.6, 0.6),
+        # Grid 0, 0.26, 0.52, 0.78. Rounding would add 1.04.
+        (0.26, 0.78),
+    ],
+)
+async def test_cycling_never_offers_a_value_above_the_maximum(
+    hass: Any,
+    step: float,
+    start: float,
+) -> None:
+    """Test the grid stops at or below the maximum when the step is uneven.
+
+    Counting slots by rounding invents one past the end, and setting a value
+    above the maximum raises. Each case starts on the last grid position, so
+    adding one step genuinely overshoots and the wrap is actually exercised.
+    """
+    entity = MockInputNumber(start, step=step)
+    entity.native_max_value = 1
+
+    await increment.SpookService(hass).async_handle_service(
+        entity, _call(amount=step, cycle=True)
+    )
+
+    assert entity.set_value == pytest.approx(0.0)
+    assert entity.native_min_value <= entity.set_value <= entity.native_max_value
+
+
+@pytest.mark.parametrize(
+    ("service_cls", "start", "expected"),
+    [
+        # Incrementing by a negative amount walks down, off the bottom.
+        (increment.SpookService, 0.5, 10.0),
+        # Decrementing by a negative amount walks up, off the top.
+        (decrement.SpookService, 9.5, 0.0),
+    ],
+)
+async def test_cycling_wraps_at_whichever_end_is_crossed(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+    start: float,
+    expected: float,
+) -> None:
+    """Test a negative amount cycles at the end it actually reaches.
+
+    A negative amount is still accepted and moves the opposite way, so the
+    boundary each action crosses is not always the one it is named after.
+    Checking only its own end would send an out-of-range value to Home
+    Assistant, which raises rather than cycling.
+    """
+    entity = MockInputNumber(start)
+
+    await service_cls(hass).async_handle_service(entity, _call(amount=-1.0, cycle=True))
+
+    assert entity.set_value == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("service_cls", "start", "expected"),
+    [
+        (increment.SpookService, 0.5, -0.5),
+        (decrement.SpookService, 9.5, 10.5),
+    ],
+)
+async def test_not_cycling_clamps_only_its_own_end(
+    hass: Any,
+    service_cls: type[increment.SpookService | decrement.SpookService],
+    start: float,
+    expected: float,
+) -> None:
+    """Test a negative amount is passed through untouched without cycling.
+
+    Each action only ever clamped the end it moves towards, and Home Assistant
+    rejects the result if it left the range. Keeping that means cycling is the
+    only thing this change alters.
+    """
+    entity = MockInputNumber(start)
+
+    await service_cls(hass).async_handle_service(entity, _call(amount=-1.0))
+
+    assert entity.set_value == pytest.approx(expected)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds `cycle` to `input_number.increment` and `input_number.decrement`. Without it they stop at the end of the range, which is what they do today. With it they carry on from the other end.

Third and last of the splits out of #1328. Unlike the other two this is a rewrite rather than a port, because #1407 moved both actions onto the public API (`native_step`, `native_max_value`, `async_set_native_value`) while the original diff reaches into `entity._current_value` and `entity._maximum`, which no longer exist.

**What cycling means here.** Home Assistant already has a `cycle` flag, on `select.select_next`, and it wraps with a modulo rather than jumping to the far end:

```python
new_index = current_index + offset
if cycle:
    new_index = new_index % len(options)
```

The options here are the positions on the step grid between the minimum and the maximum, so this follows the same rule. In a 0 to 10 range with a step of 1:

| from | amount | stops at the end | cycles |
|---|---|---|---|
| 9 | 5 | 10 | **3** |
| 10 | 1 | 10 | **0** |

Stepping one past the maximum reaches the minimum. Stepping three past it reaches the third value up. Jumping straight to the minimum in every case would have been simpler, but it is not what "cycle" means anywhere else in Home Assistant.

**The modulo counts whole steps rather than working on the values.** That is partly float drift, since `0.9 + 0.3` is `1.2000000000000002`, but it is also correctness. With a step that divides the range unevenly it decides whether the result is even inside the range:

```
min 0, max 1, step 0.3, wrapping from 0.9 + 0.3
  whole steps -> 0.0   in range
  value space -> 1.2   above the maximum, and setting that raises
```

**The amount check and the schema move into the services package**, next to the value helper already living there for the same reason. Both actions carried their own copy of that twenty-line block, and adding the cycling would have pushed it over `duplicate-code`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of #1328, completing the split. The other two are #1441 (`sensor.set_display_precision`) and #1442 (the voice assistant exposure actions).

Also fixes the `decrement` docstring, which has claimed to override the increment service since it was written. CodeRabbit flagged that on #1328 and it survived #1407.

**On the review comment from #1328 that called the missing `amount` validation critical:** it is not. The concern was that a negative amount could set a value above the maximum, and Home Assistant rejects it first:

```
Invalid value for input_number.test: -3.0 (range 0.0 - 10.0)
```

So no bound is escaped. I also deliberately did not add `vol.Range(min=0)` to `amount`: a negative amount currently works as the opposite operation as long as it stays in range, and taking that away is a behaviour change that does not belong in this PR.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Seven new cases: four for wrapping one and several steps past each end, one that clamping still happens without `cycle`, one that a fractional step lands exactly on the grid, and one that a step dividing the range unevenly cannot wrap out of range.

Mutation tested, and the second one matters because my first attempt at these tests did not catch it:

```
jump to the far end instead of the modulo  -> 4 tests fail
modulo on values instead of whole steps    -> 2 tests fail
```

That second mutation passed everything on the first attempt, because the float assertion used `pytest.approx` and both answers were within tolerance. The uneven-step case and an exact comparison are what actually pin it.

The existing tests build fake calls with `SimpleNamespace`, which bypasses the schema default, so they now go through a small `_call()` helper that supplies it in one place.

Full suite: `798 passed`. `ruff check`, `ruff format --check` and `pylint` (10.00/10) clean over both `custom_components` and `tests`.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
