### PR TITLE
Stop reading the device registry as a mapping

### DIFF
--- a/custom_components/spook/core_compat.py
+++ b/custom_components/spook/core_compat.py
@@ -1,0 +1,44 @@
+"""Spook - Your homie. Bridges the Home Assistant Core versions Spook supports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import callback
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from homeassistant.helpers import device_registry as dr
+
+
+@callback
+def async_get_device_entries(
+    device_registry: dr.DeviceRegistry,
+) -> list[dr.DeviceEntry]:
+    """Return all device entries in the device registry.
+
+    Home Assistant Core 2026.9 deprecated using `device_registry.devices` as a
+    mapping; iterating it yields the device entries there. On 2026.8 it is
+    still a mapping, so iterating yields the device IDs instead.
+    Can be removed once Spook requires Core 2026.9 or later.
+    """
+    devices = device_registry.devices
+    if isinstance(devices, Mapping):
+        return list(devices.values())
+
+    return list(devices)
+
+
+@callback
+def async_get_child_device_ids(device_registry: dr.DeviceRegistry) -> set[str]:
+    """Return the IDs of all child devices in the device registry.
+
+    Child devices arrived in Home Assistant Core 2026.9. They are devices in
+    their own right and can be targeted like any other device. Core 2026.8 has
+    no child devices at all.
+    Can be removed once Spook requires Core 2026.9 or later.
+    """
+    child_devices: Iterable[Any] = getattr(device_registry, "child_devices", ())
+    return {child_device.id for child_device in child_devices}

--- a/custom_components/spook/ectoplasms/homeassistant/device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/device.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 
+from ...core_compat import async_get_device_entries
+
 
 @callback
 def async_disable_device_and_parent_if_needed(
@@ -33,7 +35,7 @@ def async_disable_device_and_parent_if_needed(
 
         if not all(
             child.id == current_id or child.disabled_by is not None
-            for child in device_registry.devices.values()
+            for child in async_get_device_entries(device_registry)
             if child.via_device_id == device.via_device_id
         ):
             return

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -41,6 +41,7 @@ from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util.hass_dict import HassKey
 
 from .const import LOGGER
+from .core_compat import async_get_child_device_ids, async_get_device_entries
 from .listeners import async_listen_once_tracked
 
 if TYPE_CHECKING:
@@ -362,20 +363,23 @@ def async_filter_known_area_ids(
 def async_get_all_device_ids(hass: HomeAssistant) -> set[str]:
     """Return all device IDs, known to Home Assistant."""
     device_registry = dr.async_get(hass)
-    device_ids = {device.id for device in device_registry.devices.values()}
 
-    # Home Assistant Core 2026.8 split devices that belonged to multiple config
-    # entries into one device per config entry. The pre-split device ID is no
-    # longer registered, but it still resolves to those new devices, so anything
-    # targeting it keeps working. Those IDs are known, just not enumerated.
-    # Can be removed when Core drops composite devices in 2027.8.
-    get_composite_splits: Callable[[], Mapping[str, Any]] | None = getattr(
-        device_registry.devices, "get_composite_splits", None
-    )
-    if get_composite_splits is not None:
-        device_ids.update(get_composite_splits().keys())
+    device_ids: set[str] = set()
+    for device in async_get_device_entries(device_registry):
+        device_ids.add(device.id)
 
-    return device_ids
+        # Home Assistant Core 2026.8 split devices that belonged to multiple
+        # config entries into one device per config entry. The pre-split device
+        # ID is no longer registered, but it still resolves to those new
+        # devices, so anything targeting it keeps working. Those IDs are known,
+        # just not enumerated.
+        # Can be removed when Core drops composite devices in 2027.8.
+        if device.composite_device_id is not None:
+            device_ids.add(device.composite_device_id)
+
+    # Child devices arrived in Home Assistant Core 2026.9. They are not part of
+    # the device list above, but can be targeted like any other device.
+    return device_ids | async_get_child_device_ids(device_registry)
 
 
 @callback

--- a/tests/device_registry_helpers.py
+++ b/tests/device_registry_helpers.py
@@ -1,0 +1,29 @@
+"""Shared helpers for testing Spook against the device registry."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import attr
+
+if TYPE_CHECKING:
+    from homeassistant.helpers import device_registry as dr
+
+
+def simulate_composite_split(
+    device_registry: dr.DeviceRegistry,
+    device: dr.DeviceEntry,
+    composite_device_id: str,
+) -> None:
+    """Make a device look like a split of a pre-migration composite device.
+
+    Home Assistant Core 2026.8 split devices that spanned multiple config
+    entries into one device per entry, each carrying the ID of the composite
+    device it came from. Only the registry migration creates that state, so
+    tests fake it the way Core's own tests do: by replacing the stored entry.
+
+    The container moved to `_devices` in Core 2026.9, where reaching it through
+    `devices` is deprecated.
+    """
+    devices = getattr(device_registry, "_devices", device_registry.devices)
+    devices[device.id] = attr.evolve(device, composite_device_id=composite_device_id)

--- a/tests/ectoplasms/automation/repairs/test_unknown_device_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_device_references.py
@@ -11,13 +11,13 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.spook.ectoplasms.automation.repairs.unknown_device_references import (
     SpookRepair,
 )
+from tests.device_registry_helpers import simulate_composite_split
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import device_registry as dr
-    import pytest
 
 
 class MockAutomationEntity:
@@ -79,7 +79,6 @@ async def test_event_trigger_data_device_id_in_plural_triggers_is_not_reported_u
 async def test_pre_split_device_id_is_not_reported_unknown(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test a device ID from before the Core 2026.8 device split is not unknown.
 
@@ -93,13 +92,7 @@ async def test_pre_split_device_id_is_not_reported_unknown(
         config_entry_id=entry.entry_id,
         identifiers={("test", "split-device")},
     )
-    # Stubbed so this test also runs on cores that predate the device split.
-    monkeypatch.setattr(
-        device_registry.devices,
-        "get_composite_splits",
-        lambda: {"pre-split-id": [split]},
-        raising=False,
-    )
+    simulate_composite_split(device_registry, split, "pre-split-id")
 
     entity = MockAutomationEntity(
         raw_config={

--- a/tests/test_core_compat.py
+++ b/tests/test_core_compat.py
@@ -1,0 +1,87 @@
+"""Tests for the Home Assistant Core compatibility helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.spook.core_compat import (
+    async_get_child_device_ids,
+    async_get_device_entries,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import device_registry as dr
+
+
+class MockDeviceContainerView:
+    """Mock of the container view Core 2026.9 and later hand out.
+
+    It iterates as device entries, while every mapping access on it is
+    deprecated. This one refuses those instead of warning, so a helper that
+    still reaches for one fails the test.
+    """
+
+    def __init__(self, devices: list[Any]) -> None:
+        """Initialize the view."""
+        self._devices = devices
+
+    def __iter__(self) -> Iterator[Any]:
+        """Iterate over the device entries."""
+        return iter(self._devices)
+
+    def __getattr__(self, name: str) -> Any:
+        """Refuse the deprecated mapping access."""
+        message = f"Deprecated `device_registry.devices.{name}` access"
+        raise AssertionError(message)
+
+
+def test_device_entries_are_read_by_iterating() -> None:
+    """Test devices are read the way Core 2026.9 and later want them read."""
+    device = SimpleNamespace(id="a-device")
+    device_registry = SimpleNamespace(devices=MockDeviceContainerView([device]))
+
+    assert async_get_device_entries(device_registry) == [device]
+
+
+def test_device_entries_are_read_from_a_mapping(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test devices are read as entries, not as IDs.
+
+    Core 2026.8 still hands out the container itself, which iterates over
+    device IDs instead of over device entries.
+    """
+    entry = MockConfigEntry(domain="test", title="Test")
+    entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("test", "device")},
+    )
+
+    assert async_get_device_entries(device_registry) == [device]
+
+
+def test_child_device_ids_are_returned() -> None:
+    """Test child devices are picked up on Core 2026.9 and later."""
+    device_registry = SimpleNamespace(
+        child_devices=[SimpleNamespace(id="a-child-device")]
+    )
+
+    assert async_get_child_device_ids(device_registry) == {"a-child-device"}
+
+
+def test_child_device_ids_without_child_devices(
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a registry without child devices yields none.
+
+    Core 2026.8 has no child devices at all.
+    """
+    assert async_get_child_device_ids(device_registry) == set()

--- a/tests/test_entity_filtering.py
+++ b/tests/test_entity_filtering.py
@@ -19,10 +19,10 @@ from custom_components.spook.entity_filtering import (
     async_find_services_in_sequence,
     async_get_all_device_ids,
 )
+from tests.device_registry_helpers import simulate_composite_split
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-    import pytest
 
 
 def test_find_services_skips_disabled_nested_steps() -> None:
@@ -119,7 +119,6 @@ def test_registered_device_ids_are_known(
 def test_composite_device_ids_are_known(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test pre-split device IDs are not reported as unknown.
 
@@ -133,13 +132,7 @@ def test_composite_device_ids_are_known(
         config_entry_id=entry.entry_id,
         identifiers={("test", "split-device")},
     )
-    # Stubbed so the test also runs on cores that predate the device split.
-    monkeypatch.setattr(
-        device_registry.devices,
-        "get_composite_splits",
-        lambda: {"pre-split-id": [split]},
-        raising=False,
-    )
+    simulate_composite_split(device_registry, split, "pre-split-id")
 
     assert "pre-split-id" in async_get_all_device_ids(hass)
     assert async_filter_known_device_ids(hass, device_ids={"pre-split-id"}) == set()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Home Assistant Core 2026.9 turned `device_registry.devices` into a view that iterates as device entries. Using it as a mapping is deprecated, and that includes the container methods it proxies through `__getattr__`, so the `get_composite_splits` lookup would have kept warning even after fixing the `.values()` call.

Two places read the registry that way: `async_get_all_device_ids()` (the one in the report) and the enable/disable device walk, which nobody has tripped yet because it only runs on those actions.

The pre-split device IDs now come from the `composite_device_id` on each device entry, which exists since 2026.8.0, so the `getattr` guard was never needed. Child devices are new in 2026.9 and can be targeted like any other device, so they count as known device IDs now; without that, an automation targeting one would be reported as an unknown device reference. Nothing in Core creates child devices yet, so that part is insurance.

Iterating `devices` yields device IDs on 2026.8 and device entries on 2026.9, which is why the new `core_compat.py` exists. Both helpers there carry a note on when they can go.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1470

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The full suite passes against 2026.8.3, which is what the test harness pins.

There is no pytest-homeassistant-custom-component for the beta yet, so 2026.9.0b0 was installed separately and the helpers were run against the real `ActiveDeviceRegistryItems` and `_DeprecatedDeviceRegistryItemsView`, with `report_usage` rigged to raise. Device entries, composite IDs, and child device IDs all come out right, and nothing touches the deprecated path, which does still report.

The two tests that stubbed `get_composite_splits` could not survive 2026.9 anyway: the view has `__slots__`, so setting the attribute fails and even reading it warns. They now fake a migration split the way Core's own tests do.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
