### PR TITLE
Spell the two repeated headings correctly

### DIFF
--- a/documentation/areas.md
+++ b/documentation/areas.md
@@ -756,7 +756,7 @@ data:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/devices.md
+++ b/documentation/devices.md
@@ -161,7 +161,7 @@ data:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for these features. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this, for example, by adding a new service, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/devices_entities.md
+++ b/documentation/devices_entities.md
@@ -108,7 +108,7 @@ But wait, there are more counters! The following sensors are also added:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for these features. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/entities.md
+++ b/documentation/entities.md
@@ -497,7 +497,7 @@ data:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for these features. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/floors.md
+++ b/documentation/floors.md
@@ -605,7 +605,7 @@ data:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations.md
+++ b/documentation/integrations.md
@@ -335,7 +335,7 @@ data:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for these features. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/_template.md
+++ b/documentation/integrations/_template.md
@@ -45,7 +45,7 @@ Spook does not provide action enhancements for this integration.
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -55,7 +55,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -116,7 +116,7 @@ So this is not a silent failure, it is a nameless one. Home Assistant raises a g
 
 To resolve the raised issue, you can either remove the use of these triggers or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -92,7 +92,7 @@ It is recommended to import blueprints via the Home Assistant UI. The UI will sh
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -102,7 +102,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/cloud.md
+++ b/documentation/integrations/cloud.md
@@ -77,7 +77,7 @@ Spook does not provide action enhancements for this integration.
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -89,7 +89,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/group.md
+++ b/documentation/integrations/group.md
@@ -45,7 +45,7 @@ Spook inspects all groups created to find group member entities that no longer e
 
 To resolve the raised issue, you can either remove the missing entity from the group or fix the referenced source entity. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/input_number.md
+++ b/documentation/integrations/input_number.md
@@ -357,7 +357,7 @@ target:
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -370,7 +370,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/input_select.md
+++ b/documentation/integrations/input_select.md
@@ -193,7 +193,7 @@ Sorting is not persistent and will be undone once reloaded or Home Assistant res
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -204,7 +204,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/integration.md
+++ b/documentation/integrations/integration.md
@@ -37,7 +37,7 @@ Spook inspects all Riemann sum integral created {term}`entities <entity>`, and l
 
 To resolve the raised issue, you can either remove the helper or fix the referenced source {term}`entity ID <entity id>`. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/lovelace.md
+++ b/documentation/integrations/lovelace.md
@@ -75,7 +75,7 @@ A missing local resource usually means a custom card was removed but its resourc
 
 To resolve the raised issue, go to Settings > Dashboards > Resources and remove or correct these resources. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/number.md
+++ b/documentation/integrations/number.md
@@ -229,7 +229,7 @@ target:
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -240,7 +240,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/person.md
+++ b/documentation/integrations/person.md
@@ -185,7 +185,7 @@ This usually happens when a tracker was renamed, or when the integration providi
 
 The raised issue is fixable. Spook can remove the missing trackers from the person for you, or you can fix it yourself on the People page. A person set up in {term}`YAML` cannot be edited by Spook, so for those the issue points you at your configuration instead.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -195,7 +195,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/proximity.md
+++ b/documentation/integrations/proximity.md
@@ -48,7 +48,7 @@ A proximity configuration allows for ignoring certain zones. Spook inspects all 
 
 While this is not a critical issue, it is a good one to clean up. To resolve the raised issue, you can edit the proximity configuration and remove the missing ignored zone. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/recorder.md
+++ b/documentation/integrations/recorder.md
@@ -160,7 +160,7 @@ These are not harmful, but they are not free either: they take up database space
 
 To resolve the raised issue, open {term}`Developer tools` > Statistics and fix them there, or remove them with the `recorder.clear_statistics` action. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -170,7 +170,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/repairs.md
+++ b/documentation/integrations/repairs.md
@@ -319,7 +319,7 @@ action: repairs.unignore_all
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -329,7 +329,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/scene.md
+++ b/documentation/integrations/scene.md
@@ -45,7 +45,7 @@ Spook found an issue with a scene that is using non-existing entities.
 
 To resolve the raised issue, you can either remove the reference to the non-existing entity ID or fix the referenced entity ID. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/script.md
+++ b/documentation/integrations/script.md
@@ -115,7 +115,7 @@ Home Assistant raises a generic issue about the script without saying which trig
 
 To resolve the raised issue, you can either remove the use of these triggers or restore the integration that provides them. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/select.md
+++ b/documentation/integrations/select.md
@@ -105,7 +105,7 @@ data:
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -115,7 +115,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/switch_as_x.md
+++ b/documentation/integrations/switch_as_x.md
@@ -39,7 +39,7 @@ Spook inspects all Switch as X created entities, in case one of your existing he
 
 To resolve the raised issue, you can either remove the helper or fix the referenced source entity ID. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/template.md
+++ b/documentation/integrations/template.md
@@ -43,7 +43,7 @@ by Home Assistant, or restore the integration or script that provided it.
 Templated action names are ignored because their value is determined at runtime.
 Spook automatically removes the repair issue once it is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea for a new action, entity, or repair detection, [let us know
 in the discussion forums](https://github.com/frenck/spook/discussions).

--- a/documentation/integrations/timer.md
+++ b/documentation/integrations/timer.md
@@ -78,7 +78,7 @@ data:
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -88,7 +88,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/trend.md
+++ b/documentation/integrations/trend.md
@@ -34,7 +34,7 @@ Spook inspects all trend sensors created to find source entities they meter that
 
 To resolve the raised issue, you can either remove the trend helper or restore the referenced source entity. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/utility_meter.md
+++ b/documentation/integrations/utility_meter.md
@@ -34,7 +34,7 @@ Spook inspects all utility meters created to find source entities they meter tha
 
 To resolve the raised issue, you can either remove the utility meter helper or restore the referenced source entity. Spook will automatically remove the repair issue once the issue is fixed.
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/integrations/zone.md
+++ b/documentation/integrations/zone.md
@@ -260,7 +260,7 @@ data:
 
 Spook has no repair detections for this integration.
 
-## Uses cases
+## Use cases
 
 Some use cases for the enhancements Spook provides for this integration:
 
@@ -270,7 +270,7 @@ Some use cases for the enhancements Spook provides for this integration:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/labels.md
+++ b/documentation/labels.md
@@ -770,7 +770,7 @@ data:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/misc.md
+++ b/documentation/misc.md
@@ -78,7 +78,7 @@ data:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for these features. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 

--- a/documentation/users.md
+++ b/documentation/users.md
@@ -155,7 +155,7 @@ data:
 
 There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for these features. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 
-## Features requests, ideas, and support
+## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Two headings, misspelled across the documentation:

- `## Uses cases` becomes `## Use cases`, 12 pages
- `## Features requests, ideas, and support` becomes `## Feature requests, ideas, and support`, 32 pages

44 headings, 32 files, and nothing else. The diff is 44 insertions and 44 deletions, all of them one of those two lines.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Both misspellings live in `integrations/_template.md`, which is what new pages get copied from. So this was never thirty-two independent typos, it was one typo and thirty-one copies of it, and the template is the part of this change that matters most: without it the next new page brings both back.

The count before this: 12 pages spelling it "Uses cases" against 4 spelling it "Use cases", and 32 against 4 on the other. Afterwards it is 16 and 36, with nothing spelling either one the other way.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The thing that could actually break here is anchors: renaming a heading renames the fragment it generates, so anything linking to `#uses-cases` or `#features-requests` would now point at nothing. Grepping the documentation and the table of contents for both finds no references, so nothing breaks.

Beyond that:

- confirmed the diff touches only heading lines, by filtering the diff for changed lines that are not one of those two headings and getting zero
- documentation builds, and the warning set diffed against `main` is 23 against 23, empty in both directions
- prettier clean, and nothing outside `documentation/` is touched

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
