### PR TITLE
Say what went wrong instead of printing a tuple

### DIFF
--- a/custom_components/spook/services.py
+++ b/custom_components/spook/services.py
@@ -192,7 +192,7 @@ class AbstractSpookEntityService(AbstractSpookServiceBase, Generic[_EntityT]):
             msg = (
                 f"Could not find platform {self.platform} for domain "
                 f"{self.domain} to register service: "
-                f"{self.domain}.{self.service}",
+                f"{self.domain}.{self.service}"
             )
             raise RuntimeError(msg)
 
@@ -233,7 +233,7 @@ class AbstractSpookEntityComponentService(AbstractSpookServiceBase, Generic[_Ent
         if self.domain not in self.hass.data.get(DATA_INSTANCES, {}):
             msg = (
                 f"Could not find entity component {self.domain} to register "
-                f"service: {self.domain}.{self.service}",
+                f"service: {self.domain}.{self.service}"
             )
             raise RuntimeError(msg)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ src = ["custom_components/spook"]
 ignore = [
   "A005", # It is just wrong
   "ANN401", # Opiniated warning on disallowing dynamically typed expressions
+  "CPY001", # Spook has one LICENSE file, not a header on every file
   "D203", # Conflicts with other rules
   "D213", # Conflicts with other rules
   "RUF012", # Just broken

--- a/tests/test_service_registration_errors.py
+++ b/tests/test_service_registration_errors.py
@@ -1,0 +1,73 @@
+"""Tests for what Spook says when a service cannot be registered."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from custom_components.spook.services import (
+    AbstractSpookEntityComponentService,
+    AbstractSpookEntityService,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+
+class _EntityService(AbstractSpookEntityService):
+    """A Spook entity service pointed at a platform that is not loaded."""
+
+    domain = "sensor"
+    platform = "spook"
+    service = "do_something"
+    schema = {}
+
+    async def async_handle_service(self, entity: object, call: ServiceCall) -> None:
+        """Do nothing; registration never gets this far in these tests."""
+
+
+class _ComponentService(AbstractSpookEntityComponentService):
+    """A Spook component service pointed at a component that is not loaded."""
+
+    domain = "not_loaded"
+    service = "do_something"
+    schema = {}
+
+    async def async_handle_service(self, entity: object, call: ServiceCall) -> None:
+        """Do nothing; registration never gets this far in these tests."""
+
+
+def test_missing_platform_says_so_in_one_sentence(hass: HomeAssistant) -> None:
+    """Test the error names the platform, as a sentence rather than a tuple.
+
+    The message is built from implicitly concatenated f-strings. A trailing
+    comma in there turns the whole thing into a one-tuple, and the error then
+    renders as `('Could not find platform ...',)`, parentheses and quotes
+    included. It read that way until ruff 0.16 grew a check for it.
+    """
+    service = _EntityService(hass)
+
+    with pytest.raises(RuntimeError) as caught:
+        service.async_register()
+
+    assert caught.value.args[0] == (
+        "Could not find platform spook for domain sensor to register service:"
+        " sensor.do_something"
+    )
+    assert str(caught.value).startswith("Could not find platform")
+
+
+def test_missing_component_says_so_in_one_sentence(hass: HomeAssistant) -> None:
+    """Test the error names the component, as a sentence rather than a tuple."""
+    service = _ComponentService(hass)
+
+    with pytest.raises(RuntimeError) as caught:
+        service.async_register()
+
+    assert caught.value.args[0] == (
+        "Could not find entity component not_loaded to register service:"
+        " not_loaded.do_something"
+    )
+    assert str(caught.value).startswith("Could not find entity component")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

First of two PRs unblocking the pending lock file maintenance (#1434). That PR only touches `uv.lock`, but both `ruff` and `zizmor` are installed from it (`uv sync --frozen --dev` then `uv run ruff`), so bumping the lock file bumps the tools: ruff 0.15.10 to 0.16.4 and zizmor 1.25.2 to 1.29.0. This one handles the ruff half; the zizmor half follows separately.

### The interesting half: a real bug

The CI log was truncated at 334 `CPY001` lines, which hid the other finding. Ruff 0.16 also grew **`ISC004`**, and it caught this in both service base classes:

```python
msg = (
    f"Could not find platform {self.platform} for domain "
    f"{self.domain} to register service: "
    f"{self.domain}.{self.service}",     # <-- this comma
)
raise RuntimeError(msg)
```

The trailing comma makes `msg` a one-tuple rather than a string, so the error renders as:

```
('Could not find platform sensor for domain spook to register service: spook.boo',)
```

Parentheses and quotes included. Anyone registering a Spook action for a platform that is not loaded got that instead of a sentence. Both `AbstractSpookEntityService` and `AbstractSpookEntityComponentService` had it.

**Neither error path had a test**, which is why it lasted. There are two now.

### The boring half: CPY001

`CPY001` wants a copyright notice at the top of every file, and it landed on all 334 of them. That is not really about the lock file: `select = ["ALL"]` means every rule ruff adds becomes a CI failure the moment it ships, which is what the existing sixteen-entry ignore list is a record of (`COM812`, `ISC001`, `E501`, `Q000` are all "ALL drags in things we do not want").

Spook has one `LICENSE` file rather than 334 headers, so `CPY001` joins that list.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Unblocks the ruff failure on #1434, and fixes the bug that surfaced along with it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Verified against **both** ruff versions, because this merges into a main that still has the old lock file: 0.15.10 and 0.16.4 each report `All checks passed!`, and 0.15.10 accepts `CPY001` in the ignore list without complaint.

`880 passed` (2 new), `ruff format --check` clean, `pylint` at 10.00.

The two new tests were checked by putting the commas back: both fail, naming the tuple. I reproduced the whole thing locally on the `renovate/lock-file-maintenance` branch first, rather than reading it off the CI log, which is how the `ISC004` pair turned up at all.

`uv.lock` is deliberately not touched here. That bump is Renovate's to make.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
