### PR TITLE
Recheck people when a state-only device tracker comes or goes

### DIFF
--- a/custom_components/spook/ectoplasms/person/repairs/unknown_device_trackers.py
+++ b/custom_components/spook/ectoplasms/person/repairs/unknown_device_trackers.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import person
-from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_STATE_CHANGED
+from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 
@@ -14,6 +15,9 @@ from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from homeassistant.core import Event
     from homeassistant.helpers.entity_component import EntityComponent
 
 
@@ -34,6 +38,36 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_on_reload = True
     automatically_clean_up_issues = True
+
+    async def async_activate(self) -> None:
+        """Handle activating the repair."""
+        await super().async_activate()
+
+        # A device tracker can be state-only, which is the normal case for
+        # anything reporting over MQTT or the legacy known_devices.yaml. Those
+        # come and go without the entity registry hearing a thing, so registry
+        # events alone miss both the moment a person breaks and the moment it
+        # recovers.
+        @callback
+        def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
+            """Return if a state entity was added or removed."""
+            return (
+                event_data.get("old_state") is None
+                or event_data.get("new_state") is None
+            )
+
+        @callback
+        def _async_call_inspect_debouncer(_: Event) -> None:
+            """Trigger an inspection when a state entity is added or removed."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            self.hass.bus.async_listen(
+                EVENT_STATE_CHANGED,
+                _async_call_inspect_debouncer,
+                event_filter=_state_entity_changed,
+            ),
+        )
 
     async def async_inspect(self) -> None:
         """Trigger an inspection."""

--- a/tests/ectoplasms/person/repairs/test_unknown_device_trackers.py
+++ b/tests/ectoplasms/person/repairs/test_unknown_device_trackers.py
@@ -1,11 +1,14 @@
 """Tests for the person unknown device trackers repair."""
 
-# pylint: disable=wrong-import-order
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+from homeassistant.const import EVENT_STATE_CHANGED
+from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 
@@ -189,3 +192,119 @@ async def test_fix_flow_remove_yaml_person_aborts(
 
     assert result["type"] == "abort"
     assert result["reason"] == "not_editable"
+
+
+async def _count_scheduled_inspections(
+    hass: HomeAssistant,
+    old_state: State | None,
+    new_state: State | None,
+) -> int:
+    """Return how many inspections one state change schedules."""
+    repair = SpookRepair(hass)
+    await repair.async_activate()
+    repair.inspect_debouncer.async_shutdown()
+    calls = 0
+
+    def async_schedule_call() -> None:
+        """Capture scheduled inspections."""
+        nonlocal calls
+        calls += 1
+
+    repair.inspect_debouncer = SimpleNamespace(
+        async_schedule_call=async_schedule_call,
+        async_shutdown=lambda: None,
+    )
+
+    hass.bus.async_fire(
+        EVENT_STATE_CHANGED,
+        {
+            "entity_id": "device_tracker.phone",
+            "old_state": old_state,
+            "new_state": new_state,
+        },
+    )
+    await hass.async_block_till_done()
+
+    await repair.async_deactivate()
+    return calls
+
+
+async def test_state_only_tracker_going_away_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a person breaks when a state-only tracker it follows disappears.
+
+    A state-only device tracker leaves no trace in the entity registry, so
+    this transition happens without a single registry event.
+    """
+    hass.states.async_set("device_tracker.phone", "home")
+    _install_person(hass, ["device_tracker.phone"])
+    repair = SpookRepair(hass)
+
+    await repair._async_inspect_with_cleanup()
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+    hass.states.async_remove("device_tracker.phone")
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+
+async def test_issue_clears_when_a_state_only_tracker_returns(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the issue goes away once a state-only tracker exists again."""
+    _install_person(hass, ["device_tracker.phone"])
+    repair = SpookRepair(hass)
+
+    await repair._async_inspect_with_cleanup()
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+    hass.states.async_set("device_tracker.phone", "home")
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_state_only_tracker_addition_rechecks_person_repairs(
+    hass: HomeAssistant,
+) -> None:
+    """Test a state entity appearing schedules an inspection."""
+    assert (
+        await _count_scheduled_inspections(
+            hass, None, State("device_tracker.phone", "home")
+        )
+        == 1
+    )
+
+
+async def test_state_only_tracker_removal_rechecks_person_repairs(
+    hass: HomeAssistant,
+) -> None:
+    """Test a state entity disappearing schedules an inspection."""
+    assert (
+        await _count_scheduled_inspections(
+            hass, State("device_tracker.phone", "home"), None
+        )
+        == 1
+    )
+
+
+async def test_ordinary_tracker_state_change_does_not_recheck(
+    hass: HomeAssistant,
+) -> None:
+    """Test a tracker simply moving does not schedule an inspection.
+
+    Device trackers change state constantly. Rechecking on every one of
+    those would be pure noise.
+    """
+    assert (
+        await _count_scheduled_inspections(
+            hass,
+            State("device_tracker.phone", "home"),
+            State("device_tracker.phone", "not_home"),
+        )
+        == 0
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Found while reviewing the same gap in the new alert repair (#1446), which turned out to have a sibling here.

This repair already checks the entity registry *and* the states, so it does see a state-only device tracker. It just never got asked again. Registry events and component loads were the only triggers, and a state-only tracker appearing or disappearing fires neither of those.

That is not an exotic case: it is the normal one for anything reporting over MQTT or the legacy `known_devices.yaml`, which is exactly the tracker type this repair's own docstring says it goes out of its way to handle.

Two symptoms, both quiet:

- a person's tracker disappears and nothing is reported, until some unrelated registry change happens along
- an issue stays up after the tracker comes back, same story

Filtered to entities being added or removed, the way the automation, lovelace and template repairs do. Device trackers change state constantly, so rechecking on every move would be pure noise.

**No narrowing to the specific trackers a person follows**, unlike the alert repair in #1447. That one re-reads `configuration.yaml` on every inspection, so waking it for unrelated entities cost a disk read. This one walks `component.entities` in memory, so there is nothing to protect against and the sibling pattern is the right one.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up to #1446 and #1447, where this pattern was worked out.

While in the area: `homeassistant/repairs/dead_entities.py` has a related but *different* gap. Its break direction is covered by `inspect_config_entry_changed`, but its recovery direction is not. When a restored `unavailable` entity finally appears for real, its state goes from restored-unavailable to a real value, which is an update rather than an add or remove, so even this filter would not catch it, and the registry does not change because the entry already existed. That needs a different filter shape and its own thinking, so it is deliberately not in here.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

`857 passed`, `ruff check` clean, `ruff format --check` clean, `pylint` at 10.00 across `custom_components/spook` and `tests`.

Five new tests, in two kinds. Two prove the behaviour: a state-only tracker going away gets reported, and the issue clears when it returns. Three prove the wiring: appearing schedules an inspection, disappearing schedules one, and an ordinary `home` to `not_home` move schedules nothing.

Three mutations to check the tests bite, all caught:

- drop the subscription entirely, which is the bug being fixed here (2 failures)
- filter always passes, so every tracker movement triggers a recheck (1 failure)
- remove the states check from the inspection, leaving only the registry (4 failures)

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
