### PR TITLE
Build the service set once per inspection, not once per template

### DIFF
--- a/custom_components/spook/action_extraction.py
+++ b/custom_components/spook/action_extraction.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.const import CONF_ENABLED
 
 from .const import LOGGER
+from .entity_filtering import async_get_all_services
 from .template_extraction import (
     ENTITY_ID_PATTERN,
     async_extract_entities_from_template_string,
@@ -27,6 +28,7 @@ async def async_extract_entities_from_action_config(
     config: dict[str, Any] | list,
     *,
     include_disabled: bool = True,
+    known_services: set[str] | None = None,
     _in_sequence: bool = False,
     _in_payload: bool = False,
 ) -> set[str]:
@@ -40,11 +42,21 @@ async def async_extract_entities_from_action_config(
     conditions live, and never below a ``data`` key. Service data is arbitrary
     payload: a dict or a list in there that happens to carry an ``enabled`` key
     of its own must not hide the entities around it.
+
+    ``known_services`` is what tells an action name apart from an entity id,
+    and building it flattens every service Home Assistant has. So it is built
+    once here and handed down, rather than rebuilt for every template string
+    this walks past. A caller that inspects one configuration after another
+    should build it once and pass it in, or it pays for a rebuild per
+    configuration.
     """
     entities = set()
 
     if not config:
         return entities
+
+    if known_services is None:
+        known_services = async_get_all_services(hass)
 
     if isinstance(config, list):
         for item in config:
@@ -53,6 +65,7 @@ async def async_extract_entities_from_action_config(
                     hass,
                     item,
                     include_disabled=include_disabled,
+                    known_services=known_services,
                     _in_sequence=True,
                     _in_payload=_in_payload,
                 )
@@ -71,18 +84,26 @@ async def async_extract_entities_from_action_config(
         return entities
 
     # Extract entity IDs from direct fields
-    entities.update(await _extract_entities_from_action_fields(hass, config))
+    entities.update(
+        await _extract_entities_from_action_fields(hass, config, known_services)
+    )
 
     # Extract entities from target configuration
-    entities.update(await _extract_entities_from_target(hass, config))
+    entities.update(await _extract_entities_from_target(hass, config, known_services))
 
     # Extract entities from service data
-    entities.update(await _extract_entities_from_service_data(hass, config))
+    entities.update(
+        await _extract_entities_from_service_data(hass, config, known_services)
+    )
 
     # Extract from nested configs (like if/then/else, repeat, etc.)
     entities.update(
         await _extract_entities_from_nested_configs(
-            hass, config, include_disabled=include_disabled, in_payload=_in_payload
+            hass,
+            config,
+            known_services,
+            include_disabled=include_disabled,
+            in_payload=_in_payload,
         )
     )
 
@@ -90,18 +111,22 @@ async def async_extract_entities_from_action_config(
 
 
 async def _extract_entities_from_action_fields(
-    hass: HomeAssistant, config: dict[str, Any]
+    hass: HomeAssistant, config: dict[str, Any], known_services: set[str]
 ) -> set[str]:
     """Extract entities from direct action fields."""
     entities = set()
     for key in ("entity_id", "device_id"):
         if key in config:
-            entities.update(await async_extract_entities_from_value(hass, config[key]))
+            entities.update(
+                await async_extract_entities_from_value(
+                    hass, config[key], known_services=known_services
+                )
+            )
     return entities
 
 
 async def _extract_entities_from_target(
-    hass: HomeAssistant, config: dict[str, Any]
+    hass: HomeAssistant, config: dict[str, Any], known_services: set[str]
 ) -> set[str]:
     """Extract entities from target configuration."""
     entities = set()
@@ -110,7 +135,9 @@ async def _extract_entities_from_target(
         for key in ("entity_id", "device_id", "area_id", "label_id"):
             if key in target:
                 entities.update(
-                    await async_extract_entities_from_value(hass, target[key])
+                    await async_extract_entities_from_value(
+                        hass, target[key], known_services=known_services
+                    )
                 )
     return entities
 
@@ -130,7 +157,7 @@ def _should_skip_service_data_value(
 
 
 async def _extract_entities_from_service_data(
-    hass: HomeAssistant, config: dict[str, Any]
+    hass: HomeAssistant, config: dict[str, Any], known_services: set[str]
 ) -> set[str]:
     """Extract entities from service data."""
     entities = set()
@@ -138,20 +165,29 @@ async def _extract_entities_from_service_data(
         data_value = config["data"]
         if isinstance(data_value, str):
             # data field is a template string itself
-            entities.update(await async_extract_entities_from_value(hass, data_value))
+            entities.update(
+                await async_extract_entities_from_value(
+                    hass, data_value, known_services=known_services
+                )
+            )
         elif isinstance(data_value, dict):
             service = _get_action_service(config)
             # data field is a dictionary, process all its values
             for key, value in data_value.items():
                 if _should_skip_service_data_value(service, key):
                     continue
-                entities.update(await async_extract_entities_from_value(hass, value))
+                entities.update(
+                    await async_extract_entities_from_value(
+                        hass, value, known_services=known_services
+                    )
+                )
     return entities
 
 
 async def _extract_entities_from_nested_configs(
     hass: HomeAssistant,
     config: dict[str, Any],
+    known_services: set[str],
     *,
     include_disabled: bool = True,
     in_payload: bool = False,
@@ -165,6 +201,7 @@ async def _extract_entities_from_nested_configs(
                     hass,
                     value,
                     include_disabled=include_disabled,
+                    known_services=known_services,
                     _in_payload=in_payload or key == "data",
                 )
             )
@@ -172,18 +209,27 @@ async def _extract_entities_from_nested_configs(
 
 
 async def async_extract_entities_from_value(
-    hass: HomeAssistant, value: Any
+    hass: HomeAssistant,
+    value: Any,
+    *,
+    known_services: set[str] | None = None,
 ) -> set[str]:
-    """Extract entity IDs from a configuration value."""
+    """Extract entity IDs from a configuration value.
+
+    See `async_extract_entities_from_action_config` for what
+    ``known_services`` is and why passing it in matters.
+    """
     entities = set()
 
     if isinstance(value, str):
         # Check if it's a template string using util.is_template_string
         if is_template_string(value):
             # Process as template to extract entity references
+            if known_services is None:
+                known_services = async_get_all_services(hass)
             try:
                 template_entities = await async_extract_entities_from_template_string(
-                    hass, value
+                    hass, value, known_services
                 )
                 entities.update(template_entities)
             # pylint: disable-next=broad-exception-caught
@@ -197,8 +243,14 @@ async def async_extract_entities_from_value(
             # Check if it matches the entity ID pattern with known domains
             entities.add(value)
     elif isinstance(value, list):
+        if known_services is None:
+            known_services = async_get_all_services(hass)
         for item in value:
-            entities.update(await async_extract_entities_from_value(hass, item))
+            entities.update(
+                await async_extract_entities_from_value(
+                    hass, item, known_services=known_services
+                )
+            )
     elif (
         isinstance(value, dict)
         and "entity" in value

--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -13,7 +13,7 @@ from ....action_extraction import (
     async_extract_entities_from_action_config,
     async_extract_entities_from_value,
 )
-from ....entity_filtering import async_get_all_entity_ids
+from ....entity_filtering import async_get_all_entity_ids, async_get_all_services
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 from ....template_extraction import (
     async_extract_entities_from_config,
@@ -27,7 +27,9 @@ if TYPE_CHECKING:
 
 
 async def extract_template_entities_from_automation_entity(
-    hass: HomeAssistant, entity: Any
+    hass: HomeAssistant,
+    entity: Any,
+    known_services: set[str] | None = None,
 ) -> set[str]:
     """Extract entities from automation configuration using Template analysis.
 
@@ -42,44 +44,84 @@ async def extract_template_entities_from_automation_entity(
     else:
         return set()
 
-    return await async_extract_entities_from_config(hass, config)
+    return await async_extract_entities_from_config(hass, config, known_services)
 
 
 async def extract_entities_from_automation_config(
-    hass: HomeAssistant, config: dict[str, Any]
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    known_services: set[str] | None = None,
 ) -> set[str]:
-    """Extract entity IDs from automation configuration."""
+    """Extract entity IDs from automation configuration.
+
+    ``known_services`` is built once per inspection and handed down, because
+    building it flattens every service Home Assistant has and the walk below
+    passes a lot of template strings. See
+    `action_extraction.async_extract_entities_from_action_config`.
+    """
     entities = set()
 
     if not isinstance(config, dict):
         return entities
 
+    if known_services is None:
+        known_services = async_get_all_services(hass)
+
     # Extract entities from trigger config
     for key in ("trigger", "triggers"):
         if key in config:
             entities.update(
-                await extract_entities_from_trigger_config(hass, config[key])
+                await extract_entities_from_trigger_config(
+                    hass, config[key], known_services
+                )
             )
 
     # Extract entities from condition config
     for key in ("condition", "conditions"):
         if key in config:
             entities.update(
-                await extract_entities_from_condition_config(hass, config[key])
+                await extract_entities_from_condition_config(
+                    hass, config[key], known_services
+                )
             )
 
     # Extract entities from action config
     for key in ("action", "actions"):
         if key in config:
             entities.update(
-                await async_extract_entities_from_action_config(hass, config[key])
+                await async_extract_entities_from_action_config(
+                    hass, config[key], known_services=known_services
+                )
             )
 
     return entities
 
 
+async def _entities_from_reference_fields(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    known_services: set[str],
+) -> set[str]:
+    """Extract entities from the config keys that name a reference.
+
+    ``zone`` is in here because a zone trigger and a zone condition both name
+    one, and it is read exactly like the others.
+    """
+    entities = set()
+    for key in ("entity_id", "device_id", "zone"):
+        if key in config:
+            entities.update(
+                await async_extract_entities_from_value(
+                    hass, config[key], known_services=known_services
+                )
+            )
+    return entities
+
+
 async def extract_entities_from_trigger_config(
-    hass: HomeAssistant, config: dict[str, Any] | list
+    hass: HomeAssistant,
+    config: dict[str, Any] | list,
+    known_services: set[str] | None = None,
 ) -> set[str]:
     """Extract entity IDs from trigger configuration."""
     entities = set()
@@ -87,27 +129,27 @@ async def extract_entities_from_trigger_config(
     if not config:
         return entities
 
+    if known_services is None:
+        known_services = async_get_all_services(hass)
+
     if isinstance(config, list):
         for item in config:
-            entities.update(await extract_entities_from_trigger_config(hass, item))
+            entities.update(
+                await extract_entities_from_trigger_config(hass, item, known_services)
+            )
         return entities
 
     if not isinstance(config, dict):
         return entities
 
-    # Entity ID fields in triggers
-    for key in ("entity_id", "device_id"):
-        if key in config:
-            entities.update(await async_extract_entities_from_value(hass, config[key]))
-
-    # Zone trigger has zone field
-    if "zone" in config:
-        entities.update(await async_extract_entities_from_value(hass, config["zone"]))
+    entities.update(await _entities_from_reference_fields(hass, config, known_services))
 
     # Extract from nested configs
     for value in config.values():
         if isinstance(value, (dict, list)):
-            entities.update(await extract_entities_from_trigger_config(hass, value))
+            entities.update(
+                await extract_entities_from_trigger_config(hass, value, known_services)
+            )
 
     return entities
 
@@ -141,7 +183,9 @@ def extract_event_types_from_trigger_config(config: dict[str, Any] | list) -> se
 
 
 async def extract_entities_from_condition_config(
-    hass: HomeAssistant, config: dict[str, Any] | list
+    hass: HomeAssistant,
+    config: dict[str, Any] | list,
+    known_services: set[str] | None = None,
 ) -> set[str]:
     """Extract entity IDs from condition configuration."""
     entities = set()
@@ -149,23 +193,29 @@ async def extract_entities_from_condition_config(
     if not config:
         return entities
 
+    if known_services is None:
+        known_services = async_get_all_services(hass)
+
     if isinstance(config, list):
         for item in config:
-            entities.update(await extract_entities_from_condition_config(hass, item))
+            entities.update(
+                await extract_entities_from_condition_config(hass, item, known_services)
+            )
         return entities
 
     if not isinstance(config, dict):
         return entities
 
-    # Entity ID fields in conditions
-    for key in ("entity_id", "device_id", "zone"):
-        if key in config:
-            entities.update(await async_extract_entities_from_value(hass, config[key]))
+    entities.update(await _entities_from_reference_fields(hass, config, known_services))
 
     # Extract from nested configs
     for value in config.values():
         if isinstance(value, (dict, list)):
-            entities.update(await extract_entities_from_condition_config(hass, value))
+            entities.update(
+                await extract_entities_from_condition_config(
+                    hass, value, known_services
+                )
+            )
 
     return entities
 
@@ -189,6 +239,7 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
     edit_url_pattern = "/config/automation/edit/{unique_id}"
 
     _known_entity_ids: set[str]
+    _known_services: set[str]
 
     async def async_activate(self) -> None:
         """Activate the repair."""
@@ -216,10 +267,16 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
         )
 
     async def _async_setup_inspection(self) -> None:
-        """Cache known entity IDs (including ALL/NONE) for this inspection cycle."""
+        """Cache what every automation in this cycle needs looked up.
+
+        The service set is in here for the same reason as the entity ids:
+        building it flattens every service Home Assistant has, and it is the
+        same answer for every automation in one pass.
+        """
         self._known_entity_ids = async_get_all_entity_ids(
             self.hass, include_all_none=True
         )
+        self._known_services = async_get_all_services(self.hass)
 
     def _should_inspect_entity(self, entity: Any) -> bool:
         """Skip disabled automations."""
@@ -233,7 +290,7 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
         if hasattr(entity, "raw_config") and entity.raw_config:
             all_entities.update(
                 await extract_entities_from_automation_config(
-                    self.hass, entity.raw_config
+                    self.hass, entity.raw_config, self._known_services
                 )
             )
             for key in ("trigger", "triggers"):
@@ -243,7 +300,9 @@ class SpookRepair(AbstractSpookEntityComponentUnknownReferencesRepair):
 
         # Extract entities from Template objects within the automation entity
         all_entities.update(
-            await extract_template_entities_from_automation_entity(self.hass, entity)
+            await extract_template_entities_from_automation_entity(
+                self.hass, entity, self._known_services
+            )
         )
 
         return await async_filter_known_entity_ids_with_templates(

--- a/custom_components/spook/ectoplasms/template/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/template/repairs/unknown_entity_references.py
@@ -10,7 +10,11 @@ from homeassistant.helpers import entity_registry as er
 
 from ....action_extraction import async_extract_entities_from_action_config
 from ....const import LOGGER
-from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
+from ....entity_filtering import (
+    async_filter_known_entity_ids,
+    async_get_all_entity_ids,
+    async_get_all_services,
+)
 from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
 from ....template_extraction import async_extract_entities_from_config
@@ -67,12 +71,15 @@ class SpookRepair(AbstractSpookRepair):
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
         known_entity_ids = async_get_all_entity_ids(self.hass, include_all_none=True)
+        known_services = async_get_all_services(self.hass)
 
         for entry in self.hass.config_entries.async_entries(self.domain):
             self.possible_issue_ids.add(entry.entry_id)
 
             options = dict(entry.options)
-            referenced = await async_extract_entities_from_config(self.hass, options)
+            referenced = await async_extract_entities_from_config(
+                self.hass, options, known_services
+            )
 
             # Template helpers can also run action sequences: a button's press,
             # a switch's turn_on/turn_off, a cover's open/close, an alarm's
@@ -92,10 +99,13 @@ class SpookRepair(AbstractSpookRepair):
                     continue
 
                 referenced |= await async_extract_entities_from_action_config(
-                    self.hass, option
+                    self.hass, option, known_services=known_services
                 )
                 active |= await async_extract_entities_from_action_config(
-                    self.hass, option, include_disabled=False
+                    self.hass,
+                    option,
+                    include_disabled=False,
+                    known_services=known_services,
                 )
 
             if unknown_entities := async_filter_known_entity_ids(

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -415,15 +415,23 @@ def extract_template_strings_from_config(
 
 
 async def async_extract_entities_from_config(
-    hass: HomeAssistant, config: Any
+    hass: HomeAssistant,
+    config: Any,
+    known_services: set[str] | None = None,
 ) -> set[str]:
-    """Extract entity IDs referenced in templates within a configuration structure."""
+    """Extract entity IDs referenced in templates within a configuration structure.
+
+    ``known_services`` is what tells an action name apart from an entity id.
+    Building it flattens every service Home Assistant has, so a caller walking
+    one configuration after another should build it once and pass it in.
+    """
     entities = set()
     if not config:
         return entities
 
     template_strings = extract_template_strings_from_config(config)
-    known_services = async_get_all_services(hass) if template_strings else set()
+    if known_services is None:
+        known_services = async_get_all_services(hass) if template_strings else set()
     extracted_templates: dict[str, set[str]] = {}
     for template_str in template_strings:
         try:

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -11,16 +11,20 @@ silently.
 # pylint: disable=protected-access,too-few-public-methods,wrong-import-order
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from homeassistant.const import EVENT_STATE_CHANGED
-from homeassistant.core import State
+from homeassistant.core import ServiceRegistry, State
+from homeassistant.setup import async_setup_component
 
 from custom_components.spook.action_extraction import (
     async_extract_entities_from_action_config,
     async_extract_entities_from_value,
 )
+from custom_components.spook.entity_filtering import async_get_all_services
 from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
     SpookRepair,
     extract_entities_from_automation_config,
@@ -30,7 +34,7 @@ from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_refere
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
     from homeassistant.core import HomeAssistant
 
@@ -250,6 +254,9 @@ async def test_event_trigger_type_reference_is_not_reported_unknown(
     )
     repair = SpookRepair(hass)
     repair._known_entity_ids = {"timer.hot_tub"}
+    # Standing in for `_async_setup_inspection`: the real service set, so
+    # action names are still told apart from entity ids.
+    repair._known_services = async_get_all_services(hass)
 
     assert await repair._async_compute_unknown_references(entity) == set()
 
@@ -499,6 +506,9 @@ async def test_plural_condition_entity_is_reported_unknown(
     )
     repair = SpookRepair(hass)
     repair._known_entity_ids = set()
+    # Standing in for `_async_setup_inspection`: the real service set, so
+    # action names are still told apart from entity ids.
+    repair._known_services = async_get_all_services(hass)
 
     assert await repair._async_compute_unknown_references(entity) == {
         "input_boolean.snooze_uptime_alerts"
@@ -597,3 +607,145 @@ async def test_state_only_entity_update_does_not_recheck_automation_repairs(
     assert calls == 0
 
     await repair.async_deactivate()
+
+
+def _templated_actions(count: int) -> list[dict]:
+    """Return an action list with `count` steps, each holding templates."""
+    return [
+        {
+            "action": "light.turn_on",
+            "target": {"entity_id": "{{ 'light.kitchen' }}"},
+            "data": {
+                "brightness": "{{ states('sensor.brightness') | int(0) }}",
+                "transition": "{{ states('sensor.transition') | int(0) }}",
+            },
+        }
+    ] * count
+
+
+@contextmanager
+def _counting_service_lookups() -> Iterator[list[int]]:
+    """Count how often the full service registry gets flattened.
+
+    Counted on `ServiceRegistry.async_services`, the expensive call inside
+    `async_get_all_services`, rather than on the helper: several modules import
+    that helper by name, so patching one of them would miss the others.
+    """
+    counted = [0]
+    real = ServiceRegistry.async_services
+
+    def counting(self: ServiceRegistry) -> dict:
+        counted[0] += 1
+        return real(self)
+
+    with patch.object(ServiceRegistry, "async_services", counting):
+        yield counted
+
+
+async def test_the_service_set_is_not_rebuilt_per_template(
+    hass: HomeAssistant,
+) -> None:
+    """Building it flattens every service, so it must not follow the config.
+
+    It used to be rebuilt once per template string, which put the cost of a
+    repair inspection in proportion to how many templates the automations
+    happened to contain. Twenty times for one automation, measured.
+    """
+    with _counting_service_lookups() as counted:
+        await extract_entities_from_automation_config(
+            hass, {"action": _templated_actions(1)}
+        )
+        for_one = counted[0]
+
+        counted[0] = 0
+        await extract_entities_from_automation_config(
+            hass, {"action": _templated_actions(20)}
+        )
+        for_twenty = counted[0]
+
+    assert for_twenty == for_one, (
+        f"{for_one} rebuild(s) for one action, {for_twenty} for twenty"
+    )
+
+
+async def test_one_inspection_builds_the_service_set_once(
+    hass: HomeAssistant,
+) -> None:
+    """It is the same answer for every automation in one pass.
+
+    Cached in `_async_setup_inspection` next to the known entity ids, so
+    adding automations does not add rebuilds.
+    """
+    repair = SpookRepair(hass)
+    await repair._async_setup_inspection()
+
+    entity = MockAutomationEntity(
+        raw_config={"action": _templated_actions(5)},
+        referenced_entities=set(),
+    )
+
+    with _counting_service_lookups() as counted:
+        for _ in range(10):
+            await repair._async_compute_unknown_references(entity)
+
+    assert counted[0] == 0, f"{counted[0]} rebuild(s) while inspecting ten automations"
+
+
+async def test_a_service_name_in_a_template_survives_the_hand_down(
+    hass: HomeAssistant,
+) -> None:
+    """The set is handed down to be used, not just to be built once.
+
+    A service name written in a template looks exactly like an entity id, and
+    the only thing that tells them apart is this set. Handing down an empty
+    one would go unnoticed by anything that only counts how often it is built.
+    """
+    assert await async_setup_component(hass, "input_boolean", {})
+    await hass.async_block_till_done()
+
+    entities = await extract_entities_from_automation_config(
+        hass,
+        {
+            "action": [
+                {
+                    "action": "input_boolean.toggle",
+                    "data": {
+                        "which": (
+                            "{{ states('input_boolean.gate') }}"
+                            "{{ 'input_boolean.toggle' }}"
+                        ),
+                    },
+                }
+            ],
+        },
+    )
+
+    assert entities == {"input_boolean.gate"}, "the service name was not filtered out"
+
+
+async def test_the_action_walker_filters_service_names_without_being_told(
+    hass: HomeAssistant,
+) -> None:
+    """A caller that hands down nothing still gets the filtering.
+
+    Which is the other half: the walker builds the set once itself when it is
+    not given one, so an empty set is never what the filtering runs against.
+    """
+    assert await async_setup_component(hass, "input_boolean", {})
+    await hass.async_block_till_done()
+
+    entities = await async_extract_entities_from_action_config(
+        hass,
+        [
+            {
+                "action": "input_boolean.toggle",
+                "data": {
+                    "which": (
+                        "{{ states('input_boolean.gate') }}{{ 'input_boolean.toggle' }}"
+                    ),
+                },
+            }
+        ],
+    )
+
+    assert entities == {"input_boolean.gate"}, "the service name was not filtered out"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Telling an action name apart from an entity id needs the set of every service Home Assistant has. The walk over an automation configuration was rebuilding that set for every template string it passed.

Measured on an instance with 1440 services, before:

```
one rebuild:                                    0.141 ms
rebuilds for one automation with 15 templates:  20
that inspection took:                           3.92 ms
of which rebuilding the service set:            2.82 ms   (72%)
extrapolated to 200 such automations:           564 ms of pure rebuilding
```

After, same instance:

```
                                  before   after
one automation, 15 templates:       20       1   rebuilds
inspection of ten automations:      200      1   rebuilds
```

All of that ran on the event loop, which is what the report is about.

### What changed

- `known_services` is handed down through the action walker, and the entry point builds it once itself when a caller does not supply one. That alone takes 20 to 1 per configuration, with no caller having to change.
- The automation repair builds it once per inspection, in `_async_setup_inspection` next to the known entity ids it already caches there. That takes the ten-automation pass from 200 to 1. This is where the report suggested putting it, and it was right.
- The template repair got the same treatment. It was calling the walker twice per option per entry, so it had the same shape of problem.
- `async_extract_entities_from_config` can be handed the set as well, for callers walking one configuration after another.

### One thing that was not a suppression

The extra branch pushed `extract_entities_from_trigger_config` past the complexity limit. Rather than silence that, the two identical field walks in the trigger and condition extractors are now one shared helper. The trigger version handled `zone` in a separate block for no reason: it reads exactly like `entity_id` and `device_id`. Net less code than before.

### Not in here

The adaptive cooldown the report also suggests. That is a separate question, and so are the six repairs that all subscribe to `EVENT_STATE_CHANGED` and so all scan on every entity added or removed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1477.

Worth noting why this looked fixed already: the line the report names, `unknown_entity_references.py:284`, no longer exists. That code moved into `action_extraction.py` in a refactor, and the omission moved with it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The full suite passes, 1134 tests, four of them new.

Two count rebuilds, at `ServiceRegistry.async_services` rather than at the helper, because several modules import that helper by name and patching one of them would miss the others:

- The count does not follow the configuration: one templated action and twenty give the same number.
- An inspection of ten automations adds no rebuilds at all beyond the one in setup.

Two pin the behaviour, and they exist because the counting tests were not enough. Replacing the hand-down with an empty set kept them green: the count stayed flat while the filtering was quietly broken, which would report every service name in a template as a missing entity.

- A service name in a template is filtered when reached through the repair, so an empty set handed down fails.
- And when reached through the action walker with nothing handed down, so the walker's own default is pinned too. The first test does not reach that branch, which is why there are two.

Four deliberate defects, each caught: the entry point handing down an empty set, the repair resolving to an empty set, `known_services` omitted again in the value walker, and the repair not handing its cached set down.

Also ran `ruff check`, `ruff format --check`, `pylint` (through `uv run`, the way pre-commit does, which does not always agree with `python -m pylint`), and a local rebuild of hassfest's descriptor schema.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
