### PR TITLE
Add a spook.stale trigger

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/stale.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/stale.py
@@ -47,9 +47,30 @@ def _quiet_period(value: Any) -> timedelta:
     return duration
 
 
+# `TARGET_FIELDS` is a plain mapping of schema fields, so it needs compiling
+# before it can validate anything.
+_TARGET_SCHEMA = vol.Schema(cv.TARGET_FIELDS)
+
+
+def _watchable_target(value: Any) -> ConfigType:
+    """Validate the target, and refuse one that names nothing.
+
+    An empty target passes the field validation happily and then watches
+    nothing at all: a trigger that loads and can never fire. Core's own
+    target tracking helper raises on this for the same reason.
+    """
+    target: ConfigType = _TARGET_SCHEMA(value)
+    if not TargetSelection(target).has_any_target:
+        message = (
+            "The target must name at least one entity, device, area, floor or label"
+        )
+        raise vol.Invalid(message)
+    return target
+
+
 _TRIGGER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_TARGET): _watchable_target,
         vol.Required(CONF_OPTIONS): {
             vol.Required(CONF_FOR): _quiet_period,
         },
@@ -89,7 +110,16 @@ class _QuietEntityTracker(TargetEntityChangeTracker):
 
     @callback
     def _handle_entities_update(self, tracked_entities: set[str]) -> None:
-        """Re-aim at the entities the target now covers."""
+        """Re-aim at the entities the target now covers.
+
+        The base class re-expands the target on every entity, device and area
+        registry event anywhere in the system, and almost none of those move
+        this target. Tearing down and rebuilding the write listeners each time
+        would be work for nothing.
+        """
+        if tracked_entities == self._tracked:
+            return
+
         for entity_id in self._tracked - tracked_entities:
             self._cancel_timer(entity_id)
 

--- a/custom_components/spook/ectoplasms/spook/triggers/stale.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/stale.py
@@ -1,0 +1,236 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from functools import partial
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_FOR, CONF_OPTIONS, CONF_TARGET
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import (
+    async_track_point_in_time,
+    async_track_state_change_event,
+    async_track_state_report_event,
+)
+from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+
+def _quiet_period(value: Any) -> timedelta:
+    """Validate the duration, and refuse one that can never elapse.
+
+    A zero duration would put the deadline on the moment the entity last
+    spoke, which is always in the past, so the trigger would load and then
+    sit there doing nothing at all.
+    """
+    duration = cv.positive_time_period(value)
+    if duration <= timedelta(0):
+        message = "The duration must be longer than zero"
+        raise vol.Invalid(message)
+    return duration
+
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_FOR): _quiet_period,
+        },
+    }
+)
+
+
+# Everything here is called by the base class or by an event, so there is
+# nothing public to count.
+# pylint: disable-next=too-few-public-methods
+class _QuietEntityTracker(TargetEntityChangeTracker):
+    """Watch a target's entities and report the ones that fall silent.
+
+    Silence, not stillness: an entity that keeps reporting the same value is
+    alive and well. This watches `last_reported`, which moves on every write,
+    changed or not, so what it catches is nothing writing at all.
+
+    The registry listening and target re-expansion come from the base class,
+    which calls back into `_handle_entities_update` whenever the set of
+    targeted entities moves.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        target_selection: TargetSelection,
+        duration: timedelta,
+        on_quiet: Callable[[str, datetime], None],
+    ) -> None:
+        """Initialize the tracker."""
+        super().__init__(hass, target_selection, entity_filter=lambda ids: ids)
+        self._duration = duration
+        self._on_quiet = on_quiet
+        self._tracked: set[str] = set()
+        self._timers: dict[str, CALLBACK_TYPE] = {}
+        self._unsub_writes: list[CALLBACK_TYPE] = []
+
+    @callback
+    def _handle_entities_update(self, tracked_entities: set[str]) -> None:
+        """Re-aim at the entities the target now covers."""
+        for entity_id in self._tracked - tracked_entities:
+            self._cancel_timer(entity_id)
+
+        self._tracked = tracked_entities
+        self._relisten()
+
+        # Entities already quiet when the target picks them up are left alone.
+        # Firing for them would mean every automation reload replays whatever
+        # has gone silent since, which is noise rather than news.
+        for entity_id in tracked_entities:
+            if entity_id not in self._timers:
+                self._rearm(entity_id)
+
+    @callback
+    def _relisten(self) -> None:
+        """Listen for writes to exactly the entities being tracked.
+
+        A write that changes the state and a write that does not are two
+        different events, and only the pair of them adds up to "something
+        wrote to this entity".
+        """
+        for unsub in self._unsub_writes:
+            unsub()
+        self._unsub_writes.clear()
+
+        if not self._tracked:
+            return
+
+        entity_ids = list(self._tracked)
+        self._unsub_writes = [
+            async_track_state_change_event(self._hass, entity_ids, self._entity_wrote),
+            async_track_state_report_event(self._hass, entity_ids, self._entity_wrote),
+        ]
+
+    @callback
+    def _entity_wrote(self, event: Event) -> None:
+        """Start the wait over: this entity has just spoken."""
+        self._rearm(event.data["entity_id"])
+
+    @callback
+    def _rearm(self, entity_id: str) -> None:
+        """Wait until this entity would have been quiet for the whole duration."""
+        self._cancel_timer(entity_id)
+
+        if (state := self._hass.states.get(entity_id)) is None:
+            return
+
+        deadline = dt_util.as_local(state.last_reported) + self._duration
+        if deadline <= dt_util.now():
+            # Already past it, so this entity was quiet before we looked.
+            return
+
+        self._timers[entity_id] = async_track_point_in_time(
+            self._hass, partial(self._went_quiet, entity_id), deadline
+        )
+
+    @callback
+    def _went_quiet(self, entity_id: str, deadline: datetime) -> None:
+        """Report an entity that has now been quiet for the whole duration.
+
+        Core hands over the moment the wait was scheduled for, which here is
+        the deadline itself, and that is the moment worth reporting: when the
+        entity became quiet, not when the timer got round to noticing.
+        """
+        self._timers.pop(entity_id, None)
+        self._on_quiet(entity_id, deadline)
+
+    @callback
+    def _cancel_timer(self, entity_id: str) -> None:
+        """Drop the pending wait for one entity, if there is one."""
+        if (timer := self._timers.pop(entity_id, None)) is not None:
+            timer()
+
+    def _unsubscribe(self) -> None:
+        """Unsubscribe from everything, the base class' listeners included."""
+        super()._unsubscribe()
+
+        for unsub in self._unsub_writes:
+            unsub()
+        self._unsub_writes.clear()
+
+        for entity_id in list(self._timers):
+            self._cancel_timer(entity_id)
+
+        self._tracked = set()
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when an entity falls silent.
+
+    Home Assistant can tell you an entity went unavailable, but plenty of
+    things die without ever saying so: a sensor whose integration quietly
+    stopped polling, a battery device that dropped off the network, an MQTT
+    topic nobody is publishing to any more. The state sits there looking
+    perfectly fine, holding a number from last Tuesday.
+    """
+
+    trigger = "stale"
+
+    _duration: timedelta
+    _target: ConfigType
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        return _TRIGGER_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._duration = options[CONF_FOR]
+        self._target = config.target or {}
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def entity_went_quiet(entity_id: str, deadline: datetime) -> None:
+            """Run the action for the entity that fell silent."""
+            run_action(
+                {
+                    "entity_id": entity_id,
+                    "for": self._duration,
+                    "last_reported": dt_util.as_local(deadline) - self._duration,
+                },
+                f"{entity_id} reported nothing for {self._duration}",
+            )
+
+        tracker = _QuietEntityTracker(
+            self._hass,
+            TargetSelection(self._target),
+            self._duration,
+            entity_went_quiet,
+        )
+        return await tracker.async_setup()

--- a/custom_components/spook/ectoplasms/spook/triggers/stale.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/stale.py
@@ -140,19 +140,30 @@ class _QuietEntityTracker(TargetEntityChangeTracker):
         A write that changes the state and a write that does not are two
         different events, and only the pair of them adds up to "something
         wrote to this entity".
+
+        The new listeners go on before the old ones come off. Home Assistant
+        keeps one shared tracker per event type: drop the last subscriber and
+        it is torn down, taking with it events that have fired but not been
+        dispatched yet. Core's own target tracker orders it this way for that
+        reason, and losing a write here would mean an entity reported as
+        silent when it had just spoken.
         """
-        for unsub in self._unsub_writes:
+        previous = self._unsub_writes
+        self._unsub_writes = []
+
+        if self._tracked:
+            entity_ids = list(self._tracked)
+            self._unsub_writes = [
+                async_track_state_change_event(
+                    self._hass, entity_ids, self._entity_wrote
+                ),
+                async_track_state_report_event(
+                    self._hass, entity_ids, self._entity_wrote
+                ),
+            ]
+
+        for unsub in previous:
             unsub()
-        self._unsub_writes.clear()
-
-        if not self._tracked:
-            return
-
-        entity_ids = list(self._tracked)
-        self._unsub_writes = [
-            async_track_state_change_event(self._hass, entity_ids, self._entity_wrote),
-            async_track_state_report_event(self._hass, entity_ids, self._entity_wrote),
-        ]
 
     @callback
     def _entity_wrote(self, event: Event) -> None:
@@ -167,25 +178,37 @@ class _QuietEntityTracker(TargetEntityChangeTracker):
         if (state := self._hass.states.get(entity_id)) is None:
             return
 
-        deadline = dt_util.as_local(state.last_reported) + self._duration
-        if deadline <= dt_util.now():
+        # Worked out in UTC on purpose. Adding an hour to a local time is
+        # wall-clock arithmetic, and on the night the clocks go back that
+        # hour is two hours of real waiting.
+        deadline = state.last_reported + self._duration
+        if deadline <= dt_util.utcnow():
             # Already past it, so this entity was quiet before we looked.
             return
 
         self._timers[entity_id] = async_track_point_in_time(
-            self._hass, partial(self._went_quiet, entity_id), deadline
+            self._hass,
+            partial(self._went_quiet, entity_id, state.last_reported),
+            deadline,
         )
 
     @callback
-    def _went_quiet(self, entity_id: str, deadline: datetime) -> None:
+    def _went_quiet(
+        self,
+        entity_id: str,
+        last_reported: datetime,
+        _fired_at: datetime,
+    ) -> None:
         """Report an entity that has now been quiet for the whole duration.
 
-        Core hands over the moment the wait was scheduled for, which here is
-        the deadline itself, and that is the moment worth reporting: when the
-        entity became quiet, not when the timer got round to noticing.
+        The moment it last spoke is carried through from when the wait was
+        set, rather than worked back out of the time the callback is handed.
+        That one arrives in local time, and subtracting a duration from a
+        local time is wall-clock arithmetic: wrong by an hour, twice a year.
+        Not doing the arithmetic beats doing it correctly.
         """
         self._timers.pop(entity_id, None)
-        self._on_quiet(entity_id, deadline)
+        self._on_quiet(entity_id, last_reported)
 
     @callback
     def _cancel_timer(self, entity_id: str) -> None:
@@ -246,13 +269,13 @@ class SpookTrigger(Trigger):
         """Attach the trigger to an action runner."""
 
         @callback
-        def entity_went_quiet(entity_id: str, deadline: datetime) -> None:
+        def entity_went_quiet(entity_id: str, last_reported: datetime) -> None:
             """Run the action for the entity that fell silent."""
             run_action(
                 {
                     "entity_id": entity_id,
                     "for": self._duration,
-                    "last_reported": dt_util.as_local(deadline) - self._duration,
+                    "last_reported": dt_util.as_local(last_reported),
                 },
                 f"{entity_id} reported nothing for {self._duration}",
             )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -9,6 +9,16 @@
           "description": "A crontab expression with five fields: minute, hour, day of month, month, day of week. Supports ranges and steps, and the day-of-week extensions, so \"MON#2\" is the second Monday and \"5L\" the last Friday. Nicknames like \"@daily\" are not supported."
         }
       }
+    },
+    "stale": {
+      "name": "Entity fell silent",
+      "description": "Fires when nothing has written to an entity for a while, which catches a device that died quietly rather than going unavailable.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "How long an entity has to stay silent before this fires. An entity that keeps reporting the same value is not silent."
+        }
+      }
     }
   },
   "conditions": {

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -5,3 +5,13 @@ cron:
       example: "0 7 * * 1-5"
       selector:
         text:
+
+stale:
+  target:
+    entity:
+  fields:
+    for:
+      required: true
+      example: "01:00:00"
+      selector:
+        duration:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -235,6 +235,7 @@ options:
 
 - Entities that were already silent when the trigger started watching are left alone. Only silence that falls while the automation is loaded counts. Without that, reloading your automations would replay everything that has gone quiet since, which is noise rather than news.
 - A duration of zero is refused. It would put the deadline on the moment the entity last spoke, which is always in the past, so the trigger would load and then do nothing at all.
+- A target that names nothing is refused for the same reason. An empty target is valid as far as the fields go, and would sit there watching no entities at all.
 - Repeating the same value counts as speaking. If you want to know about a sensor whose reading has not moved, that is a different question, and this trigger does not answer it.
 - An entity with no state yet has nothing to be silent about, so it is skipped until it reports for the first time.
 

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -167,6 +167,79 @@ options:
 
 :::
 
+### Entity fell silent
+
+Fires when nothing has written to an entity for a while.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Entity fell silent 👻
+* - Trigger name
+  - `spook.stale`
+* - Targets
+  - {term}`Entities <entity>`, {term}`devices <device>`, {term}`areas <area>`, floors and labels
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `for`
+  - {term}`string <string>`
+  - Yes
+  - `01:00:00`
+```
+
+Home Assistant will tell you an entity went unavailable. Plenty of things die without ever saying so: an integration that quietly stopped polling, a battery device that dropped off the network, an MQTT topic nobody publishes to any more. The state sits there looking perfectly healthy, holding a reading from last Tuesday.
+
+This watches for silence rather than for a value. A sensor that keeps reporting the same 21.5 every minute is alive and is left alone; one that stops reporting altogether fires after the duration you set. Point it at whole areas, floors or labels and every entity underneath is watched, one at a time: each entity that falls silent fires separately.
+
+When it fires, `trigger.entity_id` names the entity that went quiet, `trigger.last_reported` is when it last spoke, and `trigger.for` is the duration you configured.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Any sensor in the attic that has said nothing for an hour:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.stale
+target:
+  area_id: attic
+options:
+  for: "01:00:00"
+```
+
+One specific sensor, with a shorter fuse:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.stale
+target:
+  entity_id: sensor.greenhouse_temperature
+options:
+  for: "00:15:00"
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Entities that were already silent when the trigger started watching are left alone. Only silence that falls while the automation is loaded counts. Without that, reloading your automations would replay everything that has gone quiet since, which is noise rather than news.
+- A duration of zero is refused. It would put the deadline on the moment the entity last spoke, which is always in the past, so the trigger would load and then do nothing at all.
+- Repeating the same value counts as speaking. If you want to know about a sensor whose reading has not moved, that is a different question, and this trigger does not answer it.
+- An entity with no state yet has nothing to be silent about, so it is skipped until it reports for the first time.
+
+:::
+
 ## Conditions
 
 Spook offers the following conditions that are not tied to a specific integration:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -199,7 +199,7 @@ Fires when nothing has written to an entity for a while.
 
 Home Assistant will tell you an entity went unavailable. Plenty of things die without ever saying so: an integration that quietly stopped polling, a battery device that dropped off the network, an MQTT topic nobody publishes to any more. The state sits there looking perfectly healthy, holding a reading from last Tuesday.
 
-This watches for silence rather than for a value. A sensor that keeps reporting the same 21.5 every minute is alive and is left alone; one that stops reporting altogether fires after the duration you set. Point it at whole areas, floors or labels and every entity underneath is watched, one at a time: each entity that falls silent fires separately.
+This watches for silence rather than for a value. A sensor that keeps reporting the same 21.5 every minute is alive and is left alone; one that stops reporting altogether fires after the duration you set. Point it at whole areas, floors or labels and the entities underneath are watched one at a time, each firing separately when it falls silent.
 
 When it fires, `trigger.entity_id` names the entity that went quiet, `trigger.last_reported` is when it last spoke, and `trigger.for` is the duration you configured.
 
@@ -237,6 +237,7 @@ options:
 - A duration of zero is refused. It would put the deadline on the moment the entity last spoke, which is always in the past, so the trigger would load and then do nothing at all.
 - A target that names nothing is refused for the same reason. An empty target is valid as far as the fields go, and would sit there watching no entities at all.
 - Repeating the same value counts as speaking. If you want to know about a sensor whose reading has not moved, that is a different question, and this trigger does not answer it.
+- Expanding a device, area or floor covers its primary entities. Configuration and diagnostic entities are left out, the same as every other Home Assistant trigger that takes a target. Name one as an entity and it is always watched, whichever category it is in: `entity_id: sensor.back_door_battery` works even though the area it sits in would skip it.
 - An entity with no state yet has nothing to be silent about, so it is skipped until it reports for the first time.
 
 :::

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -14,3 +14,9 @@ Spook provides new triggers to Home Assistant. This reference page lists them al
 Fires on a crontab schedule, for the times Home Assistant's own time triggers cannot express, like every weekday at seven or the last Friday of the month. _#crontab_
 
 `spook.cron`, [documentation](other-features#cron-schedule) 📚
+
+## Entity fell silent
+
+Fires when nothing has written to an entity for a while, which catches the device that died quietly instead of going unavailable. _#stale_ _#silent_ _#dead_
+
+`spook.stale`, [documentation](other-features#entity-fell-silent) 📚

--- a/tests/ectoplasms/spook/triggers/test_stale.py
+++ b/tests/ectoplasms/spook/triggers/test_stale.py
@@ -1,0 +1,407 @@
+"""Tests for the spook.stale trigger."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers.stale import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+AN_HOUR = timedelta(hours=1)
+
+
+async def _automation(hass: HomeAssistant, target: dict, duration: str) -> list[dict]:
+    """Set up an automation on the stale trigger and record every run."""
+    ran: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "gone quiet",
+                    "trigger": {
+                        "platform": "spook.stale",
+                        "target": target,
+                        "options": {"for": duration},
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {
+                                "entity_id": "{{ trigger.entity_id }}",
+                                "last_reported": "{{ trigger.last_reported }}",
+                            },
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return ran
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger.
+
+    The harness fails a test that leaves a timer or listener behind, so this
+    doubles as a check that the trigger clears up after itself.
+    """
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.gone_quiet"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "stale" in await async_get_triggers(hass)
+
+
+async def test_a_target_is_required(hass: HomeAssistant) -> None:
+    """Without a target there is nothing to watch."""
+    with pytest.raises(vol.Invalid):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"for": {"hours": 1}}}
+        )
+
+
+async def test_a_duration_is_required(hass: HomeAssistant) -> None:
+    """Without a duration there is no telling when silence counts."""
+    with pytest.raises(vol.Invalid):
+        await SpookTrigger.async_validate_config(
+            hass, {"target": {"entity_id": "sensor.probe"}, "options": {}}
+        )
+
+
+@pytest.mark.parametrize("duration", [{"hours": 0}, "00:00:00", 0])
+async def test_a_zero_duration_is_refused(
+    hass: HomeAssistant, duration: object
+) -> None:
+    """Zero would put the deadline in the past, so it would never fire at all.
+
+    Better refused at load than loading and quietly doing nothing.
+    """
+    with pytest.raises(vol.Invalid, match="longer than zero"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {"target": {"entity_id": "sensor.probe"}, "options": {"for": duration}},
+        )
+
+
+async def test_it_fires_once_an_entity_falls_silent(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Nothing writes to the entity for the whole duration, so it fires."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"entity_id": "sensor.probe"}, "01:00:00")
+
+    freezer.tick(timedelta(minutes=59))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert not ran
+
+    freezer.tick(timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    assert ran[0]["entity_id"] == "sensor.probe"
+
+    await _detach(hass)
+
+
+async def test_the_same_value_reported_again_keeps_it_alive(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An entity repeating itself is alive, and this is the whole point.
+
+    A sensor that keeps publishing 21.5 every minute has not gone anywhere.
+    Watching `last_reported` rather than `last_changed` is what tells the two
+    apart, so this is the test that pins the trigger's meaning.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"entity_id": "sensor.probe"}, "01:00:00")
+
+    # Well past the hour, but reporting the same value all the way through.
+    for _ in range(4):
+        freezer.tick(timedelta(minutes=30))
+        hass.states.async_set("sensor.probe", "21.5")
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert not ran, "fired for an entity that never stopped reporting"
+
+    await _detach(hass)
+
+
+async def test_it_still_fires_after_a_run_of_identical_reports(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The real shape of a dying sensor: repeats itself for hours, then stops.
+
+    This is the test that separates `last_reported` from `last_changed`. Keyed
+    on `last_changed`, the deadline stays pinned to the one time the value
+    moved, slides into the past, and the entity is never watched again: it
+    could die and nothing would ever say so.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"entity_id": "sensor.probe"}, "01:00:00")
+
+    # Three hours of loyally repeating the same reading.
+    for _ in range(6):
+        freezer.tick(timedelta(minutes=30))
+        hass.states.async_set("sensor.probe", "21.5")
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert not ran
+
+    # And then it stops.
+    freezer.tick(AN_HOUR + timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1, "a sensor that repeated itself then died went unnoticed"
+    assert ran[0]["entity_id"] == "sensor.probe"
+
+    await _detach(hass)
+
+
+async def test_it_reports_when_the_entity_last_spoke(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """`trigger.last_reported` is when it went quiet, not when we noticed."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"entity_id": "sensor.probe"}, "01:00:00")
+
+    # Overshoot the deadline by a long way, the way a busy system would.
+    freezer.tick(timedelta(hours=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    assert ran[0]["last_reported"].startswith("2026-08-27 12:00:00")
+
+    await _detach(hass)
+
+
+async def test_it_watches_everything_in_an_area(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry,  # noqa: ANN001
+    entity_registry,  # noqa: ANN001
+) -> None:
+    """A target can name an area, and every entity in it is watched."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+
+    area = area_registry.async_create("Attic")
+    entry = entity_registry.async_get_or_create("sensor", "demo", "attic-probe")
+    entity_registry.async_update_entity(entry.entity_id, area_id=area.id)
+
+    hass.states.async_set(entry.entity_id, "21.5")
+    hass.states.async_set("sensor.elsewhere", "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"area_id": area.id}, "01:00:00")
+
+    freezer.tick(AN_HOUR + timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert [run["entity_id"] for run in ran] == [entry.entity_id]
+
+    await _detach(hass)
+
+
+async def test_a_changing_value_keeps_it_alive(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A value that keeps moving resets the clock too.
+
+    Obvious, and the counterpart to the identical-report case: a write that
+    changes the state and a write that does not are two different events in
+    Home Assistant, and only both of them add up to "something wrote here".
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"entity_id": "sensor.probe"}, "01:00:00")
+
+    for step in range(4):
+        freezer.tick(timedelta(minutes=30))
+        hass.states.async_set("sensor.probe", f"{21.5 + step}")
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert not ran, "fired for an entity whose value kept moving"
+
+    await _detach(hass)
+
+
+async def test_an_entity_joining_the_target_is_picked_up(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry,  # noqa: ANN001
+    entity_registry,  # noqa: ANN001
+) -> None:
+    """Move an entity into the watched area and it starts being watched.
+
+    The re-aiming comes from core's target tracker, but keeping the timers and
+    the write listeners in step with the new set is this trigger's job.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+
+    area = area_registry.async_create("Attic")
+    entry = entity_registry.async_get_or_create("sensor", "demo", "late-joiner")
+    hass.states.async_set(entry.entity_id, "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"area_id": area.id}, "01:00:00")
+
+    # Nothing in the area yet, so nothing is being watched.
+    freezer.tick(AN_HOUR + timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert not ran
+
+    # Now it joins, and reports once so it starts out alive.
+    entity_registry.async_update_entity(entry.entity_id, area_id=area.id)
+    hass.states.async_set(entry.entity_id, "21.5")
+    await hass.async_block_till_done()
+
+    freezer.tick(AN_HOUR + timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert [run["entity_id"] for run in ran] == [entry.entity_id]
+
+    await _detach(hass)
+
+
+async def test_an_entity_leaving_the_target_stops_being_watched(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry,  # noqa: ANN001
+    entity_registry,  # noqa: ANN001
+) -> None:
+    """Take an entity out of the watched area and its pending wait goes too.
+
+    Without dropping it, the wait outlives the target and the automation runs
+    for something it no longer covers.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+
+    area = area_registry.async_create("Attic")
+    entry = entity_registry.async_get_or_create("sensor", "demo", "leaver")
+    entity_registry.async_update_entity(entry.entity_id, area_id=area.id)
+
+    hass.states.async_set(entry.entity_id, "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"area_id": area.id}, "01:00:00")
+
+    # Out of the area, halfway through the hour.
+    freezer.tick(timedelta(minutes=30))
+    entity_registry.async_update_entity(entry.entity_id, area_id=None)
+    await hass.async_block_till_done()
+
+    freezer.tick(AN_HOUR)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not ran, "fired for an entity that had left the target"
+
+    await _detach(hass)
+
+
+async def test_a_target_entity_without_a_state_is_skipped(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry,  # noqa: ANN001
+) -> None:
+    """A registry entry with no state yet has nothing to be silent about."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+
+    entry = entity_registry.async_get_or_create("sensor", "demo", "stateless")
+
+    ran = await _automation(hass, {"entity_id": entry.entity_id}, "01:00:00")
+
+    freezer.tick(timedelta(hours=3))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not ran
+
+    await _detach(hass)
+
+
+async def test_an_entity_already_quiet_is_left_alone(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Silence from before the trigger existed does not count.
+
+    Otherwise reloading automations would replay everything that has gone
+    quiet since, which is noise rather than news.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-27 12:00:00")))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    # Two hours of silence, and only then does anybody start watching.
+    freezer.tick(timedelta(hours=2))
+    ran = await _automation(hass, {"entity_id": "sensor.probe"}, "01:00:00")
+
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not ran
+
+    await _detach(hass)

--- a/tests/ectoplasms/spook/triggers/test_stale.py
+++ b/tests/ectoplasms/spook/triggers/test_stale.py
@@ -192,6 +192,98 @@ async def test_registry_churn_elsewhere_leaves_the_listeners_alone(
     )
 
 
+async def test_the_wait_is_real_time_across_a_clock_change(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An hour of silence is an hour, on the night the clocks go back too.
+
+    Worked out in local time, "02:30 plus an hour" on 2026-10-25 in Amsterdam
+    lands on 03:30 winter time, which is two real hours later: the entity
+    would have been silent for twice as long as asked before anybody heard
+    about it. Twice a year, and nobody would ever trace it.
+    """
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+
+    # 02:30 local, still summer time, half an hour before the clocks go back.
+    freezer.move_to(dt_util.parse_datetime("2026-10-25 00:30:00+00:00"))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, {"entity_id": "sensor.probe"}, "01:00:00")
+
+    # One real hour later. In local time the clock reads 02:30 all over again.
+    freezer.move_to(dt_util.parse_datetime("2026-10-25 01:31:00+00:00"))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1, "still waiting an hour after the hour was up"
+
+    # And the reported moment is the one the entity actually last spoke at:
+    # 02:30 in summer time, not 01:30 in winter time. Subtracting the
+    # duration from a localized deadline gets both the hour and the offset
+    # wrong here.
+    assert ran[0]["last_reported"] == "2026-10-25 02:30:00+02:00"
+
+    await _detach(hass)
+
+
+async def test_the_new_listeners_go_on_before_the_old_come_off(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry,  # noqa: ANN001
+    entity_registry,  # noqa: ANN001
+) -> None:
+    """Order matters: Home Assistant shares one tracker per event type.
+
+    Drop the last subscriber and that shared tracker is torn down, taking
+    with it events that have fired but have not been dispatched yet. A lost
+    write means an entity called silent when it had just spoken. Core's own
+    target tracker carries a comment saying exactly this.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+
+    area = area_registry.async_create("Attic")
+    first = entity_registry.async_get_or_create("sensor", "demo", "first")
+    entity_registry.async_update_entity(first.entity_id, area_id=area.id)
+    hass.states.async_set(first.entity_id, "21.5")
+    await hass.async_block_till_done()
+
+    order: list[str] = []
+    real_tracker = event_helpers.async_track_state_change_event
+
+    def _recording(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        order.append("subscribe")
+        unsub = real_tracker(*args, **kwargs)
+
+        def _unsub() -> None:
+            order.append("unsubscribe")
+            unsub()
+
+        return _unsub
+
+    with patch(f"{STALE_MODULE}.async_track_state_change_event", _recording):
+        trigger = SpookTrigger(
+            hass,
+            TriggerConfig(
+                key="spook.stale",
+                target={"area_id": area.id},
+                options={"for": AN_HOUR},
+            ),
+        )
+        unattach = await trigger.async_attach_runner(lambda *_args: None)
+        order.clear()
+
+        # A second entity joins, so the listeners are swapped for a wider set.
+        second = entity_registry.async_get_or_create("sensor", "demo", "second")
+        entity_registry.async_update_entity(second.entity_id, area_id=area.id)
+        await hass.async_block_till_done()
+
+        assert order == ["subscribe", "unsubscribe"], order
+
+        unattach()
+
+
 async def test_it_fires_once_an_entity_falls_silent(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,

--- a/tests/ectoplasms/spook/triggers/test_stale.py
+++ b/tests/ectoplasms/spook/triggers/test_stale.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
+from homeassistant.helpers import event as event_helpers
+from homeassistant.helpers.trigger import TriggerConfig
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
@@ -25,6 +28,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 AN_HOUR = timedelta(hours=1)
+STALE_MODULE = "custom_components.spook.ectoplasms.spook.triggers.stale"
 
 
 async def _automation(hass: HomeAssistant, target: dict, duration: str) -> list[dict]:
@@ -114,6 +118,78 @@ async def test_a_zero_duration_is_refused(
             hass,
             {"target": {"entity_id": "sensor.probe"}, "options": {"for": duration}},
         )
+
+
+@pytest.mark.parametrize(
+    "target",
+    [{}, {"entity_id": []}, {"area_id": None}, {"entity_id": [], "area_id": []}],
+)
+async def test_a_target_that_names_nothing_is_refused(
+    hass: HomeAssistant,
+    target: dict,
+) -> None:
+    """An empty target would load and then watch nothing at all.
+
+    Every one of these passes the field validation happily, which is why it
+    takes a check of its own. Core's target tracking helper raises on the
+    same thing.
+    """
+    with pytest.raises(vol.Invalid, match="must name at least one"):
+        await SpookTrigger.async_validate_config(
+            hass, {"target": target, "options": {"for": {"hours": 1}}}
+        )
+
+
+async def test_registry_churn_elsewhere_leaves_the_listeners_alone(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry,  # noqa: ANN001
+    entity_registry,  # noqa: ANN001
+) -> None:
+    """Registry traffic that does not move this target rebuilds nothing.
+
+    Core's tracker re-expands the target on every entity, device and area
+    registry event anywhere in the system. Rebuilding both write listeners on
+    each of those is work for nothing, and there is a lot of nothing.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+
+    area = area_registry.async_create("Attic")
+    watched = entity_registry.async_get_or_create("sensor", "demo", "watched")
+    entity_registry.async_update_entity(watched.entity_id, area_id=area.id)
+    hass.states.async_set(watched.entity_id, "21.5")
+    await hass.async_block_till_done()
+
+    builds = 0
+    real_tracker = event_helpers.async_track_state_change_event
+
+    def _counting(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        nonlocal builds
+        builds += 1
+        return real_tracker(*args, **kwargs)
+
+    with patch(f"{STALE_MODULE}.async_track_state_change_event", _counting):
+        trigger = SpookTrigger(
+            hass,
+            TriggerConfig(
+                key="spook.stale",
+                target={"area_id": area.id},
+                options={"for": AN_HOUR},
+            ),
+        )
+        unattach = await trigger.async_attach_runner(lambda *_args: None)
+        at_attach = builds
+
+        for index in range(20):
+            entity_registry.async_get_or_create("sensor", "demo", f"unrelated-{index}")
+            await hass.async_block_till_done()
+
+        unattach()
+
+    assert at_attach == 1
+    assert builds == at_attach, (
+        f"rebuilt the listeners {builds - at_attach} times for nothing"
+    )
 
 
 async def test_it_fires_once_an_entity_falls_silent(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `spook.stale` trigger, which fires when nothing has written to an entity for a while.

```yaml
trigger: spook.stale
target:
  area_id: attic
options:
  for: "01:00:00"
```

It watches `last_reported`, so it looks for silence rather than for a value. An entity that keeps reporting the same reading is alive and is left alone; one that stops reporting altogether fires after the configured duration. A target can name entities, devices, areas, floors or labels, and each entity that falls silent fires on its own.

When it fires, `trigger.entity_id` names the entity, `trigger.last_reported` is when it last spoke, and `trigger.for` is the configured duration.

Three decisions worth calling out, since they are the ones that shape the behaviour:

- **Entities already silent when the trigger starts watching are left alone.** Only silence that falls while the automation is loaded counts. Without that, reloading your automations replays everything that has gone quiet since, which is noise rather than news.
- **A duration of zero is refused.** It would put the deadline on the moment the entity last spoke, which is always in the past, so the trigger would load and then do nothing at all. That is exactly the kind of silent no-op nobody ever traces back.
- **The tracker builds on core's `TargetEntityChangeTracker`.** Registry listening and target re-expansion come from there. Keeping the per-entity timers and the write listeners in step with a changing target is what this adds.

One implementation note: a write that changes the state and a write that does not are two different events in Home Assistant (`EVENT_STATE_CHANGED` and `EVENT_STATE_REPORTED`), and only both of them together add up to "something wrote to this entity". Both are listened for.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Home Assistant will tell you an entity went unavailable. Plenty of things die without ever saying so: an integration that quietly stopped polling, a battery device that dropped off the network, an MQTT topic nobody publishes to any more. The state sits there looking perfectly healthy, holding a reading from last Tuesday, and nothing anywhere says otherwise.

There is no way to ask about that today. A template on `last_reported` gets you part-way, but it needs a polling automation per entity and cannot follow an area.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Fourteen new tests, on top of the existing suite (961 pass).

Rather than assume the tests were doing their job, I broke the trigger seven different ways and checked each one is caught:

| Deliberate defect | Caught |
| --- | --- |
| No state-report listener | yes |
| No state-change listener | yes |
| Keyed on `last_changed` instead of `last_reported` | yes |
| Fires for entities already silent at attach | yes |
| Never re-aims when the target changes | yes |
| Reports the noticing time instead of the deadline | yes |
| Leaves timers running for entities that left the target | yes |

The last two only showed up because of that pass; the first round of tests missed them. The `last_changed` case is the one that matters most: keyed on it, a sensor that repeats the same reading for hours has its deadline pinned to the one time the value moved, slides into the past, and is never watched again, so it could die and nothing would ever say so.

The firing tests turn the automation off afterwards, so the harness' lingering-timer and listener checks double as proof the trigger clears up after itself.

Also ran: `ruff check`, `ruff format --check`, `pylint` over the whole tree, `zizmor`, and the full pre-commit set. The documentation builds with the same warnings as `main`, no more (built both and diffed the warning sets), and the rendered page was checked for the admonitions and tables actually landing.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
