### PR TITLE
Add a spook.integration_failed trigger

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/integration_failed.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/integration_failed.py
@@ -58,10 +58,11 @@ IN_BETWEEN_STATES = frozenset(
 
 
 def _broken_period(value: Any) -> timedelta:
-    """Validate the duration, and refuse one that can never elapse.
+    """Validate the duration, and refuse one that leaves nothing to settle.
 
-    Zero would put the deadline in the past, so the trigger would load and
-    then never fire, which is worse than saying no.
+    A deadline of now fires straight away, so zero would report every failure
+    the instant it happened. That is the flapping this trigger exists to sit
+    out: one device off overnight would report itself about fifty times.
     """
     duration = cv.positive_time_period(value)
     if duration <= timedelta(0):

--- a/custom_components/spook/ectoplasms/spook/triggers/integration_failed.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/integration_failed.py
@@ -1,0 +1,282 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from functools import partial
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    SIGNAL_CONFIG_ENTRY_CHANGED,
+    ConfigEntryState,
+)
+from homeassistant.const import CONF_FOR, CONF_OPTIONS
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
+    from homeassistant.config_entries import ConfigEntry, ConfigEntryChange
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_ENTRY_ID = "entry_id"
+
+# The states that mean setting up went wrong.
+FAILED_STATES = frozenset(
+    {
+        ConfigEntryState.SETUP_ERROR,
+        ConfigEntryState.SETUP_RETRY,
+        ConfigEntryState.MIGRATION_ERROR,
+        ConfigEntryState.FAILED_UNLOAD,
+    }
+)
+
+# Not a failure, but not a recovery either. An entry that keeps retrying passes
+# through this on every attempt, so treating it as recovery would restart the
+# clock every time and nothing would ever be reported as broken for long.
+IN_BETWEEN_STATES = frozenset(
+    {
+        ConfigEntryState.SETUP_IN_PROGRESS,
+        ConfigEntryState.UNLOAD_IN_PROGRESS,
+    }
+)
+
+
+def _broken_period(value: Any) -> timedelta:
+    """Validate the duration, and refuse one that can never elapse.
+
+    Zero would put the deadline in the past, so the trigger would load and
+    then never fire, which is worse than saying no.
+    """
+    duration = cv.positive_time_period(value)
+    if duration <= timedelta(0):
+        message = "The duration must be longer than zero"
+        raise vol.Invalid(message)
+    return duration
+
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_FOR): _broken_period,
+            vol.Optional(CONF_ENTRY_ID): vol.All(cv.ensure_list, [cv.string]),
+        },
+    }
+)
+
+
+@dataclass
+class _Trouble:
+    """What is known about one config entry's current spell of trouble.
+
+    The state and reason are kept up to date on every failed attempt, because
+    the entry may well be mid-retry by the time the wait runs out, and
+    `setup_in_progress` with nothing attached is no answer to what went wrong.
+    """
+
+    state: ConfigEntryState
+    reason: str | None
+    wait: CALLBACK_TYPE | None = None
+    reported: bool = False
+
+
+# Everything here is driven by the dispatcher or by a timer, so there is
+# nothing public to count.
+# pylint: disable-next=too-few-public-methods
+class _FailedEntryTracker:
+    """Follow config entries and report the ones that stay broken.
+
+    One dispatcher subscription covers every entry, including ones added
+    later: Home Assistant sends `SIGNAL_CONFIG_ENTRY_CHANGED` on every state
+    change a config entry makes.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        duration: timedelta,
+        entry_ids: set[str] | None,
+        on_failed: Callable[[ConfigEntry, ConfigEntryState, str | None], None],
+    ) -> None:
+        """Initialize the tracker."""
+        self._hass = hass
+        self._duration = duration
+        self._entry_ids = entry_ids
+        self._on_failed = on_failed
+        self._troubles: dict[str, _Trouble] = {}
+        self._unsub_signal: CALLBACK_TYPE | None = None
+
+    @callback
+    def async_setup(self) -> CALLBACK_TYPE:
+        """Start watching, and return the way to stop."""
+        # Entries that are already broken are picked up too. One stuck in
+        # `SETUP_ERROR` never announces itself again, so waiting for a change
+        # would mean never hearing about the entries that broke before this
+        # automation loaded, which are the ones worth hearing about.
+        for entry in self._hass.config_entries.async_entries():
+            if entry.state in FAILED_STATES and self._is_watched(entry):
+                self._note_trouble(entry)
+
+        self._unsub_signal = async_dispatcher_connect(
+            self._hass, SIGNAL_CONFIG_ENTRY_CHANGED, self._entry_changed
+        )
+        return self._unsubscribe
+
+    def _is_watched(self, entry: ConfigEntry) -> bool:
+        """Return whether this entry is one of the ones asked about."""
+        return self._entry_ids is None or entry.entry_id in self._entry_ids
+
+    @callback
+    def _entry_changed(
+        self,
+        _change: ConfigEntryChange,
+        entry: ConfigEntry,
+    ) -> None:
+        """Follow one config entry through its states.
+
+        Removal needs no case of its own: an entry passes through
+        `not_loaded` on its way out, which is already a recovery as far as
+        this is concerned, so the wait is dropped there.
+        """
+        if not self._is_watched(entry):
+            return
+
+        if entry.state in FAILED_STATES:
+            self._note_trouble(entry)
+        elif entry.state not in IN_BETWEEN_STATES:
+            self._forget(entry.entry_id)
+
+    @callback
+    def _note_trouble(self, entry: ConfigEntry) -> None:
+        """Record this failure, and start counting if nothing is counting yet.
+
+        Already reported counts as counted: one report per spell of trouble.
+        A failing entry announces itself on every retry, and starting a fresh
+        wait on each of those would turn this into a quarter-hourly nag until
+        somebody got round to fixing it.
+        """
+        if (trouble := self._troubles.get(entry.entry_id)) is None:
+            trouble = _Trouble(entry.state, entry.reason)
+            self._troubles[entry.entry_id] = trouble
+        else:
+            trouble.state = entry.state
+            trouble.reason = entry.reason
+
+        if trouble.wait is not None or trouble.reported:
+            return
+
+        trouble.wait = async_track_point_in_time(
+            self._hass,
+            partial(self._still_broken, entry),
+            dt_util.utcnow() + self._duration,
+        )
+
+    @callback
+    def _still_broken(self, entry: ConfigEntry, _fired_at: datetime) -> None:
+        """Report an entry that has been unable to set up all this time."""
+        if (trouble := self._troubles.get(entry.entry_id)) is None:
+            return
+
+        trouble.wait = None
+        trouble.reported = True
+        self._on_failed(entry, trouble.state, trouble.reason)
+
+    @callback
+    def _forget(self, entry_id: str) -> None:
+        """Drop everything held about one entry: it is out of trouble."""
+        if (trouble := self._troubles.pop(entry_id, None)) is None:
+            return
+
+        if trouble.wait is not None:
+            trouble.wait()
+
+    @callback
+    def _unsubscribe(self) -> None:
+        """Stop watching, and drop every pending wait."""
+        if self._unsub_signal is not None:
+            self._unsub_signal()
+            self._unsub_signal = None
+
+        for entry_id in list(self._troubles):
+            self._forget(entry_id)
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when an integration stays broken.
+
+    Home Assistant retries a config entry that fails to set up, with a backoff
+    that tops out at ten minutes. A device that is off overnight therefore
+    lands in the failed state dozens of times before morning, so a trigger
+    that fired on every one of those would be useless. This one waits: it
+    fires only once an entry has been unable to set up for the whole duration,
+    which is also long enough for the ordinary failures at start-up to sort
+    themselves out.
+    """
+
+    trigger = "integration_failed"
+
+    _duration: timedelta
+    _entry_ids: set[str] | None
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        return _TRIGGER_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._duration = options[CONF_FOR]
+        entry_ids = options.get(CONF_ENTRY_ID)
+        self._entry_ids = set(entry_ids) if entry_ids else None
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def entry_stayed_broken(
+            entry: ConfigEntry,
+            state: ConfigEntryState,
+            reason: str | None,
+        ) -> None:
+            """Run the action for the entry that could not set itself up."""
+            run_action(
+                {
+                    "entry_id": entry.entry_id,
+                    "domain": entry.domain,
+                    "title": entry.title,
+                    "state": state.value,
+                    "reason": reason,
+                    "for": self._duration,
+                },
+                f"{entry.title} ({entry.domain}) failed for {self._duration}",
+            )
+
+        tracker = _FailedEntryTracker(
+            self._hass, self._duration, self._entry_ids, entry_stayed_broken
+        )
+        return tracker.async_setup()

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -10,6 +10,20 @@
         }
       }
     },
+    "integration_failed": {
+      "name": "Integration failed to set up",
+      "description": "Fires when a configuration entry has been unable to set itself up for a while, past the point where Home Assistant's own retries would have sorted it out.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "How long an entry has to keep failing before this fires. Home Assistant retries a failing entry every ten minutes at the slowest, so anything shorter than that reports trouble that may still fix itself."
+        },
+        "entry_id": {
+          "name": "Entries",
+          "description": "Limit this to particular configuration entries. Leave it empty to watch every one of them."
+        }
+      }
+    },
     "stale": {
       "name": "Entity fell silent",
       "description": "Fires when nothing has written to an entity for a while, which catches a device that died quietly rather than going unavailable.",

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -15,3 +15,16 @@ stale:
       example: "01:00:00"
       selector:
         duration:
+
+integration_failed:
+  fields:
+    for:
+      required: true
+      example: "00:15:00"
+      selector:
+        duration:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+      multiple: true

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -27,4 +27,3 @@ integration_failed:
       required: false
       selector:
         config_entry:
-      multiple: true

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -242,6 +242,78 @@ options:
 
 :::
 
+### Integration failed to set up
+
+Fires when a configuration entry has been unable to set itself up for a while.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Integration failed to set up 👻
+* - Trigger name
+  - `spook.integration_failed`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `for`
+  - {term}`string <string>`
+  - Yes
+  - `00:15:00`
+* - `entry_id`
+  - {term}`string <string>` | {term}`list of strings <list>`
+  - No
+  - Every configuration entry
+```
+
+An integration that cannot reach its hardware fails to set up, and Home Assistant keeps retrying it on a backoff that tops out at ten minutes. A device switched off overnight therefore fails dozens of times before morning, which is why this trigger waits rather than firing on each attempt. Set `for` to how long you are willing to let something be broken before you want to hear about it, and the ordinary hiccups at start-up sort themselves out well inside it.
+
+Every configuration entry is watched unless you name some in `entry_id`. Each one is reported on its own, and only once per spell of trouble: an entry has to come back before it can be reported again.
+
+When it fires, `trigger.domain` is the integration, `trigger.title` the name of the entry, `trigger.entry_id` its identifier, `trigger.state` the state it is stuck in, and `trigger.reason` whatever Home Assistant recorded about why.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Anything at all that has been broken for a quarter of an hour:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.integration_failed
+options:
+  for: "00:15:00"
+```
+
+One entry you care about more than the rest, with a shorter fuse:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.integration_failed
+options:
+  for: "00:05:00"
+  entry_id: 01JQ8XW3M4YPKZ7N2VRTGH6BDC
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- The states that count as failure are `setup_error`, `setup_retry`, `migration_error` and `failed_unload`. An entry you disabled yourself sits in `not_loaded` and is not a failure.
+- A duration of zero is refused. It would put the deadline in the past, so the trigger would load and never fire.
+- Reloading your automations starts the clock again for anything broken at that moment. That is on purpose: an entry stuck in `setup_error` never announces itself a second time, so waiting for a change would mean never hearing about whatever was already broken.
+- One report per spell of trouble. If you want to be nagged until somebody fixes it, repeat the action yourself.
+
+:::
+
 ## Conditions
 
 Spook offers the following conditions that are not tied to a specific integration:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -278,7 +278,7 @@ An integration that cannot reach its hardware fails to set up, and Home Assistan
 
 Every configuration entry is watched unless you name some in `entry_id`. Each one is reported on its own, and only once per spell of trouble: an entry has to come back before it can be reported again.
 
-When it fires, `trigger.domain` is the integration, `trigger.title` the name of the entry, `trigger.entry_id` its identifier, `trigger.state` the state it is stuck in, and `trigger.reason` whatever Home Assistant recorded about why.
+When it fires, `trigger.domain` is the integration, `trigger.title` the name of the entry, `trigger.entry_id` its identifier, `trigger.state` the state it is stuck in, `trigger.reason` whatever Home Assistant recorded about why, and `trigger.for` the duration you configured.
 
 :::{seealso} Example trigger in {term}`YAML`
 :class: dropdown
@@ -308,7 +308,7 @@ options:
 :class: dropdown
 
 - The states that count as failure are `setup_error`, `setup_retry`, `migration_error` and `failed_unload`. An entry you disabled yourself sits in `not_loaded` and is not a failure.
-- A duration of zero is refused. It would put the deadline in the past, so the trigger would load and never fire.
+- A duration of zero is refused. A deadline of now fires straight away, so zero would report every failure the moment it happened, which is the flapping this trigger exists to sit out.
 - Reloading your automations starts the clock again for anything broken at that moment. That is on purpose: an entry stuck in `setup_error` never announces itself a second time, so waiting for a change would mean never hearing about whatever was already broken.
 - One report per spell of trouble. If you want to be nagged until somebody fixes it, repeat the action yourself.
 

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -20,3 +20,9 @@ Fires on a crontab schedule, for the times Home Assistant's own time triggers ca
 Fires when nothing has written to an entity for a while, which catches the device that died quietly instead of going unavailable. _#stale_ _#silent_ _#dead_
 
 `spook.stale`, [documentation](other-features#entity-fell-silent) 📚
+
+## Integration failed to set up
+
+Fires when a configuration entry has been unable to set itself up for a while, past the point where Home Assistant's own retries would have sorted it out. _#integration_ _#broken_ _#config-entry_
+
+`spook.integration_failed`, [documentation](other-features#integration-failed-to-set-up) 📚

--- a/tests/ectoplasms/spook/triggers/test_integration_failed.py
+++ b/tests/ectoplasms/spook/triggers/test_integration_failed.py
@@ -1,0 +1,499 @@
+"""Tests for the spook.integration_failed trigger."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers.integration_failed import (
+    SpookTrigger,
+)
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+TWO_SPELLS = 2
+
+
+def _entry(
+    hass: HomeAssistant, domain: str = "demo", title: str = "Demo"
+) -> MockConfigEntry:
+    """Add a config entry that is loaded and happy."""
+    entry = MockConfigEntry(domain=domain, title=title)
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    return entry
+
+
+async def _automation(hass: HomeAssistant, options: dict) -> list[dict]:
+    """Set up an automation on the trigger and record every run."""
+    ran: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "integration broke",
+                    "trigger": {
+                        "platform": "spook.integration_failed",
+                        "options": options,
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {
+                                "domain": "{{ trigger.domain }}",
+                                "state": "{{ trigger.state }}",
+                                "reason": "{{ trigger.reason }}",
+                            },
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return ran
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger."""
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.integration_broke"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "integration_failed" in await async_get_triggers(hass)
+
+
+async def test_a_duration_is_required(hass: HomeAssistant) -> None:
+    """Without a duration there is no telling when trouble counts."""
+    with pytest.raises(vol.Invalid):
+        await SpookTrigger.async_validate_config(hass, {"options": {}})
+
+
+async def test_a_zero_duration_is_refused(hass: HomeAssistant) -> None:
+    """Zero would put the deadline in the past, so it would never fire."""
+    with pytest.raises(vol.Invalid, match="longer than zero"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"for": {"minutes": 0}}}
+        )
+
+
+async def test_it_fires_once_an_entry_stays_broken(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An entry that cannot set itself up for the whole duration is reported."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=14))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert not ran
+
+    freezer.tick(timedelta(minutes=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    assert ran[0]["domain"] == "demo"
+    assert ran[0]["state"] == "setup_retry"
+    assert ran[0]["reason"] == "no route to host"
+
+    await _detach(hass)
+
+
+async def test_a_retry_cycle_does_not_restart_the_clock(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Retrying passes through `setup_in_progress`, which is not recovery.
+
+    Home Assistant retries a failing entry on a backoff that tops out at ten
+    minutes, and every attempt walks `setup_retry` to `setup_in_progress` and
+    back. Counting that as recovery would reset the clock forever and nothing
+    would ever be reported.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    await hass.async_block_till_done()
+
+    # Three retries along the way, none of which get anywhere.
+    for _ in range(3):
+        freezer.tick(timedelta(minutes=4))
+        entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
+        entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "still no route")
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=4))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1, "the retry cycle kept resetting the clock"
+
+    await _detach(hass)
+
+
+async def test_it_reports_the_failure_not_the_retry_in_progress(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The clock can run out mid-attempt, and `setup_in_progress` is no answer.
+
+    A retrying entry is in `setup_in_progress` for the moment each attempt
+    takes, with no reason attached. Reporting that would hand somebody a
+    notification saying an integration is broken and then failing to say how.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=16))
+    entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    assert ran[0]["state"] == "setup_retry"
+    assert ran[0]["reason"] == "no route to host"
+
+    await _detach(hass)
+
+
+async def test_an_entry_that_recovers_in_time_is_not_reported(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Trouble that sorts itself out is not trouble worth waking up for."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "hub still booting")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=5))
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not ran
+
+    await _detach(hass)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        ConfigEntryState.SETUP_ERROR,
+        ConfigEntryState.SETUP_RETRY,
+        ConfigEntryState.MIGRATION_ERROR,
+        ConfigEntryState.FAILED_UNLOAD,
+    ],
+)
+async def test_every_failed_state_counts(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    state: ConfigEntryState,
+) -> None:
+    """All four ways an entry can be broken are reported.
+
+    `setup_retry` is the everyday one, but an entry can also fail outright,
+    fail to migrate, or refuse to unload, and none of those fix themselves.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, state, "something went wrong")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=16))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1, f"{state.value} went unreported"
+    assert ran[0]["state"] == state.value
+
+    await _detach(hass)
+
+
+@pytest.mark.parametrize(
+    "state", [ConfigEntryState.LOADED, ConfigEntryState.NOT_LOADED]
+)
+async def test_a_healthy_state_is_not_a_failure(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    state: ConfigEntryState,
+) -> None:
+    """Loaded is fine, and an entry you disabled yourself is fine too."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, state)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(hours=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not ran
+
+    await _detach(hass)
+
+
+async def test_the_latest_reason_is_the_one_reported(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Retries can say something more useful than the first attempt did.
+
+    A hub coming up gives "connection refused" and then, once it answers,
+    "invalid credentials". Reporting the first one would send somebody looking
+    at their network when the problem is their password.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "connection refused")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=5))
+    entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "invalid credentials")
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=11))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    assert ran[0]["reason"] == "invalid credentials", "reported a stale reason"
+
+    await _detach(hass)
+
+
+async def test_it_fires_only_once_per_spell_of_trouble(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """One report per breakage, not one per retry."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    await hass.async_block_till_done()
+
+    for _ in range(6):
+        freezer.tick(timedelta(minutes=10))
+        entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
+        entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert len(ran) == 1, f"reported {len(ran)} times for one spell of trouble"
+
+    await _detach(hass)
+
+
+async def test_a_second_spell_of_trouble_is_reported_again(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """One report per spell, but a new spell is a new report.
+
+    The other half of the once-only rule: an entry that recovers and then
+    breaks again has to be heard from, or the trigger goes quiet for good
+    after the first time it ever fires.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(minutes=16))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(ran) == 1
+
+    # It comes back, and stays up for a while.
+    entry.mock_state(hass, ConfigEntryState.LOADED)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(hours=2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert len(ran) == 1
+
+    # And then it goes again.
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(minutes=16))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == TWO_SPELLS, (
+        "went quiet after the first report and never came back"
+    )
+
+    await _detach(hass)
+
+
+async def test_an_entry_already_broken_is_picked_up(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Breakage from before the automation loaded still counts.
+
+    An entry stuck in `setup_error` never announces itself again, so waiting
+    for a change would mean never hearing about it.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+    entry.mock_state(hass, ConfigEntryState.SETUP_ERROR, "bad credentials")
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    freezer.tick(timedelta(minutes=16))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    assert ran[0]["state"] == "setup_error"
+
+    await _detach(hass)
+
+
+async def test_a_removed_entry_is_forgotten(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Deleting a broken integration is a fix, not a failure."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    entry = _entry(hass)
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=5))
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not ran, "reported an entry that had been deleted"
+
+    await _detach(hass)
+
+
+async def test_only_the_named_entries_are_watched(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Naming entries limits it to those, and leaves the rest alone."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    watched = _entry(hass, domain="alarm", title="Alarm")
+    ignored = _entry(hass, domain="doorbell", title="Doorbell")
+
+    ran = await _automation(hass, {"for": "00:15:00", "entry_id": [watched.entry_id]})
+
+    ignored.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    watched.mock_state(hass, ConfigEntryState.SETUP_RETRY, "panel unreachable")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=16))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert [run["domain"] for run in ran] == ["alarm"]
+
+    await _detach(hass)
+
+
+async def test_every_entry_is_watched_when_none_are_named(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Leaving the filter out watches the lot, each reported on its own."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    first = _entry(hass, domain="alarm", title="Alarm")
+    second = _entry(hass, domain="doorbell", title="Doorbell")
+
+    ran = await _automation(hass, {"for": "00:15:00"})
+
+    first.mock_state(hass, ConfigEntryState.SETUP_RETRY, "panel unreachable")
+    second.mock_state(hass, ConfigEntryState.SETUP_RETRY, "no route to host")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=16))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert sorted(run["domain"] for run in ran) == ["alarm", "doorbell"]
+
+    await _detach(hass)

--- a/tests/ectoplasms/spook/triggers/test_integration_failed.py
+++ b/tests/ectoplasms/spook/triggers/test_integration_failed.py
@@ -104,7 +104,12 @@ async def test_a_duration_is_required(hass: HomeAssistant) -> None:
 
 
 async def test_a_zero_duration_is_refused(hass: HomeAssistant) -> None:
-    """Zero would put the deadline in the past, so it would never fire."""
+    """Zero reports every failure the instant it happens.
+
+    A deadline of now fires straight away rather than being skipped, so this
+    is not a trigger that would sit there doing nothing: it is one that would
+    report an offline device about fifty times a night.
+    """
     with pytest.raises(vol.Invalid, match="longer than zero"):
         await SpookTrigger.async_validate_config(
             hass, {"options": {"for": {"minutes": 0}}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `spook.integration_failed` trigger, which fires when a configuration entry has been unable to set itself up for a while.

```yaml
trigger: spook.integration_failed
options:
  for: "00:15:00"
```

Every configuration entry is watched unless some are named in `entry_id`. Each one is reported on its own, and only once per spell of trouble: an entry has to come back before it can be reported again.

When it fires, `trigger.domain` is the integration, `trigger.title` the name of the entry, `trigger.entry_id` its identifier, `trigger.state` the state it is stuck in, and `trigger.reason` whatever Home Assistant recorded about why.

### Why there is a required `for`

Measured rather than assumed. Home Assistant retries a failing entry on `min(2**tries * 5, 600)` seconds, so the backoff runs 5, 10, 20, 40, 80, 160, 320 and then every ten minutes. A device switched off overnight puts its entry into the failed state roughly 55 times before morning. A trigger that fired on each of those would be unusable, so `for` is required and there is no way to ask for zero.

The duration also absorbs the ordinary start-up failures, where a hub is not answering yet and the entry sorts itself out within a minute.

### The retry cycle is not a recovery

Each retry walks the entry `setup_retry` → `setup_in_progress` → `setup_retry`. My first guess was that firing only on a transition from a healthy state would be enough; it is not, because `setup_in_progress` is not a failed state. It is treated as "still broken" rather than as recovery, otherwise the clock resets on every attempt and nothing is ever reported.

### Implementation notes

- **One dispatcher subscription covers everything.** `ConfigEntry._async_set_state` sends `SIGNAL_CONFIG_ENTRY_CHANGED` on every state change a config entry makes, so there is no need for a per-entry `async_on_state_change` and no bookkeeping for entries added later.
- **Entries already broken at attach are picked up.** An entry stuck in `setup_error` never announces itself again, so waiting for a change would mean never hearing about whatever was already broken. The trade-off is that reloading your automations restarts the clock for those; that is documented.
- **The reported failure is the failure, not whatever is happening at that instant.** The clock can run out while a retry attempt is under way, and reporting `setup_in_progress` with no reason attached would hand somebody a notification saying an integration is broken while failing to say how. The last seen failed state and reason are kept, and refreshed on each attempt, so a hub that says "connection refused" and later "invalid credentials" reports the second one.
- **There is deliberately no case for `ConfigEntryChange.REMOVED`.** An entry passes through `not_loaded` on its way out, which already drops the wait. I checked this for entries removed from `setup_retry` and from `setup_error`, and both dispatch `updated:not_loaded` before `removed`. The branch was written, found to be unreachable, and deleted rather than left as code no test can enter.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

An integration can be broken for days without anything telling you. There is a repair issue and a red card on the integrations page, but nothing you can hang an automation off, so you find out when you notice a room has stopped responding.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Sixteen new tests, on top of the existing suite (989 pass).

The trigger was then broken twelve different ways to check the tests actually earn their place:

| Deliberate defect | Caught |
| --- | --- |
| `setup_in_progress` counted as recovery | yes |
| Re-arms after reporting, so it nags every duration | yes |
| Recovery does not clear the reported mark | yes |
| Reports the live state instead of the failure | yes |
| The failure state and reason are never refreshed | yes |
| Entries already broken at attach are ignored | yes |
| The `entry_id` filter is ignored | yes |
| `failed_unload` not treated as a failure | yes |
| `migration_error` not treated as a failure | yes |
| `not_loaded` treated as a failure | yes |
| A zero duration is accepted | yes |
| A missing duration is accepted | yes |

Three of those defects were mine, found by the sweep rather than by reading: the nagging, the mid-retry payload, and the stale reason. Two coverage gaps came out of it too, which is why `failed_unload`, `migration_error` and the reason-refreshing now have tests of their own.

The firing tests turn the automation off afterwards, so the harness' lingering-timer and listener checks double as proof the trigger clears up after itself.

Also ran: `ruff check`, `ruff format --check`, `pylint` over the whole tree, `zizmor`, and the full pre-commit set. The documentation builds with the same warnings as `main`, no more (built both and diffed the warning sets), and the rendered page was checked for the tables and admonitions actually landing.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
