### PR TITLE
Add a spook.cron trigger

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/__init__.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/spook/triggers/cron.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/cron.py
@@ -44,11 +44,17 @@ def _cron_schedule(value: Any) -> str:
         raise vol.Invalid(message)
 
     try:
-        # Any date will do here; this only asks whether the expression parses.
-        CronSim(schedule, datetime(2020, 1, 1))  # noqa: DTZ001
+        # Advance it once rather than only building it. Parsing accepts some
+        # expressions that can never come round, such as a day of the month
+        # and a day of the week that never fall together, and those only show
+        # themselves when the iterator runs dry. Any date will do as a start.
+        next(CronSim(schedule, datetime(2020, 1, 1)))  # noqa: DTZ001
     except CronSimError as err:
         message = f"Invalid crontab expression '{schedule}': {err}"
         raise vol.Invalid(message) from err
+    except StopIteration:
+        message = f"Crontab expression '{schedule}' never comes round"
+        raise vol.Invalid(message) from None
 
     return schedule
 
@@ -93,11 +99,10 @@ class SpookTrigger(Trigger):
     def _next(self, after: datetime) -> datetime | None:
         """Return the next time this schedule comes round, if it ever does.
 
-        cronsim 2.7 refuses an impossible date at parse time rather than
-        accepting it and never firing, so in practice this returns a time.
-        The guard stays because exhausting an iterator is a thing iterators
-        do, and a trigger that raises instead of going quiet would take the
-        automation with it.
+        Validation already turned away the expressions that never come round,
+        so in practice this returns a time. The guard stays because exhausting
+        an iterator is a thing iterators do, and a trigger that raises rather
+        than going quiet would take the automation down with it.
         """
         try:
             return next(CronSim(self._schedule, after))

--- a/custom_components/spook/ectoplasms/spook/triggers/cron.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/cron.py
@@ -8,14 +8,14 @@ from typing import TYPE_CHECKING, Any
 from cronsim import CronSim, CronSimError
 import voluptuous as vol
 
-from homeassistant.const import CONF_OPTIONS
+from homeassistant.const import CONF_OPTIONS, EVENT_CORE_CONFIG_UPDATE
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.trigger import Trigger
 from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
-    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
     from homeassistant.helpers.trigger import (
         TriggerActionRunner,
         TriggerConfig,
@@ -116,6 +116,7 @@ class SpookTrigger(Trigger):
     ) -> CALLBACK_TYPE:
         """Attach the trigger to an action runner."""
         unsub: CALLBACK_TYPE | None = None
+        time_zone = self._hass.config.time_zone
 
         @callback
         def schedule_next(after: datetime) -> None:
@@ -124,6 +125,14 @@ class SpookTrigger(Trigger):
             if (upcoming := self._next(after)) is None:
                 return
             unsub = async_track_point_in_time(self._hass, fire, upcoming)
+
+        @callback
+        def stop_waiting() -> None:
+            """Drop the pending wait, if there is one."""
+            nonlocal unsub
+            if unsub is not None:
+                unsub()
+                unsub = None
 
         @callback
         def fire(_scheduled: datetime) -> None:
@@ -145,16 +154,38 @@ class SpookTrigger(Trigger):
                 f"cron schedule {self._schedule}",
             )
 
+        @callback
+        def core_config_changed(_event: Event) -> None:
+            """Work the pending wait out again when the time zone changes.
+
+            The wait is a single absolute instant, worked out in whichever
+            zone was configured at the time. Change the zone and that instant
+            still points at the old zone's wall clock, so one run lands at the
+            wrong hour. Core's utility meter runs on cronsim too and rebuilds
+            its schedule here for the same reason.
+            """
+            nonlocal time_zone
+            if self._hass.config.time_zone == time_zone:
+                return
+
+            time_zone = self._hass.config.time_zone
+            stop_waiting()
+            schedule_next(dt_util.now())
+
         # A local, timezone-aware time: cronsim needs the zone to get daylight
         # saving right.
         schedule_next(dt_util.now())
 
+        # Fires for any change to the core config, so the handler checks
+        # whether the time zone is the part that moved.
+        unsub_core_config = self._hass.bus.async_listen(
+            EVENT_CORE_CONFIG_UPDATE, core_config_changed
+        )
+
         @callback
         def unattach() -> None:
             """Stop waiting."""
-            nonlocal unsub
-            if unsub is not None:
-                unsub()
-                unsub = None
+            unsub_core_config()
+            stop_waiting()
 
         return unattach

--- a/custom_components/spook/ectoplasms/spook/triggers/cron.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/cron.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 CONF_SCHEDULE = "schedule"
 
-CRON_FIELDS = 5
+_CRON_FIELDS = 5
 
 
 def _cron_schedule(value: Any) -> str:
@@ -35,10 +35,10 @@ def _cron_schedule(value: Any) -> str:
     # cronsim also takes a six-field form, where the leading field is seconds.
     # That would hand out triggers firing every second, which is neither what
     # this documents nor something to run an automation off. Five fields only.
-    if len(schedule.split()) != CRON_FIELDS:
+    if len(schedule.split()) != _CRON_FIELDS:
         message = (
             f"Invalid crontab expression '{schedule}': expected "
-            f"{CRON_FIELDS} fields (minute, hour, day of month, month, "
+            f"{_CRON_FIELDS} fields (minute, hour, day of month, month, "
             "day of week)"
         )
         raise vol.Invalid(message)

--- a/custom_components/spook/ectoplasms/spook/triggers/cron.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/cron.py
@@ -1,0 +1,133 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from cronsim import CronSim, CronSimError
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.core import callback
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_SCHEDULE = "schedule"
+
+
+def _cron_schedule(value: Any) -> str:
+    """Validate a crontab expression, and say what is wrong with it if not."""
+    schedule = str(value)
+    try:
+        # Any date will do here; this only asks whether the expression parses.
+        CronSim(schedule, datetime(2020, 1, 1))  # noqa: DTZ001
+    except CronSimError as err:
+        message = f"Invalid crontab expression '{schedule}': {err}"
+        raise vol.Invalid(message) from err
+    return schedule
+
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_SCHEDULE): _cron_schedule,
+        },
+    }
+)
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires on a crontab schedule.
+
+    Home Assistant's time triggers cover a time of day and a time pattern,
+    which between them cannot say "every weekday at seven" or "the last
+    Friday of the month". A crontab expression can, in one line, and people
+    coming from cron already know how to write it.
+    """
+
+    trigger = "cron"
+
+    _schedule: str
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        return _TRIGGER_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._schedule = options[CONF_SCHEDULE]
+
+    def _next(self, after: datetime) -> datetime | None:
+        """Return the next time this schedule comes round, if it ever does.
+
+        cronsim 2.7 refuses an impossible date at parse time rather than
+        accepting it and never firing, so in practice this returns a time.
+        The guard stays because exhausting an iterator is a thing iterators
+        do, and a trigger that raises instead of going quiet would take the
+        automation with it.
+        """
+        try:
+            return next(CronSim(self._schedule, after))
+        except StopIteration:
+            return None
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+        unsub: CALLBACK_TYPE | None = None
+
+        @callback
+        def schedule_next(after: datetime) -> None:
+            """Wait for the next time the schedule comes round."""
+            nonlocal unsub
+            if (upcoming := self._next(after)) is None:
+                return
+            unsub = async_track_point_in_time(self._hass, fire, upcoming)
+
+        @callback
+        def fire(now: datetime) -> None:
+            """Run the action, then line up the one after it."""
+            nonlocal unsub
+            unsub = None
+            local = dt_util.as_local(now)
+            schedule_next(local)
+            run_action(
+                {"schedule": self._schedule, "now": local},
+                f"cron schedule {self._schedule}",
+            )
+
+        # Seeded with a timezone-aware local time on purpose: cronsim needs the
+        # zone to get daylight saving right, the same reason core's utility
+        # meter does it (home-assistant/core#102984).
+        schedule_next(dt_util.now(dt_util.get_default_time_zone()))
+
+        @callback
+        def unattach() -> None:
+            """Stop waiting."""
+            nonlocal unsub
+            if unsub is not None:
+                unsub()
+                unsub = None
+
+        return unattach

--- a/custom_components/spook/ectoplasms/spook/triggers/cron.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/cron.py
@@ -25,16 +25,31 @@ if TYPE_CHECKING:
 
 CONF_SCHEDULE = "schedule"
 
+CRON_FIELDS = 5
+
 
 def _cron_schedule(value: Any) -> str:
     """Validate a crontab expression, and say what is wrong with it if not."""
     schedule = str(value)
+
+    # cronsim also takes a six-field form, where the leading field is seconds.
+    # That would hand out triggers firing every second, which is neither what
+    # this documents nor something to run an automation off. Five fields only.
+    if len(schedule.split()) != CRON_FIELDS:
+        message = (
+            f"Invalid crontab expression '{schedule}': expected "
+            f"{CRON_FIELDS} fields (minute, hour, day of month, month, "
+            "day of week)"
+        )
+        raise vol.Invalid(message)
+
     try:
         # Any date will do here; this only asks whether the expression parses.
         CronSim(schedule, datetime(2020, 1, 1))  # noqa: DTZ001
     except CronSimError as err:
         message = f"Invalid crontab expression '{schedule}': {err}"
         raise vol.Invalid(message) from err
+
     return schedule
 
 
@@ -106,21 +121,28 @@ class SpookTrigger(Trigger):
             unsub = async_track_point_in_time(self._hass, fire, upcoming)
 
         @callback
-        def fire(now: datetime) -> None:
+        def fire(_scheduled: datetime) -> None:
             """Run the action, then line up the one after it."""
             nonlocal unsub
             unsub = None
-            local = dt_util.as_local(now)
-            schedule_next(local)
+
+            # Ask what time it is rather than trusting the time handed over:
+            # that one is the time this run was scheduled for, which stops
+            # being the current time once the machine has been asleep.
+            # Continuing from it would then work through every minute that was
+            # missed, one automation run each. Core's own time trigger fetches
+            # the time again for the same reason.
+            now = dt_util.now()
+
+            schedule_next(now)
             run_action(
-                {"schedule": self._schedule, "now": local},
+                {"schedule": self._schedule, "now": now},
                 f"cron schedule {self._schedule}",
             )
 
-        # Seeded with a timezone-aware local time on purpose: cronsim needs the
-        # zone to get daylight saving right, the same reason core's utility
-        # meter does it (home-assistant/core#102984).
-        schedule_next(dt_util.now(dt_util.get_default_time_zone()))
+        # A local, timezone-aware time: cronsim needs the zone to get daylight
+        # saving right.
+        schedule_next(dt_util.now())
 
         @callback
         def unattach() -> None:

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -28,6 +28,6 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/frenck/spook/issues",
-  "requirements": [],
+  "requirements": ["cronsim==2.7"],
   "version": "0.0.0"
 }

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1,4 +1,16 @@
 {
+  "triggers": {
+    "cron": {
+      "name": "Cron schedule",
+      "description": "Fires on a crontab schedule, for the times Home Assistant's own time triggers cannot express, like every weekday at seven or the last Friday of the month.",
+      "fields": {
+        "schedule": {
+          "name": "Schedule",
+          "description": "A crontab expression with five fields: minute, hour, day of month, month, day of week. Supports ranges and steps, and the day-of-week extensions, so \"MON#2\" is the second Monday and \"5L\" the last Friday. Nicknames like \"@daily\" are not supported."
+        }
+      }
+    }
+  },
   "conditions": {
     "triggered_by_user": {
       "name": "Triggered by a user",

--- a/custom_components/spook/trigger.py
+++ b/custom_components/spook/trigger.py
@@ -1,0 +1,47 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.trigger import Trigger
+
+# Core calls ``async_get_triggers`` repeatedly (once per config validation and
+# per trigger instantiation), so the discovery result is cached rather than
+# re-globbing and re-importing on every call.
+DATA_TRIGGERS: HassKey[dict[str, type[Trigger]]] = HassKey("spook_triggers")
+
+
+async def async_get_triggers(
+    hass: HomeAssistant,
+) -> dict[str, type[Trigger]]:
+    """Return the triggers Spook provides.
+
+    Discovered from the leaf modules under ``ectoplasms/*/triggers/``, each
+    exposing a ``SpookTrigger`` class; keys become ``spook.<key>``.
+    """
+    if (cached := hass.data.get(DATA_TRIGGERS)) is not None:
+        return cached
+
+    triggers: dict[str, type[Trigger]] = {}
+
+    def _load_all_trigger_modules() -> None:
+        """Load all trigger modules and collect their triggers."""
+        for module_file in Path(__file__).parent.rglob("ectoplasms/*/triggers/*.py"):
+            if module_file.name == "__init__.py":
+                continue
+            module_path = str(module_file.relative_to(Path(__file__).parent))[
+                :-3
+            ].replace("/", ".")
+            module = importlib.import_module(f".{module_path}", __package__)
+            triggers[module.SpookTrigger.trigger] = module.SpookTrigger
+
+    await hass.async_add_import_executor_job(_load_all_trigger_modules)
+    hass.data[DATA_TRIGGERS] = triggers
+    return triggers

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -1,0 +1,7 @@
+cron:
+  fields:
+    schedule:
+      required: true
+      example: "0 7 * * 1-5"
+      selector:
+        text:

--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -65,6 +65,7 @@ parts:
     chapters:
       - file: actions
       - file: conditions
+      - file: triggers
       - file: blueprints
       - file: glossary
 

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -92,6 +92,77 @@ action: homeassistant.random_fail
 
 :::
 
+## Triggers
+
+Spook offers the following triggers that are not tied to a specific integration:
+
+### Cron schedule
+
+Fires on a crontab schedule.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Cron schedule 👻
+* - Trigger name
+  - `spook.cron`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `schedule`
+  - {term}`string <string>`
+  - Yes
+  - `0 7 * * 1-5`
+```
+
+Home Assistant's own time triggers cover a time of day and a time pattern. Between them they cannot say "every weekday at seven" or "the last Friday of the month". A crontab expression says either in one line, and anybody who has written a crontab already knows the syntax.
+
+Five fields, in the usual order: minute, hour, day of month, month, day of week. Ranges and steps work, and so do the day-of-week extensions, so `MON#2` is the second Monday of the month and `5L` the last Friday.
+
+When it fires, `trigger.schedule` holds the expression and `trigger.now` the local time it fired at.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Every weekday at seven in the morning:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.cron
+options:
+  schedule: "0 7 * * 1-5"
+```
+
+The last Friday of the month, at three in the afternoon:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.cron
+options:
+  schedule: "0 15 * * 5L"
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Nicknames are not supported. `@daily`, `@hourly` and friends are refused: write the five fields out. The automation will not load and will say what is wrong with the expression, which is better than finding out at the hour it was supposed to run.
+- Seconds are not a field. Crontab's smallest step is a minute, so this trigger cannot fire more often than that.
+- A date that can never happen is refused too. `0 0 30 2 *` does not load, rather than loading and waiting forever.
+- Schedules follow your Home Assistant time zone, including daylight saving.
+
+:::
+
 ## Conditions
 
 Spook offers the following conditions that are not tied to a specific integration:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -157,7 +157,7 @@ options:
 :class: dropdown
 
 - Nicknames are not supported. `@daily`, `@hourly` and friends are refused: write the five fields out. The automation will not load and will say what is wrong with the expression, which is better than finding out at the hour it was supposed to run.
-- Seconds are not a field. Crontab's smallest step is a minute, so this trigger cannot fire more often than that.
+- Seconds are not a field. Five fields, no more: some cron implementations take a sixth field for seconds, and that form is refused here. The shortest interval is one minute.
 - A date that can never happen is refused too. `0 0 30 2 *` does not load, rather than loading and waiting forever.
 - Schedules follow your Home Assistant time zone, including daylight saving.
 

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -130,7 +130,9 @@ Five fields, in the usual order: minute, hour, day of month, month, day of week.
 
 When it fires, `trigger.schedule` holds the expression and `trigger.now` the local time it fired at.
 
-One crontab rule catches people out, and it is not ours. Give both a day of the month and a day of the week, and cron combines them with "or", not "and". So `0 7 15 * 1` runs at seven on the 15th of the month, and at seven every Monday as well. Leave one of the two as `*` if you only mean the other. The exception is a day of the month starting with `*`, such as `*/20`, which does combine with "and".
+One crontab rule catches people out, and it is not ours. Give both a day of the month and a day of the week, and cron combines them with "or", not "and". So `0 7 15 * 1` runs at seven on the 15th of the month, and at seven every Monday as well. Leave one of the two as `*` if you only mean the other.
+
+That "or" holds only while both fields are plain lists of days. Let either one start with a `*`, a step like `*/2` included, and the two combine with "and" instead: `0 7 15 * */2` is the 15th, but only when it falls on a Sunday, Tuesday, Thursday or Saturday.
 
 :::{seealso} Example trigger in {term}`YAML`
 :class: dropdown

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -158,7 +158,7 @@ options:
 
 - Nicknames are not supported. `@daily`, `@hourly` and friends are refused: write the five fields out. The automation will not load and will say what is wrong with the expression, which is better than finding out at the hour it was supposed to run.
 - Seconds are not a field. Five fields, no more: some cron implementations take a sixth field for seconds, and that form is refused here. The shortest interval is one minute.
-- A date that can never happen is refused too. `0 0 30 2 *` does not load, rather than loading and waiting forever.
+- A schedule that can never come round is refused. The 30th of February (`0 0 30 2 *`) is the obvious one, but so is `0 0 */20 * 1L`, which asks for the 1st or 21st of the month and for the last Monday, which is never earlier than the 25th. Neither loads, rather than loading and then waiting forever.
 - Schedules follow your Home Assistant time zone, including daylight saving.
 
 :::

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -130,6 +130,8 @@ Five fields, in the usual order: minute, hour, day of month, month, day of week.
 
 When it fires, `trigger.schedule` holds the expression and `trigger.now` the local time it fired at.
 
+One crontab rule catches people out, and it is not ours. Give both a day of the month and a day of the week, and cron combines them with "or", not "and". So `0 7 15 * 1` runs at seven on the 15th of the month, and at seven every Monday as well. Leave one of the two as `*` if you only mean the other. The exception is a day of the month starting with `*`, such as `*/20`, which does combine with "and".
+
 :::{seealso} Example trigger in {term}`YAML`
 :class: dropdown
 
@@ -158,7 +160,7 @@ options:
 
 - Nicknames are not supported. `@daily`, `@hourly` and friends are refused: write the five fields out. The automation will not load and will say what is wrong with the expression, which is better than finding out at the hour it was supposed to run.
 - Seconds are not a field. Five fields, no more: some cron implementations take a sixth field for seconds, and that form is refused here. The shortest interval is one minute.
-- A schedule that can never come round is refused. The 30th of February (`0 0 30 2 *`) is the obvious one, but so is `0 0 */20 * 1L`, which asks for the 1st or 21st of the month and for the last Monday, which is never earlier than the 25th. Neither loads, rather than loading and then waiting forever.
+- A schedule that can never come round is refused. The 30th of February (`0 0 30 2 *`) is the obvious one. So is `0 0 */20 * 1L`: the `*` makes it an "and", and no 1st or 21st of a month is ever also the last Monday. Neither loads, rather than loading and then waiting forever.
 - Schedules follow your Home Assistant time zone, including daylight saving.
 
 :::

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -1,0 +1,16 @@
+---
+subject: Reference
+title: Provided Home Assistant triggers
+short_title: Triggers
+subtitle: For the moments Home Assistant cannot name. ⏰
+description: Spook provides new triggers to Home Assistant. This reference page lists them all, and points you to the right documentation.
+date: 2026-08-27T21:15:00+02:00
+---
+
+Spook provides new triggers to Home Assistant. This reference page lists them all and points you to the right documentation for that trigger.
+
+## Cron schedule
+
+Fires on a crontab schedule, for the times Home Assistant's own time triggers cannot express, like every weekday at seven or the last Friday of the month. _#crontab_
+
+`spook.cron`, [documentation](other-features#cron-schedule) 📚

--- a/tests/ectoplasms/spook/triggers/__init__.py
+++ b/tests/ectoplasms/spook/triggers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook's triggers."""

--- a/tests/ectoplasms/spook/triggers/test_cron.py
+++ b/tests/ectoplasms/spook/triggers/test_cron.py
@@ -201,10 +201,11 @@ async def test_a_schedule_that_never_comes_round_is_refused(
     """An expression that parses but never fires is refused as well.
 
     `0 0 */20 * 1L` asks for the 1st or the 21st, and for the last Monday of
-    the month, which is never earlier than the 25th. cronsim parses it
-    happily and then produces nothing at all, so validation has to advance
-    the iterator once to find out. Otherwise the automation loads, sits there
-    and never runs, with nothing anywhere saying why.
+    the month, which falls no earlier than the 22nd (a 28-day February, such
+    as 2021). cronsim parses it happily and then produces nothing at all, so
+    validation has to advance the iterator once to find out. Otherwise the
+    automation loads, sits there and never runs, with nothing anywhere saying
+    why.
     """
     with pytest.raises(vol.Invalid, match="never comes round"):
         await SpookTrigger.async_validate_config(

--- a/tests/ectoplasms/spook/triggers/test_cron.py
+++ b/tests/ectoplasms/spook/triggers/test_cron.py
@@ -290,11 +290,18 @@ async def test_day_of_month_and_day_of_week_combine_with_or(
         assert moment is not None
         days.append((moment.day, moment.weekday()))
 
-    mondays = [day for day, weekday in days if weekday == MONDAY]
-    fifteenths = [day for day, _ in days if day == FIFTEENTH]
+    # A Monday that is not the 15th, and a 15th that is not a Monday. Merely
+    # finding a Monday and finding a 15th would also hold for an "and", where
+    # every occurrence is both at once.
+    mondays_other_than_the_15th = [
+        day for day, weekday in days if weekday == MONDAY and day != FIFTEENTH
+    ]
+    fifteenths_other_than_mondays = [
+        day for day, weekday in days if day == FIFTEENTH and weekday != MONDAY
+    ]
 
-    assert mondays, "no Mondays, so the day-of-week half was ignored"
-    assert fifteenths, "no 15th, so the day-of-month half was ignored"
+    assert mondays_other_than_the_15th, 'only ever the 15th, so this is an "and"'
+    assert fifteenths_other_than_mondays, 'only ever a Monday, so this is an "and"'
 
 
 @pytest.mark.parametrize(

--- a/tests/ectoplasms/spook/triggers/test_cron.py
+++ b/tests/ectoplasms/spook/triggers/test_cron.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 from homeassistant.helpers.trigger import TriggerConfig
 from homeassistant.setup import async_setup_component
@@ -21,9 +22,14 @@ from custom_components.spook.trigger import async_get_triggers
 import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
     from freezegun.api import FrozenDateTimeFactory
 
     from homeassistant.core import HomeAssistant
+
+CRON_MODULE = "custom_components.spook.ectoplasms.spook.triggers.cron"
 
 
 async def _detach(hass: HomeAssistant) -> None:
@@ -108,6 +114,25 @@ async def test_nicknames_are_refused(hass: HomeAssistant) -> None:
         )
 
 
+@pytest.mark.parametrize("schedule", ["*/15 * * * * *", "* * * * * *", "0 7 * * *  *"])
+async def test_a_seconds_field_is_refused(hass: HomeAssistant, schedule: str) -> None:
+    """Cronsim's six-field form is not offered.
+
+    Its leading field is seconds, so `* * * * * *` would run an automation
+    every second. Five fields is what this documents, and what it takes.
+    """
+    with pytest.raises(vol.Invalid, match="expected 5 fields"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"schedule": schedule}}
+        )
+
+
+async def test_an_empty_schedule_is_refused(hass: HomeAssistant) -> None:
+    """An empty expression is caught by the field count, not by cronsim."""
+    with pytest.raises(vol.Invalid, match="expected 5 fields"):
+        await SpookTrigger.async_validate_config(hass, {"options": {"schedule": "   "}})
+
+
 async def test_a_valid_expression_is_accepted(hass: HomeAssistant) -> None:
     """The forms the documentation advertises all validate."""
     for schedule in ("*/5 * * * *", "0 7 * * 1-5", "0 12 * * MON#2", "0 3 L * *"):
@@ -177,6 +202,55 @@ async def test_a_date_years_away_is_fine(hass: HomeAssistant) -> None:
 
     assert upcoming is not None
     assert (upcoming.year, upcoming.month, upcoming.day) == (2028, 2, 29)
+
+
+async def test_a_late_run_does_not_work_through_what_it_missed(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """After a clock jump the trigger looks forward, not back.
+
+    Core hands the callback the time the run was scheduled for, not the time
+    the timer got round to it. Those come apart when the machine has been
+    asleep, and continuing from the scheduled time would work through every
+    minute that was missed, one automation run each.
+
+    The test harness cannot reproduce that with its own timers, so this drives
+    the trigger's callback directly and checks what it asks for next.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+
+    scheduled: list[tuple[datetime, Callable[[datetime], None]]] = []
+    ran: list[dict] = []
+
+    def _track(_hass, action, point_in_time):  # noqa: ANN001, ANN202
+        scheduled.append((point_in_time, action))
+        return lambda: None
+
+    with patch(f"{CRON_MODULE}.async_track_point_in_time", _track):
+        trigger = SpookTrigger(hass, _config("*/1 * * * *"))
+        await trigger.async_attach_runner(
+            lambda payload, _description: ran.append(payload)
+        )
+
+        upcoming, fire = scheduled.pop()
+        assert upcoming == dt_util.parse_datetime("2026-08-27 12:01:00").replace(
+            tzinfo=upcoming.tzinfo
+        )
+
+        # An hour asleep. The timer only gets round to the 12:01 run now, and
+        # is handed 12:01 as its argument.
+        freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 13:00:00")))
+        fire(dt_util.as_utc(upcoming))
+
+    following, _ = scheduled.pop()
+    assert following > dt_util.now(), (
+        "asked for a time in the past, so it will catch up"
+    )
+    assert (following.hour, following.minute) == (13, 1)
+
+    assert len(ran) == 1
+    assert ran[0]["now"] == dt_util.now()
 
 
 def _config(schedule: str) -> TriggerConfig:

--- a/tests/ectoplasms/spook/triggers/test_cron.py
+++ b/tests/ectoplasms/spook/triggers/test_cron.py
@@ -182,15 +182,29 @@ async def test_it_keeps_firing(
 
 
 async def test_an_impossible_date_is_refused(hass: HomeAssistant) -> None:
-    """A date that can never happen is rejected rather than silently never firing.
-
-    cronsim catches the 30th of February at parse time, which is the better
-    of the two behaviours: the automation fails to load and says why, instead
-    of loading and waiting forever.
-    """
-    with pytest.raises(vol.Invalid, match="Invalid crontab expression"):
+    """The 30th of February is caught while parsing, and named as such."""
+    with pytest.raises(vol.Invalid, match="Bad day-of-month"):
         await SpookTrigger.async_validate_config(
             hass, {"options": {"schedule": "0 0 30 2 *"}}
+        )
+
+
+@pytest.mark.parametrize("schedule", ["0 0 */20 * 1L", "0 0 */20 * 5#5"])
+async def test_a_schedule_that_never_comes_round_is_refused(
+    hass: HomeAssistant,
+    schedule: str,
+) -> None:
+    """An expression that parses but never fires is refused as well.
+
+    `0 0 */20 * 1L` asks for the 1st or the 21st, and for the last Monday of
+    the month, which is never earlier than the 25th. cronsim parses it
+    happily and then produces nothing at all, so validation has to advance
+    the iterator once to find out. Otherwise the automation loads, sits there
+    and never runs, with nothing anywhere saying why.
+    """
+    with pytest.raises(vol.Invalid, match="never comes round"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"schedule": schedule}}
         )
 
 

--- a/tests/ectoplasms/spook/triggers/test_cron.py
+++ b/tests/ectoplasms/spook/triggers/test_cron.py
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 CRON_MODULE = "custom_components.spook.ectoplasms.spook.triggers.cron"
+# `weekday()` counts Monday as 0; crontab counts it as 1.
+MONDAY = 0
+FIFTEENTH = 15
 
 
 async def _detach(hass: HomeAssistant) -> None:
@@ -265,6 +268,33 @@ async def test_a_late_run_does_not_work_through_what_it_missed(
 
     assert len(ran) == 1
     assert ran[0]["now"] == dt_util.now()
+
+
+async def test_day_of_month_and_day_of_week_combine_with_or(
+    hass: HomeAssistant,
+) -> None:
+    """Both day fields given means "or", which is what the documentation says.
+
+    The classic crontab trap, and cronsim follows it: `0 0 15 * 1` fires on
+    every Monday and on the 15th. This pins the behaviour the documentation
+    describes, so a change in cronsim shows up here rather than in somebody's
+    automation.
+    """
+    trigger = SpookTrigger(hass, _config("0 0 15 * 1"))
+    moment = dt_util.parse_datetime("2026-01-01 00:00:00")
+
+    days = []
+    for _ in range(6):
+        # pylint: disable-next=protected-access
+        moment = trigger._next(moment)  # noqa: SLF001
+        assert moment is not None
+        days.append((moment.day, moment.weekday()))
+
+    mondays = [day for day, weekday in days if weekday == MONDAY]
+    fifteenths = [day for day, _ in days if day == FIFTEENTH]
+
+    assert mondays, "no Mondays, so the day-of-week half was ignored"
+    assert fifteenths, "no 15th, so the day-of-month half was ignored"
 
 
 def _config(schedule: str) -> TriggerConfig:

--- a/tests/ectoplasms/spook/triggers/test_cron.py
+++ b/tests/ectoplasms/spook/triggers/test_cron.py
@@ -1,0 +1,184 @@
+"""Tests for the spook.cron trigger."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.trigger import TriggerConfig
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers.cron import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger.
+
+    Home Assistant's test harness fails a test that leaves a timer behind, so
+    this doubles as a check that the trigger cleans up after itself.
+    """
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.on_a_schedule"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def _automation(hass: HomeAssistant, schedule: str) -> list[str]:
+    """Set up an automation on a cron schedule and report each time it runs."""
+    ran: list[str] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(call.data["at"])
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "on a schedule",
+                    "trigger": {
+                        "platform": "spook.cron",
+                        "options": {"schedule": schedule},
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {"at": "{{ trigger.now }}"},
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return ran
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key.
+
+    Plain, because Home Assistant prefixes it with the providing integration
+    itself: this is `spook.cron` by the time anybody writes it in YAML.
+    """
+    assert "cron" in await async_get_triggers(hass)
+
+
+async def test_a_nonsense_expression_is_refused(hass: HomeAssistant) -> None:
+    """A bad expression is rejected at validation, naming what is wrong.
+
+    Better here than at three in the morning when the automation was supposed
+    to run.
+    """
+    with pytest.raises(vol.Invalid, match="Invalid crontab expression"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"schedule": "not a schedule"}}
+        )
+
+
+async def test_nicknames_are_refused(hass: HomeAssistant) -> None:
+    """`@daily` and friends are not crontab as cronsim reads it.
+
+    Worth pinning: it is the first thing somebody used to cron will try, and
+    the documentation says so because of this.
+    """
+    with pytest.raises(vol.Invalid):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"schedule": "@daily"}}
+        )
+
+
+async def test_a_valid_expression_is_accepted(hass: HomeAssistant) -> None:
+    """The forms the documentation advertises all validate."""
+    for schedule in ("*/5 * * * *", "0 7 * * 1-5", "0 12 * * MON#2", "0 3 L * *"):
+        assert await SpookTrigger.async_validate_config(
+            hass, {"options": {"schedule": schedule}}
+        ) == {"options": {"schedule": schedule}}
+
+
+async def test_it_fires_when_the_schedule_comes_round(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The automation runs at the scheduled minute, and not before."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 11:58:00")))
+    ran = await _automation(hass, "0 * * * *")
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert not ran
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(ran) == 1
+
+    await _detach(hass)
+
+
+async def test_it_keeps_firing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Each run lines up the one after it, rather than firing once and stopping."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 11:59:30")))
+    ran = await _automation(hass, "*/1 * * * *")
+
+    minutes = 3
+    for _ in range(minutes):
+        freezer.tick(timedelta(minutes=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert len(ran) == minutes
+
+    await _detach(hass)
+
+
+async def test_an_impossible_date_is_refused(hass: HomeAssistant) -> None:
+    """A date that can never happen is rejected rather than silently never firing.
+
+    cronsim catches the 30th of February at parse time, which is the better
+    of the two behaviours: the automation fails to load and says why, instead
+    of loading and waiting forever.
+    """
+    with pytest.raises(vol.Invalid, match="Invalid crontab expression"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"schedule": "0 0 30 2 *"}}
+        )
+
+
+async def test_a_date_years_away_is_fine(hass: HomeAssistant) -> None:
+    """The 29th of February resolves to the next leap year, not to nothing."""
+    trigger = SpookTrigger(hass, _config("0 0 29 2 *"))
+    # pylint: disable-next=protected-access
+    upcoming = trigger._next(dt_util.parse_datetime("2026-08-27 12:00:00"))  # noqa: SLF001
+
+    assert upcoming is not None
+    assert (upcoming.year, upcoming.month, upcoming.day) == (2028, 2, 29)
+
+
+def _config(schedule: str) -> TriggerConfig:
+    """Build a trigger config, the way core hands one over."""
+    return TriggerConfig(key="spook.cron", options={"schedule": schedule})

--- a/tests/ectoplasms/spook/triggers/test_cron.py
+++ b/tests/ectoplasms/spook/triggers/test_cron.py
@@ -33,6 +33,7 @@ CRON_MODULE = "custom_components.spook.ectoplasms.spook.triggers.cron"
 # `weekday()` counts Monday as 0; crontab counts it as 1.
 MONDAY = 0
 FIFTEENTH = 15
+MORNING_SEVEN = 7
 
 
 async def _detach(hass: HomeAssistant) -> None:
@@ -221,6 +222,23 @@ async def test_a_date_years_away_is_fine(hass: HomeAssistant) -> None:
     assert (upcoming.year, upcoming.month, upcoming.day) == (2028, 2, 29)
 
 
+def _recording_tracker(
+    bookings: list[tuple[datetime, Callable[[datetime], None]]],
+) -> Callable[..., Callable[[], None]]:
+    """Stand in for `async_track_point_in_time` and note what it was asked for.
+
+    The trigger books a single absolute instant at a time, and most of what
+    is worth checking is which instant that was. Going through the harness'
+    own timers cannot show that.
+    """
+
+    def _track(_hass, action, point_in_time):  # noqa: ANN001, ANN202
+        bookings.append((point_in_time, action))
+        return lambda: None
+
+    return _track
+
+
 async def test_a_late_run_does_not_work_through_what_it_missed(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
@@ -237,20 +255,16 @@ async def test_a_late_run_does_not_work_through_what_it_missed(
     """
     freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
 
-    scheduled: list[tuple[datetime, Callable[[datetime], None]]] = []
+    booked: list[tuple[datetime, Callable[[datetime], None]]] = []
     ran: list[dict] = []
 
-    def _track(_hass, action, point_in_time):  # noqa: ANN001, ANN202
-        scheduled.append((point_in_time, action))
-        return lambda: None
-
-    with patch(f"{CRON_MODULE}.async_track_point_in_time", _track):
+    with patch(f"{CRON_MODULE}.async_track_point_in_time", _recording_tracker(booked)):
         trigger = SpookTrigger(hass, _config("*/1 * * * *"))
         await trigger.async_attach_runner(
             lambda payload, _description: ran.append(payload)
         )
 
-        upcoming, fire = scheduled.pop()
+        upcoming, fire = booked.pop()
         assert upcoming == dt_util.parse_datetime("2026-08-27 12:01:00").replace(
             tzinfo=upcoming.tzinfo
         )
@@ -260,7 +274,7 @@ async def test_a_late_run_does_not_work_through_what_it_missed(
         freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 13:00:00")))
         fire(dt_util.as_utc(upcoming))
 
-    following, _ = scheduled.pop()
+    following, _ = booked.pop()
     assert following > dt_util.now(), (
         "asked for a time in the past, so it will catch up"
     )
@@ -334,6 +348,66 @@ async def test_a_starred_day_field_combines_with_and(
 
         # cron counts Sunday as 0; `weekday()` counts Monday as 0.
         assert (moment.weekday() + 1) % 7 in cron_weekdays
+
+
+async def test_a_time_zone_change_reworks_the_pending_wait(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Change the time zone and the wait already booked is worked out again.
+
+    The wait is one absolute instant. Booked in US/Pacific, `0 7 * * *` means
+    07:00 Pacific; switch to Europe/Amsterdam and that same instant is no
+    longer seven in the morning anywhere the user cares about. Core's utility
+    meter rebuilds its cronsim schedule on this event too.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+
+    booked: list[tuple[datetime, Callable[[datetime], None]]] = []
+
+    with patch(f"{CRON_MODULE}.async_track_point_in_time", _recording_tracker(booked)):
+        trigger = SpookTrigger(hass, _config("0 7 * * *"))
+        unattach = await trigger.async_attach_runner(lambda *_args: None)
+
+        first, _ = booked.pop()
+        assert first.hour == MORNING_SEVEN
+
+        await hass.config.async_update(time_zone="Europe/Amsterdam")
+        await hass.async_block_till_done()
+
+        reworked, _ = booked.pop()
+        unattach()
+
+    assert reworked != first, "the wait was left on the old zone's instant"
+    assert str(reworked.tzinfo) == "Europe/Amsterdam"
+    assert reworked.hour == MORNING_SEVEN
+
+
+async def test_an_unrelated_core_config_change_is_left_alone(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The event fires for any core config change, so only the zone counts.
+
+    Rebooking on every one of them would be harmless but pointless, and it
+    would move the wait around whenever somebody renames their house.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+
+    booked: list[tuple[datetime, Callable[[datetime], None]]] = []
+
+    with patch(f"{CRON_MODULE}.async_track_point_in_time", _recording_tracker(booked)):
+        trigger = SpookTrigger(hass, _config("0 7 * * *"))
+        unattach = await trigger.async_attach_runner(lambda *_args: None)
+
+        assert len(booked) == 1
+
+        await hass.config.async_update(location_name="Somewhere else")
+        await hass.async_block_till_done()
+
+        unattach()
+
+    assert len(booked) == 1, "rebooked over a change that was not the time zone"
 
 
 def _config(schedule: str) -> TriggerConfig:

--- a/tests/ectoplasms/spook/triggers/test_cron.py
+++ b/tests/ectoplasms/spook/triggers/test_cron.py
@@ -297,6 +297,38 @@ async def test_day_of_month_and_day_of_week_combine_with_or(
     assert fifteenths, "no 15th, so the day-of-month half was ignored"
 
 
+@pytest.mark.parametrize(
+    ("schedule", "days", "cron_weekdays"),
+    [
+        ("0 0 15 * */2", {15}, {0, 2, 4, 6}),
+        ("0 0 */20 * 1", {1, 21}, {1}),
+    ],
+)
+async def test_a_starred_day_field_combines_with_and(
+    hass: HomeAssistant,
+    schedule: str,
+    days: set[int],
+    cron_weekdays: set[int],
+) -> None:
+    """Let either day field start with `*` and the "or" turns into an "and".
+
+    `0 0 15 * */2` is the 15th, but only when it lands on one of the days
+    `*/2` picks out. Both directions are pinned, because this is the half of
+    the rule that is easy to state the wrong way round.
+    """
+    trigger = SpookTrigger(hass, _config(schedule))
+    moment = dt_util.parse_datetime("2026-01-01 00:00:00")
+
+    for _ in range(8):
+        # pylint: disable-next=protected-access
+        moment = trigger._next(moment)  # noqa: SLF001
+        assert moment is not None
+        assert moment.day in days
+
+        # cron counts Sunday as 0; `weekday()` counts Monday as 0.
+        assert (moment.weekday() + 1) % 7 in cron_weekdays
+
+
 def _config(schedule: str) -> TriggerConfig:
     """Build a trigger config, the way core hands one over."""
     return TriggerConfig(key="spook.cron", options={"schedule": schedule})

--- a/tests/test_platform_validation.py
+++ b/tests/test_platform_validation.py
@@ -46,10 +46,12 @@ async def test_unknown_integration_is_reported(hass: HomeAssistant) -> None:
 async def test_integration_without_triggers_is_reported(hass: HomeAssistant) -> None:
     """Test keys from integrations without a trigger platform are reported.
 
-    Spook itself exists as an integration but ships no trigger platform.
+    `recorder` exists, and is one of Spook's own dependencies so it is always
+    resolvable, but ships no trigger platform. Spook used to play this part
+    and cannot any more, now that it provides triggers of its own.
     """
-    assert await async_filter_unknown_trigger_keys(hass, {"spook.boo"}) == {
-        "spook.boo",
+    assert await async_filter_unknown_trigger_keys(hass, {"recorder.ghost"}) == {
+        "recorder.ghost",
     }
 
 

--- a/tests/test_trigger_translations.py
+++ b/tests/test_trigger_translations.py
@@ -1,0 +1,60 @@
+"""Tests for Spook trigger descriptors and translations.
+
+The same contract the conditions have: a trigger without a descriptor is
+dropped from the automation editor entirely, and a field without a
+translation renders as its raw key. Neither fails anywhere else.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from custom_components.spook.trigger import async_get_triggers
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+SPOOK_ROOT = Path(__file__).parents[1] / "custom_components" / "spook"
+
+
+def _descriptors() -> dict:
+    """Return the trigger descriptors."""
+    return yaml.safe_load((SPOOK_ROOT / "triggers.yaml").read_text())
+
+
+def _translations() -> dict:
+    """Return the English trigger translations."""
+    return json.loads((SPOOK_ROOT / "translations" / "en.json").read_text())["triggers"]
+
+
+async def test_every_trigger_has_a_descriptor(hass: HomeAssistant) -> None:
+    """Test every discovered trigger is described in triggers.yaml."""
+    assert set(await async_get_triggers(hass)) == set(_descriptors())
+
+
+def test_every_trigger_has_translations() -> None:
+    """Test every described trigger has a matching translation."""
+    assert set(_descriptors()) == set(_translations())
+
+
+def test_every_trigger_field_has_translations() -> None:
+    """Test every described trigger field has a matching translation."""
+    translations = _translations()
+
+    for trigger, descriptor in _descriptors().items():
+        described = set((descriptor or {}).get("fields", {}))
+        translated = set(translations[trigger].get("fields", {}))
+        assert described == translated, trigger
+
+
+def test_trigger_translation_names_do_not_include_ghost() -> None:
+    """Test trigger names carry no ghost of their own.
+
+    Spook's actions get one appended while they are injected into another
+    integration's domain. These live under `spook.` and are named plainly.
+    """
+    assert all("👻" not in trigger["name"] for trigger in _translations().values())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `spook.cron` trigger, which fires on a crontab schedule.

Five fields, in the usual order: minute, hour, day of month, month, day of week. Ranges and steps work, and so do the day-of-week extensions, so `MON#2` is the second Monday of the month and `5L` the last Friday.

```yaml
trigger: spook.cron
options:
  schedule: "0 7 * * 1-5"
```

When it fires, `trigger.schedule` holds the expression and `trigger.now` the local time it fired at.

This also brings the trigger platform itself, mirroring the condition platform that landed in #1466. Triggers are discovered from `ectoplasms/*/triggers/*.py`, each module exposing a `SpookTrigger`, so the next trigger costs a module and a `triggers.yaml` entry. The discovery result is cached, because core asks for it once per config validation and once per instantiation.

Two things worth pointing out:

- This is Spook's first Python dependency. `cronsim==2.7` is the same pin as core's `package_constraints.txt`, so in a normal Home Assistant it is already installed and pip does nothing.
- `tests/test_platform_validation.py` used Spook as its example of an integration that exists but ships no trigger platform. That is no longer true, so it now uses `recorder`, which is one of Spook's own dependencies and therefore always resolvable.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Home Assistant's time triggers cover a time of day and a time pattern. Between them they cannot express "every weekday at seven" or "the last Friday of the month". Getting there today means a time pattern trigger plus a pile of template conditions, or a helper. A crontab expression says it in one line, and anybody who has written a crontab already knows the syntax.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Twelve new tests, on top of the existing suite (932 pass):

- The trigger is discovered by the platform.
- Nonsense expressions, `@daily` nicknames, and impossible dates like `0 0 30 2 *` are refused at validation, with the expression named in the error. Better there than at three in the morning when the automation was supposed to run.
- The forms the documentation advertises all validate.
- A real automation fires at the scheduled minute and not before, and keeps firing on subsequent minutes rather than stopping after the first.
- The 29th of February resolves to the next leap year rather than to nothing.
- Descriptor and translation parity, mirroring the condition tests: a trigger without a descriptor is dropped from the automation editor, and a field without a translation renders as its raw key. Neither fails anywhere else.

The firing tests turn the automation off afterwards, so the harness' lingering-timer check doubles as proof the trigger detaches cleanly.

Also ran: `ruff check`, `ruff format --check`, `pylint` over the whole tree, `zizmor`, and the full pre-commit set. The documentation builds with the same warnings as `main`, no more (built both and diffed the warning sets).

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
