### PR TITLE
Build the documentation from a locked MyST version

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -24,11 +24,12 @@ jobs:
           node-version-file: "documentation/.nvmrc"
 
       - name: 🏗 Install MyST
-        run: npm install -g mystmd
+        working-directory: ./documentation
+        run: npm ci
 
       - name: 🚀 Build documentation
         working-directory: ./documentation
-        run: myst build --html
+        run: npx myst build --html
 
       - name: ©️ Public folder
         run: cp ./documentation/public/* ./documentation/_build/html/

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -25,11 +25,11 @@ jobs:
 
       - name: 🏗 Install MyST
         working-directory: ./documentation
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: 🚀 Build documentation
         working-directory: ./documentation
-        run: npx myst build --html
+        run: ./node_modules/.bin/myst build --html
 
       - name: ©️ Public folder
         run: cp ./documentation/public/* ./documentation/_build/html/

--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "spook-documentation",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spook-documentation",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "mystmd": "1.10.1"
+      }
+    },
+    "node_modules/mystmd": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mystmd/-/mystmd-1.10.1.tgz",
+      "integrity": "sha512-nczabm7R8PmoqJVqKpaijTr1kxdwnY+hRoFC7b+NEUdxW5yZZ8n/CuJlMJKlHtG/pA4o3Ia2RP/0Ra3UPj6sFg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "myst": "dist/myst.cjs"
+      }
+    }
+  }
+}

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "spook-documentation",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Builds Spook's documentation with MyST.",
+  "license": "MIT",
+  "devDependencies": {
+    "mystmd": "1.10.1"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Second of two PRs unblocking the pending lock file maintenance (#1434), after #1456. Both `ruff` and `zizmor` are installed from `uv.lock`, so bumping it bumped them: zizmor 1.25.2 to 1.29.0. The new version grew an audit called `adhoc-packages`, and it has a point.

The docs workflow ran:

```yaml
- name: 🏗 Install MyST
  run: npm install -g mystmd
```

That fetches whatever MyST is newest at the moment the job runs. So the documentation build could break without a line of code changing, and nothing recorded which version had produced the published site. zizmor's wording is "installs a package outside of a lockfile".

### Pinning the version is not enough

I checked rather than assumed, and it mattered:

| attempt | zizmor 1.29.0 |
| --- | --- |
| `npm install -g mystmd` | 1 finding |
| `npm install -g mystmd@1.10.1` | **still 1 finding** |
| `npm ci` | no findings |

The audit is about the lockfile, not the version number. So `documentation/` gets a `package.json` and a real `package-lock.json` (with the integrity hash that comes with it), and the workflow installs with `npm ci` and builds through `npx`.

Renovate can bump MyST from there like everything else, which it could not do before.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Unblocks the zizmor failure on #1434. Independently of that, it makes the documentation build reproducible, which it was not.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ran the new install and build path end to end: `npm ci` in `documentation/`, then `npx myst build --html`. It builds 56 pages and produces `_build/html/index.html`, exit 0.

zizmor is clean at **both** versions, because this merges into a main that still has the old lock file: 1.29.0 reports "No findings to report", and 1.25.2 exits 0.

`prettier --check` clean on the workflow and the new `package.json`, and the workflow YAML parses.

`uv.lock` is deliberately not touched here. That bump is Renovate's to make.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
