### PR TITLE
Call a config entry an integration entry

### DIFF
--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -186,11 +186,11 @@ homeassistant_delete_area:
 homeassistant_disable_config_entry:
   name: Disable an integration 👻
   description: >-
-    Disables an integration configuration entry.
+    Disables an integration entry.
   fields:
     config_entry_id:
-      name: Config entry
-      description: The integration configuration entry to disable.
+      name: Integration entry
+      description: The integration entry to disable.
       required: true
       selector:
         config_entry:
@@ -198,11 +198,11 @@ homeassistant_disable_config_entry:
 homeassistant_enable_config_entry:
   name: Enable an integration 👻
   description: >-
-    Enables an integration configuration entry.
+    Enables an integration entry.
   fields:
     config_entry_id:
-      name: Config entry
-      description: The integration configuration entry to enable.
+      name: Integration entry
+      description: The integration entry to enable.
       required: true
       selector:
         config_entry:
@@ -769,11 +769,11 @@ homeassistant_ignore_all_discovered:
 homeassistant_disable_polling:
   name: Disable polling for updates 👻
   description: >-
-    Disables polling for updates for an integration configuration entry.
+    Disables polling for updates for an integration entry.
   fields:
     config_entry_id:
-      name: Config entry
-      description: The integration configuration entry to disable polling for.
+      name: Integration entry
+      description: The integration entry to disable polling for.
       required: true
       selector:
         config_entry:
@@ -781,11 +781,11 @@ homeassistant_disable_polling:
 homeassistant_enable_polling:
   name: Enable polling for updates 👻
   description: >-
-    Enables polling for updates for an integration configuration entry.
+    Enables polling for updates for an integration entry.
   fields:
     config_entry_id:
-      name: Config entry
-      description: The integration configuration entry to enable polling for.
+      name: Integration entry
+      description: The integration entry to enable polling for.
       required: true
       selector:
         config_entry:

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -724,21 +724,21 @@
     },
     "homeassistant_disable_config_entry": {
       "name": "Disable an integration",
-      "description": "Disables an integration configuration entry.",
+      "description": "Disables an integration entry.",
       "fields": {
         "config_entry_id": {
-          "name": "Config entry",
-          "description": "The integration configuration entry to disable."
+          "name": "Integration entry",
+          "description": "The integration entry to disable."
         }
       }
     },
     "homeassistant_enable_config_entry": {
       "name": "Enable an integration",
-      "description": "Enables an integration configuration entry.",
+      "description": "Enables an integration entry.",
       "fields": {
         "config_entry_id": {
-          "name": "Config entry",
-          "description": "The integration configuration entry to enable."
+          "name": "Integration entry",
+          "description": "The integration entry to enable."
         }
       }
     },
@@ -1104,21 +1104,21 @@
     },
     "homeassistant_disable_polling": {
       "name": "Disable polling for updates",
-      "description": "Disables polling for updates for an integration configuration entry.",
+      "description": "Disables polling for updates for an integration entry.",
       "fields": {
         "config_entry_id": {
-          "name": "Config entry",
-          "description": "The integration configuration entry to disable polling for."
+          "name": "Integration entry",
+          "description": "The integration entry to disable polling for."
         }
       }
     },
     "homeassistant_enable_polling": {
       "name": "Enable polling for updates",
-      "description": "Enables polling for updates for an integration configuration entry.",
+      "description": "Enables polling for updates for an integration entry.",
       "fields": {
         "config_entry_id": {
-          "name": "Config entry",
-          "description": "The integration configuration entry to enable polling for."
+          "name": "Integration entry",
+          "description": "The integration entry to enable polling for."
         }
       }
     },

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -230,7 +230,7 @@ Sorts the list of selectable options for an input select entity. _#12345_
 
 ## Integration: Disable
 
-This action can be used to disable a integration configuration entry (those you see on your integrations dashboard) on the fly. _#bye_
+This action can be used to disable an integration entry (those you see on your integrations dashboard) on the fly. _#bye_
 
 `homeassistant.disable_config_entry`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_config_entry), [documentation](integrations#disable-an-integration) 📚
 
@@ -244,13 +244,13 @@ Be amazed... this action does the reverse of [](#integration-disable). _#mindblo
 
 ## Integration: Disable polling for updates
 
-This action can be used to disable polling for updates on an integration configuration entry (those you see on your integrations dashboard). _#stopit_
+This action can be used to disable polling for updates on an integration entry (those you see on your integrations dashboard). _#stopit_
 
 `homeassistant.disable_polling`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_polling), [documentation](integrations#disable-polling-for-updates) 📚
 
 ## Integration: Enable polling for updates
 
-This action can be used to enable polling for updates on an integration configuration entry (those you see on your integrations dashboard). This service does the reverse of [](#integration-disable-polling-for-updates) _#poking_
+This action can be used to enable polling for updates on an integration entry (those you see on your integrations dashboard). This service does the reverse of [](#integration-disable-polling-for-updates) _#poking_
 
 `homeassistant.enable_polling`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_polling), [documentation](integrations#enable-polling-for-updates) 📚
 

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -73,12 +73,6 @@ Boolean
 :::
 
 :::{glossary}
-Config entry
-: A config entry in {term}`Home Assistant` is a configuration for an {term}`integration <integration>`. It is a technical term from the developer sources leaking into the user space, which may sometimes sound confusing. In short, it is the configuration you see on the integrations page. Most integrations can be set up multiple times (like adding two Hue bridges or multiple ESPHome devices). Each such "integration instance" is a config entry.
-: This is sometimes referred to as "integration instance" or "integration entry".
-:::
-
-:::{glossary}
 Dashboard
 : A dashboard in {term}`Home Assistant` is a user interface that displays information and control {term}`entities <entity>` in your home. Dashboards are used to create a user interface to control your home, such as turning on the lights or seeing the current temperature. Dashboards are fully customizable and can be created in many different ways. There is a vibrant community that shares their dashboards so that you can get inspiration and ideas for your own dashboard.
 : You might come across the term "Lovelace", which is the codename originally used for dashboards.
@@ -168,6 +162,12 @@ Integration
 a {term}`device <device>` or {term}`action <action>` with your Home Assistant installation. Home Assistant comes with well over a thousand integrations out of the box, but you can also install your own custom integrations.
 : Custom integrations, however, are not supported by the Home Assistant project. They are not reviewed or tested by the Home Assistant development team and thus may negatively impact the stability of your Home Assistant instance.
 : Spook 👻 is a custom integration for Home Assistant that is available via {term}`HACS`.
+:::
+
+:::{glossary}
+Integration entry
+: An integration entry in {term}`Home Assistant` is a configuration for an {term}`integration <integration>`. In short, it is the configuration you see on the integrations page. Most integrations can be set up multiple times (like adding two Hue bridges or multiple ESPHome devices), and each of those is an integration entry.
+: Home Assistant's own developer documentation calls this a "config entry", and you will still see `config_entry_id` when working with it in {term}`YAML`. That is a technical term from the developer sources leaking into the user space, which is why Spook says "integration entry" instead.
 :::
 
 :::{glossary}

--- a/documentation/integrations.md
+++ b/documentation/integrations.md
@@ -13,7 +13,7 @@ The following integration management actions are added to your Home Assistant in
 
 ### Disable an integration
 
-Disable a single instance of an integration by its {term}`config entry <config entry>`.
+Disable a single instance of an integration by its {term}`integration entry <integration entry>`.
 
 ```{figure} ./images/integration/disable_config_entry.png
 :alt: Screenshot of the Home Assistant disable config entry action in the developer tools.
@@ -84,7 +84,7 @@ data:
 
 ### Enable an integration
 
-Enable a single instance of an integration by its {term}`config entry <config entry>`.
+Enable a single instance of an integration by its {term}`integration entry <integration entry>`.
 
 ```{figure} ./images/integration/enable_config_entry.png
 :alt: Screenshot of the Home Assistant enable config entry action in the developer tools.
@@ -155,7 +155,7 @@ data:
 
 ### Disable polling for updates
 
-Disable integration polling of a single integration instance by its {term}`config entry <config entry>`.
+Disable integration polling of a single integration instance by its {term}`integration entry <integration entry>`.
 
 Some integrations frequently poll for updates. In some cases, it can be helpful to disable this temporarily. For example, in case you are not at home and want to stop polling on an integration that consumes a paid API.
 
@@ -217,7 +217,7 @@ data:
 
 ### Enable polling for updates
 
-Enable integration polling of a single integration instance by its {term}`config entry <config entry>`.
+Enable integration polling of a single integration instance by its {term}`integration entry <integration entry>`.
 
 Some integrations frequently poll for updates. In some cases, it can be helpful to enable this just temporarily. For example, in case you are not at home and want to stop polling on an integration that consumes a paid API and want to turn it back on again when you are back.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

"Config entry" is developer vocabulary that leaked into the interface. The glossary has been saying so for a while:

> It is a technical term from the developer sources leaking into the user space, which may sometimes sound confusing.
>
> This is sometimes referred to as "integration instance" or "integration entry".

So this stops showing it. Four field labels now read **Integration entry**, and their descriptions follow, because they still said "integration configuration entry" and half a rename reads worse than none.

**What is deliberately untouched:** the action names `homeassistant.disable_config_entry` and `homeassistant.enable_config_entry`, and the `config_entry_id` field key. Those are a contract rather than a label, and renaming them would break every automation calling them. Only what a user reads has changed.

**The glossary entry** now leads with the new name and keeps the old one findable, because `config_entry_id` is still what you type in YAML:

> Home Assistant's own developer documentation calls this a "config entry", and you will still see `config_entry_id` when working with it in YAML. That is a technical term from the developer sources leaking into the user space, which is why Spook says "integration entry" instead.

It also moves into alphabetical order. It had been sitting between Boolean and Dashboard rather than under I.

**Also left alone on purpose:** the "Finding the config entry ID" tip in the integrations docs. That section is about the raw ID you paste into YAML, and the key still carries that name, so renaming the prose there would make it harder to follow rather than easier.

Picked up along the way: `documentation/actions.md` said "a integration configuration entry".

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Came out of translating Spook into Dutch. "Config entry" had been rendered as "Configuratie invoer", which carries the developer framing into another language and reads as "configuration input". Fixing the term at the source is better than translating around it thirteen times, and it means the Dutch can say "Integratie-instantie" without inventing a meaning the English does not have.

The existing translations of those four labels will be flagged for review in Weblate, which is the intent: they should all be revisited rather than silently kept.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

`827 passed`, `ruff check` clean, and `prettier --check` clean on every touched file. `services.yaml` and `en.json` both still parse, and `tests/test_service_translations.py` covers the descriptor and translation parity for the renamed fields.

Checked that no `{term}` reference to the old glossary term survives anywhere in `documentation/`, since a dangling term would break the docs build.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

The action screenshots in the documentation still show the old "Config entry" label and will need retaking.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
