### PR TITLE
Keep blank strings out of the translation files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,7 @@
     },
     {
       "matchManagers": ["pep621"],
-      "matchPackageNames": ["!homeassistant"],
+      "matchDepTypes": ["dependency-groups"],
       "addLabels": ["python:uv"],
       "rangeStrategy": "pin"
     }

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -7,8 +7,17 @@ import re
 from pathlib import Path
 from typing import Any
 
-TRANSLATIONS_PATH = Path("custom_components/spook/translations")
+COMPONENT_PATH = Path("custom_components/spook")
 PLACEHOLDER_PATTERN = re.compile(r"\{[^{}]+\}")
+
+
+def _translation_paths() -> list[Path]:
+    """Return every directory in Spook that ships translations.
+
+    Discovered rather than listed, so a new sub-integration is covered the
+    moment it gets a translations directory.
+    """
+    return sorted(COMPONENT_PATH.glob("**/translations"))
 
 
 def _walk_translation_strings(
@@ -45,19 +54,61 @@ def _walk_translation_strings(
     return mismatches
 
 
-def test_translation_placeholders_match_english() -> None:
-    """Test translation placeholders match the English source strings."""
-    english = json.loads((TRANSLATIONS_PATH / "en.json").read_text(encoding="utf-8"))
-    mismatches = []
+def _blank_strings(translation: dict[str, Any], path: str = "") -> list[str]:
+    """Return the paths of every string in the file that has no content."""
+    blanks: list[str] = []
 
-    for translation_file in sorted(TRANSLATIONS_PATH.glob("*.json")):
-        if translation_file.name == "en.json":
+    for key, value in translation.items():
+        key_path = f"{path}.{key}" if path else key
+
+        if isinstance(value, dict):
+            blanks.extend(_blank_strings(value, key_path))
             continue
 
-        translation = json.loads(translation_file.read_text(encoding="utf-8"))
-        mismatches.extend(
-            f"{translation_file.name}: {mismatch}"
-            for mismatch in _walk_translation_strings(english, translation)
+        if isinstance(value, str) and not value.strip():
+            blanks.append(key_path)
+
+    return blanks
+
+
+def test_translation_placeholders_match_english() -> None:
+    """Test translation placeholders match the English source strings."""
+    mismatches = []
+
+    for translations_path in _translation_paths():
+        english = json.loads(
+            (translations_path / "en.json").read_text(encoding="utf-8")
         )
 
+        for translation_file in sorted(translations_path.glob("*.json")):
+            if translation_file.name == "en.json":
+                continue
+
+            translation = json.loads(translation_file.read_text(encoding="utf-8"))
+            mismatches.extend(
+                f"{translation_file}: {mismatch}"
+                for mismatch in _walk_translation_strings(english, translation)
+            )
+
     assert not mismatches, "\n".join(mismatches)
+
+
+def test_translations_hold_no_blank_strings() -> None:
+    """Test no translation file carries a string without content.
+
+    Home Assistant loads English first and then overlays the requested
+    language with a plain dictionary update. An empty string is a value, not
+    a missing key, so it wins: the label renders blank instead of falling
+    back to English. A string nobody has translated yet belongs out of the
+    file, not in it as "".
+    """
+    blanks = [
+        f"{translation_file}: {key}"
+        for translations_path in _translation_paths()
+        for translation_file in sorted(translations_path.glob("*.json"))
+        for key in _blank_strings(
+            json.loads(translation_file.read_text(encoding="utf-8"))
+        )
+    ]
+
+    assert not blanks, f"{len(blanks)} blank strings found:\n" + "\n".join(blanks)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a test that fails if any translation file carries a string with no content, and extends the existing placeholder check to the sub-integrations, which it had never covered.

Also narrows the Renovate rule added in #1458 from "every pep621 dependency except `homeassistant`" to "the `dependency-groups` depType", which is what that pull request said it was doing.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**The blank strings.** #1455 arrived carrying 735 empty strings across 37 languages in the Inverse helper. Those are not harmless placeholders. Home Assistant loads English first and then overlays the requested language with a plain dictionary update (`helpers/translation.py`), so an empty string is a value rather than a missing key: it wins, and the label renders blank instead of falling back to English.

Of the 21 keys per file, 20 would have broken. The lone top-level `title` escapes by accident, because `build_resources` drops a whole category when it is falsy and a top-level `""` is falsy. The keys under `config` and `options` sit in dictionaries that are not empty, so they go straight through.

The cause was a missing `weblate.cleanup.blank` addon on the Inverse helper component. The main component had it all along, which is exactly why only the helper was affected. That is now fixed on the Weblate side and Weblate has already rewritten the files, so #1455 is clean.

This is the part that does not depend on a setting in someone else's web UI staying put. A component added later starts with no addons, which is precisely how this happened, so the check belongs in the repository.

**The placeholder check.** It pointed at one hardcoded path, so `spook_inverse` was never checked and neither would `spook_boolean` be. It now discovers the directories itself.

**The Renovate rule.** The dependency dashboard was already offering to pin `requires-python` to `==3.14.7`. That is the same kind of deliberate floor as the `homeassistant` requirement that #1458 took care to exclude, so excluding one by name and not the other was the wrong shape. Matching on the `dependency-groups` depType scopes the rule to the dev group and leaves `project.dependencies`, `build-system.requires` and `requires-python` alone.

Credit where due: both review bots flagged that rule on #1458. They named `hatchling`, which Renovate does not even extract here, but they were right about the shape of the problem.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The guard was checked in both directions, because a guard that catches nothing is not a guard:

- green on `main` as it stands
- run against #1455 as it arrived, it failed with all 735, naming every file and key
- with a single empty string injected into one `nl.json` key, it failed with exactly that one file and key

The rest: `ruff check`, `ruff format --check`, `pylint` over all files the way CI runs it, the full prek run, and 881 tests, all clean. `renovate.json` is still valid JSON with its emoji intact, which is worth stating because a JSON round-trip mangles that file.

The depType name is not a guess. Renovate's `pep621` manager maps PEP 735 groups to the depType `dependency-groups`, and `build-system.requires` and `requires-python` to their own, so the new matcher cannot reach them.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
