### PR TITLE
Detect notify groups delivering to actions that are gone

### DIFF
--- a/custom_components/spook/ectoplasms/notify/__init__.py
+++ b/custom_components/spook/ectoplasms/notify/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/notify/repairs/__init__.py
+++ b/custom_components/spook/ectoplasms/notify/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/notify/repairs/unknown_group_members.py
+++ b/custom_components/spook/ectoplasms/notify/repairs/unknown_group_members.py
@@ -1,0 +1,87 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from homeassistant.components.group.notify import GroupNotifyPlatform
+from homeassistant.components.notify import DOMAIN
+from homeassistant.components.notify.legacy import NOTIFY_SERVICES
+from homeassistant.const import (
+    CONF_ACTION,
+    EVENT_COMPONENT_LOADED,
+    EVENT_SERVICE_REGISTERED,
+    EVENT_SERVICE_REMOVED,
+)
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds notify groups with members that do not exist.
+
+    A legacy notify group forwards a message to each action in its
+    `services:` list. When one of those is renamed or its integration is
+    removed, the group carries on delivering to the rest.
+
+    Nothing reports it, either. The group fires all its members as tasks and
+    awaits them with `asyncio.wait`, which does not re-raise, and nobody
+    retrieves the results. So the missing action raises into a task that is
+    never read, the group reports success, and one person quietly stops
+    getting notified.
+    """
+
+    domain = DOMAIN
+    repair = "notify_unknown_group_members"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        EVENT_SERVICE_REGISTERED,
+        EVENT_SERVICE_REMOVED,
+    }
+    inspect_on_reload = True
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        for services in self.hass.data.get(NOTIFY_SERVICES, {}).values():
+            for service in services:
+                # Picked out by type rather than by the key they are stored
+                # under, so a group set up through discovery is found too.
+                if not isinstance(service, GroupNotifyPlatform):
+                    continue
+
+                # The name the group is called by: `notify.<name>`. Private,
+                # but it is the only thing tying a notify service back to the
+                # action it registered.
+                # pylint: disable-next=protected-access
+                name = service._service_name  # noqa: SLF001
+                self.possible_issue_ids.add(name)
+
+                # A member is a bare action slug, so `phone` in the
+                # configuration means the `notify.phone` action.
+                unknown = sorted(
+                    member[CONF_ACTION]
+                    for member in service.entities
+                    if CONF_ACTION in member
+                    and not self.hass.services.has_service(DOMAIN, member[CONF_ACTION])
+                )
+                if not unknown:
+                    continue
+
+                self.async_create_issue(
+                    issue_id=name,
+                    translation_placeholders={
+                        "group": f"{DOMAIN}.{name}",
+                        "members": "\n".join(
+                            f"- `{DOMAIN}.{member}`" for member in unknown
+                        ),
+                    },
+                )
+                LOGGER.debug(
+                    "Spook found notify group %s.%s using unknown members %s "
+                    "and created an issue for it",
+                    DOMAIN,
+                    name,
+                    ", ".join(unknown),
+                )

--- a/custom_components/spook/ectoplasms/notify/repairs/unknown_group_members.py
+++ b/custom_components/spook/ectoplasms/notify/repairs/unknown_group_members.py
@@ -23,11 +23,15 @@ class SpookRepair(AbstractSpookRepair):
     `services:` list. When one of those is renamed or its integration is
     removed, the group carries on delivering to the rest.
 
-    Nothing reports it, either. The group fires all its members as tasks and
-    awaits them with `asyncio.wait`, which does not re-raise, and nobody
-    retrieves the results. So the missing action raises into a task that is
-    never read, the group reports success, and one person quietly stops
-    getting notified.
+    The caller never learns. The group fires all its members as tasks and
+    awaits them with `asyncio.wait`, which does not re-raise, so the group
+    action reports success no matter how many members failed.
+
+    The failure is not lost entirely: nobody retrieves the task result, so
+    the event loop eventually reports it as a stray "Task exception was never
+    retrieved". That arrives whenever the task is collected, names no group,
+    and looks like a bug rather than a configuration problem, which is a poor
+    way to find out that one person stopped getting notified.
     """
 
     domain = DOMAIN

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -406,7 +406,7 @@
       }
     },
     "notify_unknown_group_members": {
-      "description": "Spook has found a ghost in your notify groups 👻\n\nThe notify group `{group}` forwards to the following actions, which are unknown to Home Assistant:\n\n{members}\n\nThe group still delivers to the rest of its members and still reports success. It fires all of them as tasks and waits on them without ever reading the results, so a missing action fails without a word anywhere. Whoever was behind that member simply stops being notified.\n\nTo fix this error, edit the `services:` list of this group in your configuration and remove or correct these entries.\n\nSpook 👻 Your homie.",
+      "description": "Spook has found a ghost in your notify groups 👻\n\nThe notify group `{group}` forwards to the following actions, which are unknown to Home Assistant:\n\n{members}\n\nThe group still delivers to the rest of its members, and it still reports success to whatever called it, so nothing upstream notices. The failure surfaces only as a stray \"Task exception was never retrieved\" in the log, which names no group and reads like a bug. Whoever was behind that member simply stops being notified.\n\nTo fix this error, edit the `services:` list of this group in your configuration and remove or correct these entries.\n\nSpook 👻 Your homie.",
       "title": "Unknown members in notify group: {group}"
     },
     "orphaned_statistics": {

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -405,6 +405,10 @@
         }
       }
     },
+    "notify_unknown_group_members": {
+      "description": "Spook has found a ghost in your notify groups 👻\n\nThe notify group `{group}` forwards to the following actions, which are unknown to Home Assistant:\n\n{members}\n\nThe group still delivers to the rest of its members and still reports success. It fires all of them as tasks and waits on them without ever reading the results, so a missing action fails without a word anywhere. Whoever was behind that member simply stops being notified.\n\nTo fix this error, edit the `services:` list of this group in your configuration and remove or correct these entries.\n\nSpook 👻 Your homie.",
+      "title": "Unknown members in notify group: {group}"
+    },
     "orphaned_statistics": {
       "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Developer Tools > Statistics and fix them there, or remove them using the `recorder.clear_statistics` action.\n\nSpook 👻 Your homie.",
       "title": "Orphaned long-term statistics found"

--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -38,6 +38,7 @@ parts:
       - file: integrations/cloud
       - file: integrations/input_number
       - file: integrations/input_select
+      - file: integrations/notify
       - file: integrations/number
       - file: integrations/person
       - file: integrations/proximity

--- a/documentation/integrations/notify.md
+++ b/documentation/integrations/notify.md
@@ -1,0 +1,71 @@
+---
+subject: Enhanced integrations
+title: Notify
+subtitle: A message nobody receives is just a thought.
+description: Spook enhances the Home Assistant notify integration by reporting notify groups that forward to actions Home Assistant does not have.
+date: 2026-08-21T13:20:00+02:00
+---
+
+```{image} https://brands.home-assistant.io/notify/logo.png
+:alt: The Home Assistant notify logo
+:width: 250px
+:align: center
+```
+
+<br><br>
+
+The notify {term}`integration <integration>` in {term}`Home Assistant` sends messages to people. One of the things you can build with it is a notify group: a single {term}`action <performing actions>` that forwards whatever you send it to a list of other notify actions, so one call reaches everybody.
+
+Spook enhances the notify integration by raising {term}`repairs <repairs>` issues when it finds a notify group that can no longer reach all of its members.
+
+:::{note}
+This is about the notify group you configure in {term}`YAML` under `notify:`, the one whose members are action names:
+
+```yaml
+notify:
+  - platform: group
+    name: everyone
+    services:
+      - action: phone
+      - action: tablet
+```
+
+The newer notify group, the one you create as a helper and whose members are notify {term}`entities <entity>`, is covered by the [](group) page instead.
+:::
+
+## Devices & entities
+
+Spook does not provide any new devices or entities for this integration.
+
+## Actions
+
+Spook does not provide action enhancements for this integration.
+
+## Repairs
+
+While Spook is floating around in your Home Assistant instance, it will raise repairs issues if it has found something that is not right.
+
+### Unknown group members
+
+Every member of a notify group is the name of another notify action, so `phone` in the configuration means the `notify.phone` action. Spook inspects every notify group to find members Home Assistant does not have. If Spook finds such a case, it will raise a repair issue, naming the group and the actions that are missing.
+
+The group keeps working, which is the problem. It still delivers to its remaining members and still reports success, so from the outside the notification went out. Worse than that: it fires all its members off as background tasks and waits on them without ever reading the results, so the missing action fails without a word in the log either. Whoever was behind that member simply stops being notified, and nothing anywhere says so.
+
+To resolve the raised issue, edit the `services:` list of that group in your configuration and remove or correct the entries. Spook will automatically remove the repair issue once the issue is fixed.
+
+## Use cases
+
+Some use cases for the enhancements Spook provides for this integration:
+
+- Replacing a phone, and with it the notify action it was set up under. Every group that still names the old one keeps sending into nothing.
+- Removing a notify integration you no longer use. The groups that forwarded to it never mention that they lost a member.
+
+## Blueprints & tutorials
+
+There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+## Feature requests, ideas, and support
+
+If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+Are you stuck using these new features? Or maybe you've run into a bug? Please check the [](../support) page on where to go for help.

--- a/documentation/integrations/notify.md
+++ b/documentation/integrations/notify.md
@@ -47,9 +47,11 @@ While Spook is floating around in your Home Assistant instance, it will raise re
 
 ### Unknown group members
 
-Every member of a notify group is the name of another notify action, so `phone` in the configuration means the `notify.phone` action. Spook inspects every notify group to find members Home Assistant does not have. If Spook finds such a case, it will raise a repair issue, naming the group and the actions that are missing.
+Every member of a notify group is the name of another notify action, so `phone` in the configuration means the `notify.phone` action. Spook inspects every legacy YAML notify group to find members Home Assistant does not have. If Spook finds such a case, it will raise a repair issue, naming the group and the actions that are missing.
 
-The group keeps working, which is the problem. It still delivers to its remaining members and still reports success, so from the outside the notification went out. Worse than that: it fires all its members off as background tasks and waits on them without ever reading the results, so the missing action fails without a word in the log either. Whoever was behind that member simply stops being notified, and nothing anywhere says so.
+The group keeps working, which is the problem. It fires its members off as background tasks and waits on them with `asyncio.wait`, which does not re-raise, so the group action reports success to whatever called it no matter how many members failed. From the outside, the notification went out.
+
+The failure is not lost entirely. Nobody reads the task result, so the event loop eventually reports it as a stray `Task exception was never retrieved`. That arrives whenever the task happens to be collected, names no group, and reads like a bug rather than something you configured, so it is a poor way to discover that one person stopped being notified.
 
 To resolve the raised issue, edit the `services:` list of that group in your configuration and remove or correct the entries. Spook will automatically remove the repair issue once the issue is fixed.
 

--- a/tests/ectoplasms/alert/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/alert/repairs/test_unknown_entity_references.py
@@ -4,12 +4,10 @@
 # pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 
@@ -17,6 +15,7 @@ from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.alert.repairs.unknown_entity_references import (
     SpookRepair,
 )
+from tests.repair_helpers import async_count_scheduled_inspections
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -233,27 +232,9 @@ async def _count_scheduled_inspections(
         await repair.async_activate()
         await repair.async_inspect()
 
-    repair.inspect_debouncer.async_shutdown()
-    calls = 0
-
-    def async_schedule_call() -> None:
-        """Capture scheduled inspections."""
-        nonlocal calls
-        calls += 1
-
-    repair.inspect_debouncer = SimpleNamespace(
-        async_schedule_call=async_schedule_call,
-        async_shutdown=lambda: None,
+    return await async_count_scheduled_inspections(
+        hass, repair, entity_id, old_state, new_state
     )
-
-    hass.bus.async_fire(
-        EVENT_STATE_CHANGED,
-        {"entity_id": entity_id, "old_state": old_state, "new_state": new_state},
-    )
-    await hass.async_block_till_done()
-
-    await repair.async_deactivate()
-    return calls
 
 
 @pytest.mark.usefixtures("alert_set_up")

--- a/tests/ectoplasms/notify/__init__.py
+++ b/tests/ectoplasms/notify/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the notify ectoplasm."""

--- a/tests/ectoplasms/notify/repairs/__init__.py
+++ b/tests/ectoplasms/notify/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the notify repairs."""

--- a/tests/ectoplasms/notify/repairs/test_unknown_group_members.py
+++ b/tests/ectoplasms/notify/repairs/test_unknown_group_members.py
@@ -1,0 +1,162 @@
+"""Tests for the notify group unknown members repair."""
+
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.group.notify import GroupNotifyPlatform
+from homeassistant.components.notify.legacy import NOTIFY_SERVICES
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.notify.repairs.unknown_group_members import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+_ISSUE_ID = "notify_unknown_group_members_everyone"
+
+
+def _install_group(
+    hass: HomeAssistant,
+    members: list[dict[str, Any]],
+    name: str = "everyone",
+    integration: str = "group",
+) -> GroupNotifyPlatform:
+    """Register a legacy notify group the way Home Assistant does."""
+    service = GroupNotifyPlatform(hass, members)
+    service._service_name = name
+    hass.data.setdefault(NOTIFY_SERVICES, {}).setdefault(integration, []).append(
+        service
+    )
+    return service
+
+
+async def test_unknown_member_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a notify group forwarding to a non-existing action is reported."""
+    hass.services.async_register("notify", "still_here", lambda _call: None)
+    _install_group(hass, [{"action": "still_here"}, {"action": "old_phone"}])
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders is not None
+    assert issue.translation_placeholders["group"] == "notify.everyone"
+
+    # Only the missing one, named as the action it would have called.
+    assert issue.translation_placeholders["members"] == "- `notify.old_phone`"
+
+
+async def test_existing_members_are_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a notify group whose members all exist is left alone."""
+    hass.services.async_register("notify", "phone", lambda _call: None)
+    hass.services.async_register("notify", "tablet", lambda _call: None)
+    _install_group(hass, [{"action": "phone"}, {"action": "tablet"}])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.issues
+
+
+async def test_member_carrying_data_is_still_checked(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a member with its own default data is checked like any other.
+
+    A member may carry a `data:` block of per-target defaults. That changes
+    the payload, not whether the action exists.
+    """
+    _install_group(hass, [{"action": "old_phone", "data": {"priority": "high"}}])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+
+async def test_member_named_like_an_entity_is_still_checked(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a member is checked as an action, never as an entity.
+
+    A member is a bare action slug. Registering an entity by that name
+    changes nothing: the group calls `notify.<slug>` and that action is what
+    has to exist.
+    """
+    hass.states.async_set("notify.old_phone", "unknown")
+    _install_group(hass, [{"action": "old_phone"}])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+
+async def test_non_group_notify_services_are_skipped(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a plain notify platform is never inspected.
+
+    The false-positive twin. Every legacy notify platform lives in the same
+    place, and only the group ones forward to other actions.
+    """
+    plain_platform = SimpleNamespace(
+        entities=[{"action": "does_not_exist"}], _service_name="everyone"
+    )
+    hass.data.setdefault(NOTIFY_SERVICES, {})["telegram"] = [plain_platform]
+
+    await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.issues
+
+
+async def test_group_registered_by_another_integration_is_found(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test groups are found by type, not by the key they are stored under."""
+    _install_group(hass, [{"action": "old_phone"}], integration="somewhere_else")
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+
+async def test_no_notify_services_does_nothing(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test nothing happens when no legacy notify platform is set up."""
+    await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.issues
+
+
+async def test_issue_is_cleaned_up_when_the_member_returns(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the issue goes away once the notify action is registered again."""
+    _install_group(hass, [{"action": "late_phone"}])
+    repair = SpookRepair(hass)
+
+    await repair._async_inspect_with_cleanup()
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+
+    hass.services.async_register("notify", "late_phone", lambda _call: None)
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None

--- a/tests/ectoplasms/person/repairs/test_unknown_device_trackers.py
+++ b/tests/ectoplasms/person/repairs/test_unknown_device_trackers.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
-from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import DATA_INSTANCES
@@ -20,6 +19,7 @@ from custom_components.spook.repairs import (
     PersonUnknownDeviceTrackerFixFlow,
     async_create_fix_flow,
 )
+from tests.repair_helpers import async_count_scheduled_inspections
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
@@ -194,38 +194,6 @@ async def test_fix_flow_remove_yaml_person_aborts(
     assert result["reason"] == "not_editable"
 
 
-async def _count_scheduled_inspections(
-    hass: HomeAssistant,
-    entity_id: str,
-    old_state: State | None,
-    new_state: State | None,
-) -> int:
-    """Return how many inspections one state change schedules."""
-    repair = SpookRepair(hass)
-    await repair.async_activate()
-    repair.inspect_debouncer.async_shutdown()
-    calls = 0
-
-    def async_schedule_call() -> None:
-        """Capture scheduled inspections."""
-        nonlocal calls
-        calls += 1
-
-    repair.inspect_debouncer = SimpleNamespace(
-        async_schedule_call=async_schedule_call,
-        async_shutdown=lambda: None,
-    )
-
-    hass.bus.async_fire(
-        EVENT_STATE_CHANGED,
-        {"entity_id": entity_id, "old_state": old_state, "new_state": new_state},
-    )
-    await hass.async_block_till_done()
-
-    await repair.async_deactivate()
-    return calls
-
-
 async def test_state_only_tracker_going_away_is_reported(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,
@@ -263,6 +231,21 @@ async def test_issue_clears_when_a_state_only_tracker_returns(
     await repair._async_inspect_with_cleanup()
 
     assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def _count_scheduled_inspections(
+    hass: HomeAssistant,
+    entity_id: str,
+    old_state: State | None,
+    new_state: State | None,
+) -> int:
+    """Return how many inspections one state change schedules."""
+    repair = SpookRepair(hass)
+    await repair.async_activate()
+
+    return await async_count_scheduled_inspections(
+        hass, repair, entity_id, old_state, new_state
+    )
 
 
 async def test_state_only_tracker_addition_rechecks_person_repairs(

--- a/tests/repair_helpers.py
+++ b/tests/repair_helpers.py
@@ -1,0 +1,50 @@
+"""Shared helpers for testing Spook repairs."""
+
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from homeassistant.const import EVENT_STATE_CHANGED
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, State
+
+    from custom_components.spook.repairs import AbstractSpookRepair
+
+
+async def async_count_scheduled_inspections(
+    hass: HomeAssistant,
+    repair: AbstractSpookRepair,
+    entity_id: str,
+    old_state: State | None,
+    new_state: State | None,
+) -> int:
+    """Return how many inspections one state change schedules on a repair.
+
+    Takes a repair that is already activated, and inspected if its listener
+    needs to know something an inspection works out. Swaps the debouncer for
+    a counter so the scheduling is observed rather than the inspection.
+    """
+    repair.inspect_debouncer.async_shutdown()
+    calls = 0
+
+    def async_schedule_call() -> None:
+        """Capture scheduled inspections."""
+        nonlocal calls
+        calls += 1
+
+    repair.inspect_debouncer = SimpleNamespace(
+        async_schedule_call=async_schedule_call,
+        async_shutdown=lambda: None,
+    )
+
+    hass.bus.async_fire(
+        EVENT_STATE_CHANGED,
+        {"entity_id": entity_id, "old_state": old_state, "new_state": new_state},
+    )
+    await hass.async_block_till_done()
+
+    await repair.async_deactivate()
+    return calls


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A new `notify` ectoplasm with one repair: `notify_unknown_group_members`.

A legacy notify group forwards a message to each action in its `services:` list, where `phone` means the `notify.phone` action. When one of those is renamed or its integration is removed, the group carries on delivering to the rest and reports success. From the outside, the notification went out.

**And nothing says otherwise.** The group fires its members off as tasks and awaits them with `asyncio.wait`, which does not re-raise, and nobody retrieves the results. I verified that rather than assuming it: the `ServiceNotFound` ends up in a task nobody ever reads. The alert repair in #1446 covers a similar case, and alert at least logs an error. This logs nothing at all. Whoever was behind that member simply stops being notified.

### Scope

**Only the legacy YAML group needs this.** The newer notify group, the config-entry helper whose members are notify *entities*, is already covered: `group_unknown_members` walks the group entity platforms and reads `_entity_ids`, which is exactly what `NotifyGroup` uses.

**Legacy notify is not on its way out**, which I checked before building this. `migrate_notify_issue` exists in `notify/repairs.py`, but that is a helper individual integrations call when *they* migrate their own notify platform to entities. The `group` platform still ships both variants, with no deprecation on the old one.

### Notes on the implementation

Groups are found by `isinstance` rather than by the key they are stored under in `hass.data[NOTIFY_SERVICES]`, so one set up through discovery under another integration name is found too. There is a test for that.

`service.entities` is public. `_service_name` is not, but it is the only thing tying a notify service back to the action it registered, and that name is what identifies the group in the issue and gives it a stable issue ID.

The repair's domain is `notify` rather than `group`, because `notify:` is the block the user edits and the notify logo is what they will see on the issue. The new documentation page states the modern-versus-legacy distinction so somebody with a helper-based notify group is not left wondering why this does not apply to them.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Second of the three remaining small reference checks in phase 3.7 of the plan (`.plan/phase-3-new-detection-corners.md`), after the alert ones in #1446. The recorder `include`/`exclude` lists are the last one.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

`870 passed` (8 new), `ruff check` clean, `ruff format --check` clean, `pylint` at 10.00, `prettier` clean, and the documentation builds with `myst build --html` without adding warnings.

The false-positive twin: a plain (non-group) legacy notify platform with a member that does not exist is never touched, because only group platforms forward to other actions. Plus a member carrying its own `data:` defaults, which changes the payload rather than whether the action exists, and a member with a same-named entity in the state machine, which is still reported because a member is an action.

Four mutations, all caught:

- `has_service` check loses its `not` (6 failures)
- `isinstance` guard removed, so every notify platform gets inspected (1 failure)
- only the `group` key is looked at instead of every stored platform (1 failure)
- every member reported instead of only the missing ones (3 failures)

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None needed. Repairs sections in the integration documentation are prose, and the logo comes from brands.home-assistant.io.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
