### PR TITLE
Add a spook.triggered_by_automation condition

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers import issue_registry as ir
 
+from .automation_runs import async_setup_automation_runs
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .entity_filtering import async_setup_all_entity_ids_cache_invalidation
 from .integration_linking import link_sub_integrations, unlink_sub_integrations
@@ -108,6 +109,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Set up the all entity ids cache invalidation
     entry.async_on_unload(async_setup_all_entity_ids_cache_invalidation(hass))
+
+    # Start noting which automation runs under which context. It has to begin
+    # here rather than when a condition first asks: a condition inside an
+    # action sequence is only built once that sequence runs, by which point
+    # the automation it wants to know about has already been and gone.
+    entry.async_on_unload(async_setup_automation_runs(hass))
 
     # Yay, we didn't got spooked!
     return True

--- a/custom_components/spook/automation_runs.py
+++ b/custom_components/spook/automation_runs.py
@@ -31,6 +31,12 @@ class AutomationRuns:
     The context an automation runs under is the same one its actions write
     with, and it survives a script in between, so an automation reacting to
     that change finds it on `trigger.to_state.context`.
+
+    Listening starts when Spook does, not when a condition first asks. A
+    condition sitting inside an action sequence is only built once that
+    sequence runs, which is after the automation announced itself, so a
+    register that started then would have missed the very run being asked
+    about and would answer "no" to everything.
     """
 
     def __init__(self, hass: HomeAssistant) -> None:
@@ -38,26 +44,23 @@ class AutomationRuns:
         self._hass = hass
         self._by_context_id: LRU = LRU(CACHE_SIZE)
         self._unsub: CALLBACK_TYPE | None = None
-        self._users = 0
 
     @callback
-    def async_acquire(self) -> None:
-        """Start listening, if nobody was listening yet."""
-        self._users += 1
+    def async_start(self) -> CALLBACK_TYPE:
+        """Start listening, and return the way to stop."""
         if self._unsub is None:
             self._unsub = self._hass.bus.async_listen(
                 EVENT_AUTOMATION_TRIGGERED, self._async_automation_ran
             )
+        return self.async_stop
 
     @callback
-    def async_release(self) -> None:
-        """Stop listening once the last user is done."""
-        self._users = max(0, self._users - 1)
-        if self._users or self._unsub is None:
-            return
+    def async_stop(self) -> None:
+        """Stop listening and let go of what was remembered."""
+        if self._unsub is not None:
+            self._unsub()
+            self._unsub = None
 
-        self._unsub()
-        self._unsub = None
         self._by_context_id.clear()
 
     @callback
@@ -74,8 +77,15 @@ class AutomationRuns:
 
 @callback
 def async_get_automation_runs(hass: HomeAssistant) -> AutomationRuns:
-    """Return the shared register, making it if this is the first ask."""
+    """Return the shared register, starting it if this is the first ask."""
     if (runs := hass.data.get(DATA_AUTOMATION_RUNS)) is None:
         runs = AutomationRuns(hass)
         hass.data[DATA_AUTOMATION_RUNS] = runs
+        runs.async_start()
     return runs
+
+
+@callback
+def async_setup_automation_runs(hass: HomeAssistant) -> CALLBACK_TYPE:
+    """Start remembering automation runs, and return the way to stop."""
+    return async_get_automation_runs(hass).async_start()

--- a/custom_components/spook/conditions.yaml
+++ b/custom_components/spook/conditions.yaml
@@ -27,3 +27,12 @@ cooldown:
       example: "00:05:00"
       selector:
         duration:
+triggered_by_automation:
+  fields:
+    automation:
+      required: false
+      example: automation.goodnight
+      selector:
+        entity:
+          domain: automation
+          multiple: true

--- a/custom_components/spook/ectoplasms/spook/automation_runs.py
+++ b/custom_components/spook/ectoplasms/spook/automation_runs.py
@@ -1,0 +1,81 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lru import LRU
+
+from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import callback
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+
+DATA_AUTOMATION_RUNS: HassKey[AutomationRuns] = HassKey("spook_automation_runs")
+
+# Every automation run adds an entry, and a busy house has plenty of them. The
+# answer is only ever wanted for a run that has just happened, a moment or two
+# ago at most, so the oldest can be dropped without losing anything anybody
+# would ask about.
+CACHE_SIZE = 512
+
+
+class AutomationRuns:
+    """Remembers which automation started the run behind a context.
+
+    Home Assistant does not resolve a context back to whatever created it, so
+    this listens for automations announcing themselves and keeps the mapping.
+    The context an automation runs under is the same one its actions write
+    with, and it survives a script in between, so an automation reacting to
+    that change finds it on `trigger.to_state.context`.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the register."""
+        self._hass = hass
+        self._by_context_id: LRU = LRU(CACHE_SIZE)
+        self._unsub: CALLBACK_TYPE | None = None
+        self._users = 0
+
+    @callback
+    def async_acquire(self) -> None:
+        """Start listening, if nobody was listening yet."""
+        self._users += 1
+        if self._unsub is None:
+            self._unsub = self._hass.bus.async_listen(
+                EVENT_AUTOMATION_TRIGGERED, self._async_automation_ran
+            )
+
+    @callback
+    def async_release(self) -> None:
+        """Stop listening once the last user is done."""
+        self._users = max(0, self._users - 1)
+        if self._users or self._unsub is None:
+            return
+
+        self._unsub()
+        self._unsub = None
+        self._by_context_id.clear()
+
+    @callback
+    def async_which(self, context_id: str) -> str | None:
+        """Return the automation that ran under this context, if it is known."""
+        return self._by_context_id.get(context_id)  # type: ignore[no-any-return]
+
+    @callback
+    def _async_automation_ran(self, event: Event) -> None:
+        """Note the context an automation is running under."""
+        if entity_id := event.data.get(ATTR_ENTITY_ID):
+            self._by_context_id[event.context.id] = entity_id
+
+
+@callback
+def async_get_automation_runs(hass: HomeAssistant) -> AutomationRuns:
+    """Return the shared register, making it if this is the first ask."""
+    if (runs := hass.data.get(DATA_AUTOMATION_RUNS)) is None:
+        runs = AutomationRuns(hass)
+        hass.data[DATA_AUTOMATION_RUNS] = runs
+    return runs

--- a/custom_components/spook/ectoplasms/spook/conditions/triggered_by_automation.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/triggered_by_automation.py
@@ -1,0 +1,105 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.condition import Condition
+
+from ..automation_runs import async_get_automation_runs
+from ..context import source_contexts
+
+if TYPE_CHECKING:
+    from typing import Unpack
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.condition import ConditionCheckParams, ConditionConfig
+    from homeassistant.helpers.typing import ConfigType
+
+    from ..automation_runs import AutomationRuns
+
+CONF_AUTOMATION = "automation"
+
+_CONDITION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS, default=dict): {
+            vol.Optional(CONF_AUTOMATION): cv.entities_domain(AUTOMATION_DOMAIN),
+        },
+    }
+)
+
+
+class SpookCondition(Condition):
+    """Spook condition that passes when another automation set this run going.
+
+    Home Assistant gives an automation run its own context, and everything
+    that run writes carries it. So an automation reacting to a change another
+    automation made finds that context on its trigger, and it survives a
+    script in between.
+
+    What it cannot do is turn a context back into the automation that owns
+    it: nothing in Home Assistant keeps that. So this listens for automations
+    announcing themselves and remembers the mapping for the last few hundred
+    runs, which is plenty, since the run being asked about happened a moment
+    ago.
+
+    Can be narrowed to specific automations.
+    """
+
+    condition = "triggered_by_automation"
+
+    _automation_entity_ids: set[str] | None
+
+    # Core refuses to check a condition it has not set up, so by the time any
+    # check runs this is always there.
+    _runs: AutomationRuns
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the condition config."""
+        return _CONDITION_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Initialize the condition."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        automation = options.get(CONF_AUTOMATION)
+        if isinstance(automation, str):
+            # Config validation turns a single entity ID into a list, and a
+            # condition can be built from a config that never went through it.
+            automation = [automation]
+        self._automation_entity_ids = set(automation) if automation else None
+
+    async def _async_setup(self) -> None:
+        """Start remembering which automation runs under which context."""
+        self._runs = async_get_automation_runs(self._hass)
+        self._runs.async_acquire()
+
+    def _async_unload(self) -> None:
+        """Stop remembering, if nothing else still wants to know.
+
+        The register itself is left in place. Home Assistant does not stop
+        anybody checking a condition after unloading it, and a register that
+        has let go of its listener answers "no" rather than falling over.
+        """
+        self._runs.async_release()
+
+    def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:
+        """Return True when an automation started this run."""
+        for context in source_contexts(kwargs.get("variables")):
+            if (entity_id := self._runs.async_which(context.id)) is None:
+                continue
+            if self._automation_entity_ids is None:
+                return True
+            return entity_id in self._automation_entity_ids
+
+        return False

--- a/custom_components/spook/ectoplasms/spook/conditions/triggered_by_automation.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/triggered_by_automation.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_OPTIONS
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.condition import Condition
 
-from ..automation_runs import async_get_automation_runs
+from ....automation_runs import async_get_automation_runs
 from ..context import source_contexts
 
 if TYPE_CHECKING:
@@ -21,9 +21,29 @@ if TYPE_CHECKING:
     from homeassistant.helpers.condition import ConditionCheckParams, ConditionConfig
     from homeassistant.helpers.typing import ConfigType
 
-    from ..automation_runs import AutomationRuns
+    from ....automation_runs import AutomationRuns
 
 CONF_AUTOMATION = "automation"
+
+
+def _own_entity_id(variables: Any) -> str | None:
+    """Return the automation running right now, if this is inside one.
+
+    Wanted so it can be skipped. Inside an action sequence the run's own
+    context is in reach and the register knows it, so without this the
+    condition would report the automation asking the question as the one
+    that set it going, and would pass for a schedule or a person.
+    """
+    if not hasattr(variables, "get"):
+        return None
+
+    this = variables.get("this")
+    if not hasattr(this, "get"):
+        return None
+
+    entity_id = this.get("entity_id")
+    return entity_id if isinstance(entity_id, str) else None
+
 
 _CONDITION_SCHEMA = vol.Schema(
     {
@@ -43,10 +63,15 @@ class SpookCondition(Condition):
     script in between.
 
     What it cannot do is turn a context back into the automation that owns
-    it: nothing in Home Assistant keeps that. So this listens for automations
+    it: nothing in Home Assistant keeps that. So Spook listens for automations
     announcing themselves and remembers the mapping for the last few hundred
     runs, which is plenty, since the run being asked about happened a moment
     ago.
+
+    The automation doing the asking does not count as an answer. Put this
+    inside an action sequence and its own run is the nearest context in
+    reach, so without skipping it the condition would pass for a schedule or
+    a person just as readily.
 
     Can be narrowed to specific automations.
     """
@@ -80,26 +105,28 @@ class SpookCondition(Condition):
         self._automation_entity_ids = set(automation) if automation else None
 
     async def _async_setup(self) -> None:
-        """Start remembering which automation runs under which context."""
+        """Take hold of the register that knows which automation ran when."""
         self._runs = async_get_automation_runs(self._hass)
-        self._runs.async_acquire()
-
-    def _async_unload(self) -> None:
-        """Stop remembering, if nothing else still wants to know.
-
-        The register itself is left in place. Home Assistant does not stop
-        anybody checking a condition after unloading it, and a register that
-        has let go of its listener answers "no" rather than falling over.
-        """
-        self._runs.async_release()
 
     def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:
-        """Return True when an automation started this run."""
-        for context in source_contexts(kwargs.get("variables")):
-            if (entity_id := self._runs.async_which(context.id)) is None:
+        """Return True when another automation started this run."""
+        variables = kwargs.get("variables")
+        myself = _own_entity_id(variables)
+
+        for context in source_contexts(variables):
+            entity_id = self._runs.async_which(context.id)
+
+            # Keep looking rather than settling for the first answer. The
+            # nearest context inside an action sequence is this run's own, and
+            # a context that resolves to an automation nobody asked about says
+            # nothing about the ones further out.
+            if entity_id is None or entity_id == myself:
                 continue
-            if self._automation_entity_ids is None:
+
+            if (
+                self._automation_entity_ids is None
+                or entity_id in self._automation_entity_ids
+            ):
                 return True
-            return entity_id in self._automation_entity_ids
 
         return False

--- a/custom_components/spook/ectoplasms/spook/context.py
+++ b/custom_components/spook/ectoplasms/spook/context.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.core import Context
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-    from homeassistant.core import Context
 
 # Where a trigger keeps the context of the thing that set it off. A state
 # trigger carries the state it changed to; an event trigger carries the event.
@@ -47,12 +47,16 @@ def source_contexts(variables: Any) -> Iterator[Context]:
     all. What counts as an answer depends on the question: a user is named by
     ``user_id``, while which automation it was has to be looked up by
     ``id``, so the filtering is left to the caller.
+
+    Only real contexts come out. A rendered template hands over a state whose
+    context is a plain mapping rather than a ``Context``, and the callers here
+    read attributes off what they are given, so anything else is dropped.
     """
     if not hasattr(variables, "get"):
         return
 
     for context in _candidates(variables):
-        if context is not None:
+        if isinstance(context, Context):
             yield context
 
 

--- a/custom_components/spook/ectoplasms/spook/context.py
+++ b/custom_components/spook/ectoplasms/spook/context.py
@@ -40,6 +40,22 @@ def _candidates(variables: Any) -> Iterator[Any]:
         yield getattr(trigger.get(key), "context", None)
 
 
+def source_contexts(variables: Any) -> Iterator[Context]:
+    """Yield the contexts behind this run, nearest first.
+
+    Whatever set the run going is somewhere in here, if it can be known at
+    all. What counts as an answer depends on the question: a user is named by
+    ``user_id``, while which automation it was has to be looked up by
+    ``id``, so the filtering is left to the caller.
+    """
+    if not hasattr(variables, "get"):
+        return
+
+    for context in _candidates(variables):
+        if context is not None:
+            yield context
+
+
 def run_context(variables: Any) -> Context | None:
     """Return the context of whoever set this run going, if it can be known.
 
@@ -51,11 +67,8 @@ def run_context(variables: Any) -> Context | None:
     A context that exists but names nobody is the same answer as no context,
     so it is not worth telling them apart.
     """
-    if not hasattr(variables, "get"):
-        return None
-
-    for context in _candidates(variables):
-        if getattr(context, "user_id", None) is not None:
+    for context in source_contexts(variables):
+        if context.user_id is not None:
             return context
 
     return None

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -36,6 +36,16 @@
     }
   },
   "conditions": {
+    "triggered_by_automation": {
+      "name": "Triggered by an automation",
+      "description": "Passes when another automation set this run going, whether it did so directly or through a script.",
+      "fields": {
+        "automation": {
+          "name": "Automations",
+          "description": "Limit this to particular automations. Leave it empty to accept any of them."
+        }
+      }
+    },
     "triggered_by_user": {
       "name": "Triggered by a user",
       "description": "Passes when a person is behind what set this off: a state change or an event they caused, including one that made a template trigger become true. A schedule, the sun, or an integration acting on its own carries nobody, and neither does forcing a run with the Run button.",

--- a/documentation/conditions.md
+++ b/documentation/conditions.md
@@ -32,3 +32,9 @@ Passes when this automation or script has not run within a given time, so it doe
 Passes a set percentage of the time, chosen at random on every check. For when the same thing every evening gets boring. _#coinflip_
 
 `spook.chance`, [documentation](other-features#chance) 📚
+
+## Triggered by an automation
+
+Passes when another automation set this run going, directly or through a script. Can be narrowed to particular automations. _#automation_ _#context_
+
+`spook.triggered_by_automation`, [documentation](other-features#triggered-by-an-automation) 📚

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -512,3 +512,68 @@ options:
 ```
 
 :::
+
+### Triggered by an automation
+
+Passes when another automation set this run going.
+
+```{list-table}
+:header-rows: 1
+* - Condition properties
+* - {term}`Condition`
+  - Triggered by an automation 👻
+* - Condition name
+  - `spook.triggered_by_automation`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added condition
+```
+
+```{list-table}
+:header-rows: 2
+* - Condition options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `automation`
+  - {term}`list of strings <list>`
+  - No
+  - Defaults to any automation
+```
+
+Home Assistant gives every automation run its own context, and everything that run writes carries it along. So an automation reacting to a change another automation made can find out who did it, and it keeps working when there is a script in between, because the script runs under the automation's context rather than making one of its own.
+
+What Home Assistant does not do is turn a context back into the automation it belongs to, so Spook listens for automations announcing themselves and remembers the mapping for the last few hundred runs. That is far more than enough: the run being asked about happened a fraction of a second earlier.
+
+If the `automation` attribute is not provided, the condition passes for any automation. Name one or more to narrow it.
+
+:::{seealso} Example {term}`condition <condition>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+condition: spook.triggered_by_automation
+```
+
+To only pass when specific automations did it:
+
+```{code-block} yaml
+:linenos:
+condition: spook.triggered_by_automation
+options:
+  automation:
+    - automation.goodnight
+    - automation.leaving_home
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Only automations are recognised. A script running on its own, without an automation having started it, is not an automation and this does not pass for it.
+- Spook has to have been running when the other automation ran. It remembers the mapping while your automations are loaded, so a run from before a restart is no longer known.
+- It names the automation that started the chain, not the last thing in it. If your goodnight automation calls a script and that script turns off the lights, this reports the automation, which is almost always what you wanted to ask about.
+- Only the last few hundred automation runs are remembered. Not a practical limit for a condition being checked right after the run it is asking about, but it is a limit.
+
+:::

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -571,6 +571,7 @@ options:
 :::{attention} Known limitations
 :class: dropdown
 
+- The automation asking does not count. Put this inside an `if` or a `choose` in your actions and the run's own context is the nearest one in reach, so without skipping it this would pass for a schedule or a person just as readily. It looks past itself and reports whatever set the run going.
 - Only automations are recognised. A script running on its own, without an automation having started it, is not an automation and this does not pass for it.
 - Spook has to have been running when the other automation ran. It remembers the mapping while your automations are loaded, so a run from before a restart is no longer known.
 - It names the automation that started the chain, not the last thing in it. If your goodnight automation calls a script and that script turns off the lights, this reports the automation, which is almost always what you wanted to ask about.

--- a/tests/ectoplasms/spook/conditions/test_context_conditions.py
+++ b/tests/ectoplasms/spook/conditions/test_context_conditions.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 from homeassistant.core import Context
 from homeassistant.helpers import config_validation as cv
@@ -21,6 +22,10 @@ from custom_components.spook.ectoplasms.spook.conditions.triggered_by_user impor
     SpookCondition,
 )
 from custom_components.spook.condition import async_get_conditions
+from custom_components.spook.ectoplasms.spook.context import (
+    run_context,
+    source_contexts,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -193,3 +198,21 @@ async def test_a_bare_person_id_is_not_read_as_letters(hass: HomeAssistant) -> N
     )
     assert condition._async_check(variables={"context": Context(user_id=user_id)})
     assert not condition._async_check(variables={"context": Context(user_id="p")})
+
+
+def test_a_context_shaped_like_a_mapping_is_ignored() -> None:
+    """A rendered template hands over a mapping, not a `Context`.
+
+    Both callers read attributes off whatever comes out, so anything that is
+    not a real context has to be dropped rather than reached into.
+    """
+    as_a_mapping = {"id": "an-id", "parent_id": None, "user_id": "somebody"}
+
+    assert not list(source_contexts({"context": as_a_mapping}))
+    assert run_context({"context": as_a_mapping}) is None
+
+    # And a real one alongside it still comes through.
+    real = Context(user_id="somebody")
+    variables = {"context": as_a_mapping, "trigger": {"event": Mock(context=real)}}
+    assert list(source_contexts(variables)) == [real]
+    assert run_context(variables) is real

--- a/tests/ectoplasms/spook/conditions/test_triggered_by_automation.py
+++ b/tests/ectoplasms/spook/conditions/test_triggered_by_automation.py
@@ -1,0 +1,273 @@
+"""Tests for the spook.triggered_by_automation condition."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+from homeassistant.core import Context
+from homeassistant.helpers.condition import ConditionConfig
+from homeassistant.setup import async_setup_component
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.automation_runs import (
+    CACHE_SIZE,
+    AutomationRuns,
+    async_get_automation_runs,
+)
+from custom_components.spook.ectoplasms.spook.conditions.triggered_by_automation import (
+    SpookCondition,
+)
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def _house(hass: HomeAssistant, options: dict | None = None) -> list[str]:
+    """Set up an upstream automation, a script, and a guarded downstream one.
+
+    The downstream automation reacts to a switch and only runs its action when
+    the condition passes, so the returned list says what got through.
+    """
+    ran: list[str] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(call.data["by"])
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass, "input_boolean", {"input_boolean": {"switch": None}}
+    )
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "middleman": {
+                    "sequence": [
+                        {
+                            "action": "input_boolean.turn_on",
+                            "target": {"entity_id": "input_boolean.switch"},
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "upstream",
+                    "trigger": {"platform": "event", "event_type": "flip"},
+                    "action": [
+                        {
+                            "action": "input_boolean.turn_on",
+                            "target": {"entity_id": "input_boolean.switch"},
+                        }
+                    ],
+                },
+                {
+                    "alias": "upstream via script",
+                    "trigger": {"platform": "event", "event_type": "flip_via_script"},
+                    "action": [{"action": "script.middleman"}],
+                },
+                {
+                    "alias": "downstream",
+                    "trigger": {
+                        "platform": "state",
+                        "entity_id": "input_boolean.switch",
+                        "to": "on",
+                    },
+                    "condition": [
+                        {
+                            "condition": "spook.triggered_by_automation",
+                            **({"options": options} if options else {}),
+                        }
+                    ],
+                    "action": [{"action": "test.mark", "data": {"by": "automation"}}],
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return ran
+
+
+async def _reset(hass: HomeAssistant) -> None:
+    """Put the switch back, without anybody's context attached."""
+    hass.states.async_set("input_boolean.switch", "off")
+    await hass.async_block_till_done()
+
+
+async def test_it_passes_when_an_automation_caused_the_change(
+    hass: HomeAssistant,
+) -> None:
+    """The plain case: one automation writes, another reacts."""
+    ran = await _house(hass)
+
+    hass.bus.async_fire("flip")
+    await hass.async_block_till_done()
+
+    assert ran == ["automation"]
+
+
+async def test_it_passes_through_a_script(hass: HomeAssistant) -> None:
+    """A script in between keeps the automation's context, so it still counts.
+
+    The script does the writing, but it runs under the automation's context,
+    so the change still points back at the automation that started it.
+    """
+    ran = await _house(hass)
+
+    hass.bus.async_fire("flip_via_script")
+    await hass.async_block_till_done()
+
+    assert ran == ["automation"]
+
+
+async def test_it_fails_when_nothing_caused_the_change(hass: HomeAssistant) -> None:
+    """A write from nowhere is not an automation."""
+    ran = await _house(hass)
+
+    hass.states.async_set("input_boolean.switch", "on")
+    await hass.async_block_till_done()
+
+    assert not ran
+
+
+async def test_it_can_be_narrowed_to_one_automation(hass: HomeAssistant) -> None:
+    """Naming an automation accepts that one and turns the others down."""
+    ran = await _house(hass, {"automation": ["automation.upstream"]})
+
+    hass.bus.async_fire("flip")
+    await hass.async_block_till_done()
+    assert ran == ["automation"]
+
+    await _reset(hass)
+    ran.clear()
+
+    hass.bus.async_fire("flip_via_script")
+    await hass.async_block_till_done()
+    assert not ran, "accepted an automation that was not named"
+
+
+async def test_a_named_automation_still_counts_through_a_script(
+    hass: HomeAssistant,
+) -> None:
+    """Narrowing follows the chain too, and names the automation, not the script."""
+    ran = await _house(hass, {"automation": ["automation.upstream_via_script"]})
+
+    hass.bus.async_fire("flip_via_script")
+    await hass.async_block_till_done()
+
+    assert ran == ["automation"]
+
+
+async def test_a_non_automation_entity_is_refused(hass: HomeAssistant) -> None:
+    """The option only takes automations."""
+    with pytest.raises(vol.Invalid):
+        await SpookCondition.async_validate_config(
+            hass, {"options": {"automation": ["light.kitchen"]}}
+        )
+
+
+async def test_no_options_is_fine(hass: HomeAssistant) -> None:
+    """Asking about any automation at all needs no options."""
+    assert await SpookCondition.async_validate_config(hass, {}) == {"options": {}}
+
+
+async def test_checking_after_unloading_says_no_rather_than_falling_over(
+    hass: HomeAssistant,
+) -> None:
+    """Home Assistant does not stop anybody checking an unloaded condition.
+
+    So this has to answer rather than break. The register lets go of its
+    listener and its memory, which makes the answer no.
+    """
+    condition = SpookCondition(hass, ConditionConfig(options={}))
+    await condition.async_setup()
+
+    hass.bus.async_fire(
+        "automation_triggered",
+        {"entity_id": "automation.goodnight"},
+        context=Context(id="a-run"),
+    )
+    await hass.async_block_till_done()
+
+    variables = {"trigger": {"to_state": Mock(context=Context(id="a-run"))}}
+    assert condition.async_check(variables=variables) is True
+
+    condition.async_unload()
+
+    assert condition.async_check(variables=variables) is False
+
+
+async def test_the_register_stops_listening_when_the_last_user_leaves(
+    hass: HomeAssistant,
+) -> None:
+    """One shared listener, reference counted, and no listener left behind.
+
+    Every condition instance wants the same mapping, so they share it. The
+    listener has to survive one of them unloading and go away with the last.
+    """
+    runs = async_get_automation_runs(hass)
+    assert async_get_automation_runs(hass) is runs, "made a second register"
+
+    def _listeners() -> int:
+        return len(hass.bus.async_listeners().keys() & {"automation_triggered"})
+
+    assert _listeners() == 0
+
+    runs.async_acquire()
+    runs.async_acquire()
+    assert _listeners() == 1, "one listener for however many askers"
+
+    runs.async_release()
+    assert _listeners() == 1, "let go too early, with a user left"
+
+    runs.async_release()
+    assert _listeners() == 0, "left a listener behind"
+
+    # And it comes back for the next one.
+    runs.async_acquire()
+    assert _listeners() == 1
+    runs.async_release()
+
+
+async def test_the_register_forgets_the_oldest_runs(hass: HomeAssistant) -> None:
+    """The mapping is bounded: every automation run would otherwise add one.
+
+    Only a run from a moment ago is ever asked about, so dropping the oldest
+    costs nothing and keeps a busy house from growing this forever.
+    """
+    runs = AutomationRuns(hass)
+    runs.async_acquire()
+
+    overflow = 10
+    for index in range(CACHE_SIZE + overflow):
+        hass.bus.async_fire(
+            "automation_triggered",
+            {"entity_id": f"automation.number_{index}"},
+            context=Context(id=f"run-{index}"),
+        )
+    await hass.async_block_till_done()
+
+    # The newest runs are all still there.
+    for index in range(CACHE_SIZE + overflow - 5, CACHE_SIZE + overflow):
+        assert runs.async_which(f"run-{index}") == f"automation.number_{index}"
+
+    # The oldest have been dropped to make room, which is the whole point.
+    for index in range(overflow):
+        assert runs.async_which(f"run-{index}") is None, f"run-{index} was kept"
+
+    runs.async_release()

--- a/tests/ectoplasms/spook/conditions/test_triggered_by_automation.py
+++ b/tests/ectoplasms/spook/conditions/test_triggered_by_automation.py
@@ -12,10 +12,11 @@ from homeassistant.setup import async_setup_component
 import pytest
 import voluptuous as vol
 
-from custom_components.spook.ectoplasms.spook.automation_runs import (
+from custom_components.spook.automation_runs import (
     CACHE_SIZE,
     AutomationRuns,
     async_get_automation_runs,
+    async_setup_automation_runs,
 )
 from custom_components.spook.ectoplasms.spook.conditions.triggered_by_automation import (
     SpookCondition,
@@ -186,16 +187,46 @@ async def test_no_options_is_fine(hass: HomeAssistant) -> None:
     assert await SpookCondition.async_validate_config(hass, {}) == {"options": {}}
 
 
-async def test_checking_after_unloading_says_no_rather_than_falling_over(
+async def test_a_context_that_is_not_the_one_asked_about_is_not_the_end_of_it(
     hass: HomeAssistant,
 ) -> None:
-    """Home Assistant does not stop anybody checking an unloaded condition.
+    """A near context naming the wrong automation must not settle the answer.
 
-    So this has to answer rather than break. The register lets go of its
-    listener and its memory, which makes the answer no.
+    Several contexts can be in reach at once, and only one of them needs to
+    be the automation somebody asked about. Reading the nearest and returning
+    its verdict reports no whenever anything else got there first.
     """
-    condition = SpookCondition(hass, ConditionConfig(options={}))
+    runs = async_get_automation_runs(hass)
+    hass.bus.async_fire(
+        "automation_triggered",
+        {"entity_id": "automation.somebody_else"},
+        context=Context(id="near"),
+    )
+    hass.bus.async_fire(
+        "automation_triggered",
+        {"entity_id": "automation.wanted"},
+        context=Context(id="further"),
+    )
+    await hass.async_block_till_done()
+    assert runs.async_which("near") == "automation.somebody_else"
+
+    condition = SpookCondition(
+        hass, ConditionConfig(options={"automation": ["automation.wanted"]})
+    )
     await condition.async_setup()
+
+    variables = {
+        "context": Context(id="near"),
+        "trigger": {"to_state": Mock(context=Context(id="further"))},
+    }
+
+    assert condition.async_check(variables=variables) is True
+
+
+async def test_the_register_is_shared_and_listening(hass: HomeAssistant) -> None:
+    """One register for the whole integration, already listening."""
+    runs = async_get_automation_runs(hass)
+    assert async_get_automation_runs(hass) is runs, "made a second register"
 
     hass.bus.async_fire(
         "automation_triggered",
@@ -204,44 +235,36 @@ async def test_checking_after_unloading_says_no_rather_than_falling_over(
     )
     await hass.async_block_till_done()
 
-    variables = {"trigger": {"to_state": Mock(context=Context(id="a-run"))}}
-    assert condition.async_check(variables=variables) is True
-
-    condition.async_unload()
-
-    assert condition.async_check(variables=variables) is False
+    assert runs.async_which("a-run") == "automation.goodnight"
 
 
-async def test_the_register_stops_listening_when_the_last_user_leaves(
+async def test_stopping_the_register_lets_go_of_everything(
     hass: HomeAssistant,
 ) -> None:
-    """One shared listener, reference counted, and no listener left behind.
-
-    Every condition instance wants the same mapping, so they share it. The
-    listener has to survive one of them unloading and go away with the last.
-    """
+    """Setting it up hands back the way to stop, and stopping really stops."""
+    stop = async_setup_automation_runs(hass)
     runs = async_get_automation_runs(hass)
-    assert async_get_automation_runs(hass) is runs, "made a second register"
 
-    def _listeners() -> int:
-        return len(hass.bus.async_listeners().keys() & {"automation_triggered"})
+    hass.bus.async_fire(
+        "automation_triggered",
+        {"entity_id": "automation.goodnight"},
+        context=Context(id="a-run"),
+    )
+    await hass.async_block_till_done()
+    assert runs.async_which("a-run") == "automation.goodnight"
 
-    assert _listeners() == 0
+    stop()
 
-    runs.async_acquire()
-    runs.async_acquire()
-    assert _listeners() == 1, "one listener for however many askers"
+    assert runs.async_which("a-run") is None, "kept what it was told to forget"
+    assert "automation_triggered" not in hass.bus.async_listeners()
 
-    runs.async_release()
-    assert _listeners() == 1, "let go too early, with a user left"
-
-    runs.async_release()
-    assert _listeners() == 0, "left a listener behind"
-
-    # And it comes back for the next one.
-    runs.async_acquire()
-    assert _listeners() == 1
-    runs.async_release()
+    hass.bus.async_fire(
+        "automation_triggered",
+        {"entity_id": "automation.goodnight"},
+        context=Context(id="another-run"),
+    )
+    await hass.async_block_till_done()
+    assert runs.async_which("another-run") is None, "carried on listening"
 
 
 async def test_the_register_forgets_the_oldest_runs(hass: HomeAssistant) -> None:
@@ -251,7 +274,7 @@ async def test_the_register_forgets_the_oldest_runs(hass: HomeAssistant) -> None
     costs nothing and keeps a busy house from growing this forever.
     """
     runs = AutomationRuns(hass)
-    runs.async_acquire()
+    runs.async_start()
 
     overflow = 10
     for index in range(CACHE_SIZE + overflow):
@@ -270,4 +293,109 @@ async def test_the_register_forgets_the_oldest_runs(hass: HomeAssistant) -> None
     for index in range(overflow):
         assert runs.async_which(f"run-{index}") is None, f"run-{index} was kept"
 
-    runs.async_release()
+    runs.async_stop()
+
+
+async def _guarded_actions(
+    hass: HomeAssistant, options: dict | None = None
+) -> list[str]:
+    """Put the condition inside an action sequence, where the docs send people.
+
+    That placement is the one that matters for a forced run, and it is also
+    where the automation's own context is closest to hand.
+    """
+    ran: list[str] = []
+
+    # Spook starts this in its own setup, and it has to be running before the
+    # automations do: a condition inside an action sequence is only built once
+    # that sequence runs, which is after the automation announced itself.
+    async_setup_automation_runs(hass)
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(call.data["verdict"])
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass, "input_boolean", {"input_boolean": {"switch": None}}
+    )
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "upstream",
+                    "trigger": {"platform": "event", "event_type": "flip"},
+                    "action": [
+                        {
+                            "action": "input_boolean.turn_on",
+                            "target": {"entity_id": "input_boolean.switch"},
+                        }
+                    ],
+                },
+                {
+                    "alias": "asker",
+                    "trigger": [
+                        {"platform": "event", "event_type": "ask"},
+                        {
+                            "platform": "state",
+                            "entity_id": "input_boolean.switch",
+                            "to": "on",
+                        },
+                    ],
+                    "action": [
+                        {
+                            "if": [
+                                {
+                                    "condition": "spook.triggered_by_automation",
+                                    **({"options": options} if options else {}),
+                                }
+                            ],
+                            "then": [
+                                {"action": "test.mark", "data": {"verdict": "passed"}}
+                            ],
+                            "else": [
+                                {"action": "test.mark", "data": {"verdict": "failed"}}
+                            ],
+                        }
+                    ],
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return ran
+
+
+async def test_it_does_not_count_the_automation_doing_the_asking(
+    hass: HomeAssistant,
+) -> None:
+    """Inside an action sequence the run's own context is the nearest one.
+
+    The register knows it, because the automation announced itself on the way
+    in. Counting it would make this pass for a bare event, a schedule or a
+    person, which is the opposite of what it is for.
+    """
+    ran = await _guarded_actions(hass)
+
+    hass.bus.async_fire("ask")
+    await hass.async_block_till_done()
+
+    assert ran == ["failed"], "counted itself as the automation that fired it"
+
+
+async def test_it_finds_the_upstream_automation_from_inside_the_actions(
+    hass: HomeAssistant,
+) -> None:
+    """Skipping itself must not stop the search at the first context.
+
+    Narrowed to the upstream automation, the nearest context is this run's own
+    and the next one out is the answer. Settling for the first would report no.
+    """
+    ran = await _guarded_actions(hass, {"automation": ["automation.upstream"]})
+
+    hass.bus.async_fire("flip")
+    await hass.async_block_till_done()
+
+    assert ran == ["passed"], "gave up before reaching the automation upstream"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -17,10 +17,12 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STARTED,
     RESTART_EXIT_CODE,
 )
-from homeassistant.core import CoreState
+from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
+from homeassistant.core import Context, CoreState
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components import spook
+from custom_components.spook.automation_runs import async_get_automation_runs
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.integration_linking import (
     link_sub_integrations,
@@ -141,6 +143,58 @@ async def test_setup_entry_loads_and_unloads(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_entry_starts_and_stops_the_automation_run_register(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the config entry owns the automation run register.
+
+    A condition inside an action sequence is only built once that sequence
+    runs, which is after the automation announced itself, so the register has
+    to be listening before any of that. Nothing else in the suite proves the
+    entry is what starts it: the condition tests all have a register running
+    for their own reasons.
+    """
+
+    async def async_forward_no_platforms(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+    ) -> None:
+        """Forward no ectoplasm setup during the lifecycle smoke test."""
+
+    monkeypatch.setattr(spook, "PLATFORMS", [])
+    monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_noop)
+    monkeypatch.setattr(spook, "async_forward_setup_entry", async_forward_no_platforms)
+    monkeypatch.setattr(spook, "SpookServiceManager", _NoopSpookServiceManager)
+    monkeypatch.setattr(spook, "SpookRepairManager", _NoopSpookRepairManager)
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+
+    assert EVENT_AUTOMATION_TRIGGERED not in hass.bus.async_listeners()
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert EVENT_AUTOMATION_TRIGGERED in hass.bus.async_listeners()
+
+    hass.bus.async_fire(
+        EVENT_AUTOMATION_TRIGGERED,
+        {"entity_id": "automation.goodnight"},
+        context=Context(id="a-run"),
+    )
+    await hass.async_block_till_done()
+
+    runs = async_get_automation_runs(hass)
+    assert runs.async_which("a-run") == "automation.goodnight"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert EVENT_AUTOMATION_TRIGGERED not in hass.bus.async_listeners()
+    assert runs.async_which("a-run") is None, "kept remembering after unloading"
 
 
 async def test_unload_after_start_does_not_remove_fired_one_time_listeners(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `spook.triggered_by_automation` condition, which passes when another automation set this run going.

```yaml
condition: spook.triggered_by_automation
options:
  automation:
    - automation.goodnight
```

Leave `automation` out and it passes for any of them.

### How it knows

Home Assistant gives every automation run its own context, and everything that run writes carries it along. So an automation reacting to a change another automation made has that context sitting on its trigger. Measured rather than assumed: the context id in `EVENT_AUTOMATION_TRIGGERED` is exactly the id the downstream automation sees on `trigger.to_state.context`, and it survives a script in between, because a script runs under the automation's context rather than making one of its own.

What Home Assistant does not do is turn a context back into the automation it belongs to. Nothing keeps that mapping, so Spook keeps it: one shared listener on `EVENT_AUTOMATION_TRIGGERED` holding the last 512 runs in an `LRU`. Bounded because every automation run would otherwise add an entry forever, and unbounded is not needed: the run being asked about happened a fraction of a second earlier.

**The Spook config entry owns that listener**, started in `async_setup_entry` and removed through `entry.async_on_unload`. It cannot wait until a condition asks for it: a condition inside an action sequence is only built once that sequence runs, which is after the automation it wants to know about has already announced itself, so a register starting then would answer no to everything. The condition itself only takes hold of the register in `_async_setup`.

**The automation asking does not count as an answer.** Inside an action sequence the run's own context is the nearest one in reach and the register knows it, so the condition looks past itself and carries on searching. It also keeps searching past a context naming an automation nobody asked about, since that says nothing about the ones further out.

### Also in here

`source_contexts` is split out of `run_context` in `context.py`. Which automation it was has to be looked up by context id, while `run_context` filters on `user_id`, so the walking and the filtering wanted separating. `run_context` behaves exactly as before.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Completes the set that landed in #1466. `spook.triggered_by_user` answers "was this a person", and this answers "was this another automation", which is the other half of the question people actually ask when they want to stop automations setting each other off.

The counterpart, `not_triggered_by_automation`, is not in here. Say the word and it follows in the same shape as `not_triggered_by_user`.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ten new tests, on top of the existing suite (1001 pass). Most of them run real automations against each other rather than poking a condition object, because the whole point is what survives a real context chain.

Covered: an automation causing a change, the same through a script, a change from nowhere, narrowing to one automation and turning the others down, narrowing following the chain and naming the automation rather than the script, a non-automation entity being refused, the register being shared and already listening, stopping it letting go of both the listener and the memory, the register dropping its oldest runs, the automation asking not counting as an answer from inside an action sequence, the search reaching the upstream automation from there, a nearer context naming the wrong automation not ending the search, a mapping-shaped context being ignored rather than reached into, and the config entry starting the register on load and stopping it on unload.

The implementation was then broken repeatedly to check the tests earn their place, and each is caught: ignoring the automation filter, never listening, forgetting every context, looking at only the first context, not skipping the automation asking, settling for the first resolved context, dropping the guard on non-`Context` values, removing the setup call from the config entry, and starting the register without registering the unload.

Several things came out of those passes rather than out of reading:

- **A documentation anchor got stolen.** `other_features.md` carries an explicit `(triggered-by-a-user)=` and the new section landed between it and its heading, so the new heading took `id="triggered-by-a-user"` and the existing one became `-1`, which also silently repointed the cross-reference in **Not triggered by a user**. The warning count stayed at 23 throughout, because the anchor still resolved, just to the wrong heading. Only checking the rendered HTML showed it. Both new sections now sit at the end, in the order the others are in.
- **A guard for a condition that was never set up was dead code.** The public `async_check` refuses one with `HomeAssistantError`, so that branch is unreachable. Removed, and replaced with a test for the case that *is* reachable: checking after unloading.
- **Two tests reached into internals.** They now go through `async_check` and `async_which`, the way the sibling condition tests do, and the cache bound is tested with chosen context ids rather than `len()` on a private attribute.
- **The condition counted itself.** Inside an action sequence the run's own context is the nearest one, so unfiltered it passed for a bare event, a schedule or a person. My first probe said otherwise, which was misleading: the register had not started listening in that setup, so it resolved nothing at all. That lateness turned out to be a third fault of its own, and the reason the listener now starts with the config entry.
- **The setup call itself was untested.** Removing it left all 1005 tests green, because every condition test had a register running for its own reasons. There is now a config entry lifecycle test, and dropping either half of the call fails it.
- **Splitting `source_contexts` out dropped a guard.** `getattr(context, "user_id", None)` became `context.user_id`, and a rendered template hands over a state whose context is a plain mapping. Fixed at the source: it yields only real contexts, which also makes its `Iterator[Context]` annotation true.

Also ran: `ruff check`, `ruff format --check`, `pylint` over the whole tree, `zizmor`, the full pre-commit set, and a local rebuild of hassfest's descriptor schema over `conditions.yaml` and `triggers.yaml`. The documentation builds with the same warnings as `main`, no more.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
