### PR TITLE
Add a spook.quota condition

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -22,6 +22,7 @@ from .entity_filtering import async_setup_all_entity_ids_cache_invalidation
 from .integration_linking import link_sub_integrations, unlink_sub_integrations
 from .listeners import async_listen_once_tracked
 from .repairs import SpookRepairManager
+from .run_history import async_setup_run_history
 from .services import SpookServiceManager
 from .setup_helpers import async_forward_setup_entry
 
@@ -115,6 +116,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # action sequence is only built once that sequence runs, by which point
     # the automation it wants to know about has already been and gone.
     entry.async_on_unload(async_setup_automation_runs(hass))
+
+    # And when they ran, for the conditions that count runs rather than
+    # contexts. Same reason it cannot wait to be asked.
+    entry.async_on_unload(async_setup_run_history(hass))
 
     # Yay, we didn't got spooked!
     return True

--- a/custom_components/spook/conditions.yaml
+++ b/custom_components/spook/conditions.yaml
@@ -36,3 +36,19 @@ triggered_by_automation:
         entity:
           domain: automation
           multiple: true
+quota:
+  fields:
+    limit:
+      required: true
+      example: 5
+      selector:
+        number:
+          min: 1
+          max: 64
+          step: 1
+          mode: box
+    period:
+      required: true
+      example: "24:00:00"
+      selector:
+        duration:

--- a/custom_components/spook/ectoplasms/spook/conditions/quota.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/quota.py
@@ -74,10 +74,11 @@ def _limit(value: Any) -> int:
     return int(as_decimal)
 
 
-# The longest window on offer. The history lives in memory and is cleared by a
-# restart, so an allowance measured over more than a year could not be answered
-# honestly anyway, and a period long enough to reach past the start of the
-# calendar crashes the subtraction it is used for.
+# The longest window on offer, and a policy rather than a safeguard: the
+# history compares ages and has no trouble with a period of any size. The
+# reason is that it lives in memory and a restart clears it, so an allowance
+# measured over more than a year is not something this could answer honestly,
+# and accepting one would promise what it cannot keep.
 MAX_PERIOD = timedelta(days=366)
 
 

--- a/custom_components/spook/ectoplasms/spook/conditions/quota.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/quota.py
@@ -60,12 +60,25 @@ def _limit(value: Any) -> int:
     return int(vol.Range(min=1, max=MAX_RUNS_REMEMBERED)(int(as_decimal)))
 
 
+# The longest window on offer. The history lives in memory and is cleared by a
+# restart, so an allowance measured over more than a year could not be answered
+# honestly anyway, and a period long enough to reach past the start of the
+# calendar crashes the subtraction it is used for.
+MAX_PERIOD = timedelta(days=366)
+
+
 def _period(value: Any) -> timedelta:
-    """Validate the period, and refuse one nothing can fit inside."""
+    """Validate the period, and refuse one nothing useful fits inside."""
     period = cv.positive_time_period(value)
+
     if period <= timedelta(0):
         message = "The period must be longer than zero"
         raise vol.Invalid(message)
+
+    if period > MAX_PERIOD:
+        message = f"The period must be {MAX_PERIOD.days} days or shorter"
+        raise vol.Invalid(message)
+
     return period
 
 

--- a/custom_components/spook/ectoplasms/spook/conditions/quota.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/quota.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
 CONF_LIMIT = "limit"
 CONF_PERIOD = "period"
 
+# Fewer than one run is not an allowance, it is a way of switching something off.
+MIN_LIMIT = 1
+
 
 def _limit(value: Any) -> int:
     """Validate the limit, and refuse anything that is not a whole count.
@@ -57,7 +60,18 @@ def _limit(value: Any) -> int:
     if not as_decimal.is_finite() or as_decimal != as_decimal.to_integral_value():
         raise vol.Invalid(message)
 
-    return int(vol.Range(min=1, max=MAX_RUNS_REMEMBERED)(int(as_decimal)))
+    # Range checked while it is still a Decimal, before anything becomes an
+    # int. "1e1000000000" is twelve characters of config and a billion digits
+    # of integer, and building it just to find out it is too large is the
+    # whole cost: `int(Decimal("1e1000000"))` already takes 25 seconds, while
+    # comparing the Decimal takes microseconds whatever the exponent.
+    if not MIN_LIMIT <= as_decimal <= MAX_RUNS_REMEMBERED:
+        message = (
+            f"The limit must be between {MIN_LIMIT} and {MAX_RUNS_REMEMBERED} runs"
+        )
+        raise vol.Invalid(message)
+
+    return int(as_decimal)
 
 
 # The longest window on offer. The history lives in memory and is cleared by a

--- a/custom_components/spook/ectoplasms/spook/conditions/quota.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/quota.py
@@ -27,6 +27,32 @@ CONF_LIMIT = "limit"
 CONF_PERIOD = "period"
 
 
+def _limit(value: Any) -> int:
+    """Validate the limit, and refuse anything that is not a whole count.
+
+    `vol.Coerce(int)` hands back 1 for both 1.5 and `True`, so a mistyped
+    limit would quietly become a different one. And only half quietly: 0.5 is
+    already refused, because truncating it lands below the minimum. An
+    allowance is a number of runs, so it has to be a whole one.
+    """
+    message = f"The limit must be a whole number of runs, got '{value}'"
+
+    # A bool is an int as far as Python is concerned, and `True` would sail
+    # through everything below as a limit of one.
+    if isinstance(value, bool):
+        raise vol.Invalid(message)
+
+    try:
+        as_number = float(value)
+    except (TypeError, ValueError) as err:
+        raise vol.Invalid(message) from err
+
+    if not as_number.is_integer():
+        raise vol.Invalid(message)
+
+    return int(vol.Range(min=1, max=MAX_RUNS_REMEMBERED)(int(as_number)))
+
+
 def _period(value: Any) -> timedelta:
     """Validate the period, and refuse one nothing can fit inside."""
     period = cv.positive_time_period(value)
@@ -39,9 +65,7 @@ def _period(value: Any) -> timedelta:
 _CONDITION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_OPTIONS): {
-            vol.Required(CONF_LIMIT): vol.All(
-                vol.Coerce(int), vol.Range(min=1, max=MAX_RUNS_REMEMBERED)
-            ),
+            vol.Required(CONF_LIMIT): _limit,
             vol.Required(CONF_PERIOD): _period,
         },
     }

--- a/custom_components/spook/ectoplasms/spook/conditions/quota.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/quota.py
@@ -75,15 +75,17 @@ _CONDITION_SCHEMA = vol.Schema(
 class SpookCondition(Condition):
     """Spook condition that passes until a run allowance is used up.
 
-    Passes while this automation or script has run fewer than the given
-    number of times within the given period, so something can be held to a
-    few runs an hour or a handful a day. The counterpart to
-    ``spook.cooldown``, which spaces runs out rather than capping them.
+    Passes while this automation has run fewer than the given number of times
+    within the given period, so something can be held to a few runs an hour or
+    a handful a day. The counterpart to ``spook.cooldown``, which spaces runs
+    out rather than capping them.
 
     The window rolls: a limit of five over a day means no more than five runs
     in any twenty-four hours, not five between midnights. Runs are counted
     from what actually ran, so a run some other condition turned down does
     not cost anything.
+
+    Automations only. See ``run_history`` for why scripts are left out.
     """
 
     condition = "quota"

--- a/custom_components/spook/ectoplasms/spook/conditions/quota.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/quota.py
@@ -1,0 +1,110 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.condition import Condition
+
+from ....run_history import MAX_RUNS_REMEMBERED, async_get_run_history
+from ..context import own_entity_id
+
+if TYPE_CHECKING:
+    from typing import Unpack
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.condition import ConditionCheckParams, ConditionConfig
+    from homeassistant.helpers.typing import ConfigType
+
+    from ....run_history import RunHistory
+
+CONF_LIMIT = "limit"
+CONF_PERIOD = "period"
+
+
+def _period(value: Any) -> timedelta:
+    """Validate the period, and refuse one nothing can fit inside."""
+    period = cv.positive_time_period(value)
+    if period <= timedelta(0):
+        message = "The period must be longer than zero"
+        raise vol.Invalid(message)
+    return period
+
+
+_CONDITION_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_LIMIT): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=MAX_RUNS_REMEMBERED)
+            ),
+            vol.Required(CONF_PERIOD): _period,
+        },
+    }
+)
+
+
+class SpookCondition(Condition):
+    """Spook condition that passes until a run allowance is used up.
+
+    Passes while this automation or script has run fewer than the given
+    number of times within the given period, so something can be held to a
+    few runs an hour or a handful a day. The counterpart to
+    ``spook.cooldown``, which spaces runs out rather than capping them.
+
+    The window rolls: a limit of five over a day means no more than five runs
+    in any twenty-four hours, not five between midnights. Runs are counted
+    from what actually ran, so a run some other condition turned down does
+    not cost anything.
+    """
+
+    condition = "quota"
+
+    _limit: int
+    _period: timedelta
+
+    # Core refuses to check a condition it has not set up, so by the time any
+    # check runs this is always there.
+    _history: RunHistory
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the condition config."""
+        return _CONDITION_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Initialize the condition."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._limit = options[CONF_LIMIT]
+        self._period = options[CONF_PERIOD]
+
+    async def _async_setup(self) -> None:
+        """Take hold of the history of what ran when."""
+        self._history = async_get_run_history(self._hass)
+
+    def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:
+        """Return True while there is allowance left."""
+        variables = kwargs.get("variables")
+        entity_id = own_entity_id(variables)
+        if entity_id is None:
+            # Nothing to count against, so nothing has been used up.
+            return True
+
+        # The run this is part of does not count against the allowance. A
+        # script announces itself before its sequence starts, so without this
+        # a limit of one would turn down the very first run.
+        context = variables.get("context") if hasattr(variables, "get") else None
+
+        used = self._history.async_runs_within(
+            entity_id, self._period, ignoring=getattr(context, "id", None)
+        )
+        return used < self._limit

--- a/custom_components/spook/ectoplasms/spook/conditions/quota.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/quota.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -42,15 +43,21 @@ def _limit(value: Any) -> int:
     if isinstance(value, bool):
         raise vol.Invalid(message)
 
+    # Decimal rather than float, and from the text rather than the value.
+    # `float("5.0000000000000001")` is exactly 5.0, so a fractional limit would
+    # round its way through, and a large enough integer raises OverflowError on
+    # the way in rather than being refused for being too large.
     try:
-        as_number = float(value)
-    except (TypeError, ValueError) as err:
+        as_decimal = Decimal(str(value))
+    except (ArithmeticError, TypeError, ValueError) as err:
         raise vol.Invalid(message) from err
 
-    if not as_number.is_integer():
+    # Infinity and not-a-number are both "integral" as far as Decimal is
+    # concerned, and only fall over on the way to an int.
+    if not as_decimal.is_finite() or as_decimal != as_decimal.to_integral_value():
         raise vol.Invalid(message)
 
-    return int(vol.Range(min=1, max=MAX_RUNS_REMEMBERED)(int(as_number)))
+    return int(vol.Range(min=1, max=MAX_RUNS_REMEMBERED)(int(as_decimal)))
 
 
 def _period(value: Any) -> timedelta:

--- a/custom_components/spook/ectoplasms/spook/conditions/quota.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/quota.py
@@ -145,9 +145,10 @@ class SpookCondition(Condition):
             # Nothing to count against, so nothing has been used up.
             return True
 
-        # The run this is part of does not count against the allowance. A
-        # script announces itself before its sequence starts, so without this
-        # a limit of one would turn down the very first run.
+        # The run this is part of does not count against the allowance. An
+        # automation is recorded before its actions start, so a condition
+        # sitting in an `if` finds its own run already there, and without this
+        # a limit of one would turn down every run.
         context = variables.get("context") if hasattr(variables, "get") else None
 
         used = self._history.async_runs_within(

--- a/custom_components/spook/ectoplasms/spook/conditions/triggered_by_automation.py
+++ b/custom_components/spook/ectoplasms/spook/conditions/triggered_by_automation.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.condition import Condition
 
 from ....automation_runs import async_get_automation_runs
-from ..context import source_contexts
+from ..context import own_entity_id, source_contexts
 
 if TYPE_CHECKING:
     from typing import Unpack
@@ -24,25 +24,6 @@ if TYPE_CHECKING:
     from ....automation_runs import AutomationRuns
 
 CONF_AUTOMATION = "automation"
-
-
-def _own_entity_id(variables: Any) -> str | None:
-    """Return the automation running right now, if this is inside one.
-
-    Wanted so it can be skipped. Inside an action sequence the run's own
-    context is in reach and the register knows it, so without this the
-    condition would report the automation asking the question as the one
-    that set it going, and would pass for a schedule or a person.
-    """
-    if not hasattr(variables, "get"):
-        return None
-
-    this = variables.get("this")
-    if not hasattr(this, "get"):
-        return None
-
-    entity_id = this.get("entity_id")
-    return entity_id if isinstance(entity_id, str) else None
 
 
 _CONDITION_SCHEMA = vol.Schema(
@@ -111,7 +92,7 @@ class SpookCondition(Condition):
     def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool:
         """Return True when another automation started this run."""
         variables = kwargs.get("variables")
-        myself = _own_entity_id(variables)
+        myself = own_entity_id(variables)
 
         for context in source_contexts(variables):
             entity_id = self._runs.async_which(context.id)

--- a/custom_components/spook/ectoplasms/spook/context.py
+++ b/custom_components/spook/ectoplasms/spook/context.py
@@ -76,3 +76,20 @@ def run_context(variables: Any) -> Context | None:
             return context
 
     return None
+
+
+def own_entity_id(variables: Any) -> str | None:
+    """Return the automation or script being run right now, if there is one.
+
+    Home Assistant puts the running entity in ``this``, so this is how a
+    condition finds out what it is a part of.
+    """
+    if not hasattr(variables, "get"):
+        return None
+
+    this = variables.get("this")
+    if not hasattr(this, "get"):
+        return None
+
+    entity_id = this.get("entity_id")
+    return entity_id if isinstance(entity_id, str) else None

--- a/custom_components/spook/run_history.py
+++ b/custom_components/spook/run_history.py
@@ -99,7 +99,10 @@ class RunHistory:
         chain, so several runs can share one, and dropping every match would
         leave an allowance unspent.
         """
-        since = dt_util.utcnow() - period
+        # Each run's age is compared with the period rather than working out
+        # the moment the window opens. Same boundary, and no datetime that a
+        # long enough period could push out of range.
+        now = dt_util.utcnow()
         within = 0
         own_run_skipped = False
 
@@ -107,7 +110,7 @@ class RunHistory:
             # A run exactly a period old has served its time, which is how
             # `spook.cooldown` reads its own boundary: expired at `elapsed >=
             # duration` rather than one instant later.
-            if when <= since:
+            if now - when >= period:
                 continue
 
             if not own_run_skipped and context_id == ignoring:

--- a/custom_components/spook/run_history.py
+++ b/custom_components/spook/run_history.py
@@ -1,0 +1,128 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import TYPE_CHECKING
+
+from lru import LRU
+
+from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
+from homeassistant.components.script.const import EVENT_SCRIPT_STARTED
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import callback
+from homeassistant.util import dt as dt_util
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime, timedelta
+
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+
+DATA_RUN_HISTORY: HassKey[RunHistory] = HassKey("spook_run_history")
+
+# How many automations and scripts are followed at once. Whichever ran least
+# recently is dropped, which is the right one to lose: nobody asks about the
+# rate of something that has stopped running.
+TRACKED_ENTITIES = 256
+
+# How many run times are kept for each of them. This is the ceiling on what a
+# quota can ask for, since answering "have there been N runs" needs the Nth
+# most recent one to still be there.
+MAX_RUNS_REMEMBERED = 64
+
+
+class RunHistory:
+    """Remembers when automations and scripts last ran.
+
+    Home Assistant records only the most recent run, on
+    ``this.attributes.last_triggered``, which answers "how long ago" but not
+    "how many". Both events used here fire when something really runs: an
+    automation whose conditions turned the run down does not announce itself,
+    so a blocked run is not counted.
+
+    Listening starts when Spook does, so the history is already there by the
+    time anything asks.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the history."""
+        self._hass = hass
+        self._runs: LRU = LRU(TRACKED_ENTITIES)
+        self._unsubs: list[CALLBACK_TYPE] = []
+
+    @callback
+    def async_start(self) -> CALLBACK_TYPE:
+        """Start listening, and return the way to stop."""
+        if not self._unsubs:
+            self._unsubs = [
+                self._hass.bus.async_listen(event_type, self._async_ran)
+                for event_type in (EVENT_AUTOMATION_TRIGGERED, EVENT_SCRIPT_STARTED)
+            ]
+        return self.async_stop
+
+    @callback
+    def async_stop(self) -> None:
+        """Stop listening and let go of what was remembered."""
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+        self._runs.clear()
+
+    @callback
+    def async_runs_within(
+        self,
+        entity_id: str,
+        period: timedelta,
+        ignoring: str | None = None,
+    ) -> int:
+        """Return how many times this one ran within the given period.
+
+        ``ignoring`` leaves out the run under that context, which is how a
+        caller excludes the run it is part of. A script announces itself
+        before its sequence starts, so a condition inside that sequence would
+        otherwise find its own run already counted. An automation announces
+        itself only once its conditions have passed, so for one of those this
+        changes nothing.
+        """
+        since = dt_util.utcnow() - period
+        return sum(
+            1
+            for when, context_id in self._async_runs(entity_id)
+            if when >= since and context_id != ignoring
+        )
+
+    @callback
+    def _async_runs(self, entity_id: str) -> Sequence[tuple[datetime, str]]:
+        """Return when this one ran and under which context, most recent first."""
+        return self._runs.get(entity_id) or ()  # type: ignore[no-any-return]
+
+    @callback
+    def _async_ran(self, event: Event) -> None:
+        """Note that something just ran."""
+        if not (entity_id := event.data.get(ATTR_ENTITY_ID)):
+            return
+
+        if (runs := self._runs.get(entity_id)) is None:
+            runs = deque(maxlen=MAX_RUNS_REMEMBERED)
+            self._runs[entity_id] = runs
+
+        # Newest first, so the oldest is the one a full deque drops.
+        runs.appendleft((dt_util.utcnow(), event.context.id))
+
+
+@callback
+def async_get_run_history(hass: HomeAssistant) -> RunHistory:
+    """Return the shared history, starting it if this is the first ask."""
+    if (history := hass.data.get(DATA_RUN_HISTORY)) is None:
+        history = RunHistory(hass)
+        hass.data[DATA_RUN_HISTORY] = history
+        history.async_start()
+    return history
+
+
+@callback
+def async_setup_run_history(hass: HomeAssistant) -> CALLBACK_TYPE:
+    """Start remembering when things ran, and return the way to stop."""
+    return async_get_run_history(hass).async_start()

--- a/custom_components/spook/run_history.py
+++ b/custom_components/spook/run_history.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from collections import deque
+from datetime import datetime  # noqa: TC003
 from typing import TYPE_CHECKING
-
-from lru import LRU
 
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.const import ATTR_ENTITY_ID
@@ -15,7 +14,7 @@ from homeassistant.util.hass_dict import HassKey
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from datetime import datetime, timedelta
+    from datetime import timedelta
 
     from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
 
@@ -59,7 +58,11 @@ class RunHistory:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the history."""
         self._hass = hass
-        self._runs: LRU = LRU(TRACKED_ENTITIES)
+        # A plain dict, ordered by when each entity last ran. An LRU would
+        # do the eviction, but its reads refresh recency, and reading here
+        # is what a quota check does: an automation checked often but never
+        # run would outlive one that actually ran.
+        self._runs: dict[str, deque[tuple[datetime, str]]] = {}
         self._unsubs: list[CALLBACK_TYPE] = []
 
     @callback
@@ -124,7 +127,7 @@ class RunHistory:
     @callback
     def _async_runs(self, entity_id: str) -> Sequence[tuple[datetime, str]]:
         """Return when this one ran and under which context, most recent first."""
-        return self._runs.get(entity_id) or ()  # type: ignore[no-any-return]
+        return self._runs.get(entity_id) or ()
 
     @callback
     def _async_ran(self, event: Event) -> None:
@@ -132,12 +135,18 @@ class RunHistory:
         if not (entity_id := event.data.get(ATTR_ENTITY_ID)):
             return
 
-        if (runs := self._runs.get(entity_id)) is None:
+        # Popped and re-inserted, so the mapping stays in order of when each
+        # entity last ran and the front is always the one to forget first.
+        runs = self._runs.pop(entity_id, None)
+        if runs is None:
             runs = deque(maxlen=_RUNS_KEPT)
-            self._runs[entity_id] = runs
+        self._runs[entity_id] = runs
 
         # Newest first, so the oldest is the one a full deque drops.
         runs.appendleft((dt_util.utcnow(), event.context.id))
+
+        while len(self._runs) > TRACKED_ENTITIES:
+            del self._runs[next(iter(self._runs))]
 
 
 @callback

--- a/custom_components/spook/run_history.py
+++ b/custom_components/spook/run_history.py
@@ -32,6 +32,12 @@ TRACKED_ENTITIES = 256
 # most recent one to still be there.
 MAX_RUNS_REMEMBERED = 64
 
+# One more than that is actually kept. A script announces itself before its
+# sequence starts, so the run doing the asking is already in here, and without
+# the spare it would push the oldest of the runs it is asking about out of
+# reach: a limit of 64 could then only ever see 63 and would never be reached.
+_RUNS_KEPT = MAX_RUNS_REMEMBERED + 1
+
 
 class RunHistory:
     """Remembers when automations and scripts last ran.
@@ -79,19 +85,33 @@ class RunHistory:
     ) -> int:
         """Return how many times this one ran within the given period.
 
-        ``ignoring`` leaves out the run under that context, which is how a
-        caller excludes the run it is part of. A script announces itself
-        before its sequence starts, so a condition inside that sequence would
-        otherwise find its own run already counted. An automation announces
-        itself only once its conditions have passed, so for one of those this
-        changes nothing.
+        ``ignoring`` leaves out the most recent run under that context, which
+        is how a caller excludes the run it is part of. A script announces
+        itself before its sequence starts, so a condition inside that sequence
+        would otherwise find its own run already counted. An automation
+        announces itself only once its conditions have passed, so for one of
+        those this changes nothing.
+
+        The most recent one, and only that one. A script inherits its caller's
+        context, so an automation calling the same script three times over
+        gives all three runs the same one. Dropping every match would mean
+        such a script never spent anything at all.
         """
         since = dt_util.utcnow() - period
-        return sum(
-            1
-            for when, context_id in self._async_runs(entity_id)
-            if when >= since and context_id != ignoring
-        )
+        within = 0
+        own_run_skipped = False
+
+        for when, context_id in self._async_runs(entity_id):
+            if when < since:
+                continue
+
+            if not own_run_skipped and context_id == ignoring:
+                own_run_skipped = True
+                continue
+
+            within += 1
+
+        return within
 
     @callback
     def _async_runs(self, entity_id: str) -> Sequence[tuple[datetime, str]]:
@@ -105,7 +125,7 @@ class RunHistory:
             return
 
         if (runs := self._runs.get(entity_id)) is None:
-            runs = deque(maxlen=MAX_RUNS_REMEMBERED)
+            runs = deque(maxlen=_RUNS_KEPT)
             self._runs[entity_id] = runs
 
         # Newest first, so the oldest is the one a full deque drops.

--- a/custom_components/spook/run_history.py
+++ b/custom_components/spook/run_history.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from lru import LRU
 
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
-from homeassistant.components.script.const import EVENT_SCRIPT_STARTED
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
@@ -22,9 +21,9 @@ if TYPE_CHECKING:
 
 DATA_RUN_HISTORY: HassKey[RunHistory] = HassKey("spook_run_history")
 
-# How many automations and scripts are followed at once. Whichever ran least
-# recently is dropped, which is the right one to lose: nobody asks about the
-# rate of something that has stopped running.
+# How many automations are followed at once. Whichever ran least recently is
+# dropped, which is the right one to lose: nobody asks about the rate of
+# something that has stopped running.
 TRACKED_ENTITIES = 256
 
 # How many run times are kept for each of them. This is the ceiling on what a
@@ -32,21 +31,26 @@ TRACKED_ENTITIES = 256
 # most recent one to still be there.
 MAX_RUNS_REMEMBERED = 64
 
-# One more than that is actually kept. A script announces itself before its
-# sequence starts, so the run doing the asking is already in here, and without
-# the spare it would push the oldest of the runs it is asking about out of
-# reach: a limit of 64 could then only ever see 63 and would never be reached.
+# One more than that is actually kept, as headroom for a caller that is itself
+# already in here: without the spare it would push the oldest of the runs it is
+# asking about out of reach, and a limit of 64 could then only ever see 63.
 _RUNS_KEPT = MAX_RUNS_REMEMBERED + 1
 
 
 class RunHistory:
-    """Remembers when automations and scripts last ran.
+    """Remembers when automations last ran.
 
     Home Assistant records only the most recent run, on
     ``this.attributes.last_triggered``, which answers "how long ago" but not
-    "how many". Both events used here fire when something really runs: an
-    automation whose conditions turned the run down does not announce itself,
-    so a blocked run is not counted.
+    "how many".
+
+    Automations only, and that is a decision rather than an oversight.
+    `EVENT_AUTOMATION_TRIGGERED` fires once a run is really happening: one
+    whose conditions turned it down does not announce itself, so a blocked run
+    costs nothing. Scripts have no equivalent. `EVENT_SCRIPT_STARTED` fires
+    before the engine decides whether the run is allowed at all, so a call
+    turned down by `mode: single` announces itself just the same, and counting
+    those would spend an allowance on runs that never happened.
 
     Listening starts when Spook does, so the history is already there by the
     time anything asks.
@@ -63,8 +67,7 @@ class RunHistory:
         """Start listening, and return the way to stop."""
         if not self._unsubs:
             self._unsubs = [
-                self._hass.bus.async_listen(event_type, self._async_ran)
-                for event_type in (EVENT_AUTOMATION_TRIGGERED, EVENT_SCRIPT_STARTED)
+                self._hass.bus.async_listen(EVENT_AUTOMATION_TRIGGERED, self._async_ran)
             ]
         return self.async_stop
 
@@ -86,16 +89,15 @@ class RunHistory:
         """Return how many times this one ran within the given period.
 
         ``ignoring`` leaves out the most recent run under that context, which
-        is how a caller excludes the run it is part of. A script announces
-        itself before its sequence starts, so a condition inside that sequence
-        would otherwise find its own run already counted. An automation
-        announces itself only once its conditions have passed, so for one of
-        those this changes nothing.
+        is how a caller excludes the run it is part of. An automation
+        announces itself only once its conditions have passed, so a condition
+        gating one of those is not in here yet and this changes nothing. A
+        condition sitting inside the actions is, and should not be made to
+        count the run it is part of.
 
-        The most recent one, and only that one. A script inherits its caller's
-        context, so an automation calling the same script three times over
-        gives all three runs the same one. Dropping every match would mean
-        such a script never spent anything at all.
+        The most recent one, and only that one. Contexts are inherited down a
+        chain, so several runs can share one, and dropping every match would
+        leave an allowance unspent.
         """
         since = dt_util.utcnow() - period
         within = 0

--- a/custom_components/spook/run_history.py
+++ b/custom_components/spook/run_history.py
@@ -104,7 +104,10 @@ class RunHistory:
         own_run_skipped = False
 
         for when, context_id in self._async_runs(entity_id):
-            if when < since:
+            # A run exactly a period old has served its time, which is how
+            # `spook.cooldown` reads its own boundary: expired at `elapsed >=
+            # duration` rather than one instant later.
+            if when <= since:
                 continue
 
             if not own_run_skipped and context_id == ignoring:

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -38,7 +38,7 @@
   "conditions": {
     "quota": {
       "name": "Run allowance left",
-      "description": "Passes while this automation or script has run fewer than a given number of times within a given period.",
+      "description": "Passes while this automation has run fewer than a given number of times within a given period. Scripts are not counted.",
       "fields": {
         "limit": {
           "name": "Limit",

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -36,6 +36,20 @@
     }
   },
   "conditions": {
+    "quota": {
+      "name": "Run allowance left",
+      "description": "Passes while this automation or script has run fewer than a given number of times within a given period.",
+      "fields": {
+        "limit": {
+          "name": "Limit",
+          "description": "How many runs are allowed within the period."
+        },
+        "period": {
+          "name": "Period",
+          "description": "The window the limit applies to. It rolls, so a day means any twenty-four hours rather than between midnights."
+        }
+      }
+    },
     "triggered_by_automation": {
       "name": "Triggered by an automation",
       "description": "Passes when another automation set this run going, whether it did so directly or through a script.",

--- a/documentation/conditions.md
+++ b/documentation/conditions.md
@@ -38,3 +38,9 @@ Passes a set percentage of the time, chosen at random on every check. For when t
 Passes when another automation set this run going, directly or through a script. Can be narrowed to particular automations. _#automation_ _#context_
 
 `spook.triggered_by_automation`, [documentation](other-features#triggered-by-an-automation) 📚
+
+## Run allowance left
+
+Passes while this automation or script has run fewer than a given number of times within a given period. The counterpart to Cooldown: that one spaces runs out, this one caps them. _#quota_ _#ratelimit_
+
+`spook.quota`, [documentation](other-features#run-allowance-left) 📚

--- a/documentation/conditions.md
+++ b/documentation/conditions.md
@@ -41,6 +41,6 @@ Passes when another automation set this run going, directly or through a script.
 
 ## Run allowance left
 
-Passes while this automation or script has run fewer than a given number of times within a given period. The counterpart to Cooldown: that one spaces runs out, this one caps them. _#quota_ _#ratelimit_
+Passes while this automation has run fewer than a given number of times within a given period. The counterpart to Cooldown: that one spaces runs out, this one caps them. _#quota_ _#ratelimit_
 
 `spook.quota`, [documentation](other-features#run-allowance-left) 📚

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -650,6 +650,7 @@ options:
 - The count starts again after a restart. Spook remembers the runs while it is running, and nothing is written down, so a restart hands back a full allowance.
 - The limit cannot go above 64. Spook keeps the last 64 runs of each automation and script, and answering a larger limit would need a longer memory than that. Above 64 runs in a window it is not really an allowance any more.
 - Only automations and scripts have an allowance. Both are counted, but a condition checked outside either has nothing to count against and passes.
+- Only the 256 most recently active automations and scripts are followed. Beyond that the least recently used one is forgotten, which hands its allowance back. Not something a normal house will reach, but it is a limit.
 - The run doing the asking does not count against itself. A script announces itself before its sequence starts, so without that a limit of one would turn down the very first run.
 
 :::

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -583,7 +583,7 @@ options:
 
 ### Run allowance left
 
-Passes while this automation or script has runs to spare.
+Passes while this automation has runs to spare.
 
 ```{list-table}
 :header-rows: 1
@@ -648,9 +648,9 @@ options:
 :class: dropdown
 
 - The count starts again after a restart. Spook remembers the runs while it is running, and nothing is written down, so a restart hands back a full allowance.
-- The limit cannot go above 64. Spook keeps the last 64 runs of each automation and script, and answering a larger limit would need a longer memory than that. Above 64 runs in a window it is not really an allowance any more.
-- Only automations and scripts have an allowance. Both are counted, but a condition checked outside either has nothing to count against and passes.
-- Only the 256 most recently active automations and scripts are followed. Beyond that the least recently used one is forgotten, which hands its allowance back. Not something a normal house will reach, but it is a limit.
-- The run doing the asking does not count against itself. A script announces itself before its sequence starts, so without that a limit of one would turn down the very first run.
+- The limit cannot go above 64. Spook keeps the last 64 runs of each automation, and answering a larger limit would need a longer memory than that. Above 64 runs in a window it is not really an allowance any more.
+- Automations only. Scripts are left out on purpose: Home Assistant announces a script run before deciding whether it is allowed, so a call turned down for already running would spend an allowance on a run that never happened. A condition checked anywhere other than an automation has nothing to count against and passes.
+- Only the 256 most recently run automations are followed. Beyond that the least recently used one is forgotten, which hands its allowance back. Not something a normal house will reach, but it is a limit.
+- The run doing the asking does not count against itself. A condition sitting inside the actions is checked while the run is already under way, so without that a limit of one would turn down every run.
 
 :::

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -423,6 +423,8 @@ condition: spook.not_triggered_by_user
 
 :::
 
+(cooldown)=
+
 ### Cooldown
 
 Passes when this automation or script has not run within a given time.
@@ -576,5 +578,78 @@ options:
 - Spook has to have been running when the other automation ran. It remembers the mapping while your automations are loaded, so a run from before a restart is no longer known.
 - It names the automation that started the chain, not the last thing in it. If your goodnight automation calls a script and that script turns off the lights, this reports the automation, which is almost always what you wanted to ask about.
 - Only the last few hundred automation runs are remembered. Not a practical limit for a condition being checked right after the run it is asking about, but it is a limit.
+
+:::
+
+### Run allowance left
+
+Passes while this automation or script has runs to spare.
+
+```{list-table}
+:header-rows: 1
+* - Condition properties
+* - {term}`Condition`
+  - Run allowance left 👻
+* - Condition name
+  - `spook.quota`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added condition
+```
+
+```{list-table}
+:header-rows: 2
+* - Condition options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `limit`
+  - {term}`integer <integer>`
+  - Yes
+  - `5`
+* - `period`
+  - {term}`string <string>`
+  - Yes
+  - `24:00:00`
+```
+
+The counterpart to [Cooldown](#cooldown): that one spaces runs out, this one caps how many there are. Handy for something that is fine now and then but not fifty times a day, like a notification about a door that keeps being opened.
+
+The window rolls. A limit of five over a day means no more than five runs in any twenty-four hours, not five between midnights, so the allowance comes back gradually as the oldest run drops out of the window rather than all at once.
+
+Runs are counted from what actually ran. Home Assistant does not announce an automation whose conditions turned the run down, so an attempt something else held back costs nothing.
+
+:::{seealso} Example {term}`condition <condition>` in {term}`YAML`
+:class: dropdown
+
+At most five runs in any twenty-four hours:
+
+```{code-block} yaml
+:linenos:
+condition: spook.quota
+options:
+  limit: 5
+  period: "24:00:00"
+```
+
+Twice an hour, and no more:
+
+```{code-block} yaml
+:linenos:
+condition: spook.quota
+options:
+  limit: 2
+  period: "01:00:00"
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- The count starts again after a restart. Spook remembers the runs while it is running, and nothing is written down, so a restart hands back a full allowance.
+- The limit cannot go above 64. Spook keeps the last 64 runs of each automation and script, and answering a larger limit would need a longer memory than that. Above 64 runs in a window it is not really an allowance any more.
+- Only automations and scripts have an allowance. Both are counted, but a condition checked outside either has nothing to count against and passes.
+- The run doing the asking does not count against itself. A script announces itself before its sequence starts, so without that a limit of one would turn down the very first run.
 
 :::

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -649,6 +649,7 @@ options:
 
 - The count starts again after a restart. Spook remembers the runs while it is running, and nothing is written down, so a restart hands back a full allowance.
 - The limit cannot go above 64. Spook keeps the last 64 runs of each automation, and answering a larger limit would need a longer memory than that. Above 64 runs in a window it is not really an allowance any more.
+- The period cannot go above 366 days. Since a restart clears the count anyway, an allowance measured over more than a year is not something this could answer honestly.
 - Automations only. Scripts are left out on purpose: Home Assistant announces a script run before deciding whether it is allowed, so a call turned down for already running would spend an allowance on a run that never happened. A condition checked anywhere other than an automation has nothing to count against and passes.
 - Only the 256 most recently run automations are followed. Beyond that the least recently used one is forgotten, which hands its allowance back. Not something a normal house will reach, but it is a limit.
 - The run doing the asking does not count against itself. A condition sitting inside the actions is checked while the run is already under way, so without that a limit of one would turn down every run.

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -15,7 +15,10 @@ import pytest
 import voluptuous as vol
 
 from custom_components.spook.condition import async_get_conditions
-from custom_components.spook.ectoplasms.spook.conditions.quota import SpookCondition
+from custom_components.spook.ectoplasms.spook.conditions.quota import (
+    MAX_PERIOD,
+    SpookCondition,
+)
 from custom_components.spook.run_history import (
     MAX_RUNS_REMEMBERED,
     async_get_run_history,
@@ -180,6 +183,43 @@ async def test_a_limit_beyond_what_is_remembered_is_refused(
         await SpookCondition.async_validate_config(
             hass, {"options": {"limit": limit, "period": "01:00:00"}}
         )
+
+
+@pytest.mark.parametrize(
+    "period",
+    [
+        {"days": MAX_PERIOD.days + 1},
+        # Long enough that subtracting it from now reaches past the start of
+        # the calendar, which used to crash the check rather than the config.
+        {"days": 999999999},
+        "9999999:00:00",
+    ],
+)
+async def test_a_period_longer_than_a_year_is_refused(
+    hass: HomeAssistant,
+    period: object,
+) -> None:
+    """A window nothing useful fits inside, and one that cannot be measured.
+
+    The history lives in memory and a restart clears it, so an allowance over
+    more than a year could not be answered honestly. And a period long enough
+    to reach past the start of the calendar broke the subtraction it is used
+    for, which failed inside the condition rather than at load.
+    """
+    with pytest.raises(vol.Invalid, match="days or shorter"):
+        await SpookCondition.async_validate_config(
+            hass, {"options": {"limit": 1, "period": period}}
+        )
+
+
+async def test_the_longest_period_on_offer_still_works(hass: HomeAssistant) -> None:
+    """And the boundary itself is usable, not just accepted."""
+    condition = SpookCondition(
+        hass, ConditionConfig(options={"limit": 1, "period": MAX_PERIOD})
+    )
+    await condition.async_setup()
+
+    assert condition.async_check(variables={}) is True
 
 
 async def test_it_allows_the_limit_and_then_stops(

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers.condition import ConditionConfig
-from homeassistant.components.script.const import EVENT_SCRIPT_STARTED
+from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -284,57 +284,16 @@ async def test_it_counts_per_automation(
     assert ran == ["first", "second"], "one automation spent the other's allowance"
 
 
-async def test_it_counts_scripts_too(
+async def test_scripts_have_no_allowance(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """A script has an allowance as well, the same as `cooldown` covers both."""
-    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
-    async_setup_run_history(hass)
+    """Scripts are deliberately left out, so nothing is counted for them.
 
-    ran: list[int] = []
-    hass.services.async_register("test", "mark", lambda _call: ran.append(1))
-
-    assert await async_setup_component(
-        hass,
-        "script",
-        {
-            "script": {
-                "rationed": {
-                    "sequence": [
-                        {
-                            "if": [
-                                {
-                                    "condition": "spook.quota",
-                                    "options": {"limit": 1, "period": "01:00:00"},
-                                }
-                            ],
-                            "then": [{"action": "test.mark"}],
-                        }
-                    ]
-                }
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    for _ in range(3):
-        await hass.services.async_call("script", "rationed", blocking=True)
-        await hass.async_block_till_done()
-
-    assert len(ran) == 1, f"let {len(ran)} through on an allowance of one"
-
-
-async def test_repeated_calls_sharing_a_context_still_spend_the_allowance(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """A script inherits its caller's context, so runs can share one.
-
-    An automation calling the same script three times over gives all three
-    runs the same context. Leaving out every run under the current context
-    rather than only the current run would mean this script never spent
-    anything at all.
+    `EVENT_SCRIPT_STARTED` fires before the engine decides whether the run is
+    allowed, so a call turned down by `mode: single` announces itself just the
+    same. Counting those would spend an allowance on runs that never happened,
+    which is worse than not counting scripts at all.
     """
     freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
     async_setup_run_history(hass)
@@ -363,20 +322,48 @@ async def test_repeated_calls_sharing_a_context_still_spend_the_allowance(
             }
         },
     )
+    await hass.async_block_till_done()
+
+    for _ in range(THREE):
+        await hass.services.async_call("script", "rationed", blocking=True)
+        await hass.async_block_till_done()
+
+    assert len(ran) == THREE, "a script was rationed, which is not the promise"
+
+
+async def test_the_run_doing_the_asking_does_not_count_against_itself(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Inside the actions, the run is already under way and already counted.
+
+    An automation announces itself before its actions start, so a condition
+    sitting in an `if` finds its own run in the history. Counting that would
+    make a limit of one turn down every run there ever was.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    async_setup_run_history(hass)
+
+    ran: list[int] = []
+    hass.services.async_register("test", "mark", lambda _call: ran.append(1))
+
     assert await async_setup_component(
         hass,
         "automation",
         {
             "automation": [
                 {
-                    "alias": "caller",
+                    "alias": "rationed inside",
                     "trigger": {"platform": "event", "event_type": "kick"},
                     "action": [
                         {
-                            "repeat": {
-                                "count": 3,
-                                "sequence": [{"action": "script.rationed"}],
-                            }
+                            "if": [
+                                {
+                                    "condition": "spook.quota",
+                                    "options": {"limit": 1, "period": "01:00:00"},
+                                }
+                            ],
+                            "then": [{"action": "test.mark"}],
                         }
                     ],
                 }
@@ -387,8 +374,37 @@ async def test_repeated_calls_sharing_a_context_still_spend_the_allowance(
 
     hass.bus.async_fire("kick")
     await hass.async_block_till_done()
+    assert len(ran) == 1, "turned down the first run by counting it against itself"
 
-    assert len(ran) == 1, f"let {len(ran)} through on an allowance of one"
+    # And the allowance really is spent for the next one.
+    hass.bus.async_fire("kick")
+    await hass.async_block_till_done()
+    assert len(ran) == 1, "let a second run through on an allowance of one"
+
+
+async def test_only_the_newest_run_under_a_context_is_left_out(
+    hass: HomeAssistant,
+) -> None:
+    """Contexts are inherited down a chain, so runs can share one.
+
+    Leaving out every run under the current context rather than only the
+    current run would hand an allowance back that had been spent.
+    """
+    async_setup_run_history(hass)
+    history = async_get_run_history(hass)
+
+    for _ in range(THREE):
+        hass.bus.async_fire(
+            EVENT_AUTOMATION_TRIGGERED,
+            {"entity_id": "automation.rationed"},
+            context=Context(id="shared"),
+        )
+    await hass.async_block_till_done()
+
+    counted = history.async_runs_within(
+        "automation.rationed", timedelta(hours=1), ignoring="shared"
+    )
+    assert counted == ALLOWANCE, f"left out {THREE - counted} of three runs"
 
 
 async def test_the_history_keeps_room_for_the_run_doing_the_asking(
@@ -405,22 +421,22 @@ async def test_the_history_keeps_room_for_the_run_doing_the_asking(
 
     for index in range(MAX_RUNS_REMEMBERED):
         hass.bus.async_fire(
-            EVENT_SCRIPT_STARTED,
-            {"entity_id": "script.busy"},
+            EVENT_AUTOMATION_TRIGGERED,
+            {"entity_id": "automation.busy"},
             context=Context(id=f"prior-{index}"),
         )
     await hass.async_block_till_done()
 
     # And now the run that is about to ask, arriving before the check.
     hass.bus.async_fire(
-        EVENT_SCRIPT_STARTED,
-        {"entity_id": "script.busy"},
+        EVENT_AUTOMATION_TRIGGERED,
+        {"entity_id": "automation.busy"},
         context=Context(id="current"),
     )
     await hass.async_block_till_done()
 
     prior = history.async_runs_within(
-        "script.busy", timedelta(hours=1), ignoring="current"
+        "automation.busy", timedelta(hours=1), ignoring="current"
     )
     assert prior == MAX_RUNS_REMEMBERED, (
         f"only {prior} of {MAX_RUNS_REMEMBERED} prior runs left countable"

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -28,6 +28,7 @@ import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
 
 ALLOWANCE = 2
 THREE = 3
+FIVE = 5
 
 
 if TYPE_CHECKING:
@@ -112,6 +113,37 @@ async def test_a_nonsense_allowance_is_refused(
     """
     with pytest.raises(vol.Invalid):
         await SpookCondition.async_validate_config(hass, {"options": options})
+
+
+@pytest.mark.parametrize("limit", [1.5, 0.5, "5.5", True, False, "five", None])
+async def test_a_limit_that_is_not_a_whole_count_is_refused(
+    hass: HomeAssistant,
+    limit: object,
+) -> None:
+    """An allowance is a number of runs, so half a run is not one.
+
+    Coercing would hand back 1 for both 1.5 and `True`, so a mistyped limit
+    would quietly become a different one. And only half quietly: 0.5 already
+    landed below the minimum and was refused, which made the silent half
+    inconsistent as well as wrong.
+    """
+    with pytest.raises(vol.Invalid, match="whole number"):
+        await SpookCondition.async_validate_config(
+            hass, {"options": {"limit": limit, "period": "01:00:00"}}
+        )
+
+
+@pytest.mark.parametrize("limit", [5, "5", 5.0])
+async def test_a_whole_count_is_accepted_however_it_is_written(
+    hass: HomeAssistant,
+    limit: object,
+) -> None:
+    """YAML hands numbers over in more than one shape, and all of these are five."""
+    validated = await SpookCondition.async_validate_config(
+        hass, {"options": {"limit": limit, "period": "01:00:00"}}
+    )
+
+    assert validated["options"]["limit"] == FIVE
 
 
 async def test_a_limit_beyond_what_is_remembered_is_refused(

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -242,13 +242,31 @@ async def test_a_period_longer_than_a_year_is_refused(
 
 
 async def test_the_longest_period_on_offer_still_works(hass: HomeAssistant) -> None:
-    """And the boundary itself is usable, not just accepted."""
+    """And the boundary itself is usable, not just accepted.
+
+    It has to be checked against a real automation: without a `this` the
+    check answers before it ever looks at the period or the history, so it
+    would pass no matter what the longest period did.
+    """
+    async_setup_run_history(hass)
     condition = SpookCondition(
         hass, ConditionConfig(options={"limit": 1, "period": MAX_PERIOD})
     )
     await condition.async_setup()
 
-    assert condition.async_check(variables={}) is True
+    variables = {"this": {"entity_id": "automation.rationed"}}
+    assert condition.async_check(variables=variables) is True
+
+    hass.bus.async_fire(
+        EVENT_AUTOMATION_TRIGGERED,
+        {"entity_id": "automation.rationed"},
+        context=Context(id="a-run"),
+    )
+    await hass.async_block_till_done()
+
+    assert condition.async_check(variables=variables) is False, (
+        "a run inside the longest window on offer went uncounted"
+    )
 
 
 async def test_it_allows_the_limit_and_then_stops(

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -218,8 +218,9 @@ async def test_exponent_notation_still_works_for_a_sensible_limit(
     "period",
     [
         {"days": MAX_PERIOD.days + 1},
-        # Long enough that subtracting it from now reaches past the start of
-        # the calendar, which used to crash the check rather than the config.
+        # Absurd rather than dangerous: the history compares ages, so nothing
+        # here overflows. It is refused because a window this long cannot be
+        # answered by a history a restart clears.
         {"days": 999999999},
         "9999999:00:00",
     ],
@@ -228,12 +229,11 @@ async def test_a_period_longer_than_a_year_is_refused(
     hass: HomeAssistant,
     period: object,
 ) -> None:
-    """A window nothing useful fits inside, and one that cannot be measured.
+    """A window nothing useful fits inside.
 
     The history lives in memory and a restart clears it, so an allowance over
-    more than a year could not be answered honestly. And a period long enough
-    to reach past the start of the calendar broke the subtraction it is used
-    for, which failed inside the condition rather than at load.
+    more than a year could not be answered honestly, and accepting one would
+    promise something this cannot keep.
     """
     with pytest.raises(vol.Invalid, match="days or shorter"):
         await SpookCondition.async_validate_config(

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -115,7 +115,27 @@ async def test_a_nonsense_allowance_is_refused(
         await SpookCondition.async_validate_config(hass, {"options": options})
 
 
-@pytest.mark.parametrize("limit", [1.5, 0.5, "5.5", True, False, "five", None])
+@pytest.mark.parametrize(
+    "limit",
+    [
+        1.5,
+        0.5,
+        "5.5",
+        True,
+        False,
+        "five",
+        None,
+        # Rounds to exactly 5.0 as a float, so checking whole numbers through
+        # binary floating point would let it through.
+        "5.0000000000000001",
+        "5.000000000000000000001",
+        # Integral as far as Decimal is concerned, and only falls over on the
+        # way to an int.
+        "inf",
+        "-inf",
+        "nan",
+    ],
+)
 async def test_a_limit_that_is_not_a_whole_count_is_refused(
     hass: HomeAssistant,
     limit: object,
@@ -146,14 +166,19 @@ async def test_a_whole_count_is_accepted_however_it_is_written(
     assert validated["options"]["limit"] == FIVE
 
 
+@pytest.mark.parametrize("limit", [MAX_RUNS_REMEMBERED + 1, 10**400])
 async def test_a_limit_beyond_what_is_remembered_is_refused(
     hass: HomeAssistant,
+    limit: int,
 ) -> None:
-    """The history is bounded, so a limit above it could never be answered."""
+    """The history is bounded, so a limit above it could never be answered.
+
+    Including one too large to become a float at all, which has to be turned
+    down for being out of range rather than blowing up on the way in.
+    """
     with pytest.raises(vol.Invalid):
         await SpookCondition.async_validate_config(
-            hass,
-            {"options": {"limit": MAX_RUNS_REMEMBERED + 1, "period": "01:00:00"}},
+            hass, {"options": {"limit": limit, "period": "01:00:00"}}
         )
 
 

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -7,6 +7,8 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers.condition import ConditionConfig
+from homeassistant.components.script.const import EVENT_SCRIPT_STARTED
+from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 import pytest
@@ -16,6 +18,7 @@ from custom_components.spook.condition import async_get_conditions
 from custom_components.spook.ectoplasms.spook.conditions.quota import SpookCondition
 from custom_components.spook.run_history import (
     MAX_RUNS_REMEMBERED,
+    async_get_run_history,
     async_setup_run_history,
 )
 
@@ -288,6 +291,108 @@ async def test_it_counts_scripts_too(
         await hass.async_block_till_done()
 
     assert len(ran) == 1, f"let {len(ran)} through on an allowance of one"
+
+
+async def test_repeated_calls_sharing_a_context_still_spend_the_allowance(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A script inherits its caller's context, so runs can share one.
+
+    An automation calling the same script three times over gives all three
+    runs the same context. Leaving out every run under the current context
+    rather than only the current run would mean this script never spent
+    anything at all.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    async_setup_run_history(hass)
+
+    ran: list[int] = []
+    hass.services.async_register("test", "mark", lambda _call: ran.append(1))
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "rationed": {
+                    "sequence": [
+                        {
+                            "if": [
+                                {
+                                    "condition": "spook.quota",
+                                    "options": {"limit": 1, "period": "01:00:00"},
+                                }
+                            ],
+                            "then": [{"action": "test.mark"}],
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "caller",
+                    "trigger": {"platform": "event", "event_type": "kick"},
+                    "action": [
+                        {
+                            "repeat": {
+                                "count": 3,
+                                "sequence": [{"action": "script.rationed"}],
+                            }
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire("kick")
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1, f"let {len(ran)} through on an allowance of one"
+
+
+async def test_the_history_keeps_room_for_the_run_doing_the_asking(
+    hass: HomeAssistant,
+) -> None:
+    """The current run must not push the oldest run being counted out of reach.
+
+    A script's run is remembered before its condition is checked, so with only
+    as many slots as the largest allowance the oldest of them would be gone by
+    the time anybody counted. A limit of 64 could then never be reached.
+    """
+    async_setup_run_history(hass)
+    history = async_get_run_history(hass)
+
+    for index in range(MAX_RUNS_REMEMBERED):
+        hass.bus.async_fire(
+            EVENT_SCRIPT_STARTED,
+            {"entity_id": "script.busy"},
+            context=Context(id=f"prior-{index}"),
+        )
+    await hass.async_block_till_done()
+
+    # And now the run that is about to ask, arriving before the check.
+    hass.bus.async_fire(
+        EVENT_SCRIPT_STARTED,
+        {"entity_id": "script.busy"},
+        context=Context(id="current"),
+    )
+    await hass.async_block_till_done()
+
+    prior = history.async_runs_within(
+        "script.busy", timedelta(hours=1), ignoring="current"
+    )
+    assert prior == MAX_RUNS_REMEMBERED, (
+        f"only {prior} of {MAX_RUNS_REMEMBERED} prior runs left countable"
+    )
 
 
 async def test_it_passes_when_there_is_nothing_to_count_against(

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -1,0 +1,302 @@
+"""Tests for the spook.quota condition."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.condition import ConditionConfig
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.condition import async_get_conditions
+from custom_components.spook.ectoplasms.spook.conditions.quota import SpookCondition
+from custom_components.spook.run_history import (
+    MAX_RUNS_REMEMBERED,
+    async_setup_run_history,
+)
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+ALLOWANCE = 2
+THREE = 3
+
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+
+async def _automation(
+    hass: HomeAssistant,
+    limit: int = 2,
+    period: str = "01:00:00",
+    extra_conditions: list[dict] | None = None,
+) -> list[str]:
+    """Set up an automation guarded by a quota, and record what got through."""
+    ran: list[str] = []
+
+    # Spook starts this in its own setup, and it has to be running before
+    # anything runs: it is what remembers the runs being counted.
+    async_setup_run_history(hass)
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(call.data["at"])
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "rationed",
+                    "trigger": {"platform": "event", "event_type": "kick"},
+                    "condition": [
+                        *(extra_conditions or []),
+                        {
+                            "condition": "spook.quota",
+                            "options": {"limit": limit, "period": period},
+                        },
+                    ],
+                    "action": [{"action": "test.mark", "data": {"at": "{{ now() }}"}}],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return ran
+
+
+async def _kick(hass: HomeAssistant, times: int = 1) -> None:
+    """Set the automation off, and let it settle."""
+    for _ in range(times):
+        hass.bus.async_fire("kick")
+        await hass.async_block_till_done()
+
+
+async def test_the_condition_is_discovered(hass: HomeAssistant) -> None:
+    """The condition turns up in Spook's discovery, under a plain key."""
+    assert "quota" in await async_get_conditions(hass)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {},
+        {"limit": 5},
+        {"period": "01:00:00"},
+        {"limit": 0, "period": "01:00:00"},
+        {"limit": -1, "period": "01:00:00"},
+        {"limit": 5, "period": "00:00:00"},
+    ],
+)
+async def test_a_nonsense_allowance_is_refused(
+    hass: HomeAssistant,
+    options: dict,
+) -> None:
+    """Both options are required, and neither can be zero.
+
+    A limit of zero never passes and a period of zero always does, so both
+    are ways of writing a condition that does not do anything.
+    """
+    with pytest.raises(vol.Invalid):
+        await SpookCondition.async_validate_config(hass, {"options": options})
+
+
+async def test_a_limit_beyond_what_is_remembered_is_refused(
+    hass: HomeAssistant,
+) -> None:
+    """The history is bounded, so a limit above it could never be answered."""
+    with pytest.raises(vol.Invalid):
+        await SpookCondition.async_validate_config(
+            hass,
+            {"options": {"limit": MAX_RUNS_REMEMBERED + 1, "period": "01:00:00"}},
+        )
+
+
+async def test_it_allows_the_limit_and_then_stops(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Two an hour means two, and the third is turned down."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    ran = await _automation(hass, limit=2, period="01:00:00")
+
+    await _kick(hass, 5)
+
+    assert len(ran) == ALLOWANCE, f"let {len(ran)} through on an allowance of two"
+
+
+async def test_the_allowance_comes_back_as_the_window_rolls(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The window rolls rather than resetting on the hour.
+
+    Two runs at noon and the allowance is back at one minute past one, not at
+    one o'clock sharp, because that is when the first of them leaves the last
+    hour.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    ran = await _automation(hass, limit=2, period="01:00:00")
+
+    await _kick(hass, 3)
+    assert len(ran) == ALLOWANCE
+
+    freezer.tick(timedelta(minutes=59))
+    await _kick(hass)
+    assert len(ran) == ALLOWANCE, "let one through before the window had rolled"
+
+    freezer.tick(timedelta(minutes=2))
+    await _kick(hass)
+    assert len(ran) == THREE, "allowance never came back"
+
+
+async def test_a_run_something_else_turned_down_costs_nothing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Only runs that really happened count against the allowance.
+
+    Home Assistant does not announce an automation whose conditions turned the
+    run down, which is what makes this true, so it is worth pinning: a blocked
+    run must not quietly eat somebody's allowance.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    assert await async_setup_component(
+        hass, "input_boolean", {"input_boolean": {"gate": None}}
+    )
+    hass.states.async_set("input_boolean.gate", "off")
+
+    ran = await _automation(
+        hass,
+        limit=2,
+        period="01:00:00",
+        extra_conditions=[
+            {
+                "condition": "state",
+                "entity_id": "input_boolean.gate",
+                "state": "on",
+            }
+        ],
+    )
+
+    # Five attempts, all held back by the gate rather than by the quota.
+    await _kick(hass, 5)
+    assert not ran
+
+    hass.states.async_set("input_boolean.gate", "on")
+    await _kick(hass, 3)
+
+    assert len(ran) == ALLOWANCE, "the blocked attempts ate into the allowance"
+
+
+async def test_it_counts_per_automation(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """One automation using up its allowance does not spend another's."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    async_setup_run_history(hass)
+
+    ran: list[str] = []
+    hass.services.async_register(
+        "test", "mark", lambda call: ran.append(call.data["who"])
+    )
+
+    def _automation_config(name: str, event: str) -> dict:
+        return {
+            "alias": name,
+            "trigger": {"platform": "event", "event_type": event},
+            "condition": [
+                {
+                    "condition": "spook.quota",
+                    "options": {"limit": 1, "period": "01:00:00"},
+                }
+            ],
+            "action": [{"action": "test.mark", "data": {"who": name}}],
+        }
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                _automation_config("first", "kick_first"),
+                _automation_config("second", "kick_second"),
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    for _ in range(3):
+        hass.bus.async_fire("kick_first")
+        await hass.async_block_till_done()
+
+    assert ran == ["first"]
+
+    hass.bus.async_fire("kick_second")
+    await hass.async_block_till_done()
+
+    assert ran == ["first", "second"], "one automation spent the other's allowance"
+
+
+async def test_it_counts_scripts_too(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A script has an allowance as well, the same as `cooldown` covers both."""
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    async_setup_run_history(hass)
+
+    ran: list[int] = []
+    hass.services.async_register("test", "mark", lambda _call: ran.append(1))
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "rationed": {
+                    "sequence": [
+                        {
+                            "if": [
+                                {
+                                    "condition": "spook.quota",
+                                    "options": {"limit": 1, "period": "01:00:00"},
+                                }
+                            ],
+                            "then": [{"action": "test.mark"}],
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    for _ in range(3):
+        await hass.services.async_call("script", "rationed", blocking=True)
+        await hass.async_block_till_done()
+
+    assert len(ran) == 1, f"let {len(ran)} through on an allowance of one"
+
+
+async def test_it_passes_when_there_is_nothing_to_count_against(
+    hass: HomeAssistant,
+) -> None:
+    """Checked outside an automation or script, there is no allowance to spend."""
+    condition = SpookCondition(
+        hass, ConditionConfig(options={"limit": 1, "period": timedelta(hours=1)})
+    )
+    await condition.async_setup()
+
+    assert condition.async_check(variables={}) is True

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -602,9 +602,11 @@ async def test_the_history_keeps_room_for_the_run_doing_the_asking(
 ) -> None:
     """The current run must not push the oldest run being counted out of reach.
 
-    A script's run is remembered before its condition is checked, so with only
-    as many slots as the largest allowance the oldest of them would be gone by
-    the time anybody counted. A limit of 64 could then never be reached.
+    An automation is recorded before its actions start, so a condition sitting
+    in an `if` asks about a history its own run is already in. With only as
+    many slots as the largest allowance the oldest of the runs being counted
+    would be gone by the time anybody counted them, and a limit of 64 could
+    never be reached.
     """
     async_setup_run_history(hass)
     history = async_get_run_history(hass)
@@ -636,7 +638,11 @@ async def test_the_history_keeps_room_for_the_run_doing_the_asking(
 async def test_it_passes_when_there_is_nothing_to_count_against(
     hass: HomeAssistant,
 ) -> None:
-    """Checked outside an automation or script, there is no allowance to spend."""
+    """With no `this` at all there is nothing to spend an allowance against.
+
+    A condition can be checked outside a run entirely, and then there is no
+    automation to count runs for.
+    """
     condition = SpookCondition(
         hass, ConditionConfig(options={"limit": 1, "period": timedelta(hours=1)})
     )

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -407,6 +407,35 @@ async def test_the_run_doing_the_asking_does_not_count_against_itself(
     assert len(ran) == 1, "let a second run through on an allowance of one"
 
 
+async def test_a_run_exactly_a_period_old_has_served_its_time(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The boundary reads the same way `spook.cooldown` reads its own.
+
+    That one is satisfied at `elapsed >= duration`, so a run exactly a period
+    old is spent rather than holding the allowance for one more instant.
+    """
+    freezer.move_to(dt_util.as_utc(dt_util.parse_datetime("2026-08-28 12:00:00")))
+    async_setup_run_history(hass)
+    history = async_get_run_history(hass)
+
+    hass.bus.async_fire(
+        EVENT_AUTOMATION_TRIGGERED,
+        {"entity_id": "automation.rationed"},
+        context=Context(id="a-run"),
+    )
+    await hass.async_block_till_done()
+
+    period = timedelta(hours=1)
+    assert history.async_runs_within("automation.rationed", period) == 1
+
+    freezer.tick(period)
+    assert history.async_runs_within("automation.rationed", period) == 0, (
+        "held the allowance one instant past the period"
+    )
+
+
 async def test_only_the_newest_run_under_a_context_is_left_out(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -32,6 +32,7 @@ import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
 ALLOWANCE = 2
 THREE = 3
 FIVE = 5
+TEN = 10
 
 
 if TYPE_CHECKING:
@@ -169,20 +170,48 @@ async def test_a_whole_count_is_accepted_however_it_is_written(
     assert validated["options"]["limit"] == FIVE
 
 
-@pytest.mark.parametrize("limit", [MAX_RUNS_REMEMBERED + 1, 10**400])
+@pytest.mark.parametrize(
+    "limit",
+    [
+        MAX_RUNS_REMEMBERED + 1,
+        # Too large to become a float at all.
+        10**400,
+        # Short to write and enormous to build. The exponent is kept modest so
+        # that a regression costs a slow test rather than a hung one: at
+        # `1e1000000` building the integer already takes 25 seconds, and the
+        # whole point is that it is never built.
+        "1e100000",
+    ],
+)
 async def test_a_limit_beyond_what_is_remembered_is_refused(
     hass: HomeAssistant,
-    limit: int,
+    limit: object,
 ) -> None:
     """The history is bounded, so a limit above it could never be answered.
 
-    Including one too large to become a float at all, which has to be turned
-    down for being out of range rather than blowing up on the way in.
+    Including ones that have to be turned down while still a decimal, rather
+    than converted to an integer first and refused afterwards.
+
+    The message is what pins that down. Turning it down as a decimal says so
+    in Spook's own words; converting first and leaning on `vol.Range` gives
+    that library's wording instead, so matching here catches the difference
+    without timing anything.
     """
-    with pytest.raises(vol.Invalid):
+    with pytest.raises(vol.Invalid, match="between 1 and 64 runs"):
         await SpookCondition.async_validate_config(
             hass, {"options": {"limit": limit, "period": "01:00:00"}}
         )
+
+
+async def test_exponent_notation_still_works_for_a_sensible_limit(
+    hass: HomeAssistant,
+) -> None:
+    """Refusing the enormous ones must not refuse the ordinary ones."""
+    validated = await SpookCondition.async_validate_config(
+        hass, {"options": {"limit": "1e1", "period": "01:00:00"}}
+    )
+
+    assert validated["options"]["limit"] == TEN
 
 
 @pytest.mark.parametrize(

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -22,6 +22,7 @@ from custom_components.spook.ectoplasms.spook.conditions.quota import (
 )
 from custom_components.spook.run_history import (
     MAX_RUNS_REMEMBERED,
+    TRACKED_ENTITIES,
     async_get_run_history,
     async_setup_run_history,
 )
@@ -570,6 +571,50 @@ async def test_a_rejected_single_mode_trigger_costs_nothing(
 
     counted = history.async_runs_within("automation.slow", timedelta(hours=1))
     assert counted == 1, f"counted {counted} runs where only one was admitted"
+
+
+async def test_checking_an_allowance_does_not_keep_it_from_being_forgotten(
+    hass: HomeAssistant,
+) -> None:
+    """Only running refreshes an entity, not being asked about.
+
+    The history holds a fixed number of automations and forgets the one that
+    ran longest ago. Reading is what a quota check does, constantly, so if
+    reading counted as recent then an automation checked every minute and run
+    never would sit there while one that actually ran got forgotten and had
+    its allowance handed back.
+    """
+    async_setup_run_history(hass)
+    history = async_get_run_history(hass)
+    window = timedelta(hours=1)
+
+    def _ran(entity_id: str) -> None:
+        hass.bus.async_fire(
+            EVENT_AUTOMATION_TRIGGERED,
+            {"entity_id": entity_id},
+            context=Context(id=f"run-{entity_id}"),
+        )
+
+    for index in range(TRACKED_ENTITIES):
+        _ran(f"automation.number_{index}")
+    await hass.async_block_till_done()
+
+    # The one that ran longest ago, asked about over and over.
+    oldest = "automation.number_0"
+    for _ in range(THREE):
+        assert history.async_runs_within(oldest, window) == 1
+
+    # One more automation runs, so something has to be forgotten.
+    _ran("automation.late_arrival")
+    await hass.async_block_till_done()
+
+    assert history.async_runs_within(oldest, window) == 0, (
+        "asking about it kept it resident"
+    )
+    assert history.async_runs_within("automation.number_1", window) == 1, (
+        "forgot one that had run more recently"
+    )
+    assert history.async_runs_within("automation.late_arrival", window) == 1
 
 
 async def test_only_the_newest_run_under_a_context_is_left_out(

--- a/tests/ectoplasms/spook/conditions/test_quota.py
+++ b/tests/ectoplasms/spook/conditions/test_quota.py
@@ -3,6 +3,7 @@
 # pylint: disable=wrong-import-order
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -521,6 +522,54 @@ async def test_a_run_exactly_a_period_old_has_served_its_time(
     assert history.async_runs_within("automation.rationed", period) == 0, (
         "held the allowance one instant past the period"
     )
+
+
+async def test_a_rejected_single_mode_trigger_costs_nothing(
+    hass: HomeAssistant,
+) -> None:
+    """Only admitted runs are counted, which is the whole basis of this.
+
+    `EVENT_AUTOMATION_TRIGGERED` is fired from a callback handed to
+    `action_script.async_run`, so the engine raises it once the run really
+    starts. A `mode: single` automation already running turns further
+    triggers away and they are never announced.
+
+    This is what separates automations from scripts here, so it is worth
+    holding: `EVENT_SCRIPT_STARTED` is fired before that decision and does
+    announce the rejected calls, which is why scripts have no allowance.
+
+    Runs on the real clock, since the run has to still be going when the next
+    trigger arrives.
+    """
+    async_setup_run_history(hass)
+    history = async_get_run_history(hass)
+
+    hass.services.async_register("test", "mark", lambda _call: None)
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "slow",
+                    "mode": "single",
+                    "trigger": {"platform": "event", "event_type": "kick"},
+                    "action": [
+                        {"action": "test.mark"},
+                        {"delay": {"seconds": 2}},
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    for _ in range(THREE):
+        hass.bus.async_fire("kick")
+        await asyncio.sleep(0.02)
+
+    counted = history.async_runs_within("automation.slow", timedelta(hours=1))
+    assert counted == 1, f"counted {counted} runs where only one was admitted"
 
 
 async def test_only_the_newest_run_under_a_context_is_left_out(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -18,12 +19,14 @@ from homeassistant.const import (
     RESTART_EXIT_CODE,
 )
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
+from homeassistant.components.script.const import EVENT_SCRIPT_STARTED
 from homeassistant.core import Context, CoreState
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components import spook
 from custom_components.spook.automation_runs import async_get_automation_runs
 from custom_components.spook.const import DOMAIN
+from custom_components.spook.run_history import async_get_run_history
 from custom_components.spook.integration_linking import (
     link_sub_integrations,
     unlink_sub_integrations,
@@ -195,6 +198,51 @@ async def test_setup_entry_starts_and_stops_the_automation_run_register(
 
     assert EVENT_AUTOMATION_TRIGGERED not in hass.bus.async_listeners()
     assert runs.async_which("a-run") is None, "kept remembering after unloading"
+
+
+async def test_setup_entry_starts_and_stops_the_run_history(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the config entry owns the run history as well.
+
+    Same reason as the register above: a condition inside an action sequence
+    is only built once that sequence runs, and a history that started then
+    would have missed the runs it is being asked to count.
+    """
+
+    async def async_forward_no_platforms(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+    ) -> None:
+        """Forward no ectoplasm setup during the lifecycle smoke test."""
+
+    monkeypatch.setattr(spook, "PLATFORMS", [])
+    monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_noop)
+    monkeypatch.setattr(spook, "async_forward_setup_entry", async_forward_no_platforms)
+    monkeypatch.setattr(spook, "SpookServiceManager", _NoopSpookServiceManager)
+    monkeypatch.setattr(spook, "SpookRepairManager", _NoopSpookRepairManager)
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+
+    assert EVENT_SCRIPT_STARTED not in hass.bus.async_listeners()
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert EVENT_SCRIPT_STARTED in hass.bus.async_listeners()
+
+    history = async_get_run_history(hass)
+    hass.bus.async_fire(EVENT_SCRIPT_STARTED, {"entity_id": "script.nightly"})
+    await hass.async_block_till_done()
+    assert history.async_runs_within("script.nightly", timedelta(hours=1)) == 1
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert EVENT_SCRIPT_STARTED not in hass.bus.async_listeners()
+    assert history.async_runs_within("script.nightly", timedelta(hours=1)) == 0
 
 
 async def test_unload_after_start_does_not_remove_fired_one_time_listeners(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     RESTART_EXIT_CODE,
 )
 from homeassistant.components.automation import EVENT_AUTOMATION_TRIGGERED
-from homeassistant.components.script.const import EVENT_SCRIPT_STARTED
 from homeassistant.core import Context, CoreState
 from homeassistant.helpers import issue_registry as ir
 
@@ -226,23 +225,26 @@ async def test_setup_entry_starts_and_stops_the_run_history(
     entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
     entry.add_to_hass(hass)
 
-    assert EVENT_SCRIPT_STARTED not in hass.bus.async_listeners()
-
+    # Asserted through behaviour rather than the listener list: the context
+    # register listens to the same event, so its presence proves nothing.
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert EVENT_SCRIPT_STARTED in hass.bus.async_listeners()
-
     history = async_get_run_history(hass)
-    hass.bus.async_fire(EVENT_SCRIPT_STARTED, {"entity_id": "script.nightly"})
+    hass.bus.async_fire(EVENT_AUTOMATION_TRIGGERED, {"entity_id": "automation.nightly"})
     await hass.async_block_till_done()
-    assert history.async_runs_within("script.nightly", timedelta(hours=1)) == 1
+    assert history.async_runs_within("automation.nightly", timedelta(hours=1)) == 1
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert EVENT_SCRIPT_STARTED not in hass.bus.async_listeners()
-    assert history.async_runs_within("script.nightly", timedelta(hours=1)) == 0
+    assert history.async_runs_within("automation.nightly", timedelta(hours=1)) == 0
+
+    hass.bus.async_fire(EVENT_AUTOMATION_TRIGGERED, {"entity_id": "automation.nightly"})
+    await hass.async_block_till_done()
+    assert history.async_runs_within("automation.nightly", timedelta(hours=1)) == 0, (
+        "carried on listening after unloading"
+    )
 
 
 async def test_unload_after_start_does_not_remove_fired_one_time_listeners(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `spook.quota` condition, which passes while this automation has runs to spare.

```yaml
condition: spook.quota
options:
  limit: 5
  period: "24:00:00"
```

The counterpart to `spook.cooldown`: that one spaces runs out, this one caps how many there are. For something that is fine now and then but not fifty times a day.

The window rolls. Five over a day means five in any twenty-four hours rather than five between midnights, so the allowance comes back gradually as the oldest run leaves the window.

### What the measuring settled

Three things, each of which changed the design:

- **`EVENT_AUTOMATION_TRIGGERED` does not fire when an automation's conditions turn the run down**, and `last_triggered` stays unset. So that event marks runs that really happened, which is exactly what a quota should count: an attempt something else held back costs nothing. There is a test on it, because the whole thing rests on it.
- **Scripts are deliberately left out**, and getting there took two attempts. `EVENT_SCRIPT_STARTED` exists and looked like the obvious counterpart, but it fires in `_async_start_run` before the engine decides whether the run is allowed. Measured with a `mode: single` script already running: two calls, two announcements, one body, so a rejected call would have spent an allowance on a run that never happened. `last_triggered` is accurate about admission and I built that too, on a filtered `state_changed` listener, but it detects an attribute value changing rather than a run happening, so two runs sharing a timestamp count as one. That is a property of the signal, not of the test that found it. `EVENT_AUTOMATION_TRIGGERED` has neither problem, so automations it is, with the reason recorded next to the listener and in the documented limits.
- **A run must not count against itself.** A condition inside an automation's actions is checked while the run is already under way and already announced, so a limit of one would turn down every run. Each remembered run carries its context and a check leaves out the most recent run under its own. Only the most recent one: contexts are inherited down a chain, so several runs can share one and dropping every match would leave an allowance unspent.
- **The boundary reads the same way `spook.cooldown` reads its own**, expired at `elapsed >= duration`, so a run exactly a period old is spent rather than holding the allowance one instant longer.
- **The limit is checked exactly**, through `Decimal` rather than a float. `float("5.0000000000000001")` is exactly 5.0, so a fractional limit would otherwise round its way through, and a large enough integer raised an uncaught `OverflowError` on the way in. Infinity and not-a-number needed a guard of their own, being integral as far as `Decimal` is concerned and only falling over on the way to an `int`.

### Also in here

- `run_history.py`, a shared register of when automations ran, owned by the Spook config entry for the same reason `automation_runs.py` is: a condition inside an action sequence is only built once that sequence runs, so a history starting then would have missed the runs it is asked to count. Bounded at 256 tracked automations with 64 runs each plus one spare for the run doing the asking, and `limit` is validated against that ceiling.
- `own_entity_id` moves from `triggered_by_automation.py` into `context.py`, since both conditions need it.
- An explicit `(cooldown)=` anchor, because linking to the heading implicitly raised a documentation warning.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`spook.cooldown` answers "not too often". It cannot answer "not too many", and a template cannot either: Home Assistant records only the most recent run on `last_triggered`, so there is nothing to count. Rate limiting building blocks are a recurring request (`home-assistant/feature-requests` #1279).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Twenty-two new tests, on top of the existing suite (1043 pass).

Covered: discovery, both options being required, a zero limit and a zero period being refused, thirteen shapes of limit that are not a whole count being refused and three that are being accepted however they are written, a limit beyond what is remembered being refused, the limit being honoured and the surplus turned down, the allowance returning as the window rolls rather than on the hour, a run exactly a period old having served its time, a run another condition blocked costing nothing, counting per automation rather than in aggregate, a condition inside the actions not counting its own run, only the newest run under a shared context being left out, the history keeping room for the run doing the asking, scripts having no allowance, a check outside an automation passing, and the config entry starting and stopping the history.

The implementation was then broken repeatedly to check the tests earn their place, and each is caught: an off-by-one on the limit, ignoring the period, reading the boundary strictly, counting the run doing the asking, excluding every run under a shared context rather than the newest, dropping the spare slot, counting every automation together, never listening at all, going back to a float check, dropping the non-finite guard, removing the setup call from the config entry, and starting the history without registering the unload.

Those last two were my own gap, found by checking rather than by being told: removing the setup call left all 1022 tests green, exactly as it did in #1482. There is a config entry lifecycle test now, and both halves of the call fail without it.

Also ran: `ruff check`, `ruff format --check`, `pylint` over the whole tree, `zizmor`, the full pre-commit set, and a local rebuild of hassfest's descriptor schema over both descriptor files. The documentation builds with the same warnings as `main`, and the rendered page was checked for duplicate anchors, since a heading anchor got stolen in an earlier PR.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
