### PR TITLE
Add repair issue triggers and a repair issue condition

### DIFF
--- a/custom_components/spook/conditions.yaml
+++ b/custom_components/spook/conditions.yaml
@@ -36,3 +36,21 @@ triggered_by_automation:
         entity:
           domain: automation
           multiple: true
+repair_issue_present:
+  fields:
+    domain:
+      required: false
+      example: hue
+      selector:
+        text:
+          multiple: true
+    severity:
+      required: false
+      selector:
+        select:
+          multiple: true
+          translation_key: repair_issue_severity
+          options:
+            - critical
+            - error
+            - warning

--- a/custom_components/spook/ectoplasms/spook/conditions/repair_issue_present.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/repair_issue_present.py
@@ -1,0 +1,65 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.helpers.condition import Condition
+
+from ..repair_issues import FILTER_SCHEMA, active_issues, as_filter, matches
+
+if TYPE_CHECKING:
+    from typing import Unpack
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.condition import ConditionCheckParams, ConditionConfig
+    from homeassistant.helpers.typing import ConfigType
+
+_CONDITION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS, default=dict): FILTER_SCHEMA,
+    }
+)
+
+
+class SpookCondition(Condition):
+    """Spook condition that passes while a repair issue is outstanding.
+
+    For holding something back until the house is in order: not running a
+    nightly job while an integration is complaining, or nagging once a day
+    for as long as anything is wrong.
+
+    Issues somebody has ignored do not count. Ignoring one is telling Home
+    Assistant to stop bringing it up, and this is not the place to overrule
+    that.
+    """
+
+    condition = "repair_issue_present"
+
+    _domains: set[str] | None
+    _severities: set[str] | None
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the condition config."""
+        return _CONDITION_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Initialize the condition."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._domains, self._severities = as_filter(options)
+
+    def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:  # noqa: ARG002
+        """Return True while anything asked about is outstanding."""
+        return any(
+            matches(issue, self._domains, self._severities)
+            for issue in active_issues(self._hass)
+        )

--- a/custom_components/spook/ectoplasms/spook/repair_issues.py
+++ b/custom_components/spook/ectoplasms/spook/repair_issues.py
@@ -1,0 +1,90 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from homeassistant.core import HomeAssistant
+
+CONF_DOMAIN = "domain"
+CONF_SEVERITY = "severity"
+
+SEVERITIES = tuple(severity.value for severity in ir.IssueSeverity)
+
+# Optional filters, shared by the repair triggers and the condition so they
+# read the same in the automation editor and in YAML.
+FILTER_SCHEMA = {
+    vol.Optional(CONF_DOMAIN): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_SEVERITY): vol.All(cv.ensure_list, [vol.In(SEVERITIES)]),
+}
+
+DOMAIN_ONLY_FILTER_SCHEMA = {
+    vol.Optional(CONF_DOMAIN): vol.All(cv.ensure_list, [cv.string]),
+}
+
+
+def as_filter(options: dict[str, Any]) -> tuple[set[str] | None, set[str] | None]:
+    """Turn the options into the two sets that do the filtering.
+
+    ``None`` means "no opinion", which is not the same as an empty set: a
+    filter nobody set has to let everything through.
+    """
+    domains = options.get(CONF_DOMAIN)
+    severities = options.get(CONF_SEVERITY)
+    return (
+        set(cv.ensure_list(domains)) if domains else None,
+        set(cv.ensure_list(severities)) if severities else None,
+    )
+
+
+def matches(
+    issue: ir.IssueEntry,
+    domains: set[str] | None,
+    severities: set[str] | None,
+) -> bool:
+    """Return whether this issue is one that was asked about."""
+    if domains is not None and issue.domain not in domains:
+        return False
+
+    if severities is None:
+        return True
+
+    # An issue is allowed to carry no severity at all, and then it cannot
+    # answer a question about severity.
+    return issue.severity is not None and issue.severity.value in severities
+
+
+def is_ignored(issue: ir.IssueEntry) -> bool:
+    """Return whether somebody told Home Assistant to stop nagging about this.
+
+    Ignoring an issue does not deactivate it or take it out of the registry,
+    it stamps the version it was ignored in, so that is what has to be read.
+    """
+    return issue.dismissed_version is not None
+
+
+def active_issues(hass: HomeAssistant) -> Iterable[ir.IssueEntry]:
+    """Yield the issues worth counting: present, active, and not ignored."""
+    for issue in ir.async_get(hass).issues.values():
+        if issue.active and not is_ignored(issue):
+            yield issue
+
+
+def payload(issue: ir.IssueEntry) -> dict[str, Any]:
+    """Describe an issue for the trigger variables."""
+    return {
+        "domain": issue.domain,
+        "issue_id": issue.issue_id,
+        "severity": issue.severity.value if issue.severity else None,
+        "is_fixable": issue.is_fixable,
+        "breaks_in_ha_version": issue.breaks_in_ha_version,
+        "learn_more_url": issue.learn_more_url,
+        "translation_key": issue.translation_key,
+    }

--- a/custom_components/spook/ectoplasms/spook/triggers/repair_issue_created.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/repair_issue_created.py
@@ -1,0 +1,92 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.core import callback
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.trigger import Trigger
+
+from ..repair_issues import FILTER_SCHEMA, as_filter, matches, payload
+
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS, default=dict): FILTER_SCHEMA,
+    }
+)
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when a repair issue turns up.
+
+    Home Assistant collects these on the repairs page and waits to be
+    visited. This is for the ones you would rather hear about: an integration
+    reporting it needs attention, or Spook finding a reference to something
+    that no longer exists.
+
+    Only genuinely new issues fire it. Re-reporting an issue that is already
+    there is an update as far as the registry is concerned, which is what
+    keeps a repair that is checked on a schedule from firing every time.
+    """
+
+    trigger = "repair_issue_created"
+
+    _domains: set[str] | None
+    _severities: set[str] | None
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        return _TRIGGER_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._domains, self._severities = as_filter(options)
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+        registry = ir.async_get(self._hass)
+
+        @callback
+        def issue_registry_changed(event: Event) -> None:
+            """Look at what the registry just did."""
+            if event.data["action"] != "create":
+                return
+
+            issue = registry.async_get_issue(
+                event.data["domain"], event.data["issue_id"]
+            )
+            if issue is None or not matches(issue, self._domains, self._severities):
+                return
+
+            run_action(
+                payload(issue),
+                f"repair issue {issue.domain}/{issue.issue_id} created",
+            )
+
+        return self._hass.bus.async_listen(
+            ir.EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED, issue_registry_changed
+        )

--- a/custom_components/spook/ectoplasms/spook/triggers/repair_issue_removed.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/repair_issue_removed.py
@@ -1,0 +1,87 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.core import callback
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.trigger import Trigger
+
+from ..repair_issues import DOMAIN_ONLY_FILTER_SCHEMA, as_filter
+
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS, default=dict): DOMAIN_ONLY_FILTER_SCHEMA,
+    }
+)
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when a repair issue goes away.
+
+    Something got fixed, or whatever was complaining stopped complaining.
+    Useful for closing a notification you opened when the issue turned up.
+
+    There is no severity to filter on here. By the time the registry
+    announces a removal the entry is already gone, so the only things left to
+    say about it are which integration it belonged to and what it was called.
+    """
+
+    trigger = "repair_issue_removed"
+
+    _domains: set[str] | None
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        return _TRIGGER_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._domains, _ = as_filter(options)
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def issue_registry_changed(event: Event) -> None:
+            """Look at what the registry just did."""
+            if event.data["action"] != "remove":
+                return
+
+            domain = event.data["domain"]
+            if self._domains is not None and domain not in self._domains:
+                return
+
+            issue_id = event.data["issue_id"]
+            run_action(
+                {"domain": domain, "issue_id": issue_id},
+                f"repair issue {domain}/{issue_id} removed",
+            )
+
+        return self._hass.bus.async_listen(
+            ir.EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED, issue_registry_changed
+        )

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -24,6 +24,30 @@
         }
       }
     },
+    "repair_issue_created": {
+      "name": "Repair issue created",
+      "description": "Fires when a new repair issue turns up, so you can hear about one without visiting the repairs page.",
+      "fields": {
+        "domain": {
+          "name": "Integrations",
+          "description": "Limit this to issues reported by particular integrations, by their domain. Leave it empty for all of them."
+        },
+        "severity": {
+          "name": "Severity",
+          "description": "Limit this to issues of a particular severity. Leave it empty for all of them."
+        }
+      }
+    },
+    "repair_issue_removed": {
+      "name": "Repair issue resolved",
+      "description": "Fires when a repair issue goes away, either fixed or no longer reported.",
+      "fields": {
+        "domain": {
+          "name": "Integrations",
+          "description": "Limit this to issues reported by particular integrations, by their domain. Leave it empty for all of them."
+        }
+      }
+    },
     "stale": {
       "name": "Entity fell silent",
       "description": "Fires when nothing has written to an entity for a while, which catches a device that died quietly rather than going unavailable.",
@@ -35,7 +59,30 @@
       }
     }
   },
+  "selector": {
+    "repair_issue_severity": {
+      "options": {
+        "critical": "Critical",
+        "error": "Error",
+        "warning": "Warning"
+      }
+    }
+  },
   "conditions": {
+    "repair_issue_present": {
+      "name": "Repair issue outstanding",
+      "description": "Passes while a repair issue is outstanding. Issues somebody has ignored do not count.",
+      "fields": {
+        "domain": {
+          "name": "Integrations",
+          "description": "Limit this to issues reported by particular integrations, by their domain. Leave it empty for all of them."
+        },
+        "severity": {
+          "name": "Severity",
+          "description": "Limit this to issues of a particular severity. Leave it empty for all of them."
+        }
+      }
+    },
     "triggered_by_automation": {
       "name": "Triggered by an automation",
       "description": "Passes when another automation set this run going, whether it did so directly or through a script.",

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -27,3 +27,29 @@ integration_failed:
       required: false
       selector:
         config_entry:
+repair_issue_created:
+  fields:
+    domain:
+      required: false
+      example: hue
+      selector:
+        text:
+          multiple: true
+    severity:
+      required: false
+      selector:
+        select:
+          multiple: true
+          translation_key: repair_issue_severity
+          options:
+            - critical
+            - error
+            - warning
+repair_issue_removed:
+  fields:
+    domain:
+      required: false
+      example: hue
+      selector:
+        text:
+          multiple: true

--- a/documentation/conditions.md
+++ b/documentation/conditions.md
@@ -38,3 +38,9 @@ Passes a set percentage of the time, chosen at random on every check. For when t
 Passes when another automation set this run going, directly or through a script. Can be narrowed to particular automations. _#automation_ _#context_
 
 `spook.triggered_by_automation`, [documentation](other-features#triggered-by-an-automation) 📚
+
+## Repair issue outstanding
+
+Passes while a repair issue is outstanding, for holding something back until the house is in order. Issues somebody has ignored do not count. _#repairs_ _#issue_
+
+`spook.repair_issue_present`, [documentation](other-features#repair-issue-outstanding) 📚

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -314,6 +314,122 @@ options:
 
 :::
 
+### Repair issue created
+
+Fires when a new repair issue turns up.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Repair issue created 👻
+* - Trigger name
+  - `spook.repair_issue_created`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `domain`
+  - {term}`list of strings <list>`
+  - No
+  - Defaults to every integration
+* - `severity`
+  - {term}`list of strings <list>`
+  - No
+  - `critical`, `error`, `warning`
+```
+
+Home Assistant collects repair issues on the repairs page and waits to be visited. This is for the ones you would rather hear about: an integration reporting it needs attention, or Spook finding a reference to something that no longer exists.
+
+Only genuinely new issues fire it. An integration re-reporting an issue that is already there counts as an update rather than a creation, which is what keeps a repair checked on a schedule from firing on every pass.
+
+When it fires, `trigger.domain` is the integration that reported it, `trigger.issue_id` names the issue, and `trigger.severity`, `trigger.is_fixable`, `trigger.breaks_in_ha_version`, `trigger.learn_more_url` and `trigger.translation_key` carry the rest of what the registry knows.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Anything at all, as soon as it turns up:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.repair_issue_created
+```
+
+Only the serious ones, and only from two integrations:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.repair_issue_created
+options:
+  domain:
+    - hue
+    - zwave_js
+  severity:
+    - critical
+    - error
+```
+
+:::
+
+### Repair issue resolved
+
+Fires when a repair issue goes away.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Repair issue resolved 👻
+* - Trigger name
+  - `spook.repair_issue_removed`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `domain`
+  - {term}`list of strings <list>`
+  - No
+  - Defaults to every integration
+```
+
+Something got fixed, or whatever was complaining stopped complaining. Handy for closing a notification you opened when the issue turned up.
+
+When it fires, `trigger.domain` and `trigger.issue_id` say which issue it was.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+trigger: spook.repair_issue_removed
+options:
+  domain: hue
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- There is no severity to filter on, and none in the trigger variables. By the time Home Assistant announces a removal the issue is already out of the registry, so the only things left to say about it are which integration it belonged to and what it was called.
+- Ignoring an issue is not resolving it. It stays in the registry, so this does not fire for it.
+
+:::
+
 ## Conditions
 
 Spook offers the following conditions that are not tied to a specific integration:
@@ -576,5 +692,73 @@ options:
 - Spook has to have been running when the other automation ran. It remembers the mapping while your automations are loaded, so a run from before a restart is no longer known.
 - It names the automation that started the chain, not the last thing in it. If your goodnight automation calls a script and that script turns off the lights, this reports the automation, which is almost always what you wanted to ask about.
 - Only the last few hundred automation runs are remembered. Not a practical limit for a condition being checked right after the run it is asking about, but it is a limit.
+
+:::
+
+### Repair issue outstanding
+
+Passes while a repair issue is outstanding.
+
+```{list-table}
+:header-rows: 1
+* - Condition properties
+* - Condition
+  - Repair issue outstanding 👻
+* - Condition name
+  - `spook.repair_issue_present`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added condition
+```
+
+```{list-table}
+:header-rows: 2
+* - Condition options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `domain`
+  - {term}`list of strings <list>`
+  - No
+  - Defaults to every integration
+* - `severity`
+  - {term}`list of strings <list>`
+  - No
+  - `critical`, `error`, `warning`
+```
+
+For holding something back until the house is in order: not running a nightly job while an integration is complaining, or nagging once a day for as long as anything is wrong.
+
+Leave the options out and any outstanding issue passes it. Name integrations, severities, or both, and all the named parts have to match the same issue.
+
+:::{seealso} Example {term}`condition <condition>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+condition: spook.repair_issue_present
+```
+
+Only if something serious is wrong with one of these:
+
+```{code-block} yaml
+:linenos:
+condition: spook.repair_issue_present
+options:
+  domain:
+    - hue
+    - zwave_js
+  severity:
+    - critical
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Issues somebody has ignored do not count. Ignoring one is telling Home Assistant to stop bringing it up, and this is not the place to overrule that.
+- Nor do issues waiting to be confirmed. Home Assistant keeps issues across a restart so it can remember which were ignored, but marks them as awaiting confirmation until the integration reports them again. Counting those would pass on every startup for anything that has since been fixed.
+- An issue with no severity recorded cannot answer a question about severity, so naming severities leaves it out.
 
 :::

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -337,11 +337,11 @@ Fires when a new repair issue turns up.
   - Required
   - Default / Example
 * - `domain`
-  - {term}`list of strings <list>`
+  - {term}`string <string>` | {term}`list of strings <list>`
   - No
   - Defaults to every integration
 * - `severity`
-  - {term}`list of strings <list>`
+  - {term}`string <string>` | {term}`list of strings <list>`
   - No
   - `critical`, `error`, `warning`
 ```
@@ -401,7 +401,7 @@ Fires when a repair issue goes away.
   - Required
   - Default / Example
 * - `domain`
-  - {term}`list of strings <list>`
+  - {term}`string <string>` | {term}`list of strings <list>`
   - No
   - Defaults to every integration
 ```
@@ -718,11 +718,11 @@ Passes while a repair issue is outstanding.
   - Required
   - Default / Example
 * - `domain`
-  - {term}`list of strings <list>`
+  - {term}`string <string>` | {term}`list of strings <list>`
   - No
   - Defaults to every integration
 * - `severity`
-  - {term}`list of strings <list>`
+  - {term}`string <string>` | {term}`list of strings <list>`
   - No
   - `critical`, `error`, `warning`
 ```

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -26,3 +26,15 @@ Fires when nothing has written to an entity for a while, which catches the devic
 Fires when a configuration entry has been unable to set itself up for a while, past the point where Home Assistant's own retries would have sorted it out. _#integration_ _#broken_ _#config-entry_
 
 `spook.integration_failed`, [documentation](other-features#integration-failed-to-set-up) 📚
+
+## Repair issue created
+
+Fires when a new repair issue turns up, so you hear about one without visiting the repairs page. Can be narrowed by integration and severity. _#repairs_ _#issue_
+
+`spook.repair_issue_created`, [documentation](other-features#repair-issue-created) 📚
+
+## Repair issue resolved
+
+Fires when a repair issue goes away, either fixed or no longer reported. _#repairs_ _#issue_
+
+`spook.repair_issue_removed`, [documentation](other-features#repair-issue-resolved) 📚

--- a/tests/ectoplasms/spook/triggers/test_repair_issues.py
+++ b/tests/ectoplasms/spook/triggers/test_repair_issues.py
@@ -177,6 +177,53 @@ async def test_it_fires_when_an_issue_goes_away(hass: HomeAssistant) -> None:
     assert ran == [{"domain": "demo", "issue_id": "boiler", "severity": "none"}]
 
 
+async def test_the_removed_trigger_stays_quiet_for_anything_else(
+    hass: HomeAssistant,
+) -> None:
+    """The registry announces creations and updates on the same event.
+
+    Without checking which it was, this would fire the moment an issue turned
+    up, which is the opposite of what it says on the tin.
+    """
+    ran = await _automation(hass, [{"platform": "spook.repair_issue_removed"}])
+
+    _raise(hass)
+    await hass.async_block_till_done()
+    assert not ran, "fired when an issue was created"
+
+    _raise(hass, severity=ir.IssueSeverity.CRITICAL)
+    await hass.async_block_till_done()
+    assert not ran, "fired when an issue was updated"
+
+    ir.async_ignore_issue(hass, "demo", "boiler", ignore=True)
+    await hass.async_block_till_done()
+    assert not ran, "fired when an issue was ignored"
+
+    ir.async_delete_issue(hass, "demo", "boiler")
+    await hass.async_block_till_done()
+    assert len(ran) == 1, "did not fire when the issue actually went away"
+
+
+async def test_the_removed_trigger_honours_the_domain_filter(
+    hass: HomeAssistant,
+) -> None:
+    """Naming integrations limits the removals it reports, too."""
+    _raise(hass, domain="zwave_js", issue_id="node_dead")
+    _raise(hass, domain="hue", issue_id="bridge_gone")
+    await hass.async_block_till_done()
+
+    ran = await _automation(
+        hass,
+        [{"platform": "spook.repair_issue_removed", "options": {"domain": ["hue"]}}],
+    )
+
+    ir.async_delete_issue(hass, "zwave_js", "node_dead")
+    ir.async_delete_issue(hass, "hue", "bridge_gone")
+    await hass.async_block_till_done()
+
+    assert [run["domain"] for run in ran] == ["hue"]
+
+
 async def test_the_domain_filter_turns_the_others_down(hass: HomeAssistant) -> None:
     """Naming integrations limits it to those."""
     ran = await _automation(

--- a/tests/ectoplasms/spook/triggers/test_repair_issues.py
+++ b/tests/ectoplasms/spook/triggers/test_repair_issues.py
@@ -1,0 +1,300 @@
+"""Tests for the repair issue triggers and condition."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.condition import ConditionConfig
+from homeassistant.setup import async_setup_component
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.condition import async_get_conditions
+from custom_components.spook.ectoplasms.spook.conditions.repair_issue_present import (
+    SpookCondition,
+)
+from custom_components.spook.ectoplasms.spook.triggers.repair_issue_created import (
+    SpookTrigger as CreatedTrigger,
+)
+from custom_components.spook.ectoplasms.spook.triggers.repair_issue_removed import (
+    SpookTrigger as RemovedTrigger,
+)
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the platforms.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _raise(
+    hass: HomeAssistant,
+    domain: str = "demo",
+    issue_id: str = "boiler",
+    severity: ir.IssueSeverity = ir.IssueSeverity.WARNING,
+) -> None:
+    """Report a repair issue, the way an integration would."""
+    ir.async_create_issue(
+        hass,
+        domain,
+        issue_id,
+        is_fixable=False,
+        severity=severity,
+        translation_key=issue_id,
+    )
+
+
+async def _condition(hass: HomeAssistant, **options: list[str]) -> SpookCondition:
+    """Build the condition and set it up, the way core would."""
+    condition = SpookCondition(hass, ConditionConfig(options=options))
+    await condition.async_setup()
+    return condition
+
+
+async def _automation(hass: HomeAssistant, triggers: list[dict]) -> list[dict]:
+    """Set up an automation on the given triggers and record every run."""
+    ran: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "repairs",
+                    "trigger": triggers,
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {
+                                "domain": "{{ trigger.domain }}",
+                                "issue_id": "{{ trigger.issue_id }}",
+                                "severity": "{{ trigger.severity | default('none') }}",
+                            },
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return ran
+
+
+async def test_both_triggers_are_discovered(hass: HomeAssistant) -> None:
+    """The triggers turn up in Spook's discovery, under plain keys."""
+    triggers = await async_get_triggers(hass)
+    assert "repair_issue_created" in triggers
+    assert "repair_issue_removed" in triggers
+
+
+async def test_the_condition_is_discovered(hass: HomeAssistant) -> None:
+    """The condition turns up in Spook's discovery too."""
+    assert "repair_issue_present" in await async_get_conditions(hass)
+
+
+@pytest.mark.parametrize(
+    "trigger_class", [CreatedTrigger, RemovedTrigger, SpookCondition]
+)
+async def test_no_options_is_fine(hass: HomeAssistant, trigger_class) -> None:  # noqa: ANN001
+    """Asking about every issue there is needs no options."""
+    assert await trigger_class.async_validate_config(hass, {}) == {"options": {}}
+
+
+@pytest.mark.parametrize("provider", [CreatedTrigger, SpookCondition])
+async def test_a_made_up_severity_is_refused(hass: HomeAssistant, provider) -> None:  # noqa: ANN001
+    """Severity only takes the three Home Assistant has."""
+    with pytest.raises(vol.Invalid):
+        await provider.async_validate_config(
+            hass, {"options": {"severity": ["catastrophic"]}}
+        )
+
+
+async def test_it_fires_when_an_issue_turns_up(hass: HomeAssistant) -> None:
+    """A new issue sets the trigger off, carrying what it is."""
+    ran = await _automation(hass, [{"platform": "spook.repair_issue_created"}])
+
+    _raise(hass, severity=ir.IssueSeverity.ERROR)
+    await hass.async_block_till_done()
+
+    assert ran == [{"domain": "demo", "issue_id": "boiler", "severity": "error"}]
+
+
+async def test_reporting_the_same_issue_again_does_not_fire(
+    hass: HomeAssistant,
+) -> None:
+    """A repair checked on a schedule would otherwise fire on every pass.
+
+    The registry treats a repeat as an update rather than a creation, which is
+    what makes this safe, so it is worth pinning.
+    """
+    ran = await _automation(hass, [{"platform": "spook.repair_issue_created"}])
+
+    _raise(hass)
+    await hass.async_block_till_done()
+    assert len(ran) == 1
+
+    for _ in range(3):
+        _raise(hass)
+        await hass.async_block_till_done()
+
+    assert len(ran) == 1, "fired again for an issue that was already there"
+
+
+async def test_ignoring_an_issue_does_not_fire(hass: HomeAssistant) -> None:
+    """Telling Home Assistant to stop nagging is not a new issue."""
+    ran = await _automation(hass, [{"platform": "spook.repair_issue_created"}])
+
+    _raise(hass)
+    await hass.async_block_till_done()
+    assert len(ran) == 1
+
+    ir.async_ignore_issue(hass, "demo", "boiler", ignore=True)
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+
+
+async def test_it_fires_when_an_issue_goes_away(hass: HomeAssistant) -> None:
+    """Removal sets the other trigger off."""
+    _raise(hass)
+    await hass.async_block_till_done()
+
+    ran = await _automation(hass, [{"platform": "spook.repair_issue_removed"}])
+
+    ir.async_delete_issue(hass, "demo", "boiler")
+    await hass.async_block_till_done()
+
+    assert ran == [{"domain": "demo", "issue_id": "boiler", "severity": "none"}]
+
+
+async def test_the_domain_filter_turns_the_others_down(hass: HomeAssistant) -> None:
+    """Naming integrations limits it to those."""
+    ran = await _automation(
+        hass,
+        [{"platform": "spook.repair_issue_created", "options": {"domain": ["hue"]}}],
+    )
+
+    _raise(hass, domain="zwave_js", issue_id="node_dead")
+    _raise(hass, domain="hue", issue_id="bridge_gone")
+    await hass.async_block_till_done()
+
+    assert [run["domain"] for run in ran] == ["hue"]
+
+
+async def test_the_severity_filter_turns_the_others_down(hass: HomeAssistant) -> None:
+    """Naming severities limits it to those."""
+    ran = await _automation(
+        hass,
+        [
+            {
+                "platform": "spook.repair_issue_created",
+                "options": {"severity": ["critical"]},
+            }
+        ],
+    )
+
+    _raise(hass, issue_id="mild", severity=ir.IssueSeverity.WARNING)
+    _raise(hass, issue_id="dire", severity=ir.IssueSeverity.CRITICAL)
+    await hass.async_block_till_done()
+
+    assert [run["issue_id"] for run in ran] == ["dire"]
+
+
+async def test_the_condition_passes_while_something_is_outstanding(
+    hass: HomeAssistant,
+) -> None:
+    """Present means present, and gone means gone."""
+    condition = await _condition(hass)
+
+    assert condition.async_check() is False
+
+    _raise(hass)
+    await hass.async_block_till_done()
+    assert condition.async_check() is True
+
+    ir.async_delete_issue(hass, "demo", "boiler")
+    await hass.async_block_till_done()
+    assert condition.async_check() is False
+
+
+async def test_the_condition_ignores_ignored_issues(hass: HomeAssistant) -> None:
+    """Ignoring one is telling Home Assistant to stop bringing it up.
+
+    Overruling that here would make the condition useless for the thing it is
+    for: holding something back until the house is in order.
+    """
+    condition = await _condition(hass)
+
+    _raise(hass)
+    await hass.async_block_till_done()
+    assert condition.async_check() is True
+
+    ir.async_ignore_issue(hass, "demo", "boiler", ignore=True)
+    await hass.async_block_till_done()
+
+    assert condition.async_check() is False, "counted an issue somebody had ignored"
+
+
+async def test_the_condition_ignores_an_issue_waiting_to_be_confirmed(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """An issue restored from before a restart is not known to be real yet.
+
+    Home Assistant keeps non-persistent issues across a restart so it can
+    remember whether they were ignored, but marks them inactive until the
+    integration reports them again. Counting those would make this pass every
+    startup for anything that has since been fixed.
+    """
+    hass_storage[ir.STORAGE_KEY] = {
+        "version": ir.STORAGE_VERSION_MAJOR,
+        "minor_version": ir.STORAGE_VERSION_MINOR,
+        "data": {
+            "issues": [
+                {
+                    "created": "2026-08-01T12:00:00+00:00",
+                    "dismissed_version": None,
+                    "domain": "demo",
+                    "is_persistent": False,
+                    "issue_id": "boiler",
+                }
+            ]
+        },
+    }
+    await ir.async_load(hass)
+
+    restored = ir.async_get(hass).async_get_issue("demo", "boiler")
+    assert restored is not None
+    assert restored.active is False, "expected a restored issue to await confirmation"
+
+    condition = await _condition(hass)
+    assert condition.async_check() is False, "counted an unconfirmed issue"
+
+    # And once the integration reports it again, it counts.
+    _raise(hass)
+    await hass.async_block_till_done()
+    assert condition.async_check() is True
+
+
+async def test_the_condition_filters_the_same_way(hass: HomeAssistant) -> None:
+    """The filters read the same on the condition as on the trigger."""
+    condition = await _condition(hass, domain=["hue"], severity=["critical"])
+
+    _raise(hass, domain="zwave_js", issue_id="node", severity=ir.IssueSeverity.CRITICAL)
+    _raise(hass, domain="hue", issue_id="mild", severity=ir.IssueSeverity.WARNING)
+    await hass.async_block_till_done()
+    assert condition.async_check() is False, "matched on only half the filter"
+
+    _raise(hass, domain="hue", issue_id="dire", severity=ir.IssueSeverity.CRITICAL)
+    await hass.async_block_till_done()
+    assert condition.async_check() is True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds two triggers and a condition for repair issues, sharing one filter helper so they read the same in the automation editor and in YAML.

**`spook.repair_issue_created`** fires when a new repair issue turns up. Filters on `domain` and `severity`.

```yaml
trigger: spook.repair_issue_created
options:
  severity:
    - critical
    - error
```

**`spook.repair_issue_removed`** fires when one goes away. Filters on `domain`.

**`spook.repair_issue_present`** passes while anything asked about is outstanding. Filters on `domain` and `severity`.

### What the measuring settled

Each of these shaped the design, so they are worth writing down:

- **`event.data` carries only `{action, domain, issue_id}`**, so details come from the registry rather than the event.
- **Re-reporting an existing issue is an `update`, not a `create`.** This is what makes the created trigger safe at all: Spook's own repairs run on a schedule, and without that distinction the trigger would fire on every pass. There is a test on it, because the whole design rests on it.
- **On `remove` the entry is already out of the registry.** So the removed trigger cannot filter on severity and does not carry one. Documented rather than worked around with a cache; the alternative was remembering every issue's details for the sake of a filter nobody has asked for.
- **Ignoring an issue leaves `active` as `True`** and stamps `dismissed_version`, so that is what "ignored" has to be read from.
- **`active=False` is a real state**, for non-persistent issues restored from storage that the integration has not reported again since the restart. Those do not count: the registry keeps them so it can remember which were ignored, and counting them would make the condition pass on every startup for something since fixed.

### On loop guards

There is deliberately no automatic exclusion of Spook's own issues. Spook raises a lot of them, but that is noise rather than a loop: an automation would have to create an issue itself to feed back in. The `domain` filter is there for anybody who wants Spook's own findings out of the way. Happy to add an explicit guard if you would rather have one.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Repair issues are a notification channel that only works if you go and look. There is no way to react to one, so an integration can be asking for attention for a fortnight before anybody notices. The condition covers the other half: holding a job back while the house is not in order.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Seventeen new tests, on top of the existing suite (1027 pass).

Covered: both triggers and the condition turning up in discovery, no options being valid for all three, a made-up severity being refused, an issue turning up and carrying its details, the same issue re-reported not firing again, ignoring an issue not firing, removal firing the other trigger, the domain and severity filters each turning the others down, the condition following an issue appearing and going away, the condition skipping ignored issues, the condition skipping issues awaiting confirmation after a restart, and both filters having to match the same issue.

The implementation was then broken five ways to check the tests earn their place, and each is caught: ignoring the domain filter, ignoring the severity filter, counting ignored issues, firing on `update` as well as `create`, and counting issues awaiting confirmation.

That last one was the only gap the first round of tests left, which is how the `active=False` state got a test at all. It is seeded through `hass_storage`, since it only happens on a restart.

Also ran: `ruff check`, `ruff format --check`, `pylint` over the whole tree, `zizmor`, the full pre-commit set, and a local rebuild of hassfest's descriptor schema over both descriptor files. The documentation builds with the same warnings as `main`, and the rendered page was checked to confirm all three new anchors are unique, since an earlier PR silently stole one.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
