### PR TITLE
Correct what the repair documentation claims

### DIFF
--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -102,15 +102,19 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 
 ### Unknown referenced conditions
 
-Automations are inspected for the conditions they use. Conditions are provided by {term}`integrations <integration>`, so a condition that no installed integration can provide is one nothing will ever evaluate. If an automation uses such a condition, Spook will raise a repair issue naming the automation and the conditions in question.
+Automations are inspected for the conditions they use. Conditions are provided by {term}`integrations <integration>`, so a condition that no installed integration can provide cannot be evaluated. An automation like that fails validation outright and becomes unavailable, which is why Spook deliberately inspects unavailable automations: they are the broken ones.
+
+Home Assistant does notice, but it raises a generic issue about the automation. Spook names the exact conditions, which is the part you need in order to fix it.
 
 This usually means the integration that provided the condition was removed. To resolve the raised issue, you can either remove the use of these conditions or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
 
 ### Unknown referenced triggers
 
-Automations are inspected for the triggers they use. Like conditions, triggers come from integrations, and a trigger no installed integration can provide will never fire. If an automation uses such a trigger, Spook will raise a repair issue naming the automation and the triggers in question.
+Automations are inspected for the triggers they use. Like conditions, triggers come from integrations, and one no installed integration can provide takes the whole automation down with it: it fails validation and becomes unavailable.
 
-A trigger that never fires is the quietest kind of broken: the automation still exists, still looks fine, and simply never runs. To resolve the raised issue, you can either remove the use of these triggers or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
+So this is not a silent failure, it is a nameless one. Home Assistant raises a generic issue about the automation without saying which trigger caused it. Spook names the trigger.
+
+To resolve the raised issue, you can either remove the use of these triggers or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
 
 ## Features requests, ideas, and support
 

--- a/documentation/integrations/energy.md
+++ b/documentation/integrations/energy.md
@@ -16,9 +16,9 @@ date: 2026-08-21T16:20:00+02:00
 
 The energy {term}`dashboard <dashboard>` in {term}`Home Assistant` is where your consumption, production, gas, water, and battery numbers come together. It is configured once, in Settings > Dashboards > Energy, by pointing it at the {term}`entities <entity>` that carry those numbers.
 
-That configuration is a list of {term}`entity IDs <entity id>` held separately from the entities themselves. Nothing keeps the two in step, and nothing tells you when they drift apart.
+That configuration is a list of {term}`entity IDs <entity id>` held separately from the entities themselves, and nothing keeps the two in step. Home Assistant does validate it, but it shows the result only inside that configuration panel, which is a page you visit when you are changing something rather than one you check.
 
-Spook enhances the energy dashboard by raising {term}`repairs <repairs>` issues when it finds an entity in that configuration that Home Assistant no longer has.
+Spook enhances the energy dashboard by taking Home Assistant's own validation and raising a {term}`repairs <repairs>` issue for it, so a removed entity comes to you instead of waiting to be found.
 
 ## Devices & entities
 
@@ -34,9 +34,9 @@ While Spook is floating around in your Home Assistant instance, it will raise re
 
 ### Unknown referenced entities
 
-Spook inspects the energy configuration to find the entities it names that no longer exist. If Spook finds such a case, it will raise a repair issue listing the entities that are missing.
+Spook runs Home Assistant's own energy validation and looks for the one result that means a reference has gone stale: an entity that has no state at all, because it was removed. The other results it can report are either transient (an entity that happens to be unavailable right now) or a configuration choice rather than a mistake, so Spook leaves those alone.
 
-The dashboard does not complain about this. It draws the sources it can still read and leaves out the one it cannot, so the graph stays plausible while quietly being wrong. A missing gas sensor does not look like an error, it looks like a month where you used no gas.
+What this buys you is where the answer appears. The dashboard itself does not complain: it draws the sources it can still read and leaves out the one it cannot, so the graph stays plausible while quietly being wrong. A missing gas sensor does not look like an error, it looks like a month where you used no gas.
 
 To resolve the raised issue, go to Settings > Dashboards > Energy and update or remove these entities. Spook will automatically remove the repair issue once the issue is fixed.
 

--- a/documentation/integrations/homeassistant.md
+++ b/documentation/integrations/homeassistant.md
@@ -22,7 +22,7 @@ Spook enhances the core integration by raising {term}`repairs <repairs>` issues 
 
 ## Devices & entities
 
-Spook does not provide any new devices or entities for this integration.
+Spook turns Home Assistant itself into a device, with buttons to reload and restart it and a sensor counting the entities of every type you have. Those are documented on [](../devices_entities).
 
 ## Actions
 
@@ -33,6 +33,8 @@ Spook adds a large number of actions in the `homeassistant` domain, but they are
 While Spook is floating around in your Home Assistant instance, it will raise repairs issues if it has found something that is not right.
 
 Some of these are broken things, and some are only untidy ones. The untidy ones are all fixable from the issue itself, and every one of them offers to stop mentioning it, because an empty area you keep on purpose is nobody's business but yours.
+
+The tidiness repairs also hold off for a day, so setting something up and filling it in after lunch does not earn you a repair issue in between. A new area, floor or label is left alone for its first twenty-four hours. A blueprint is judged by when its file was last touched rather than when it first appeared, which also spares one you edited yesterday.
 
 ### Non-existing registered entities
 
@@ -54,7 +56,9 @@ To resolve the raised issue, edit the `customize:` section in your configuration
 
 ### Unknown helper sources
 
-Many {term}`helpers <helper>` are built on top of another entity: a threshold on a sensor, a derivative on a counter, a group on a handful of switches. Spook reads each helper's own configuration to find the source entities it names, and raises a repair issue when one of them is unknown to Home Assistant.
+A number of {term}`helpers <helper>` are built on top of another entity: a threshold on a sensor, a derivative on a counter, a utility meter on an energy reading. Spook knows which twelve helper types store a source reference and where each one keeps it, reads that configuration, and raises a repair issue when a source is unknown to Home Assistant.
+
+Groups and min/max helpers are handled elsewhere on purpose. Both have a repair of their own that can do something better than reporting the problem, so this one stays out of their way.
 
 Reading the configuration rather than the running helper matters here: it means a helper whose entity failed to set up entirely is still checked, and that is exactly the helper most likely to be broken.
 
@@ -96,8 +100,6 @@ The raised issue is fixable: Spook can remove the label for you.
 
 {term}`Blueprints <blueprint>` collect. You import one to try it, decide against it, and it stays. Spook raises a repair issue for a blueprint that no automation or script uses.
 
-A blueprint whose file was added or changed in the last day is left alone, so importing one and setting it up a few minutes later does not earn you an instant repair issue for your trouble.
-
 The raised issue is fixable: Spook can remove the blueprint for you.
 
 ## Use cases
@@ -107,7 +109,7 @@ Some use cases for the enhancements Spook provides for this integration:
 - Replacing a batch of devices. The new ones set themselves up, the old registry entries stay behind as permanently unavailable entities, and grouping them per integration turns a wall of unavailable entities into one issue you can act on.
 - Auditing who still has a key to your instance. Long-lived tokens are easy to create and easy to forget, and nothing else in Home Assistant will bring one up unprompted.
 - Cleaning up after a reorganisation. Renaming and regrouping leaves empty areas, empty floors and unused labels behind, and none of them are visible unless you go looking.
-- Finding helpers that broke months ago. A helper without its source is not merely wrong, it is silently wrong, and it will keep reporting a last known value as if nothing happened.
+- Finding helpers that broke months ago. A helper without its source is not merely wrong, it is quietly wrong: depending on the helper it may sit on a stale value, go unavailable, or never have set up at all. None of those announce themselves.
 
 ## Blueprints & tutorials
 

--- a/documentation/integrations/lovelace.md
+++ b/documentation/integrations/lovelace.md
@@ -59,17 +59,19 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 
 ### Unknown referenced areas
 
-Dashboards are inspected for the use of {term}`areas <area>`. Cards can target an area rather than a list of entities, and when that area is renamed or removed the card is left pointing at nothing. If Spook finds such a case, it will raise a repair issue naming the dashboard and the areas that are missing.
+Dashboards are inspected for the use of {term}`areas <area>`. An area can be referenced in more than one way: by an area card, by the area view strategy, by the areas dashboard strategy listing areas to hide or order, and by an `area_id` used as the target of an action. Spook looks for all of them and raises a repair issue naming the dashboard and the areas that are missing.
 
-A card like that does not break the dashboard. It simply shows nothing, which looks a lot like an area where nothing is happening.
+None of this breaks the dashboard. An area card with a missing area shows nothing, which looks a lot like an area where nothing is happening; a button whose action targets a missing area renders perfectly and does nothing when you press it.
 
 To resolve the raised issue, you can either remove the reference to the non-existing area or fix the referenced area. Spook will automatically remove the repair issue once the issue is fixed.
 
 ### Missing dashboard resources
 
-Dashboard resources tell Home Assistant which extra JavaScript and CSS files to load, which is how custom cards get there. Spook checks that the file behind each resource actually exists. If one does not, it will raise a repair issue listing the resources in question.
+Dashboard resources tell Home Assistant which extra JavaScript and CSS files to load, which is how custom cards get there. Spook checks the ones it can: a resource served from `/local/` or `/hacsfiles/` maps to a file on disk, so Spook can see whether that file is there. If it is not, it will raise a repair issue listing the resources in question.
 
-This usually happens when a custom card was removed but its resource stayed behind. The cost is paid on every page load, by every browser, for a file that is never going to arrive.
+Resources on an external URL, or served by an integration, are deliberately skipped. Spook cannot verify those without going and asking, so it does not claim to.
+
+A missing local resource usually means a custom card was removed but its resource stayed behind. The cost is paid on every page load, by every browser, for a file that is never going to arrive.
 
 To resolve the raised issue, go to Settings > Dashboards > Resources and remove or correct these resources. Spook will automatically remove the repair issue once the issue is fixed.
 

--- a/documentation/integrations/script.md
+++ b/documentation/integrations/script.md
@@ -101,13 +101,17 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 
 ### Unknown referenced conditions
 
-Scripts are inspected for the conditions they use. Conditions are provided by {term}`integrations <integration>`, so a condition that no installed integration can provide is one nothing will ever evaluate. If a script uses such a condition, Spook will raise a repair issue naming the script and the conditions in question.
+Scripts are inspected for the conditions they use. Conditions are provided by {term}`integrations <integration>`, so a condition that no installed integration can provide cannot be evaluated. A script like that fails validation outright and becomes unavailable, which is why Spook deliberately inspects unavailable scripts: they are the broken ones.
+
+Home Assistant does notice, but it raises a generic issue about the script. Spook names the exact conditions, which is the part you need in order to fix it.
 
 This usually means the integration that provided the condition was removed. To resolve the raised issue, you can either remove the use of these conditions or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
 
 ### Unknown referenced triggers
 
-Scripts are inspected for the triggers they use. A script is normally started by something else, but it can carry triggers of its own, and a trigger no installed integration can provide will never fire. If a script uses such a trigger, Spook will raise a repair issue naming the script and the triggers in question.
+Scripts are inspected for the trigger configurations they contain, such as the ones a `wait_for_trigger` step waits on. A trigger no installed integration can provide takes the whole script down with it: it fails validation and becomes unavailable.
+
+Home Assistant raises a generic issue about the script without saying which trigger caused it. Spook names the trigger.
 
 To resolve the raised issue, you can either remove the use of these triggers or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fixes ten factually wrong passages in the repair documentation that landed in #1461. Eight were flagged by the review bots on that pull request; two I found while checking the other eight.

| Page | What was wrong |
| --- | --- |
| `homeassistant.md` | Said Spook provides no devices or entities for the integration. That ectoplasm ships the reload and restart buttons and a counter sensor per entity type. |
| `homeassistant.md` | "Many helpers" with a group as the example. It is twelve specific helper types, and `group` and `min_max` are excluded on purpose. |
| `homeassistant.md` | The one-day grace period was only mentioned for blueprints. It applies to empty areas, empty floors and unused labels too. |
| `homeassistant.md` | Claimed a helper without its source keeps reporting a last known value. This repair also covers helpers that never set up at all. |
| `energy.md` | "Nothing tells you when they drift apart." Home Assistant does; the repair calls its validator. |
| `lovelace.md` | Claimed every dashboard resource is checked. Only `/local/` and `/hacsfiles/` map to a file. |
| `lovelace.md` | Described area references as area cards only, and said the card shows nothing. |
| `automation.md`, `script.md` | Triggers: said the automation looks healthy and never runs. It fails validation and goes unavailable. |
| `automation.md`, `script.md` | Conditions: same mistake. Not flagged by anyone. |

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I wrote that documentation from the repair issue text and the titles, and inferred the mechanics rather than reading them. The repair docstrings say plainly what happens, and in several cases they say the opposite of what I wrote.

The trigger and condition ones are worth calling out, because the mistake had a shape. I wrote that an unknown trigger leaves an automation looking healthy and simply never running: a good line about a silent failure. The automation actually fails validation and goes unavailable, which the docstring states, along with the note that unavailable automations are inspected deliberately because they are the broken ones. So Spook's value there is not spotting something invisible, it is naming which trigger broke it where Home Assistant only raises a generic issue. That is a better story than the one I made up, and it has the advantage of being true.

Documentation that is confidently wrong about mechanics is worse than documentation that is missing, because someone will act on it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Every claim in this pull request was checked against the code, not against the review comment that raised it:

- `ectoplasms/homeassistant/button.py` and `sensor.py` exist and provide the entities, and `devices_entities.md` already documents them
- `SOURCE_OPTION_KEYS` in `unknown_helper_source_references.py` holds twelve domains, with a comment saying `group` and `min_max` are excluded and why
- `_MINIMUM_AGE` is one day in `empty_areas.py`, `empty_floors.py`, `unused_labels.py` and `unused_blueprints.py`; the first three compare `created_at`, the fourth compares file modification time, which is why the wording distinguishes them
- `energy/repairs/unknown_references.py` calls `homeassistant.components.energy.validate.async_validate` and filters to `entity_not_defined`
- `missing_resources.py` maps only `_LOCAL_PREFIX` and `_HACS_PREFIX` to disk
- `dashboard_extraction.py` collects `area`, `area_id` and `areas_display`
- the trigger and condition repair docstrings in both `automation/repairs/` and `script/repairs/` state the unavailable behaviour

Build: clean. Warning set diffed against `main`, 23 against 23, empty in both directions.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
