### PR TITLE
Catch the exception the condition_met test means to catch

### DIFF
--- a/tests/ectoplasms/spook/triggers/test_condition_met.py
+++ b/tests/ectoplasms/spook/triggers/test_condition_met.py
@@ -9,6 +9,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
 from homeassistant.setup import async_setup_component
 import pytest
+import voluptuous as vol
 
 from custom_components.spook.ectoplasms.spook.triggers.condition_met import SpookTrigger
 from custom_components.spook.trigger import async_get_triggers
@@ -154,7 +155,7 @@ async def test_it_takes_the_ordinary_building_blocks(hass: HomeAssistant) -> Non
 
 async def test_a_condition_is_required(hass: HomeAssistant) -> None:
     """Without one there is nothing to watch."""
-    with pytest.raises(Exception, match="required key"):
+    with pytest.raises(vol.Invalid, match="required key"):
         await SpookTrigger.async_validate_config(hass, {"options": {}})
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A leftover from #1485, spotted by Copilot after it was merged.

`test_a_condition_is_required` asserted with `pytest.raises(Exception, match="required key")`. That passes on any exception whose message happens to contain those words, so the test could have gone green while validation was failing for a completely different reason.

Measured what the refusal actually is:

```
raised voluptuous.error.MultipleInvalid: required key not provided @ data['options']['condition']
mro: ['MultipleInvalid', 'Invalid', 'Error', 'Exception', 'BaseException', 'object']
isinstance vol.Invalid: True
```

So `vol.Invalid` catches it, and the broad catch was sloppiness on my part rather than a workaround for anything. Worth checking, because Home Assistant swaps voluptuous for `probatio` on import and `vol.Invalid` is not always the class you think it is; here it is.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A test that cannot fail for the right reason is not doing its job. This is the only `pytest.raises(Exception` left in the suite.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The full suite passes, 1130 tests.

The point of the change is checked directly: raising a `RuntimeError` carrying the same "required key not provided" message from the validator fails the test now and passed it before.

Also ran `ruff check`, `ruff format --check` and `pylint` over the whole tree, all clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
