### PR TITLE
Notice an entity dying or returning without waiting for a coincidence

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
@@ -3,13 +3,25 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_RESTORED, EVENT_COMPONENT_LOADED, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_RESTORED,
+    EVENT_COMPONENT_LOADED,
+    EVENT_STATE_CHANGED,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 
 from ....const import LOGGER
 from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from homeassistant.core import Event, State
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -29,6 +41,45 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_config_entry_changed = True
     automatically_clean_up_issues = True
+
+    async def async_activate(self) -> None:
+        """Handle activating the repair."""
+        await super().async_activate()
+
+        # The restored placeholder state can appear and disappear without
+        # anything else saying so. An entity removed while its registry entry
+        # survives gets one written for it, and an entity that finally shows
+        # up overwrites the one it had. Neither touches the entity registry,
+        # and the config entry stays loaded throughout, so the events above
+        # only catch this at startup or by coincidence.
+        #
+        # Watched by the restored flag flipping rather than by entities being
+        # added or removed: crossing into or out of that placeholder is the
+        # entire signal this repair reads, and it is not something an ordinary
+        # state change does.
+        @callback
+        def _restored_flag_changed(event_data: Mapping[str, Any]) -> bool:
+            """Return if an entity entered or left the restored state."""
+
+            def is_restored(state: State | None) -> bool:
+                return bool(state and state.attributes.get(ATTR_RESTORED))
+
+            return is_restored(event_data.get("old_state")) != is_restored(
+                event_data.get("new_state")
+            )
+
+        @callback
+        def _async_call_inspect_debouncer(_: Event) -> None:
+            """Trigger an inspection when the restored flag flips."""
+            self.inspect_debouncer.async_schedule_call()
+
+        self._event_subs.add(
+            self.hass.bus.async_listen(
+                EVENT_STATE_CHANGED,
+                _async_call_inspect_debouncer,
+                event_filter=_restored_flag_changed,
+            ),
+        )
 
     async def async_inspect(self) -> None:
         """Trigger an inspection."""

--- a/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
@@ -1,6 +1,7 @@
 """Tests for the dead entities repair."""
 
-# pylint: disable=wrong-import-order
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -9,11 +10,13 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_RESTORED, STATE_UNAVAILABLE
+from homeassistant.core import State
 
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.homeassistant.repairs.dead_entities import (
     SpookRepair,
 )
+from tests.repair_helpers import async_count_scheduled_inspections
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -125,3 +128,121 @@ async def test_restored_entity_without_config_entry_is_not_reported(
         for domain, issue_id in issue_registry.issues
         if domain == DOMAIN
     )
+
+
+async def test_entity_dying_mid_session_is_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test an entity that dies while its entry stays loaded is reported.
+
+    Home Assistant writes the restored placeholder when an entity is removed
+    but its registry entry survives. The entity registry does not change and
+    the config entry stays loaded, so nothing else marks the moment.
+    """
+    entry = _loaded_entry(hass)
+    reg = entity_registry.async_get_or_create(
+        "sensor", "hue", "dies", config_entry=entry
+    )
+    hass.states.async_set(reg.entity_id, "21.5")
+    repair = SpookRepair(hass)
+
+    await repair._async_inspect_with_cleanup()
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+        is None
+    )
+
+    hass.states.async_set(reg.entity_id, STATE_UNAVAILABLE, {ATTR_RESTORED: True})
+    await repair._async_inspect_with_cleanup()
+
+    assert issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+
+
+async def test_issue_clears_when_the_entity_finally_appears(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the issue goes away once the entity shows up for real."""
+    entry = _loaded_entry(hass)
+    dead = _register_restored(hass, entity_registry, entry, "late")
+    repair = SpookRepair(hass)
+
+    await repair._async_inspect_with_cleanup()
+    assert issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+
+    hass.states.async_set(dead, "21.5")
+    await repair._async_inspect_with_cleanup()
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+        is None
+    )
+
+
+async def _count_scheduled_inspections(
+    hass: HomeAssistant,
+    old_state: State | None,
+    new_state: State | None,
+) -> int:
+    """Return how many inspections one state change schedules."""
+    repair = SpookRepair(hass)
+    await repair.async_activate()
+
+    return await async_count_scheduled_inspections(
+        hass, repair, "sensor.hue_thing", old_state, new_state
+    )
+
+
+def _restored(entity_id: str = "sensor.hue_thing") -> State:
+    """Return the restored placeholder state Home Assistant writes."""
+    return State(entity_id, STATE_UNAVAILABLE, {ATTR_RESTORED: True})
+
+
+def _live(entity_id: str = "sensor.hue_thing", state: str = "21.5") -> State:
+    """Return an ordinary state."""
+    return State(entity_id, state)
+
+
+async def test_entering_the_restored_state_rechecks(hass: HomeAssistant) -> None:
+    """Test an entity dying into the placeholder schedules an inspection."""
+    assert await _count_scheduled_inspections(hass, _live(), _restored()) == 1
+
+
+async def test_leaving_the_restored_state_rechecks(hass: HomeAssistant) -> None:
+    """Test an entity coming back for real schedules an inspection."""
+    assert await _count_scheduled_inspections(hass, _restored(), _live()) == 1
+
+
+async def test_appearing_as_restored_rechecks(hass: HomeAssistant) -> None:
+    """Test the placeholder being written from nothing schedules an inspection."""
+    assert await _count_scheduled_inspections(hass, None, _restored()) == 1
+
+
+async def test_ordinary_state_change_does_not_recheck(hass: HomeAssistant) -> None:
+    """Test a normal state change schedules nothing.
+
+    This is the one that matters for cost: entities change state constantly,
+    and this repair walks every state in the machine.
+    """
+    assert await _count_scheduled_inspections(hass, _live(), _live(state="22.0")) == 0
+
+
+async def test_entity_appearing_normally_does_not_recheck(hass: HomeAssistant) -> None:
+    """Test an entity appearing without a placeholder schedules nothing.
+
+    The false-positive twin for the filter. A brand new entity was never
+    dead, so its arrival says nothing about a dead one.
+    """
+    assert await _count_scheduled_inspections(hass, None, _live()) == 0
+
+
+async def test_entity_removed_outright_does_not_recheck(hass: HomeAssistant) -> None:
+    """Test an entity removed along with its registry entry schedules nothing.
+
+    No placeholder is left behind in that case, so there is nothing for this
+    repair to find.
+    """
+    assert await _count_scheduled_inspections(hass, _live(), None) == 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Third and last of the state-listener gaps found while doing the alert repair, after #1448 (person) and its follow-up #1449.

The restored placeholder state comes and goes without anything else saying so, **in both directions**:

- When an entity is removed while its registry entry survives, Home Assistant writes the placeholder for it (`helpers/entity.py:1501`).
- When the entity finally shows up, it overwrites the placeholder it had.

Neither touches the entity registry, and the config entry stays `LOADED` throughout, so `inspect_config_entry_changed` and the registry event caught this at startup or by coincidence: an incidental `async_update_entity` from the arriving entity, some unrelated registry change happening along.

There is a third path that writes a placeholder, the entity ID rename in `helpers/entity_registry.py:2661`, but that one arrives with a registry event, so it was already covered.

### The filter is deliberately not the one from #1448

Those repairs filter on entities being added or removed. That could not work here: both transitions are state *updates*, real to placeholder and placeholder back to real. Neither is an add or a remove.

So this watches the restored flag flipping between `old_state` and `new_state`. That is the entire signal this repair reads, and it is not something an ordinary state change does.

The precision earns its keep more here than in the other two. This repair walks every state in the state machine on each inspection, so waking it on each temperature reading would be genuinely expensive rather than merely pointless.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Flagged as a known-but-unresolved gap in the description of #1448, where I said only the recovery direction was affected and the break direction was covered by `inspect_config_entry_changed`. That was half right: the config-entry trigger covers the startup case only, and the mid-session death has the same gap.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

`878 passed`, `ruff check` clean, `ruff format --check` clean, and `pylint` over all files exits 0. All four tests that were in this file already are untouched and still there.

Eight new tests. Two prove the behaviour in each direction: an entity dying mid-session while its entry stays loaded gets reported, and the issue clears once the entity appears for real. Three prove the wiring fires: entering the placeholder, leaving it, and the placeholder being written from nothing.

Three are false-positive twins for the filter:

- a brand new entity appearing without a placeholder, which was never dead
- an entity removed along with its registry entry, which leaves no placeholder behind
- an ordinary value change

Four mutations, all caught:

- the whole subscription removed, which is the gap being fixed (3 failures)
- **the generic add/remove filter from #1448 swapped in (4 failures)** — this is the argument for writing a different filter rather than reusing that one
- filter always passes (3 failures)
- only entering the placeholder is watched, not leaving it (1 failure)

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
