### PR TITLE
Only wake the person repair for device trackers

### DIFF
--- a/custom_components/spook/ectoplasms/person/repairs/unknown_device_trackers.py
+++ b/custom_components/spook/ectoplasms/person/repairs/unknown_device_trackers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import person
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_STATE_CHANGED
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
@@ -48,24 +49,34 @@ class SpookRepair(AbstractSpookRepair):
         # come and go without the entity registry hearing a thing, so registry
         # events alone miss both the moment a person breaks and the moment it
         # recovers.
+        #
+        # Limited to device trackers, unlike the sibling repairs that watch
+        # every domain. Home Assistant validates a person's `device_trackers`
+        # with `cv.entities_domain(device_tracker)`, so nothing else can ever
+        # end up in that list and nothing else is worth waking up for.
         @callback
-        def _state_entity_changed(event_data: Mapping[str, Any]) -> bool:
-            """Return if a state entity was added or removed."""
+        def _tracker_entity_changed(event_data: Mapping[str, Any]) -> bool:
+            """Return if a device tracker state entity was added or removed."""
+            entity_id = event_data.get("entity_id")
             return (
-                event_data.get("old_state") is None
-                or event_data.get("new_state") is None
+                isinstance(entity_id, str)
+                and entity_id.startswith(f"{DEVICE_TRACKER_DOMAIN}.")
+                and (
+                    event_data.get("old_state") is None
+                    or event_data.get("new_state") is None
+                )
             )
 
         @callback
         def _async_call_inspect_debouncer(_: Event) -> None:
-            """Trigger an inspection when a state entity is added or removed."""
+            """Trigger an inspection when a device tracker appears or goes."""
             self.inspect_debouncer.async_schedule_call()
 
         self._event_subs.add(
             self.hass.bus.async_listen(
                 EVENT_STATE_CHANGED,
                 _async_call_inspect_debouncer,
-                event_filter=_state_entity_changed,
+                event_filter=_tracker_entity_changed,
             ),
         )
 

--- a/tests/ectoplasms/person/repairs/test_unknown_device_trackers.py
+++ b/tests/ectoplasms/person/repairs/test_unknown_device_trackers.py
@@ -196,6 +196,7 @@ async def test_fix_flow_remove_yaml_person_aborts(
 
 async def _count_scheduled_inspections(
     hass: HomeAssistant,
+    entity_id: str,
     old_state: State | None,
     new_state: State | None,
 ) -> int:
@@ -217,11 +218,7 @@ async def _count_scheduled_inspections(
 
     hass.bus.async_fire(
         EVENT_STATE_CHANGED,
-        {
-            "entity_id": "device_tracker.phone",
-            "old_state": old_state,
-            "new_state": new_state,
-        },
+        {"entity_id": entity_id, "old_state": old_state, "new_state": new_state},
     )
     await hass.async_block_till_done()
 
@@ -274,7 +271,7 @@ async def test_state_only_tracker_addition_rechecks_person_repairs(
     """Test a state entity appearing schedules an inspection."""
     assert (
         await _count_scheduled_inspections(
-            hass, None, State("device_tracker.phone", "home")
+            hass, "device_tracker.phone", None, State("device_tracker.phone", "home")
         )
         == 1
     )
@@ -286,7 +283,7 @@ async def test_state_only_tracker_removal_rechecks_person_repairs(
     """Test a state entity disappearing schedules an inspection."""
     assert (
         await _count_scheduled_inspections(
-            hass, State("device_tracker.phone", "home"), None
+            hass, "device_tracker.phone", State("device_tracker.phone", "home"), None
         )
         == 1
     )
@@ -303,8 +300,32 @@ async def test_ordinary_tracker_state_change_does_not_recheck(
     assert (
         await _count_scheduled_inspections(
             hass,
+            "device_tracker.phone",
             State("device_tracker.phone", "home"),
             State("device_tracker.phone", "not_home"),
+        )
+        == 0
+    )
+
+
+async def test_other_domain_lifecycle_does_not_recheck(
+    hass: HomeAssistant,
+) -> None:
+    """Test entities outside device_tracker never schedule an inspection.
+
+    Home Assistant validates a person's trackers with
+    `cv.entities_domain(device_tracker)`, so nothing in another domain can
+    ever be in that list. Waking for a sensor would be pure overhead.
+    """
+    assert (
+        await _count_scheduled_inspections(
+            hass, "sensor.something_else", None, State("sensor.something_else", "42")
+        )
+        == 0
+    )
+    assert (
+        await _count_scheduled_inspections(
+            hass, "sensor.something_else", State("sensor.something_else", "42"), None
         )
         == 0
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Follow-up to #1448. CodeRabbit raised this after that one merged.

The state listener added in #1448 watches every domain, copying the automation, lovelace and template repairs. Those reference entities in any domain, so they cannot narrow. This one can.

Home Assistant validates a person's `device_trackers` with `cv.entities_domain(device_tracker)` in all three of its schemas: the YAML one and both storage ones. Nothing outside that domain can ever end up in the list.

**It was filed as a performance finding, and that undersells it.** An inspection here walks person entities in memory and costs almost nothing, so waking for a sensor was never expensive. It was *pointless*, which is the better argument. And the domain constraint is exactly what makes narrowing safe: there is no entity outside `device_tracker` that this repair could ever have an opinion about, so nothing can be missed by not listening for it.

That verification mattered more than the change itself. Narrowing a filter on a guess is how you get a repair that silently stops noticing things.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up to #1448, which merged before this was pushed.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

`858 passed`, `ruff check` clean, `ruff format --check` clean, `pylint` at 10.00 across `custom_components/spook` and `tests`.

One new test covering both directions for an unrelated domain: a `sensor` appearing and a `sensor` disappearing each schedule zero inspections.

Two mutations to check the tests bite, both caught:

- domain narrowing removed, back to any entity (1 failure)
- only the domain check, with the add/remove narrowing dropped, so ordinary tracker movement gets through (1 failure)

The second one matters here: device trackers change state constantly, so losing the add/remove half would turn this into a recheck on every movement.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
