### PR TITLE
Handle child devices in the device actions

### DIFF
--- a/custom_components/spook/core_compat.py
+++ b/custom_components/spook/core_compat.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import callback
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from homeassistant.helpers import device_registry as dr
 
 
@@ -32,13 +30,69 @@ def async_get_device_entries(
 
 
 @callback
-def async_get_child_device_ids(device_registry: dr.DeviceRegistry) -> set[str]:
-    """Return the IDs of all child devices in the device registry.
+def async_get_child_devices(device_registry: dr.DeviceRegistry) -> list[Any]:
+    """Return all child devices in the device registry.
 
     Child devices arrived in Home Assistant Core 2026.9. They are devices in
     their own right and can be targeted like any other device. Core 2026.8 has
     no child devices at all.
     Can be removed once Spook requires Core 2026.9 or later.
     """
-    child_devices: Iterable[Any] = getattr(device_registry, "child_devices", ())
-    return {child_device.id for child_device in child_devices}
+    return list(getattr(device_registry, "child_devices", ()))
+
+
+@callback
+def async_get_child_device_ids(device_registry: dr.DeviceRegistry) -> set[str]:
+    """Return the IDs of all child devices in the device registry."""
+    return {
+        child_device.id for child_device in async_get_child_devices(device_registry)
+    }
+
+
+@callback
+def async_get_child_devices_for_parent(
+    device_registry: dr.DeviceRegistry,
+    parent_device_id: str,
+) -> list[Any]:
+    """Return the child devices of a device."""
+    return [
+        child_device
+        for child_device in async_get_child_devices(device_registry)
+        if child_device.parent_device_id == parent_device_id
+    ]
+
+
+@callback
+def async_is_child_device(device: Any) -> bool:
+    """Return if a device entry is a child device.
+
+    A child device names the device it belongs to, and nothing else carries
+    that attribute. Child devices arrived in Home Assistant Core 2026.9, so on
+    2026.8 nothing is one.
+    Can be reduced to an isinstance check on `dr.ChildDeviceEntry` once Spook
+    requires Core 2026.9 or later.
+    """
+    return getattr(device, "parent_device_id", None) is not None
+
+
+@callback
+def async_update_any_device(
+    device_registry: dr.DeviceRegistry,
+    device_id: str,
+    **changes: Any,
+) -> None:
+    """Update a device, whether it is a device or a child device.
+
+    Home Assistant Core 2026.9 gave child devices their own update method, and
+    refuses a child device ID in `async_update_device`. Pass only changes both
+    methods take: `area_id`, `disabled_by`, `labels`, `name` and
+    `name_by_user`.
+
+    An unknown device ID is left to the registry to complain about, the way it
+    did before child devices existed.
+    """
+    if async_is_child_device(device_registry.async_get(device_id)):
+        device_registry.async_update_child_device(device_id, **changes)
+        return
+
+    device_registry.async_update_device(device_id, **changes)

--- a/custom_components/spook/ectoplasms/homeassistant/device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/device.py
@@ -2,10 +2,50 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 
-from ...core_compat import async_get_device_entries
+from ...core_compat import (
+    async_get_child_devices_for_parent,
+    async_get_device_entries,
+    async_is_child_device,
+    async_update_any_device,
+)
+
+
+@callback
+def _async_get_parent_device_id(device: Any) -> str | None:
+    """Return the device a device hangs off, if it hangs off one at all.
+
+    A child device names its parent device, everything else names the device
+    it is connected through.
+    """
+    if async_is_child_device(device):
+        return device.parent_device_id
+
+    return device.via_device_id
+
+
+@callback
+def _async_get_devices_hanging_off(
+    device_registry: dr.DeviceRegistry,
+    device_id: str,
+) -> list[Any]:
+    """Return the devices that hang off a device.
+
+    A device can be the parent of child devices and the device others are
+    connected through at the same time. Both hang off it.
+    """
+    return [
+        *async_get_child_devices_for_parent(device_registry, device_id),
+        *(
+            device
+            for device in async_get_device_entries(device_registry)
+            if device.via_device_id == device_id
+        ),
+    ]
 
 
 @callback
@@ -13,7 +53,7 @@ def async_disable_device_and_parent_if_needed(
     device_registry: dr.DeviceRegistry,
     device_id: str,
 ) -> None:
-    """Disable a device and its parent when no enabled child devices remain."""
+    """Disable a device and its parent when nothing enabled hangs off it."""
     # A registry can contain via_device_id cycles (including self-references),
     # so track visited devices to avoid walking the chain forever.
     seen: set[str] = set()
@@ -25,22 +65,25 @@ def async_disable_device_and_parent_if_needed(
             return
 
         if device.disabled_by is None:
-            device_registry.async_update_device(
-                device_id=current_id,
+            async_update_any_device(
+                device_registry,
+                current_id,
                 disabled_by=dr.DeviceEntryDisabler.USER,
             )
 
-        if device.via_device_id is None:
+        parent_id = _async_get_parent_device_id(device)
+        if parent_id is None:
             return
 
         if not all(
-            child.id == current_id or child.disabled_by is not None
-            for child in async_get_device_entries(device_registry)
-            if child.via_device_id == device.via_device_id
+            hanging_device.id == current_id or hanging_device.disabled_by is not None
+            for hanging_device in _async_get_devices_hanging_off(
+                device_registry, parent_id
+            )
         ):
             return
 
-        current_id = device.via_device_id
+        current_id = parent_id
 
 
 @callback
@@ -60,11 +103,10 @@ def async_enable_device_and_parent(
             break
         seen.add(current_id)
         chain.append(current_id)
-        current_id = device.via_device_id
+        current_id = _async_get_parent_device_id(device)
 
-    # Enable parents before their children, like the previous recursive walk
+    # Enable parents before their children, like the previous recursive walk.
+    # Home Assistant Core refuses to enable a child device while its parent is
+    # disabled, so the order is not just cosmetic.
     for chain_device_id in reversed(chain):
-        device_registry.async_update_device(
-            device_id=chain_device_id,
-            disabled_by=None,
-        )
+        async_update_any_device(device_registry, chain_device_id, disabled_by=None)

--- a/custom_components/spook/ectoplasms/homeassistant/services/add_device_to_area.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/add_device_to_area.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import (
     device_registry as dr,
 )
 
+from ....core_compat import async_update_any_device
 from ....services import AbstractSpookAdminService
 
 if TYPE_CHECKING:
@@ -39,7 +40,8 @@ class SpookService(AbstractSpookAdminService):
 
         device_registry = dr.async_get(self.hass)
         for device_id in call.data["device_id"]:
-            device_registry.async_update_device(
+            async_update_any_device(
+                device_registry,
                 device_id,
                 area_id=call.data["area_id"],
             )

--- a/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_device.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import (
     label_registry as lr,
 )
 
+from ....core_compat import async_update_any_device
 from ....services import AbstractSpookAdminService
 
 if TYPE_CHECKING:
@@ -43,4 +44,4 @@ class SpookService(AbstractSpookAdminService):
             if device_entry := device_registry.async_get(device_id):
                 labels = device_entry.labels.copy()
                 labels.update(call.data["label_id"])
-                device_registry.async_update_device(device_id, labels=labels)
+                async_update_any_device(device_registry, device_id, labels=labels)

--- a/custom_components/spook/ectoplasms/homeassistant/services/remove_device_from_area.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/remove_device_from_area.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.components.homeassistant import DOMAIN
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
+from ....core_compat import async_update_any_device
 from ....services import AbstractSpookAdminService
 
 if TYPE_CHECKING:
@@ -28,7 +29,8 @@ class SpookService(AbstractSpookAdminService):
         """Handle the service call."""
         device_registry = dr.async_get(self.hass)
         for device_id in call.data["device_id"]:
-            device_registry.async_update_device(
+            async_update_any_device(
+                device_registry,
                 device_id,
                 area_id=None,
             )

--- a/custom_components/spook/ectoplasms/homeassistant/services/remove_label_from_device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/remove_label_from_device.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.components.homeassistant import DOMAIN
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 
+from ....core_compat import async_update_any_device
 from ....services import AbstractSpookAdminService
 
 if TYPE_CHECKING:
@@ -32,4 +33,4 @@ class SpookService(AbstractSpookAdminService):
             if device_entry := device_registry.async_get(device_id):
                 labels = device_entry.labels.copy()
                 labels.difference_update(call.data["label_id"])
-                device_registry.async_update_device(device_id, labels=labels)
+                async_update_any_device(device_registry, device_id, labels=labels)

--- a/tests/ectoplasms/homeassistant/services/test_device.py
+++ b/tests/ectoplasms/homeassistant/services/test_device.py
@@ -143,7 +143,7 @@ async def test_disable_device_service_disables_parent_without_other_children(
     child = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={("test", "child-device")},
-        via_device=("test", "parent-device"),
+        via_device_id=parent.id,
     )
 
     await hass.services.async_call(
@@ -174,7 +174,7 @@ async def test_disable_device_service_preserves_parent_disabled_reason(
     parent = device_registry.async_get_or_create(
         config_entry_id=disabled_config_entry.entry_id,
         identifiers={("test", "parent-device")},
-        via_device=("test", "grandparent-device"),
+        via_device_id=grandparent.id,
     )
 
     assert parent.disabled_by is DeviceEntryDisabler.CONFIG_ENTRY
@@ -182,7 +182,7 @@ async def test_disable_device_service_preserves_parent_disabled_reason(
     child = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={("test", "child-device")},
-        via_device=("test", "parent-device"),
+        via_device_id=parent.id,
     )
 
     await hass.services.async_call(
@@ -219,12 +219,12 @@ async def test_disable_device_service_keeps_parent_enabled_with_enabled_children
     child = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={("test", "child-device")},
-        via_device=("test", "parent-device"),
+        via_device_id=parent.id,
     )
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={("test", "sibling-device")},
-        via_device=("test", "parent-device"),
+        via_device_id=parent.id,
     )
 
     await hass.services.async_call(
@@ -256,7 +256,7 @@ async def test_enable_device_service_enables_parent_device(
         config_entry_id=config_entry.entry_id,
         identifiers={("test", "child-device")},
         disabled_by=DeviceEntryDisabler.USER,
-        via_device=("test", "parent-device"),
+        via_device_id=parent.id,
     )
 
     await hass.services.async_call(

--- a/tests/ectoplasms/homeassistant/test_device.py
+++ b/tests/ectoplasms/homeassistant/test_device.py
@@ -1,0 +1,151 @@
+"""Tests for the device walks behind the Home Assistant device services.
+
+The Core the tests pin has no child devices, so the registry is mocked here to
+build the trees that only exist on Home Assistant Core 2026.9 and later. The
+walk over regular devices is covered against the real registry in the device
+service tests.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from homeassistant.helpers.device_registry import DeviceEntryDisabler
+
+from custom_components.spook.ectoplasms.homeassistant.device import (
+    async_disable_device_and_parent_if_needed,
+    async_enable_device_and_parent,
+)
+
+
+def mock_device(device_id: str, *, via_device_id: str | None = None) -> Any:
+    """Return a device that is connected through another device, or nothing."""
+    return SimpleNamespace(id=device_id, disabled_by=None, via_device_id=via_device_id)
+
+
+def mock_child_device(device_id: str, *, parent_device_id: str) -> Any:
+    """Return a child device of a device.
+
+    A child device has no `via_device_id` at all, so reaching for one raises
+    here instead of quietly answering nothing.
+    """
+    return SimpleNamespace(
+        id=device_id, disabled_by=None, parent_device_id=parent_device_id
+    )
+
+
+class MockDeviceRegistry:
+    """Mock of a device registry that has child devices.
+
+    Devices iterate as entries, child devices live in their own collection,
+    and each kind has its own update method, the way Home Assistant Core
+    2026.9 and later hand them out.
+    """
+
+    def __init__(self, *, devices: list[Any], child_devices: list[Any]) -> None:
+        """Initialize the registry with the devices it holds."""
+        self.devices = devices
+        self.child_devices = child_devices
+        self.updates: list[tuple[str, str]] = []
+
+    def async_get(self, device_id: str) -> Any:
+        """Return the device or child device with this ID."""
+        for device in (*self.devices, *self.child_devices):
+            if device.id == device_id:
+                return device
+
+        return None
+
+    def async_update_device(self, device_id: str, **changes: Any) -> None:
+        """Update a device."""
+        self._apply("device", device_id, changes)
+
+    def async_update_child_device(self, device_id: str, **changes: Any) -> None:
+        """Update a child device."""
+        self._apply("child_device", device_id, changes)
+
+    def _apply(self, kind: str, device_id: str, changes: dict[str, Any]) -> None:
+        """Record the update and apply it to the device."""
+        self.updates.append((kind, device_id))
+        device = self.async_get(device_id)
+        for name, value in changes.items():
+            setattr(device, name, value)
+
+
+def test_disabling_a_child_device_disables_its_parent() -> None:
+    """Test disabling the last child device of a device disables that device."""
+    parent = mock_device("a-device")
+    child = mock_child_device("a-child-device", parent_device_id=parent.id)
+    device_registry = MockDeviceRegistry(devices=[parent], child_devices=[child])
+
+    async_disable_device_and_parent_if_needed(device_registry, child.id)
+
+    assert child.disabled_by is DeviceEntryDisabler.USER
+    assert parent.disabled_by is DeviceEntryDisabler.USER
+    assert device_registry.updates == [
+        ("child_device", child.id),
+        ("device", parent.id),
+    ]
+
+
+def test_disabling_one_of_two_child_devices_keeps_the_parent_enabled() -> None:
+    """Test a device with another enabled child device stays enabled."""
+    parent = mock_device("a-device")
+    child = mock_child_device("a-child-device", parent_device_id=parent.id)
+    other_child = mock_child_device("another-child-device", parent_device_id=parent.id)
+    device_registry = MockDeviceRegistry(
+        devices=[parent], child_devices=[child, other_child]
+    )
+
+    async_disable_device_and_parent_if_needed(device_registry, child.id)
+
+    assert child.disabled_by is DeviceEntryDisabler.USER
+    assert other_child.disabled_by is None
+    assert parent.disabled_by is None
+
+
+def test_a_connected_device_keeps_the_parent_of_a_child_device_enabled() -> None:
+    """Test both kinds of device hanging off a device count as its children.
+
+    A device can be the parent of child devices and the device others are
+    connected through at the same time. Disabling the last child device while
+    a connected device is still enabled leaves nothing to clean up.
+    """
+    parent = mock_device("a-device")
+    connected = mock_device("a-connected-device", via_device_id=parent.id)
+    child = mock_child_device("a-child-device", parent_device_id=parent.id)
+    device_registry = MockDeviceRegistry(
+        devices=[parent, connected], child_devices=[child]
+    )
+
+    async_disable_device_and_parent_if_needed(device_registry, child.id)
+
+    assert parent.disabled_by is None
+
+    async_disable_device_and_parent_if_needed(device_registry, connected.id)
+
+    assert connected.disabled_by is DeviceEntryDisabler.USER
+    assert parent.disabled_by is DeviceEntryDisabler.USER
+
+
+def test_enabling_a_child_device_enables_the_parent_first() -> None:
+    """Test a child device is enabled after its parent device.
+
+    Home Assistant Core refuses to enable a child device while its parent is
+    disabled, so the order is not just cosmetic.
+    """
+    parent = mock_device("a-device")
+    parent.disabled_by = DeviceEntryDisabler.USER
+    child = mock_child_device("a-child-device", parent_device_id=parent.id)
+    child.disabled_by = DeviceEntryDisabler.USER
+    device_registry = MockDeviceRegistry(devices=[parent], child_devices=[child])
+
+    async_enable_device_and_parent(device_registry, child.id)
+
+    assert parent.disabled_by is None
+    assert child.disabled_by is None
+    assert device_registry.updates == [
+        ("device", parent.id),
+        ("child_device", child.id),
+    ]

--- a/tests/test_core_compat.py
+++ b/tests/test_core_compat.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.spook.core_compat import (
     async_get_child_device_ids,
+    async_get_child_devices_for_parent,
     async_get_device_entries,
+    async_is_child_device,
+    async_update_any_device,
 )
 
 if TYPE_CHECKING:
@@ -85,3 +89,101 @@ def test_child_device_ids_without_child_devices(
     Core 2026.8 has no child devices at all.
     """
     assert async_get_child_device_ids(device_registry) == set()
+
+
+class MockUpdateRegistry:
+    """Mock of the device registry, recording how a device was updated.
+
+    Core 2026.9 and later have a separate update method for child devices, and
+    refuse a child device ID in the regular one.
+    """
+
+    def __init__(self, device: Any) -> None:
+        """Initialize the registry with the one device it knows."""
+        self._device = device
+        self.updates: list[tuple[str, str, dict[str, Any]]] = []
+
+    def async_get(self, device_id: str) -> Any:
+        """Return the device, if it is the one this registry knows."""
+        return self._device if device_id == self._device.id else None
+
+    def async_update_device(self, device_id: str, **changes: Any) -> None:
+        """Record an update of a device."""
+        self.updates.append(("device", device_id, changes))
+
+    def async_update_child_device(self, device_id: str, **changes: Any) -> None:
+        """Record an update of a child device."""
+        self.updates.append(("child_device", device_id, changes))
+
+
+def test_a_device_is_a_child_device_when_it_has_a_parent() -> None:
+    """Test child devices are told apart from devices and from nothing."""
+    assert async_is_child_device(SimpleNamespace(parent_device_id="a-device")) is True
+    assert async_is_child_device(SimpleNamespace(via_device_id="a-device")) is False
+    assert async_is_child_device(None) is False
+
+
+def test_a_child_device_is_updated_as_a_child_device() -> None:
+    """Test a child device is updated through the method Core wants for it."""
+    device_registry = MockUpdateRegistry(
+        SimpleNamespace(id="a-child-device", parent_device_id="a-device")
+    )
+
+    async_update_any_device(device_registry, "a-child-device", area_id="an-area")
+
+    assert device_registry.updates == [
+        ("child_device", "a-child-device", {"area_id": "an-area"})
+    ]
+
+
+def test_a_device_is_updated_as_a_device() -> None:
+    """Test anything that is not a child device takes the regular method."""
+    device_registry = MockUpdateRegistry(
+        SimpleNamespace(id="a-device", via_device_id=None)
+    )
+
+    async_update_any_device(device_registry, "a-device", area_id="an-area")
+
+    assert device_registry.updates == [("device", "a-device", {"area_id": "an-area"})]
+
+
+def test_child_devices_are_looked_up_by_parent() -> None:
+    """Test only the child devices of the parent asked for come back."""
+    child_device = SimpleNamespace(id="a-child-device", parent_device_id="a-device")
+    device_registry = SimpleNamespace(
+        child_devices=[
+            child_device,
+            SimpleNamespace(
+                id="another-child-device", parent_device_id="another-device"
+            ),
+        ]
+    )
+
+    assert async_get_child_devices_for_parent(device_registry, "a-device") == [
+        child_device
+    ]
+
+
+def test_an_unknown_device_is_left_to_the_registry(
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test an unknown device ID is not quietly swallowed."""
+    with pytest.raises(KeyError):
+        async_update_any_device(device_registry, "not-a-device", area_id=None)
+
+
+def test_a_registered_device_is_updated(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a device in the registry is updated for real."""
+    entry = MockConfigEntry(domain="test", title="Test")
+    entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("test", "device")},
+    )
+
+    async_update_any_device(device_registry, device.id, labels={"a-label"})
+
+    assert device_registry.async_get(device.id).labels == {"a-label"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Home Assistant Core 2026.9 introduced child devices. They are registry entries in their own right, with their own update method, and Core refuses a child device ID in `async_update_device`. Six call sites across five Spook actions passed whatever device ID they were handed straight into it: add a device to an area, remove it from one, add a label, remove a label, enable a device and disable a device. All six would have raised on a child device.

`async_update_any_device()` in `core_compat.py` routes the update to the method Core wants for that kind of device. An unknown device ID is still left to the registry to complain about, so nothing gets swallowed.

The enable and disable walks follow `parent_device_id` for a child device, and `via_device_id` for everything else. A device can be the parent of child devices and the device others are connected through at the same time, so the "is anything enabled still hanging off this parent" check counts both. A hub with one child device and one connected device now stays enabled until both are disabled.

Nothing in Core creates child devices yet, so none of this is reachable today. It stops being unreachable the moment an integration adopts them.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up on #1471, which found this while fixing the device registry deprecation warnings from #1470.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The full suite passes against 2026.8.3, which is what the test harness pins. Child devices cannot be created there, so the new unit tests cover the dispatch and the lookups, next to real registry checks that a regular update still lands and that an unknown device ID still raises.

There is no pytest-homeassistant-custom-component for the beta yet, so 2026.9.0b0 was installed separately and both walks were run against a real registry with real child devices, with `report_usage` rigged to raise:

```
after disable -> child: user   parent: user
after enable  -> child: None   parent: None
one of two    -> child: user   other: None   parent: None
mixed tree    -> child: user   via: None     parent: None
both gone     -> via: user     parent: user
child labels: {'a-label'}
```

Nothing deprecated is touched anywhere in the walk.

The tests dropped the deprecated `via_device` parameter along the way. On 2026.9 it reports with `core_behavior=ERROR`, and a test frame is not an integration frame, so those six tests would have raised the moment the test harness moves to 2026.9.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
