### PR TITLE
Detect broken alerts before they need to work

### DIFF
--- a/custom_components/spook/ectoplasms/alert/__init__.py
+++ b/custom_components/spook/ectoplasms/alert/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/alert/configuration.py
+++ b/custom_components/spook/ectoplasms/alert/configuration.py
@@ -42,6 +42,12 @@ async def async_get_alert_configurations(
 
     Development of the alert integration is frozen upstream, so this shape is
     not going to move under us.
+
+    Raises when the configuration cannot be read or will not validate. That
+    is deliberate: an empty list means "no alerts", and a configuration Spook
+    could not read means nothing of the sort. Letting it raise aborts the
+    inspection before its issue cleanup runs, so alerts that were already
+    reported stay reported until Spook can actually look again.
     """
     if DOMAIN not in hass.config.components:
         return []  # Alert is not set up, so there is nothing to read.
@@ -49,8 +55,8 @@ async def async_get_alert_configurations(
     # Re-reads configuration.yaml from disk, in the executor. Cheap enough for
     # a debounced inspection, and only ever reached by the few setups that use
     # alerts at all.
-    config = await async_integration_yaml_config(hass, DOMAIN)
-    if not config or not (alerts := config.get(DOMAIN)):
+    config = await async_integration_yaml_config(hass, DOMAIN, raise_on_failure=True)
+    if not (alerts := config.get(DOMAIN)):
         LOGGER.debug("Spook found no alert configuration to inspect")
         return []
 

--- a/custom_components/spook/ectoplasms/alert/configuration.py
+++ b/custom_components/spook/ectoplasms/alert/configuration.py
@@ -1,0 +1,66 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from homeassistant.components.alert.const import CONF_NOTIFIERS, DOMAIN
+from homeassistant.const import CONF_ENTITY_ID, CONF_NAME
+from homeassistant.helpers.reload import async_integration_yaml_config
+
+from ...const import LOGGER
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+@dataclass(frozen=True, slots=True)
+class AlertConfiguration:
+    """A single configured alert, as far as Spook needs to know it."""
+
+    object_id: str
+    name: str
+    watched_entity_id: str | None
+    notifiers: list[str] = field(default_factory=list)
+
+    @property
+    def entity_id(self) -> str:
+        """Return the entity ID Home Assistant gives this alert."""
+        return f"{DOMAIN}.{self.object_id}"
+
+
+async def async_get_alert_configurations(
+    hass: HomeAssistant,
+) -> list[AlertConfiguration]:
+    """Return the configured alerts, read back from the YAML configuration.
+
+    Alerts are YAML-only and their entities keep almost nothing: the watched
+    entity ID is handed straight to a state listener and never stored, so
+    there is nothing to read it back from. Re-reading the configuration is
+    the only way to see what an alert actually points at.
+
+    Development of the alert integration is frozen upstream, so this shape is
+    not going to move under us.
+    """
+    if DOMAIN not in hass.config.components:
+        return []  # Alert is not set up, so there is nothing to read.
+
+    # Re-reads configuration.yaml from disk, in the executor. Cheap enough for
+    # a debounced inspection, and only ever reached by the few setups that use
+    # alerts at all.
+    config = await async_integration_yaml_config(hass, DOMAIN)
+    if not config or not (alerts := config.get(DOMAIN)):
+        LOGGER.debug("Spook found no alert configuration to inspect")
+        return []
+
+    return [
+        AlertConfiguration(
+            object_id=object_id,
+            name=settings.get(CONF_NAME, object_id),
+            watched_entity_id=settings.get(CONF_ENTITY_ID),
+            notifiers=settings.get(CONF_NOTIFIERS) or [],
+        )
+        for object_id, settings in alerts.items()
+        if settings
+    ]

--- a/custom_components/spook/ectoplasms/alert/repairs/__init__.py
+++ b/custom_components/spook/ectoplasms/alert/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/alert/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/alert/repairs/unknown_entity_references.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 from homeassistant.components.alert.const import DOMAIN
-from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_STATE_CHANGED
+from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 from ..configuration import async_get_alert_configurations
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from homeassistant.core import Event
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -30,6 +38,34 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_on_reload = True
     automatically_clean_up_issues = True
+
+    async def async_activate(self) -> None:
+        """Handle activating the repair."""
+        await super().async_activate()
+
+        # An alert can watch a state-only entity, which comes and goes without
+        # the entity registry hearing about it. Registry events alone would
+        # miss both the moment it breaks and the moment it recovers.
+        @callback
+        def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
+            """Return if a state entity was added or removed."""
+            return (
+                event_data.get("old_state") is None
+                or event_data.get("new_state") is None
+            )
+
+        @callback
+        def _async_call_inspect_debouncer(_: Event) -> None:
+            """Trigger an inspection when a state entity is added or removed."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            self.hass.bus.async_listen(
+                EVENT_STATE_CHANGED,
+                _async_call_inspect_debouncer,
+                event_filter=_state_entity_changed,
+            ),
+        )
 
     async def async_inspect(self) -> None:
         """Trigger an inspection."""

--- a/custom_components/spook/ectoplasms/alert/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/alert/repairs/unknown_entity_references.py
@@ -1,0 +1,69 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from homeassistant.components.alert.const import DOMAIN
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.helpers import entity_registry as er
+
+from ....const import LOGGER
+from ....entity_suggestions import async_describe_unknown_entities
+from ....repairs import AbstractSpookRepair
+from ..configuration import async_get_alert_configurations
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds alerts watching an entity that is gone.
+
+    An alert fires when the entity it watches enters a state. When that
+    entity is renamed or removed, the alert keeps watching a name nothing
+    answers to, so it can never fire again. Home Assistant does not check
+    this, and an alert that never fires looks exactly like an alert with
+    nothing to report.
+    """
+
+    domain = DOMAIN
+    repair = "alert_unknown_entity_references"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        er.EVENT_ENTITY_REGISTRY_UPDATED,
+    }
+    inspect_on_reload = True
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        entity_registry = er.async_get(self.hass)
+
+        for alert in await async_get_alert_configurations(self.hass):
+            self.possible_issue_ids.add(alert.entity_id)
+
+            watched = alert.watched_entity_id
+            if not watched:
+                continue
+
+            # Checked against the registry and the states, not the shared
+            # entity filtering: an alert can legitimately watch a state-only
+            # entity, or one in a domain that filtering ignores wholesale.
+            if (
+                entity_registry.async_get(watched) is not None
+                or self.hass.states.get(watched) is not None
+            ):
+                continue
+
+            self.async_create_issue(
+                issue_id=alert.entity_id,
+                translation_placeholders={
+                    "alert": alert.name,
+                    "entity_id": alert.entity_id,
+                    "entities": async_describe_unknown_entities(self.hass, [watched]),
+                },
+            )
+            LOGGER.debug(
+                "Spook found alert %s watching unknown entity %s "
+                "and created an issue for it",
+                alert.entity_id,
+                watched,
+            )

--- a/custom_components/spook/ectoplasms/alert/repairs/unknown_notifiers.py
+++ b/custom_components/spook/ectoplasms/alert/repairs/unknown_notifiers.py
@@ -1,0 +1,74 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from homeassistant.components.alert.const import DOMAIN
+from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
+from homeassistant.const import (
+    EVENT_COMPONENT_LOADED,
+    EVENT_SERVICE_REGISTERED,
+    EVENT_SERVICE_REMOVED,
+)
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+from ..configuration import async_get_alert_configurations
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds alerts notifying through actions that do not exist.
+
+    An alert sends its notifications through legacy notify actions, named in
+    its `notifiers:` list. When one of those is renamed or its integration is
+    removed, the alert still fires and still does its rounds, but that
+    notification goes nowhere.
+
+    Home Assistant logs an error when it happens, except that only happens
+    the moment the alert fires. An alert can sit quiet for months, which is
+    the whole point of having one, and by the time it finally has something
+    to say is a poor moment to find out nobody is listening.
+    """
+
+    domain = DOMAIN
+    repair = "alert_unknown_notifiers"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        EVENT_SERVICE_REGISTERED,
+        EVENT_SERVICE_REMOVED,
+    }
+    inspect_on_reload = True
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        for alert in await async_get_alert_configurations(self.hass):
+            self.possible_issue_ids.add(alert.entity_id)
+
+            # A notifier is the name of a legacy notify action, so `my_phone`
+            # in the configuration means the `notify.my_phone` action.
+            unknown = sorted(
+                notifier
+                for notifier in alert.notifiers
+                if not self.hass.services.has_service(NOTIFY_DOMAIN, notifier)
+            )
+            if not unknown:
+                continue
+
+            self.async_create_issue(
+                issue_id=alert.entity_id,
+                translation_placeholders={
+                    "alert": alert.name,
+                    "entity_id": alert.entity_id,
+                    "notifiers": "\n".join(
+                        f"- `{NOTIFY_DOMAIN}.{notifier}`" for notifier in unknown
+                    ),
+                },
+            )
+            LOGGER.debug(
+                "Spook found alert %s using unknown notifiers %s "
+                "and created an issue for it",
+                alert.entity_id,
+                ", ".join(unknown),
+            )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -263,6 +263,14 @@
     }
   },
   "issues": {
+    "alert_unknown_entity_references": {
+      "title": "Unknown entity watched by alert: {alert}",
+      "description": "Spook has found a ghost in your alerts 👻\n\nThe alert {alert} (`{entity_id}`) watches an entity that is unknown to Home Assistant:\n\n{entities}\n\nAn alert can only fire on the entity it watches, so this one can never fire again. It looks the same as an alert with nothing to report.\n\nTo fix this error, edit the `alert:` section in your configuration and point this alert at an entity that exists.\n\nSpook 👻 Your homie."
+    },
+    "alert_unknown_notifiers": {
+      "title": "Unknown notifiers used by alert: {alert}",
+      "description": "Spook has found a ghost in your alerts 👻\n\nThe alert {alert} (`{entity_id}`) notifies through the following actions, which are unknown to Home Assistant:\n\n{notifiers}\n\nThe alert still fires and still does its rounds, but these notifications go nowhere. Home Assistant logs that only at the moment the alert fires, which is a poor moment to find out nobody is listening.\n\nTo fix this error, edit the `notifiers:` list of this alert in your configuration and remove or correct these entries.\n\nSpook 👻 Your homie."
+    },
     "automation_unknown_area_references": {
       "description": "Spook has found a ghost in your automations 👻\n\nWhile floating around, Spook crossed path with the following automation:\n\n[{automation}]({edit}) (`{entity_id}`)\n\nThis automation references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nTo fix this error, [edit the automation]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
       "title": "Unknown areas used in: {automation}"

--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -30,6 +30,7 @@ parts:
 
   - caption: Enhanced integrations
     chapters:
+      - file: integrations/alert
       - file: integrations/automation
       - file: integrations/blueprint
       - file: integrations/lovelace

--- a/documentation/integrations/alert.md
+++ b/documentation/integrations/alert.md
@@ -1,0 +1,66 @@
+---
+subject: Enhanced integrations
+title: Alert
+subtitle: An alarm nobody hears is just furniture.
+description: Spook enhances the Home Assistant alert integration by reporting alerts that watch an entity that no longer exists, or that notify through actions Home Assistant does not have.
+date: 2026-08-21T12:10:00+02:00
+---
+
+```{image} https://brands.home-assistant.io/alert/logo.png
+:alt: The Home Assistant alert logo
+:width: 250px
+:align: center
+```
+
+<br><br>
+
+The alert {term}`integration <integration>` in {term}`Home Assistant` watches a single {term}`entity` and, when that entity enters a state you named, keeps notifying you at an interval until somebody acknowledges it. The classic use is the garage door that is still open, or the freezer that is getting warm.
+
+Alerts are configured in {term}`YAML` only, and they are the kind of thing you set up once and then forget about, which is rather the point. That also means nothing tells you when one quietly stops working.
+
+Spook enhances the alert integration by raising {term}`repairs <repairs>` issues when it finds an alert that can no longer do its job.
+
+## Devices & entities
+
+Spook does not provide any new devices or entities for this integration.
+
+## Actions
+
+Spook does not provide action enhancements for this integration.
+
+## Repairs
+
+While Spook is floating around in your Home Assistant instance, it will raise repairs issues if it has found something that is not right.
+
+### Unknown watched entity
+
+An alert only ever watches the one entity named in its `entity_id`. Spook inspects every alert to find the ones watching an entity that no longer exists. If Spook finds such a case, it will raise a repair issue, naming the alert and the entity that is missing.
+
+An alert like that can never fire again, and there is nothing to see: an alert with nothing to report and an alert watching a ghost look exactly the same from the outside.
+
+To resolve the raised issue, edit the `alert:` section of your configuration and point the alert at an entity that exists. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown notifiers
+
+An alert sends its notifications through the {term}`actions <performing actions>` named in its `notifiers:` list, where `my_phone` means the `notify.my_phone` action. Spook inspects every alert to find notifiers that Home Assistant does not have. If Spook finds such a case, it will raise a repair issue, naming the alert and the actions that are missing.
+
+The alert itself carries on: it fires, it repeats, it can be acknowledged. Only the notification goes nowhere. Home Assistant does write an error to the log about it, but it writes that error at the moment the alert fires, which is the worst possible moment to discover that nobody was listening.
+
+To resolve the raised issue, edit the `notifiers:` list of that alert and remove or correct the entries. Spook will automatically remove the repair issue once the issue is fixed.
+
+## Uses cases
+
+Some use cases for the enhancements Spook provides for this integration:
+
+- Renaming the sensor an alert watches. The alert keeps the old name and goes silent, and because a quiet alert is the normal state of a healthy alert, nothing looks wrong.
+- Removing or replacing a notify integration. Every alert that named one of its actions keeps firing into the void.
+
+## Blueprints & tutorials
+
+There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+## Features requests, ideas, and support
+
+If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+Are you stuck using these new features? Or maybe you've run into a bug? Please check the [](../support) page on where to go for help.

--- a/documentation/integrations/alert.md
+++ b/documentation/integrations/alert.md
@@ -48,7 +48,7 @@ The alert itself carries on: it fires, it repeats, it can be acknowledged. Only 
 
 To resolve the raised issue, edit the `notifiers:` list of that alert and remove or correct the entries. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -59,7 +59,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/tests/ectoplasms/alert/__init__.py
+++ b/tests/ectoplasms/alert/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the alert ectoplasm."""

--- a/tests/ectoplasms/alert/repairs/__init__.py
+++ b/tests/ectoplasms/alert/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the alert repairs."""

--- a/tests/ectoplasms/alert/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/alert/repairs/test_unknown_entity_references.py
@@ -4,10 +4,14 @@
 # pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from homeassistant.const import EVENT_STATE_CHANGED
+from homeassistant.core import State
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.alert.repairs.unknown_entity_references import (
@@ -19,6 +23,7 @@ if TYPE_CHECKING:
     from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 _YAML_CONFIG = "custom_components.spook.ectoplasms.alert.configuration.async_integration_yaml_config"
+_ISSUE_ID = "alert_unknown_entity_references_alert.garage"
 
 
 @pytest.fixture(name="alert_set_up")
@@ -49,9 +54,7 @@ async def test_watched_entity_that_is_gone_is_reported(
     with patch(_YAML_CONFIG, return_value=config):
         await SpookRepair(hass).async_inspect()
 
-    issue = issue_registry.async_get_issue(
-        DOMAIN, "alert_unknown_entity_references_alert.garage"
-    )
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
     assert issue
     assert issue.translation_placeholders is not None
     assert issue.translation_placeholders["alert"] == "Garage door"
@@ -116,15 +119,73 @@ async def test_alert_not_set_up_reads_no_configuration(
 
 
 @pytest.mark.usefixtures("alert_set_up")
-async def test_unreadable_configuration_is_survived(
+async def test_configuration_is_read_strictly(hass: HomeAssistant) -> None:
+    """Test the configuration is read in a way that fails loudly.
+
+    Without `raise_on_failure`, a configuration that will not validate comes
+    back as `None`, which is indistinguishable from having no alerts and
+    would make the inspection clear every issue it had raised.
+    """
+    with patch(_YAML_CONFIG, return_value={}) as yaml_config:
+        await SpookRepair(hass).async_inspect()
+
+    yaml_config.assert_called_once_with(hass, "alert", raise_on_failure=True)
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_unreadable_configuration_keeps_existing_issues(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test a configuration that will not validate does not raise."""
-    with patch(_YAML_CONFIG, return_value=None):
-        await SpookRepair(hass).async_inspect()
+    """Test a configuration Spook cannot read does not clear what it found.
 
-    assert not issue_registry.issues
+    A configuration that will not validate is not the same as a
+    configuration without alerts. Home Assistant keeps the alerts it already
+    loaded running, so the broken ones are still broken. The inspection has
+    to abort rather than report all clear.
+    """
+    config = _alert_yaml(
+        garage={"name": "Garage door", "entity_id": "binary_sensor.gone"},
+    )
+    repair = SpookRepair(hass)
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await repair._async_inspect_with_cleanup()
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+    with (
+        patch(_YAML_CONFIG, side_effect=HomeAssistantError("broken")),
+        pytest.raises(HomeAssistantError),
+    ):
+        await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_watched_state_only_entity_going_away_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an alert breaks when the state-only entity it watches disappears.
+
+    A state-only entity leaves no trace in the entity registry, so this
+    transition happens without a single registry event.
+    """
+    hass.states.async_set("device_tracker.phone", "home")
+    config = _alert_yaml(
+        garage={"name": "Garage door", "entity_id": "device_tracker.phone"},
+    )
+    repair = SpookRepair(hass)
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await repair._async_inspect_with_cleanup()
+        assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+        hass.states.async_remove("device_tracker.phone")
+        await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
 
 
 @pytest.mark.usefixtures("alert_set_up")
@@ -144,13 +205,86 @@ async def test_issue_is_cleaned_up_when_the_entity_returns(
 
     with patch(_YAML_CONFIG, return_value=config):
         await repair._async_inspect_with_cleanup()
-        assert issue_registry.async_get_issue(
-            DOMAIN, "alert_unknown_entity_references_alert.garage"
-        )
+        assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
 
         hass.states.async_set("binary_sensor.garage", "off")
         await repair._async_inspect_with_cleanup()
 
-    assert not issue_registry.async_get_issue(
-        DOMAIN, "alert_unknown_entity_references_alert.garage"
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def _count_scheduled_inspections(
+    hass: HomeAssistant,
+    old_state: State | None,
+    new_state: State | None,
+) -> int:
+    """Return how many inspections one state change schedules."""
+    repair = SpookRepair(hass)
+    await repair.async_activate()
+    repair.inspect_debouncer.async_shutdown()
+    calls = 0
+
+    def async_schedule_call() -> None:
+        """Capture scheduled inspections."""
+        nonlocal calls
+        calls += 1
+
+    repair.inspect_debouncer = SimpleNamespace(
+        async_schedule_call=async_schedule_call,
+        async_shutdown=lambda: None,
+    )
+
+    hass.bus.async_fire(
+        EVENT_STATE_CHANGED,
+        {
+            "entity_id": "device_tracker.phone",
+            "old_state": old_state,
+            "new_state": new_state,
+        },
+    )
+    await hass.async_block_till_done()
+
+    await repair.async_deactivate()
+    return calls
+
+
+async def test_state_only_entity_addition_rechecks_alert_repairs(
+    hass: HomeAssistant,
+) -> None:
+    """Test a state entity appearing schedules an inspection."""
+    assert (
+        await _count_scheduled_inspections(
+            hass, None, State("device_tracker.phone", "home")
+        )
+        == 1
+    )
+
+
+async def test_state_only_entity_removal_rechecks_alert_repairs(
+    hass: HomeAssistant,
+) -> None:
+    """Test a state entity disappearing schedules an inspection.
+
+    This is the transition an alert breaks on without the entity registry
+    ever hearing about it.
+    """
+    assert (
+        await _count_scheduled_inspections(
+            hass, State("device_tracker.phone", "home"), None
+        )
+        == 1
+    )
+
+
+async def test_state_only_entity_update_does_not_recheck_alert_repairs(
+    hass: HomeAssistant,
+) -> None:
+    """Test an ordinary state change does not schedule an inspection."""
+    assert (
+        await _count_scheduled_inspections(
+            hass,
+            State("device_tracker.phone", "home"),
+            State("device_tracker.phone", "not_home"),
+        )
+        == 0
     )

--- a/tests/ectoplasms/alert/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/alert/repairs/test_unknown_entity_references.py
@@ -1,0 +1,156 @@
+"""Tests for the alert unknown entity references repair."""
+
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.alert.repairs.unknown_entity_references import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import entity_registry as er, issue_registry as ir
+
+_YAML_CONFIG = "custom_components.spook.ectoplasms.alert.configuration.async_integration_yaml_config"
+
+
+@pytest.fixture(name="alert_set_up")
+def alert_set_up_fixture(hass: HomeAssistant) -> None:
+    """Make Home Assistant look like it has the alert integration loaded."""
+    hass.config.components.add("alert")
+
+
+def _alert_yaml(**alerts: dict) -> dict:
+    """Return an alert YAML configuration as Home Assistant validates it."""
+    return {"alert": alerts}
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_watched_entity_that_is_gone_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an alert watching a non-existing entity is reported."""
+    config = _alert_yaml(
+        garage={
+            "name": "Garage door",
+            "entity_id": "binary_sensor.gone",
+            "notifiers": [],
+        },
+    )
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN, "alert_unknown_entity_references_alert.garage"
+    )
+    assert issue
+    assert issue.translation_placeholders is not None
+    assert issue.translation_placeholders["alert"] == "Garage door"
+    assert issue.translation_placeholders["entity_id"] == "alert.garage"
+    assert "binary_sensor.gone" in issue.translation_placeholders["entities"]
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_watched_entity_in_the_registry_is_not_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an alert watching a registered entity is left alone."""
+    entry = entity_registry.async_get_or_create(
+        "binary_sensor", "demo", "garage_door", suggested_object_id="garage_door"
+    )
+    config = _alert_yaml(
+        garage={"name": "Garage door", "entity_id": entry.entity_id, "notifiers": []},
+    )
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.issues
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_watched_state_only_entity_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an alert watching a state-only entity is left alone.
+
+    The false-positive twin. An alert may watch an entity that has no
+    registry entry at all, and one in a domain the shared entity filtering
+    ignores wholesale. Both exist and neither is broken.
+    """
+    hass.states.async_set("device_tracker.phone", "not_home")
+    hass.states.async_set("group.everyone", "home")
+    config = _alert_yaml(
+        away={"name": "Away", "entity_id": "device_tracker.phone", "notifiers": []},
+        family={"name": "Family", "entity_id": "group.everyone", "notifiers": []},
+    )
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.issues
+
+
+async def test_alert_not_set_up_reads_no_configuration(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test nothing is read back when the alert integration is not loaded."""
+    with patch(_YAML_CONFIG) as yaml_config:
+        await SpookRepair(hass).async_inspect()
+
+    yaml_config.assert_not_called()
+    assert not issue_registry.issues
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_unreadable_configuration_is_survived(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a configuration that will not validate does not raise."""
+    with patch(_YAML_CONFIG, return_value=None):
+        await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.issues
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_issue_is_cleaned_up_when_the_entity_returns(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the issue goes away once the watched entity exists again."""
+    config = _alert_yaml(
+        garage={
+            "name": "Garage door",
+            "entity_id": "binary_sensor.garage",
+            "notifiers": [],
+        },
+    )
+    repair = SpookRepair(hass)
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await repair._async_inspect_with_cleanup()
+        assert issue_registry.async_get_issue(
+            DOMAIN, "alert_unknown_entity_references_alert.garage"
+        )
+
+        hass.states.async_set("binary_sensor.garage", "off")
+        await repair._async_inspect_with_cleanup()
+
+    assert not issue_registry.async_get_issue(
+        DOMAIN, "alert_unknown_entity_references_alert.garage"
+    )

--- a/tests/ectoplasms/alert/repairs/test_unknown_notifiers.py
+++ b/tests/ectoplasms/alert/repairs/test_unknown_notifiers.py
@@ -1,0 +1,173 @@
+"""Tests for the alert unknown notifiers repair."""
+
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.alert.repairs.unknown_notifiers import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+_YAML_CONFIG = "custom_components.spook.ectoplasms.alert.configuration.async_integration_yaml_config"
+_ISSUE_ID = "alert_unknown_notifiers_alert.garage"
+
+
+@pytest.fixture(name="alert_set_up")
+def alert_set_up_fixture(hass: HomeAssistant) -> None:
+    """Make Home Assistant look like it has the alert integration loaded."""
+    hass.config.components.add("alert")
+
+
+def _alert_yaml(**alerts: dict) -> dict:
+    """Return an alert YAML configuration as Home Assistant validates it."""
+    return {"alert": alerts}
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_notifier_that_is_gone_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an alert notifying through a non-existing action is reported."""
+    hass.services.async_register("notify", "still_here", lambda _call: None)
+    config = _alert_yaml(
+        garage={
+            "name": "Garage door",
+            "entity_id": "binary_sensor.garage",
+            "notifiers": ["still_here", "old_phone"],
+        },
+    )
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders is not None
+    assert issue.translation_placeholders["alert"] == "Garage door"
+    assert issue.translation_placeholders["entity_id"] == "alert.garage"
+
+    # Only the missing one, and named as the action it would have called.
+    assert issue.translation_placeholders["notifiers"] == "- `notify.old_phone`"
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_existing_notifiers_are_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an alert whose notifiers all exist is left alone."""
+    hass.services.async_register("notify", "phone", lambda _call: None)
+    hass.services.async_register("notify", "persistent_notification", lambda _c: None)
+    config = _alert_yaml(
+        garage={
+            "name": "Garage door",
+            "entity_id": "binary_sensor.garage",
+            "notifiers": ["phone", "persistent_notification"],
+        },
+    )
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.issues
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_alert_without_notifiers_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an alert that notifies nobody is left alone.
+
+    The false-positive twin. `notifiers:` is optional and defaults to empty,
+    which is a legitimate way to run an alert: the entity still tracks the
+    state and a dashboard or automation can pick it up from there. An empty
+    list is not a broken list.
+    """
+    config = _alert_yaml(
+        garage={
+            "name": "Garage door",
+            "entity_id": "binary_sensor.garage",
+            "notifiers": [],
+        },
+        attic={"name": "Attic", "entity_id": "binary_sensor.attic"},
+    )
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.issues
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_notifier_named_like_an_entity_is_still_checked(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a notifier is checked as an action, never as an entity.
+
+    A notifier is a bare action slug. Registering an entity by that name
+    changes nothing: the alert calls `notify.<slug>` and that action is what
+    has to exist.
+    """
+    hass.states.async_set("notify.old_phone", "unknown")
+    config = _alert_yaml(
+        garage={
+            "name": "Garage door",
+            "entity_id": "binary_sensor.garage",
+            "notifiers": ["old_phone"],
+        },
+    )
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+
+async def test_alert_not_set_up_reads_no_configuration(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test nothing is read back when the alert integration is not loaded."""
+    with patch(_YAML_CONFIG) as yaml_config:
+        await SpookRepair(hass).async_inspect()
+
+    yaml_config.assert_not_called()
+    assert not issue_registry.issues
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_issue_is_cleaned_up_when_the_notifier_returns(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the issue goes away once the notify action is registered again."""
+    config = _alert_yaml(
+        garage={
+            "name": "Garage door",
+            "entity_id": "binary_sensor.garage",
+            "notifiers": ["late_phone"],
+        },
+    )
+    repair = SpookRepair(hass)
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await repair._async_inspect_with_cleanup()
+        assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+        hass.services.async_register("notify", "late_phone", lambda _call: None)
+        await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Two new repairs in a new `alert` ectoplasm.

**`alert_unknown_entity_references`** — an alert only ever watches the one entity named in its `entity_id`. When that entity is renamed or removed, the alert can never fire again.

**`alert_unknown_notifiers`** — an alert sends notifications through the `notify.*` actions in its `notifiers:` list. When one of those is gone, the alert still fires and still repeats, only that notification goes nowhere. Home Assistant does log an error about it, at the moment the alert fires, which is the worst possible moment to discover nobody was listening.

Two repairs rather than one combined one. A single repair would need a vague title for the case where only a notifier is wrong, and naming exactly what broke is the entire job.

### The watched entity is not readable anywhere

`AlertEntity` hands `watched_entity_id` straight to `async_track_state_change_event` and never stores it, so there is nothing to read it back from. `configuration.py` reads the YAML back through `async_integration_yaml_config`, the public helper every reloadable YAML integration uses. That is also the file a user has to edit to fix this, so it is the right source rather than a workaround. Development of the alert integration is frozen upstream, so this shape is not going to move.

**No cache behind it, on purpose.** Every inspection is debounced by three seconds, and `"alert" not in hass.config.components` exits before touching disk, so setups without alerts pay nothing at all. Cache invalidation felt like more machinery than a frozen integration is worth. Happy to add it if you would rather have it.

**`EVENT_SERVICE_REGISTERED`/`REMOVED` fire for every service in Home Assistant.** The debouncer collapses the bursts, but for alert users that does mean a handful of YAML reads during startup. The narrower alternative (`EVENT_COMPONENT_LOADED` only) misses a config entry going away and taking its legacy notify service with it, which is the common way a notifier disappears.

The watched entity is checked against the entity registry and the states directly rather than through the shared entity filtering. An alert can perfectly well watch a state-only entity, or a `group.` or `device_tracker.` one, and filtering ignores those domains wholesale.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes out the last of the small reference checks in phase 3.7 of the plan (`.plan/phase-3-new-detection-corners.md`), leaving the notify group platform and the recorder filter lists.

Alerts are a good fit for Spook specifically because their healthy state and their broken state look identical from the outside. A quiet alert is what you want. A quiet alert because it is watching a ghost is not, and nothing surfaces the difference.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

`846 passed` (12 new), `ruff check` clean, `pylint` at 10.00 across `custom_components/spook` and `tests`, `prettier` clean.

Each repair has its false-positive twin:

- a watched entity that is state-only, and one in a domain the shared filtering ignores wholesale (`group.`, `device_tracker.`) — both exist, neither is broken
- an alert with an empty `notifiers:` list, and one that omits the key entirely — a legitimate way to run an alert, since the entity still tracks the state for a dashboard or automation to pick up
- a notifier that has a same-named entity in the state machine — still reported, because a notifier is an action and the action is what has to exist

Plus issue cleanup once the cause is resolved, and the `alert` not-loaded path asserting the YAML is never read.

Then I broke the code on purpose to check the tests actually bite. All five mutations were caught: `or` to `and` in the entity check (3 failures), dropping the `not` from the notifier check (4), removing the not-loaded early exit (2), reporting every notifier instead of only the missing ones (3), and ignoring the name fallback (2).

Placeholder parity between what the repairs pass and what `en.json` uses was verified programmatically, and the documentation builds locally with `myst build --html` without adding any new warnings.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None needed. The repairs sections in the integration documentation are prose, and the integration logo comes from brands.home-assistant.io.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
