### PR TITLE
Correct four more claims in the repair documentation

### DIFF
--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -110,7 +110,7 @@ This usually means the integration that provided the condition was removed. To r
 
 ### Unknown referenced triggers
 
-Automations are inspected for the triggers they use. Like conditions, triggers come from integrations, and one no installed integration can provide takes the whole automation down with it: it fails validation and becomes unavailable.
+Automations are inspected for the triggers they use. Like conditions, triggers come from integrations, and if no installed integration can provide a trigger, the whole automation goes down with it: it fails validation and becomes unavailable.
 
 So this is not a silent failure, it is a nameless one. Home Assistant raises a generic issue about the automation without saying which trigger caused it. Spook names the trigger.
 

--- a/documentation/integrations/energy.md
+++ b/documentation/integrations/energy.md
@@ -34,7 +34,7 @@ While Spook is floating around in your Home Assistant instance, it will raise re
 
 ### Unknown referenced entities
 
-Spook runs Home Assistant's own energy validation and looks for the one result that means a reference has gone stale: an entity that has no state at all, because it was removed. The other results it can report are either transient (an entity that happens to be unavailable right now) or a configuration choice rather than a mistake, so Spook leaves those alone.
+Spook runs Home Assistant's own energy validation and looks for one result out of the several it can return: an entity with no state at all. That is usually one that was removed, though the same result covers an entity that never loaded or failed to set up, so treat it as a reference worth checking rather than a verdict. The other results are either transient (an entity that happens to be unavailable right now) or a configuration choice rather than a mistake, so Spook leaves those alone.
 
 What this buys you is where the answer appears. The dashboard itself does not complain: it draws the sources it can still read and leaves out the one it cannot, so the graph stays plausible while quietly being wrong. A missing gas sensor does not look like an error, it looks like a month where you used no gas.
 

--- a/documentation/integrations/homeassistant.md
+++ b/documentation/integrations/homeassistant.md
@@ -22,7 +22,7 @@ Spook enhances the core integration by raising {term}`repairs <repairs>` issues 
 
 ## Devices & entities
 
-Spook turns Home Assistant itself into a device, with buttons to reload and restart it and a sensor counting the entities of every type you have. Those are documented on [](../devices_entities).
+Spook turns Home Assistant itself into a device, with buttons to reload and restart it and a set of counting sensors: your entities in total, one per entity type for a long list of types, and counts of things like areas, devices and integrations. Those are documented on [](../devices_entities).
 
 ## Actions
 
@@ -56,7 +56,7 @@ To resolve the raised issue, edit the `customize:` section in your configuration
 
 ### Unknown helper sources
 
-A number of {term}`helpers <helper>` are built on top of another entity: a threshold on a sensor, a derivative on a counter, a utility meter on an energy reading. Spook knows which twelve helper types store a source reference and where each one keeps it, reads that configuration, and raises a repair issue when a source is unknown to Home Assistant.
+A number of {term}`helpers <helper>` are built on top of another entity: a threshold on a sensor, a derivative on a counter, a utility meter on an energy reading. Spook knows which thirteen helper types store a source reference and where each one keeps it, reads that configuration, and raises a repair issue when a source is unknown to Home Assistant.
 
 Groups and min/max helpers are handled elsewhere on purpose. Both have a repair of their own that can do something better than reporting the problem, so this one stays out of their way.
 

--- a/documentation/integrations/lovelace.md
+++ b/documentation/integrations/lovelace.md
@@ -61,7 +61,7 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 
 Dashboards are inspected for the use of {term}`areas <area>`. An area can be referenced in more than one way: by an area card, by the area view strategy, by the areas dashboard strategy listing areas to hide or order, and by an `area_id` used as the target of an action. Spook looks for all of them and raises a repair issue naming the dashboard and the areas that are missing.
 
-None of this breaks the dashboard. An area card with a missing area shows nothing, which looks a lot like an area where nothing is happening; a button whose action targets a missing area renders perfectly and does nothing when you press it.
+What you see depends on where the reference sits, and the frontend decides that rather than Spook, so this page will not promise you a particular symptom. What Spook can tell you is which dashboard names which missing area, which is the part you need either way.
 
 To resolve the raised issue, you can either remove the reference to the non-existing area or fix the referenced area. Spook will automatically remove the repair issue once the issue is fixed.
 

--- a/documentation/integrations/script.md
+++ b/documentation/integrations/script.md
@@ -109,7 +109,7 @@ This usually means the integration that provided the condition was removed. To r
 
 ### Unknown referenced triggers
 
-Scripts are inspected for the trigger configurations they contain, such as the ones a `wait_for_trigger` step waits on. A trigger no installed integration can provide takes the whole script down with it: it fails validation and becomes unavailable.
+Scripts are inspected for the trigger configurations they contain, such as the ones a `wait_for_trigger` step waits on. If no installed integration can provide a trigger a script waits on, the whole script goes down with it: it fails validation and becomes unavailable.
 
 Home Assistant raises a generic issue about the script without saying which trigger caused it. Spook names the trigger.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Follow-up to #1462. The review there found four claims still wrong, which is a fair result for a pull request whose entire point was accuracy. All four are fixed here, plus one wording change.

| Page | What was still wrong |
| --- | --- |
| `homeassistant.md` | Promised "a sensor counting the entities of every type you have". Twelve Home Assistant platforms have no counter. |
| `homeassistant.md` | Said the helper source repair covers twelve helper types. It inspects thirteen. |
| `energy.md` | Described `entity_not_defined` as meaning the entity was removed. It means it has no state. |
| `lovelace.md` | Described what a missing area looks like on the dashboard. That is frontend behaviour I cannot verify from this repository. |
| `automation.md`, `script.md` | Trigger sentence was awkward enough that a reviewer stopped on the grammar instead of the content. |

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The helper count is the one worth dwelling on. I counted the entries in `SOURCE_OPTION_KEYS` and wrote down that number. `_inspected_domains` is `frozenset({*SOURCE_OPTION_KEYS, "bayesian"})`, because bayesian stores its sources somewhere a shared option-key table cannot describe. So I read one structure, found a number, and did not check whether that structure was the whole answer. That is precisely the class of mistake #1462 existed to fix, committed inside the fix.

The lovelace one is a different lesson. I replaced an unverifiable claim about the frontend with a different unverifiable claim about the frontend. The frontend lives in another repository. The honest move is to say what Spook knows, which is which dashboard references which missing area, and stop there.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Each claim was checked against the code:

- Comparing `translation_key="homeassistant_*"` in `ectoplasms/homeassistant/sensor.py` against `homeassistant.const.Platform` gives 53 counters, and twelve platforms with none: ai_task, assist_satellite, conversation, event, geo_location, image_processing, infrared, lawn_mower, notify, radio_frequency, valve, wake_word
- `_inspected_domains` in `unknown_helper_source_references.py` is the twelve `SOURCE_OPTION_KEYS` entries plus `bayesian`
- `components/energy/validate.py` raises `entity_not_defined` when `hass.states.get(entity_id) is None`, in three separate places, none of which establish removal

Build clean, and the warning set diffed against `main`: 23 against 23, empty both ways.

**One review point is not taken.** `[](../devices_entities)` was flagged as an empty link that would render without identifiable text. Reading the built output (`_build/html/homeassistant.json`), that link renders with the text `Devices & entities`, and MyST raises no warning for it while it does raise one for each of the nine existing `[](../support)` links. So this link resolves, follows the convention already used throughout these pages, and is better behaved than the ones that were already here.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
