### PR TITLE
Document every repair Spook can raise

### DIFF
--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -36,6 +36,8 @@ parts:
       - file: integrations/lovelace
       - file: integrations/group
       - file: integrations/cloud
+      - file: integrations/energy
+      - file: integrations/homeassistant
       - file: integrations/input_number
       - file: integrations/input_select
       - file: integrations/notify

--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -88,6 +88,30 @@ Automations are inspected for the use of actions. If an automation is using a ac
 
 To resolve the raised issue, you can either remove the reference to the non-existing actions. Spook will automatically remove the repair issue once the issue is fixed.
 
+### Unknown referenced floors
+
+Automations are inspected for the use of {term}`floors <floor>`. If an automation is targeting a floor in one of its actions that does not exist, Spook will raise a repair issue. The repairs issue raised will contain the name of the automation and the floor that is referenced but not found.
+
+To resolve the raised issue, you can either remove the reference to the non-existing floor or fix the referenced floor. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown referenced labels
+
+Automations are inspected for the use of {term}`labels <label>`. If an automation is targeting a label that does not exist, Spook will raise a repair issue. The repairs issue raised will contain the name of the automation and the label that is referenced but not found.
+
+To resolve the raised issue, you can either remove the reference to the non-existing label or fix the referenced label. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown referenced conditions
+
+Automations are inspected for the conditions they use. Conditions are provided by {term}`integrations <integration>`, so a condition that no installed integration can provide is one nothing will ever evaluate. If an automation uses such a condition, Spook will raise a repair issue naming the automation and the conditions in question.
+
+This usually means the integration that provided the condition was removed. To resolve the raised issue, you can either remove the use of these conditions or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown referenced triggers
+
+Automations are inspected for the triggers they use. Like conditions, triggers come from integrations, and a trigger no installed integration can provide will never fire. If an automation uses such a trigger, Spook will raise a repair issue naming the automation and the triggers in question.
+
+A trigger that never fires is the quietest kind of broken: the automation still exists, still looks fine, and simply never runs. To resolve the raised issue, you can either remove the use of these triggers or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
+
 ## Features requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).

--- a/documentation/integrations/energy.md
+++ b/documentation/integrations/energy.md
@@ -1,0 +1,58 @@
+---
+subject: Enhanced integrations
+title: Energy
+subtitle: Watching the meter so you do not have to.
+description: Spook enhances the Home Assistant energy dashboard by reporting entities it is configured to use that no longer exist.
+date: 2026-08-21T16:20:00+02:00
+---
+
+```{image} https://brands.home-assistant.io/energy/logo.png
+:alt: The Home Assistant energy logo
+:width: 250px
+:align: center
+```
+
+<br><br>
+
+The energy {term}`dashboard <dashboard>` in {term}`Home Assistant` is where your consumption, production, gas, water, and battery numbers come together. It is configured once, in Settings > Dashboards > Energy, by pointing it at the {term}`entities <entity>` that carry those numbers.
+
+That configuration is a list of {term}`entity IDs <entity id>` held separately from the entities themselves. Nothing keeps the two in step, and nothing tells you when they drift apart.
+
+Spook enhances the energy dashboard by raising {term}`repairs <repairs>` issues when it finds an entity in that configuration that Home Assistant no longer has.
+
+## Devices & entities
+
+Spook does not provide any new devices or entities for this integration.
+
+## Actions
+
+Spook does not provide action enhancements for this integration.
+
+## Repairs
+
+While Spook is floating around in your Home Assistant instance, it will raise repairs issues if it has found something that is not right.
+
+### Unknown referenced entities
+
+Spook inspects the energy configuration to find the entities it names that no longer exist. If Spook finds such a case, it will raise a repair issue listing the entities that are missing.
+
+The dashboard does not complain about this. It draws the sources it can still read and leaves out the one it cannot, so the graph stays plausible while quietly being wrong. A missing gas sensor does not look like an error, it looks like a month where you used no gas.
+
+To resolve the raised issue, go to Settings > Dashboards > Energy and update or remove these entities. Spook will automatically remove the repair issue once the issue is fixed.
+
+## Use cases
+
+Some use cases for the enhancements Spook provides for this integration:
+
+- Replacing an energy meter. The new integration gives you new entity IDs, the energy dashboard keeps the old ones, and the totals silently stop adding up.
+- Renaming a sensor that feeds the dashboard. Renaming is cheap and easy to do, which is exactly why it is easy to forget that the energy configuration was pointing at the old name.
+
+## Blueprints & tutorials
+
+There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+## Feature requests, ideas, and support
+
+If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+Are you stuck using these new features? Or maybe you've run into a bug? Please check the [](../support) page on where to go for help.

--- a/documentation/integrations/homeassistant.md
+++ b/documentation/integrations/homeassistant.md
@@ -1,0 +1,120 @@
+---
+subject: Enhanced integrations
+title: Home Assistant
+subtitle: The tidying up nobody volunteers for.
+description: Spook enhances the Home Assistant core integration by reporting dead entity registrations, dangling customizations, forgotten access tokens, helpers whose sources are gone, and areas, floors, labels and blueprints that are not doing anything.
+date: 2026-08-21T16:20:00+02:00
+---
+
+```{image} https://brands.home-assistant.io/homeassistant/logo.png
+:alt: The Home Assistant logo
+:width: 250px
+:align: center
+```
+
+<br><br>
+
+`homeassistant` is the {term}`integration <integration>` that is {term}`Home Assistant` itself. It owns the registries that everything else hangs off: the {term}`areas <area>`, {term}`floors <floor>`, {term}`labels <label>`, {term}`devices <device>` and {term}`entities <entity>` that give your configuration its shape, plus the `homeassistant:` section of your {term}`YAML`.
+
+Registries are good at remembering and bad at forgetting. An entry stays until something removes it, and almost nothing ever does. That is the right default, and it is also why an instance that has been running for a few years accumulates a quiet layer of things that refer to nothing.
+
+Spook enhances the core integration by raising {term}`repairs <repairs>` issues for that layer.
+
+## Devices & entities
+
+Spook does not provide any new devices or entities for this integration.
+
+## Actions
+
+Spook adds a large number of actions in the `homeassistant` domain, but they are documented by subject rather than all on one page. See [](../areas), [](../floors), [](../labels), [](../devices), [](../entities), [](../devices_entities), [](../users) and [](../misc).
+
+## Repairs
+
+While Spook is floating around in your Home Assistant instance, it will raise repairs issues if it has found something that is not right.
+
+Some of these are broken things, and some are only untidy ones. The untidy ones are all fixable from the issue itself, and every one of them offers to stop mentioning it, because an empty area you keep on purpose is nobody's business but yours.
+
+### Non-existing registered entities
+
+An {term}`entity <entity>` is registered by its integration, and the registry entry survives across restarts so the entity keeps its ID, its name and its settings. When the thing behind it is gone, the entry stays.
+
+Spook watches for integrations that finished setting up and then never provided entities they have registry entries for. Those entities do not exist any more: they show as unavailable, forever, and they are grouped per integration entry so one removed device does not produce twenty separate issues.
+
+Only integrations that finished loading are considered, so an integration that is slow to start or retrying is never mistaken for a dead one.
+
+To resolve the raised issue, remove these entities from the entity registry if you no longer need them. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown customized entities
+
+The `customize:` section of your configuration pins attributes onto a specific entity, which is how a sensor gets a friendly name or a different icon that its integration does not offer.
+
+Spook checks the entity each customization names. If the entity does not exist, that block of YAML is doing nothing at all. Only exact entity keys are checked: glob and domain customizations are patterns rather than references, so they are left alone.
+
+To resolve the raised issue, edit the `customize:` section in your configuration and remove these entities. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown helper sources
+
+Many {term}`helpers <helper>` are built on top of another entity: a threshold on a sensor, a derivative on a counter, a group on a handful of switches. Spook reads each helper's own configuration to find the source entities it names, and raises a repair issue when one of them is unknown to Home Assistant.
+
+Reading the configuration rather than the running helper matters here: it means a helper whose entity failed to set up entirely is still checked, and that is exactly the helper most likely to be broken.
+
+Without its source, a helper like this cannot work. The raised issue is fixable: Spook can remove the helper for you, or you can fix it yourself on the Helpers page.
+
+### Unknown min/max helper members
+
+A min/max helper combines several entities into one number. Spook reads its configuration and raises a repair issue when it names members that no longer exist.
+
+This one is fixable by pruning rather than removing: Spook can drop the missing members so the helper carries on with the ones that remain. A min/max helper needs at least two members, though, so if removing the missing ones would leave fewer than that, Spook says so and sends you to the Helpers page instead of quietly breaking the helper a different way.
+
+### Forgotten long-lived access tokens
+
+A long-lived access token does not expire. That is the point of it, and it is also the problem: a token issued for a script you stopped running three years ago is still a working key to your instance.
+
+Spook raises a repair issue for every token that has not been used in 180 days, one issue per token, and checks once a day.
+
+The raised issue is fixable: Spook can revoke the token for you. Be deliberate about it. Revoking a token stops anything still using it from working until it gets a new one, and "not used in 180 days" is evidence, not proof.
+
+### Empty areas
+
+An {term}`area` with no devices, no entities, and no automation or script targeting it is not doing anything.
+
+Spook checks references as well as contents, so an area that is deliberately empty because an automation targets it is left alone. The raised issue is fixable: Spook can remove the area for you.
+
+### Empty floors
+
+A {term}`floor` exists to group areas. One with no areas at all, and no automation or script targeting it, is not doing that.
+
+The raised issue is fixable: Spook can remove the floor for you.
+
+### Unused labels
+
+A {term}`label` that is applied to no entity, device or area, and that no automation or script targets, is not doing anything either.
+
+The raised issue is fixable: Spook can remove the label for you.
+
+### Unused blueprints
+
+{term}`Blueprints <blueprint>` collect. You import one to try it, decide against it, and it stays. Spook raises a repair issue for a blueprint that no automation or script uses.
+
+A blueprint whose file was added or changed in the last day is left alone, so importing one and setting it up a few minutes later does not earn you an instant repair issue for your trouble.
+
+The raised issue is fixable: Spook can remove the blueprint for you.
+
+## Use cases
+
+Some use cases for the enhancements Spook provides for this integration:
+
+- Replacing a batch of devices. The new ones set themselves up, the old registry entries stay behind as permanently unavailable entities, and grouping them per integration turns a wall of unavailable entities into one issue you can act on.
+- Auditing who still has a key to your instance. Long-lived tokens are easy to create and easy to forget, and nothing else in Home Assistant will bring one up unprompted.
+- Cleaning up after a reorganisation. Renaming and regrouping leaves empty areas, empty floors and unused labels behind, and none of them are visible unless you go looking.
+- Finding helpers that broke months ago. A helper without its source is not merely wrong, it is silently wrong, and it will keep reporting a last known value as if nothing happened.
+
+## Blueprints & tutorials
+
+There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+## Feature requests, ideas, and support
+
+If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+Are you stuck using these new features? Or maybe you've run into a bug? Please check the [](../support) page on where to go for help.

--- a/documentation/integrations/lovelace.md
+++ b/documentation/integrations/lovelace.md
@@ -57,6 +57,22 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 - Spook is not aware of all possible configuration for all possible cards. Especially with third-party cards, configuration can sometimes differ and Spook might not be able to detect the use of an unknown entity ID in such cases.
   :::
 
+### Unknown referenced areas
+
+Dashboards are inspected for the use of {term}`areas <area>`. Cards can target an area rather than a list of entities, and when that area is renamed or removed the card is left pointing at nothing. If Spook finds such a case, it will raise a repair issue naming the dashboard and the areas that are missing.
+
+A card like that does not break the dashboard. It simply shows nothing, which looks a lot like an area where nothing is happening.
+
+To resolve the raised issue, you can either remove the reference to the non-existing area or fix the referenced area. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Missing dashboard resources
+
+Dashboard resources tell Home Assistant which extra JavaScript and CSS files to load, which is how custom cards get there. Spook checks that the file behind each resource actually exists. If one does not, it will raise a repair issue listing the resources in question.
+
+This usually happens when a custom card was removed but its resource stayed behind. The cost is paid on every page load, by every browser, for a file that is never going to arrive.
+
+To resolve the raised issue, go to Settings > Dashboards > Resources and remove or correct these resources. Spook will automatically remove the repair issue once the issue is fixed.
+
 ## Features requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).

--- a/documentation/integrations/person.md
+++ b/documentation/integrations/person.md
@@ -175,7 +175,15 @@ data:
 
 ## Repairs
 
-Spook has no repair detections for this integration.
+While Spook is floating around in your Home Assistant instance, it will raise repairs issues if it has found something that is not right.
+
+### Unknown device trackers
+
+A person is a collection of device trackers, and the person's location is whatever those trackers say it is. Spook inspects every person to find trackers that no longer exist. If Spook finds such a case, it will raise a repair issue, naming the person and the trackers that are missing.
+
+This usually happens when a tracker was renamed, or when the integration providing it was removed. Nothing announces it: the person keeps working on the trackers that remain, so somebody whose phone tracker quietly disappeared just becomes a little less accurately located.
+
+The raised issue is fixable. Spook can remove the missing trackers from the person for you, or you can fix it yourself on the People page. A person set up in {term}`YAML` cannot be edited by Spook, so for those the issue points you at your configuration instead.
 
 ## Uses cases
 

--- a/documentation/integrations/recorder.md
+++ b/documentation/integrations/recorder.md
@@ -150,7 +150,15 @@ Messing with the recorder directly is not recommended. It is very easy to break 
 
 ## Repairs
 
-Spook has no repair detections for this integration.
+While Spook is floating around in your Home Assistant instance, it will raise repairs issues if it has found something that is not right.
+
+### Orphaned long-term statistics
+
+The recorder keeps long-term statistics separately from the states it records, and it keeps them by statistic ID rather than by entity. That means they outlive the entity they were collected for. Spook compares the statistics in the database against the entities that still exist and raises a repair issue listing the ones with nothing behind them anymore.
+
+These are not harmful, but they are not free either: they take up database space, and they keep showing up in pickers and graphs long after the sensor they belonged to is gone.
+
+To resolve the raised issue, open {term}`Developer tools` > Statistics and fix them there, or remove them with the `recorder.clear_statistics` action. Spook will automatically remove the repair issue once the issue is fixed.
 
 ## Uses cases
 

--- a/documentation/integrations/script.md
+++ b/documentation/integrations/script.md
@@ -87,6 +87,30 @@ Scripts are inspected for the use of actions. If a script is using an action tha
 
 To resolve the raised issue, you can either remove the reference to the non-existing action or restore the integration that provides the action. Spook will automatically remove the repair issue once the issue is fixed.
 
+### Unknown referenced floors
+
+Scripts are inspected for the use of {term}`floors <floor>`. If a script is targeting a floor in one of its actions that does not exist, Spook will raise a repair issue. The repairs issue raised will contain the name of the script and the floor that is referenced but not found.
+
+To resolve the raised issue, you can either remove the reference to the non-existing floor or fix the referenced floor. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown referenced labels
+
+Scripts are inspected for the use of {term}`labels <label>`. If a script is targeting a label that does not exist, Spook will raise a repair issue. The repairs issue raised will contain the name of the script and the label that is referenced but not found.
+
+To resolve the raised issue, you can either remove the reference to the non-existing label or fix the referenced label. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown referenced conditions
+
+Scripts are inspected for the conditions they use. Conditions are provided by {term}`integrations <integration>`, so a condition that no installed integration can provide is one nothing will ever evaluate. If a script uses such a condition, Spook will raise a repair issue naming the script and the conditions in question.
+
+This usually means the integration that provided the condition was removed. To resolve the raised issue, you can either remove the use of these conditions or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
+
+### Unknown referenced triggers
+
+Scripts are inspected for the triggers they use. A script is normally started by something else, but it can carry triggers of its own, and a trigger no installed integration can provide will never fire. If a script uses such a trigger, Spook will raise a repair issue naming the script and the triggers in question.
+
+To resolve the raised issue, you can either remove the use of these triggers or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
+
 ## Features requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Spook has 41 repair detections. Nineteen of them were not documented anywhere, spread over twenty-two missing sections, and two pages stated outright that Spook had no repair detections for their integration.

Extended pages:

- `automation.md` and `script.md`: floors, labels, conditions and triggers (four each, they had four of eight)
- `lovelace.md`: unknown areas, and missing dashboard resources
- `person.md`: unknown device trackers, replacing the "no repair detections" line
- `recorder.md`: orphaned long-term statistics, same

New pages:

- `integrations/energy.md`: the energy dashboard and its one repair
- `integrations/homeassistant.md`: the nine core repairs, from dead entity registrations and dangling `customize:` entries through forgotten access tokens to the tidiness ones (empty areas, empty floors, unused labels, unused blueprints)

Both are added to `_toc.yml`.

Putting those nine on one page is a judgement call worth flagging. The documentation mirrors the ectoplasms, one page per domain, and the ectoplasm is literally called `homeassistant`, so this is the consistent place for them. Spreading them across the Core extensions pages by subject (empty areas onto Areas, unused labels onto Labels, and so on) would read better for someone already on that page, at the cost of introducing a Repairs section to six pages that currently have none. Happy to move them if that is the better trade.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A repair nobody has documented is a repair nobody can look up when it fires. That matters most for the ones that need explaining rather than just naming: why a min/max helper gets pruned instead of removed, why a token that has been idle for 180 days is evidence rather than proof, why a blueprint imported five minutes ago is left alone.

Two pages were also actively wrong, telling readers there was nothing to see.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The documentation builds, and both new pages render.

The useful check was building `main` as well and diffing the two sets of MyST warnings: 23 against 23, empty in both directions. This adds no new build warnings, which is the thing a documentation change is most likely to do quietly.

Coverage is counted rather than eyeballed: a script walks the repair classes in `custom_components/spook/ectoplasms/*/repairs/`, walks the `###` sections under `## Repairs` on each page, and compares. It reads 41 in code against 41 documented, zero gaps, and no page still claiming it has no repair detections while shipping one.

The figures in the prose come from the code, not from memory: `_STALE_AFTER` is 180 days, `_MINIMUM_AGE` for a blueprint is one day, and the min/max fix flow refuses to leave a helper with fewer than two members.

Three terms the new pages reached for (Settings, device tracker, long-lived access token) turned out not to exist in the glossary, so they are written as plain prose instead. MyST is what established that, after my own glossary parser got it wrong three times running; the build output is the authority here, not a regex.

Not touched on purpose: the `Uses cases` and `Features requests` headings, which are misspelled in a dozen and three dozen files respectively. That is its own sweep. The two new pages use the correct headings.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

The existing repair sections on `automation.md` and `lovelace.md` carry screenshots. The new sections do not: capturing 22 repair issues means provoking 22 of them, and prose that explains what the issue means is worth more here than a picture of a card with a title on it. Happy to add them for individual repairs if you want them.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
