### PR TITLE
Only wake the alert repair for entities an alert watches

### DIFF
--- a/custom_components/spook/ectoplasms/alert/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/alert/repairs/unknown_entity_references.py
@@ -17,7 +17,7 @@ from ..configuration import async_get_alert_configurations
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from homeassistant.core import Event
+    from homeassistant.core import Event, HomeAssistant
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -39,6 +39,11 @@ class SpookRepair(AbstractSpookRepair):
     inspect_on_reload = True
     automatically_clean_up_issues = True
 
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the repair."""
+        super().__init__(hass)
+        self._watched_entity_ids: set[str] = set()
+
     async def async_activate(self) -> None:
         """Handle activating the repair."""
         await super().async_activate()
@@ -46,24 +51,30 @@ class SpookRepair(AbstractSpookRepair):
         # An alert can watch a state-only entity, which comes and goes without
         # the entity registry hearing about it. Registry events alone would
         # miss both the moment it breaks and the moment it recovers.
+        #
+        # Narrowed to the entities some alert actually watches, because an
+        # inspection here re-reads the configuration from disk. The sibling
+        # repairs filter on add/remove alone, but they only walk objects
+        # already in memory. The set comes from the last inspection, so a
+        # newly watched entity is picked up by the reload that introduced it.
         @callback
-        def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
-            """Return if a state entity was added or removed."""
-            return (
+        def _watched_entity_changed(event_data: Mapping[str, Any]) -> bool:
+            """Return if a watched state entity was added or removed."""
+            return event_data.get("entity_id") in self._watched_entity_ids and (
                 event_data.get("old_state") is None
                 or event_data.get("new_state") is None
             )
 
         @callback
         def _async_call_inspect_debouncer(_: Event) -> None:
-            """Trigger an inspection when a state entity is added or removed."""
+            """Trigger an inspection when a watched entity appears or goes."""
             self.inspect_debouncer.async_schedule_call()
 
         self._event_subs.add(
             self.hass.bus.async_listen(
                 EVENT_STATE_CHANGED,
                 _async_call_inspect_debouncer,
-                event_filter=_state_entity_changed,
+                event_filter=_watched_entity_changed,
             ),
         )
 
@@ -73,7 +84,14 @@ class SpookRepair(AbstractSpookRepair):
 
         entity_registry = er.async_get(self.hass)
 
-        for alert in await async_get_alert_configurations(self.hass):
+        alerts = await async_get_alert_configurations(self.hass)
+        self._watched_entity_ids = {
+            alert.watched_entity_id
+            for alert in alerts
+            if alert.watched_entity_id is not None
+        }
+
+        for alert in alerts:
             self.possible_issue_ids.add(alert.entity_id)
 
             watched = alert.watched_entity_id

--- a/tests/ectoplasms/alert/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/alert/repairs/test_unknown_entity_references.py
@@ -215,12 +215,24 @@ async def test_issue_is_cleaned_up_when_the_entity_returns(
 
 async def _count_scheduled_inspections(
     hass: HomeAssistant,
+    entity_id: str,
     old_state: State | None,
     new_state: State | None,
 ) -> int:
-    """Return how many inspections one state change schedules."""
+    """Return how many inspections one state change schedules.
+
+    Runs a real inspection first, because that is what tells the listener
+    which entities are worth waking up for.
+    """
+    config = _alert_yaml(
+        garage={"name": "Garage door", "entity_id": "device_tracker.phone"},
+    )
     repair = SpookRepair(hass)
-    await repair.async_activate()
+
+    with patch(_YAML_CONFIG, return_value=config):
+        await repair.async_activate()
+        await repair.async_inspect()
+
     repair.inspect_debouncer.async_shutdown()
     calls = 0
 
@@ -236,11 +248,7 @@ async def _count_scheduled_inspections(
 
     hass.bus.async_fire(
         EVENT_STATE_CHANGED,
-        {
-            "entity_id": "device_tracker.phone",
-            "old_state": old_state,
-            "new_state": new_state,
-        },
+        {"entity_id": entity_id, "old_state": old_state, "new_state": new_state},
     )
     await hass.async_block_till_done()
 
@@ -248,43 +256,73 @@ async def _count_scheduled_inspections(
     return calls
 
 
-async def test_state_only_entity_addition_rechecks_alert_repairs(
+@pytest.mark.usefixtures("alert_set_up")
+async def test_watched_entity_addition_rechecks_alert_repairs(
     hass: HomeAssistant,
 ) -> None:
-    """Test a state entity appearing schedules an inspection."""
+    """Test a watched entity appearing schedules an inspection."""
     assert (
         await _count_scheduled_inspections(
-            hass, None, State("device_tracker.phone", "home")
+            hass,
+            "device_tracker.phone",
+            None,
+            State("device_tracker.phone", "home"),
         )
         == 1
     )
 
 
-async def test_state_only_entity_removal_rechecks_alert_repairs(
+@pytest.mark.usefixtures("alert_set_up")
+async def test_watched_entity_removal_rechecks_alert_repairs(
     hass: HomeAssistant,
 ) -> None:
-    """Test a state entity disappearing schedules an inspection.
+    """Test a watched entity disappearing schedules an inspection.
 
     This is the transition an alert breaks on without the entity registry
     ever hearing about it.
     """
     assert (
         await _count_scheduled_inspections(
-            hass, State("device_tracker.phone", "home"), None
+            hass,
+            "device_tracker.phone",
+            State("device_tracker.phone", "home"),
+            None,
         )
         == 1
     )
 
 
-async def test_state_only_entity_update_does_not_recheck_alert_repairs(
+@pytest.mark.usefixtures("alert_set_up")
+async def test_watched_entity_update_does_not_recheck_alert_repairs(
     hass: HomeAssistant,
 ) -> None:
     """Test an ordinary state change does not schedule an inspection."""
     assert (
         await _count_scheduled_inspections(
             hass,
+            "device_tracker.phone",
             State("device_tracker.phone", "home"),
             State("device_tracker.phone", "not_home"),
+        )
+        == 0
+    )
+
+
+@pytest.mark.usefixtures("alert_set_up")
+async def test_unwatched_entity_does_not_recheck_alert_repairs(
+    hass: HomeAssistant,
+) -> None:
+    """Test an entity no alert watches never schedules an inspection.
+
+    An inspection re-reads the configuration from disk, so entities coming
+    and going elsewhere in Home Assistant must not drag it along.
+    """
+    assert (
+        await _count_scheduled_inspections(
+            hass,
+            "sensor.something_else",
+            None,
+            State("sensor.something_else", "42"),
         )
         == 0
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Follow-up to #1446. CodeRabbit made a point the earlier review round did not, and it arrived after that one was merged.

The state listener added in #1446 filters on entities being added or removed, copying the automation, lovelace and template repairs. Those repairs walk objects that are already in memory. This one re-reads `configuration.yaml`, so any entity appearing or disappearing anywhere in Home Assistant was dragging a disk read along with it.

Narrowed to the entities an alert actually watches. The set is built by the inspection itself, which is the only thing in a position to know: reading the configuration is how you find out what an alert points at in the first place.

Starting from an empty set costs nothing. The first inspection runs at activation, before any of this can matter. A newly watched entity arrives with the reload that introduced it, and `inspect_on_reload` already covers that.

This is the last cost objection to #1446 having no cache behind its YAML read. What remains is `EVENT_SERVICE_REGISTERED`/`REMOVED` on the notifiers repair, which is unfiltered by nature: whether a `notify.*` action exists is exactly what that repair is asking.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up to #1446, which merged before this was pushed.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

`852 passed`, `ruff check` clean, `ruff format --check` clean, `pylint` at 10.00 across `custom_components/spook` and `tests`.

The three event tests now run a real inspection before firing, because that is what tells the listener which entities are worth waking for. Testing it any other way would have tested the mock. A fourth test covers the new behaviour directly: an entity no alert watches schedules nothing.

Three mutations to check the tests bite, all caught:

- filter drops the watched-ID narrowing, back to any entity (1 failure)
- the watched set is never populated (2 failures)
- the set is used but the add/remove narrowing is gone, so ordinary state changes get through (1 failure)

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
