### PR TITLE
Add a spook.sequence trigger

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/sequence.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/sequence.py
@@ -1,0 +1,381 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS, CONF_TIMEOUT
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv, trigger as trigger_helper
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.util import dt as dt_util
+
+from ....const import DOMAIN, LOGGER
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime, timedelta
+
+    from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_STEPS = "steps"
+CONF_RESET = "reset"
+
+# One trigger is not an order, it is a trigger. Two is the smallest thing this
+# can say something about.
+_MINIMUM_STEPS = 2
+
+# What gets lifted out of the step that completed the sequence and put at the
+# top of the payload, so `trigger.to_state` and friends mean here what they
+# mean everywhere else. It is also what carries the user through: an automation
+# starts a fresh context, so a condition asking who set the run going reads the
+# person off `trigger.to_state`.
+#
+# An allowlist on purpose. A step's payload also carries `id`, `idx`,
+# `platform` and `description`, and what is handed to `run_action` overrides
+# those, so merging a step wholesale would replace the automation's own
+# `trigger.id` with the step's and break every `choose` keyed on it.
+_CARRIED_FROM_LAST_STEP = ("entity_id", "from_state", "to_state", "event")
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_STEPS): cv.TRIGGER_SCHEMA,
+            vol.Optional(CONF_TIMEOUT): cv.positive_time_period,
+            vol.Optional(CONF_RESET): cv.TRIGGER_SCHEMA,
+        },
+    }
+)
+
+
+@callback
+def _log(level: int, message: str, **kwargs: Any) -> None:
+    """Take the log line Home Assistant writes about a nested trigger.
+
+    `async_initialize_triggers` insists on somewhere to write, and what it
+    writes is about a trigger the user did not attach themselves, so it goes
+    to Spook's logger rather than an automation's.
+    """
+    LOGGER.log(level, "Spook sequence trigger: %s", message, **kwargs)
+
+
+@dataclass(frozen=True, slots=True)
+class _Sequence:
+    """What to wait for. Fixed for the life of the trigger."""
+
+    steps: list[ConfigType]
+    reset: list[ConfigType]
+    timeout: timedelta | None
+
+
+@dataclass(slots=True)
+class _Run:
+    """Where one pass through the sequence has got to.
+
+    Together in one place because they are abandoned together: a reset or a
+    deadline throws the whole thing away rather than picking fields off it.
+    The deadline belongs to the run for the same reason.
+    """
+
+    armed: int = 0
+    collected: list[dict[str, Any]] = field(default_factory=list)
+    started: datetime | None = None
+    unsub_timeout: CALLBACK_TYPE | None = None
+
+
+class _SequenceWatcher:
+    """Arms one step at a time and reports when the last one lands.
+
+    Only the step it is waiting for is attached, which is what makes the order
+    mean anything: the second trigger firing before the first has fired is not
+    a sequence, and nothing is listening for it at that point.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        sequence: _Sequence,
+        on_complete: Callable[[list[dict[str, Any]], timedelta, Context | None], None],
+    ) -> None:
+        """Initialize the watcher."""
+        self._hass = hass
+        self._sequence = sequence
+        self._on_complete = on_complete
+
+        self._run = _Run()
+        self._unsub_step: CALLBACK_TYPE | None = None
+        self._unsub_reset: CALLBACK_TYPE | None = None
+
+        # A step landing, a reset firing and a deadline passing all move the
+        # same run, and all of them suspend while they re-arm. One at a time,
+        # or two of them interleave and the run ends up half moved.
+        self._lock = asyncio.Lock()
+
+    async def async_start(self) -> CALLBACK_TYPE:
+        """Arm the first step, and the reset triggers if there are any.
+
+        The reset triggers stay attached for as long as this watcher lives,
+        rather than only during a run. Attaching them is asynchronous, so
+        arming them per run would leave a window where a reset that arrives
+        early is missed, and ignoring them while idle costs nothing.
+        """
+        if self._sequence.reset:
+            self._unsub_reset = await trigger_helper.async_initialize_triggers(
+                self._hass,
+                self._sequence.reset,
+                self._async_reset_fired,
+                DOMAIN,
+                "sequence reset",
+                _log,
+            )
+
+        await self._async_arm(0)
+        return self.async_stop
+
+    @callback
+    def async_stop(self) -> None:
+        """Detach everything."""
+        self._async_disarm_step()
+        self._async_drop_timeout()
+
+        if self._unsub_reset is not None:
+            self._unsub_reset()
+            self._unsub_reset = None
+
+    async def _async_arm(self, index: int) -> None:
+        """Attach the step at `index` and wait for it."""
+        self._run.armed = index
+
+        async def _fired(
+            variables: dict[str, Any] | None = None,
+            context: Context | None = None,
+        ) -> None:
+            """Hand this step over, saying which step it was.
+
+            A closure rather than a callable object holding the index. Home
+            Assistant decides whether to await an action by inspecting it, and
+            an instance with an async `__call__` is not recognised as
+            awaitable: the coroutine is created, dropped, and the sequence
+            never advances. Measured, at the cost of an afternoon.
+            """
+            await self._async_step_fired(index, variables, context)
+
+        self._unsub_step = await trigger_helper.async_initialize_triggers(
+            self._hass,
+            [self._sequence.steps[index]],
+            _fired,
+            DOMAIN,
+            f"step {index + 1}",
+            _log,
+        )
+
+        if self._unsub_step is None:
+            # `async_initialize_triggers` hands back nothing when it could not
+            # attach anything, having logged why. Say so as well: a sequence
+            # stuck on a step it cannot listen for is a trigger that never
+            # fires, and that is the failure mode worth being loud about.
+            LOGGER.warning(
+                "Spook could not attach step %s of a sequence trigger, "
+                "so it will not fire",
+                index + 1,
+            )
+
+    @callback
+    def _async_disarm_step(self) -> None:
+        """Stop waiting for the currently armed step."""
+        if self._unsub_step is not None:
+            self._unsub_step()
+            self._unsub_step = None
+
+    @callback
+    def _async_drop_timeout(self) -> None:
+        """Drop the deadline, if one is pending."""
+        if self._run.unsub_timeout is not None:
+            self._run.unsub_timeout()
+            self._run.unsub_timeout = None
+
+    async def _async_step_fired(
+        self,
+        index: int,
+        variables: dict[str, Any] | None,
+        context: Context | None,
+    ) -> None:
+        """Take a step that landed, and either finish or move on."""
+        async with self._lock:
+            if index != self._run.armed:
+                # A firing of a step already left behind, which happens when
+                # this had to queue on the lock: a reset or a deadline holds it
+                # while it moves the run back to the start, and the step waiting
+                # behind them is answering a question nobody is asking any more.
+                #
+                # Not the double-firing case. Home Assistant starts the action
+                # eagerly, so a step detaches itself while the first event is
+                # still being handed out, and a second event never reaches it.
+                # Measured, after writing the opposite here first.
+                return
+
+            self._async_disarm_step()
+            self._run.collected.append((variables or {}).get("trigger", {}))
+
+            if index == 0:
+                self._run.started = dt_util.utcnow()
+                self._async_start_timeout()
+
+            if index + 1 < len(self._sequence.steps):
+                await self._async_arm(index + 1)
+                return
+
+            collected = self._run.collected
+            started = self._run.started or dt_util.utcnow()
+            self._async_abandon()
+            await self._async_arm(0)
+
+            self._on_complete(collected, dt_util.utcnow() - started, context)
+
+    async def _async_reset_fired(
+        self,
+        _variables: dict[str, Any] | None = None,
+        _context: Context | None = None,
+    ) -> None:
+        """Abandon a run in progress, because something said to."""
+        async with self._lock:
+            if self._run.armed == 0 and not self._run.collected:
+                # Nothing under way, so nothing to abandon.
+                return
+
+            self._async_disarm_step()
+            self._async_abandon()
+            await self._async_arm(0)
+
+    @callback
+    def _async_start_timeout(self) -> None:
+        """Put a deadline on the whole run, if one was configured."""
+        if self._sequence.timeout is None:
+            return
+
+        self._run.unsub_timeout = async_call_later(
+            self._hass, self._sequence.timeout.total_seconds(), self._async_timed_out
+        )
+
+    async def _async_timed_out(self, _now: datetime) -> None:
+        """Give up on the run, the deadline passed."""
+        self._run.unsub_timeout = None
+        async with self._lock:
+            self._async_disarm_step()
+            self._async_abandon()
+            await self._async_arm(0)
+
+    @callback
+    def _async_abandon(self) -> None:
+        """Forget the run so far. The caller arms the first step again.
+
+        Dropping the deadline first, because replacing the run would otherwise
+        lose the handle to it and leave a timer behind.
+        """
+        self._async_drop_timeout()
+        self._run = _Run()
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when several triggers happen in order.
+
+    Home Assistant can fire on one thing happening. It cannot fire on one
+    thing happening after another, which is most of what a house does: the
+    door opened and then somebody moved in the hall, the washing machine
+    started and then went quiet. Written out by hand that needs a helper
+    entity per step and an automation to set each one.
+
+    Only the step being waited for is attached, so a later trigger firing
+    before an earlier one is not a match, and neither is the same step firing
+    twice.
+    """
+
+    trigger = "sequence"
+
+    _sequence: _Sequence
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config, nested triggers and all.
+
+        Both halves, the same as a condition needs: the schema turns what the
+        selector sends into a list of trigger configs, and
+        `async_validate_trigger_config` is what checks each of them against
+        the platform it names.
+        """
+        shaped: ConfigType = _TRIGGER_SCHEMA(config)
+        options = shaped[CONF_OPTIONS]
+
+        if len(options[CONF_STEPS]) < _MINIMUM_STEPS:
+            msg = (
+                f"A sequence needs at least {_MINIMUM_STEPS} steps to be a "
+                f"sequence, and this one has {len(options[CONF_STEPS])}."
+            )
+            raise vol.Invalid(msg)
+
+        options[CONF_STEPS] = await trigger_helper.async_validate_trigger_config(
+            hass, options[CONF_STEPS]
+        )
+        if CONF_RESET in options:
+            options[CONF_RESET] = await trigger_helper.async_validate_trigger_config(
+                hass, options[CONF_RESET]
+            )
+
+        return shaped
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._sequence = _Sequence(
+            steps=options[CONF_STEPS],
+            reset=options.get(CONF_RESET, []),
+            timeout=options.get(CONF_TIMEOUT),
+        )
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def completed(
+            steps: list[dict[str, Any]],
+            duration: timedelta,
+            context: Context | None,
+        ) -> None:
+            """Run the action, the last step having landed."""
+            last = steps[-1] if steps else {}
+            description = last.get("description", "the last step")
+
+            run_action(
+                {
+                    **{
+                        key: last[key] for key in _CARRIED_FROM_LAST_STEP if key in last
+                    },
+                    "steps": steps,
+                    "duration": duration,
+                },
+                f"{description}, completing a sequence of {len(self._sequence.steps)}",
+                context,
+            )
+
+        watcher = _SequenceWatcher(self._hass, self._sequence, completed)
+        return await watcher.async_start()

--- a/custom_components/spook/ectoplasms/spook/triggers/sequence.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/sequence.py
@@ -91,6 +91,7 @@ class _Run:
     armed: int = 0
     collected: list[dict[str, Any]] = field(default_factory=list)
     started: datetime | None = None
+    unsub_step: CALLBACK_TYPE | None = None
     unsub_timeout: CALLBACK_TYPE | None = None
 
 
@@ -114,8 +115,11 @@ class _SequenceWatcher:
         self._on_complete = on_complete
 
         self._run = _Run()
-        self._unsub_step: CALLBACK_TYPE | None = None
         self._unsub_reset: CALLBACK_TYPE | None = None
+
+        # Stopping is synchronous, arming is not, so a re-arm can be suspended
+        # while this is set. See `async_stop`.
+        self._stopped = False
 
         # A step landing, a reset firing and a deadline passing all move the
         # same run, and all of them suspend while they re-arm. One at a time,
@@ -140,12 +144,31 @@ class _SequenceWatcher:
                 _log,
             )
 
+            if self._unsub_reset is None:
+                # Nothing attached, and it has already logged why. Worth
+                # repeating, because a sequence whose reset never arrives is
+                # one that quietly stops being interruptible.
+                LOGGER.warning(
+                    "Spook could not attach the reset triggers of a sequence "
+                    "trigger, so nothing will abandon a run under way"
+                )
+
         await self._async_arm(0)
         return self.async_stop
 
     @callback
     def async_stop(self) -> None:
-        """Detach everything."""
+        """Detach everything, and refuse to attach any more.
+
+        Stopping is synchronous while arming is not, so a re-arm can be
+        suspended inside `async_initialize_triggers` at this very moment.
+        Whatever that attaches afterwards would have nobody left to detach it,
+        so the flag tells it to let go of what it just took. Reproduced before
+        fixing: without it, a watcher belonging to an automation that had been
+        turned off still completed sequences.
+        """
+        self._stopped = True
+
         self._async_disarm_step()
         self._async_drop_timeout()
 
@@ -171,7 +194,7 @@ class _SequenceWatcher:
             """
             await self._async_step_fired(index, variables, context)
 
-        self._unsub_step = await trigger_helper.async_initialize_triggers(
+        unsub = await trigger_helper.async_initialize_triggers(
             self._hass,
             [self._sequence.steps[index]],
             _fired,
@@ -180,7 +203,16 @@ class _SequenceWatcher:
             _log,
         )
 
-        if self._unsub_step is None:
+        if self._stopped:
+            # Stopped while this was suspended. Nobody is holding the handle
+            # any more, so let go of it here.
+            if unsub is not None:
+                unsub()
+            return
+
+        self._run.unsub_step = unsub
+
+        if unsub is None:
             # `async_initialize_triggers` hands back nothing when it could not
             # attach anything, having logged why. Say so as well: a sequence
             # stuck on a step it cannot listen for is a trigger that never
@@ -194,9 +226,9 @@ class _SequenceWatcher:
     @callback
     def _async_disarm_step(self) -> None:
         """Stop waiting for the currently armed step."""
-        if self._unsub_step is not None:
-            self._unsub_step()
-            self._unsub_step = None
+        if self._run.unsub_step is not None:
+            self._run.unsub_step()
+            self._run.unsub_step = None
 
     @callback
     def _async_drop_timeout(self) -> None:
@@ -213,7 +245,7 @@ class _SequenceWatcher:
     ) -> None:
         """Take a step that landed, and either finish or move on."""
         async with self._lock:
-            if index != self._run.armed:
+            if self._stopped or index != self._run.armed:
                 # A firing of a step already left behind, which happens when
                 # this had to queue on the lock: a reset or a deadline holds it
                 # while it moves the run back to the start, and the step waiting
@@ -236,12 +268,16 @@ class _SequenceWatcher:
                 await self._async_arm(index + 1)
                 return
 
+            # Read before re-arming: arming suspends, and a duration that
+            # includes how long it took to start listening again is not how
+            # long the sequence took.
             collected = self._run.collected
-            started = self._run.started or dt_util.utcnow()
+            duration = dt_util.utcnow() - (self._run.started or dt_util.utcnow())
+
             self._async_abandon()
             await self._async_arm(0)
 
-            self._on_complete(collected, dt_util.utcnow() - started, context)
+            self._on_complete(collected, duration, context)
 
     async def _async_reset_fired(
         self,
@@ -250,7 +286,7 @@ class _SequenceWatcher:
     ) -> None:
         """Abandon a run in progress, because something said to."""
         async with self._lock:
-            if self._run.armed == 0 and not self._run.collected:
+            if self._stopped or (self._run.armed == 0 and not self._run.collected):
                 # Nothing under way, so nothing to abandon.
                 return
 
@@ -272,6 +308,9 @@ class _SequenceWatcher:
         """Give up on the run, the deadline passed."""
         self._run.unsub_timeout = None
         async with self._lock:
+            if self._stopped:
+                return
+
             self._async_disarm_step()
             self._async_abandon()
             await self._async_arm(0)

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1,5 +1,23 @@
 {
   "triggers": {
+    "sequence": {
+      "name": "Triggers in order",
+      "description": "Fires when several triggers happen one after another, in the order given.",
+      "fields": {
+        "steps": {
+          "name": "Steps",
+          "description": "The triggers that have to happen, in order. Only the one being waited for is listening, so a later step firing early is not a match."
+        },
+        "timeout": {
+          "name": "Timeout",
+          "description": "How long the whole sequence may take, counted from the first step. Left out, it waits indefinitely."
+        },
+        "reset": {
+          "name": "Reset",
+          "description": "Triggers that abandon a sequence already under way, putting it back to waiting for the first step."
+        }
+      }
+    },
     "condition_met": {
       "name": "Condition turned true",
       "description": "Fires when a condition goes from false to true, using the same condition building blocks as anywhere else.",

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -59,3 +59,18 @@ condition_met:
       required: true
       selector:
         condition:
+sequence:
+  fields:
+    steps:
+      required: true
+      selector:
+        trigger:
+    timeout:
+      required: false
+      example: "00:02:00"
+      selector:
+        duration:
+    reset:
+      required: false
+      selector:
+        trigger:

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -303,6 +303,14 @@ Template test function
 :::
 
 :::{glossary}
+Trigger
+: A trigger is what sets an {term}`automation <automation>` going. Something happens, a state changes, a time comes round, an event is fired, and the automation runs. An automation can have several, and any one of them firing is enough.
+: A trigger is not a {term}`condition <condition>`. A trigger is a moment; a condition is a question asked at that moment.
+: {term}`Integrations <integration>` can provide their own triggers, which is how Spook adds some. Those are named after the integration providing them, like `sun.sunset` or `spook.sequence`, while the ones built into Home Assistant itself, `state` or `time`, carry no prefix at all.
+: [Learn more in the official Home Assistant documentation](https://www.home-assistant.io/docs/automation/trigger/)
+:::
+
+:::{glossary}
 YAML
 : The complex definition would be: <wiki:YAML> is a human-readable data-serialization language. But a more simplified explanation would be: It is a structure in which we can write configuration files that are readable for both humans and machines.
 : It is the format {term}`Home Assistant` uses to store its configuration and data. Opinions are divided on whether YAML is a good or bad format or hard or easy to use. The fact remains, is that Home Assistant uses it a lot, and it definitly worth while learning it. YAML itself really isn't that complex, but it does have some quirks that you need to be aware of. The most complex part of using YAML with Home Assistant is not YAML itself but all the things you can do with it in Home Assistant.

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -933,6 +933,100 @@ options:
 
 :::
 
+### Triggers in order
+
+Fires when several triggers happen one after another, in the order given.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Triggers in order
+* - Trigger name
+  - `spook.sequence`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `steps`
+  - {term}`trigger <trigger>`
+  - Yes
+  - Two or more triggers, in the order they have to happen
+* - `timeout`
+  - {term}`string <string>`
+  - No
+  - Waits indefinitely when left out
+* - `reset`
+  - {term}`trigger <trigger>`
+  - No
+  - Nothing abandons a run when left out
+```
+
+Home Assistant fires on one thing happening. It does not fire on one thing happening _after_ another, which is most of what a house actually does: the door opened and then somebody moved in the hall, the washing machine started and then went quiet, the alarm armed and then a window opened. Written by hand that needs a helper entity per step and an automation to set each one.
+
+Only the step being waited for is listening. So a later step firing before an earlier one is not a match, and neither is the same step firing twice. Two steps is the minimum, because one trigger in order is just a trigger.
+
+Once the last step lands the trigger fires and goes back to waiting for the first, so it works as many times as you like.
+
+When it fires, `trigger.steps` holds what each step reported, in order, and `trigger.duration` is how long the whole thing took. The step that completed the sequence is also lifted to the top, so `trigger.entity_id`, `trigger.from_state` and `trigger.to_state` describe the thing that finished it, and `spook.triggered_by_user` and friends find the person behind it there.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Somebody came in through the front door and walked into the hall, within two minutes:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.sequence
+options:
+  timeout: "00:02:00"
+  steps:
+    - trigger: state
+      entity_id: binary_sensor.front_door
+      to: "on"
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+```
+
+Same again, but disarming the alarm halfway through means it no longer counts:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.sequence
+options:
+  timeout: "00:02:00"
+  steps:
+    - trigger: state
+      entity_id: binary_sensor.front_door
+      to: "on"
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+  reset:
+    - trigger: state
+      entity_id: alarm_control_panel.home
+      to: disarmed
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- One step is one trigger. A step that should accept either of two things is written as one trigger that matches both, for example a state trigger naming several entities.
+- The `timeout` covers the whole run, counted from the first step. There is no per-step deadline.
+- A run under way is abandoned when Home Assistant restarts, along with everything else in memory. A sequence half finished before a restart starts again from the first step.
+- A step that cannot be attached at all disables that automation and says why in the log, rather than sitting there never firing.
+  :::
+
 ### Condition turned true
 
 Fires when a condition goes from false to true.

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1023,8 +1023,9 @@ options:
 
 - One step is one trigger. A step that should accept either of two things is written as one trigger that matches both, for example a state trigger naming several entities.
 - The `timeout` covers the whole run, counted from the first step. There is no per-step deadline.
-- A run under way is abandoned when Home Assistant restarts, along with everything else in memory. A sequence half finished before a restart starts again from the first step.
-- A step that cannot be attached at all disables that automation and says why in the log, rather than sitting there never firing.
+- A run under way is abandoned when Home Assistant restarts, along with everything else in memory. A sequence half-finished before a restart starts again from the first step.
+- The automation's `trigger_variables` do not reach the steps. Home Assistant hands those to a trigger platform, not to a trigger like this one, so a step whose own configuration is written as a template referring to them has nothing to render from. Steps written the ordinary way are unaffected.
+- A step that cannot be attached at all disables that automation and says why in the log, rather than sitting there never firing. A `reset` that cannot be attached leaves the steps working, so that one only says so in the log.
   :::
 
 ### Condition turned true

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -44,3 +44,9 @@ Fires when a repair issue goes away, either fixed or no longer reported. _#repai
 Fires when a condition goes from false to true, using the same condition building blocks as anywhere else. _#condition_ _#template_
 
 `spook.condition_met`, [documentation](other-features#condition-turned-true) 📚
+
+## Triggers in order
+
+Fires when several triggers happen one after another, in the order given, optionally within a time limit. _#sequence_ _#order_ _#timeout_
+
+`spook.sequence`, [documentation](other-features#triggers-in-order) 📚

--- a/tests/ectoplasms/spook/triggers/test_sequence.py
+++ b/tests/ectoplasms/spook/triggers/test_sequence.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
@@ -508,3 +509,160 @@ async def test_a_step_answering_late_is_dropped(hass: HomeAssistant) -> None:
     finally:
         stop()
         await hass.async_block_till_done()
+
+
+async def test_stopping_while_re_arming_leaves_nothing_behind(
+    hass: HomeAssistant,
+) -> None:
+    """Turning the automation off mid-flight must not leak a listener.
+
+    Stopping is synchronous, arming is not. Reproduced before it was fixed: a
+    watcher belonging to an automation that had been turned off went on
+    completing sequences, because the arm that was suspended when it stopped
+    stored its handle afterwards and nobody was left to call it.
+    """
+    await _reset_entities(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass, {"options": {"steps": [DOOR, MOTION]}}
+    )
+    completed: list[list[dict]] = []
+
+    watcher = sequence_module._SequenceWatcher(  # noqa: SLF001
+        hass,
+        sequence_module._Sequence(  # noqa: SLF001
+            steps=validated["options"]["steps"], reset=[], timeout=None
+        ),
+        lambda collected, _duration, _context: completed.append(collected),
+    )
+    stop = await watcher.async_start()
+
+    real = trigger_helper.async_initialize_triggers
+    hold = asyncio.Event()
+    arming = asyncio.Event()
+
+    async def _suspending(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if args[4].startswith("step 2"):
+            arming.set()
+            await hold.wait()
+        return await real(*args, **kwargs)
+
+    with patch.object(
+        sequence_module.trigger_helper,
+        "async_initialize_triggers",
+        _suspending,
+    ):
+        landing = hass.async_create_task(
+            watcher._async_step_fired(0, {"trigger": {}}, None)  # noqa: SLF001
+        )
+        async with asyncio.timeout(5):
+            await arming.wait()
+
+        # The automation is turned off while arming the second step waits.
+        stop()
+
+        hold.set()
+        async with asyncio.timeout(5):
+            await landing
+        await hass.async_block_till_done()
+
+    assert watcher._run.unsub_step is None, "a listener was left behind"  # noqa: SLF001
+
+    # And it really is deaf: the second step arriving does nothing.
+    await _move(hass, "binary_sensor.motion", "on")
+    assert not completed, "a stopped watcher completed a sequence"
+
+
+async def test_the_duration_ends_when_the_last_step_lands(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Not when it has finished listening again.
+
+    Arming the first step again suspends, so reading the clock after it would
+    fold however long that took into what the sequence is reported to have
+    taken.
+    """
+    await _reset_entities(hass)
+    reported: list[timedelta] = []
+
+    validated = await SpookTrigger.async_validate_config(
+        hass, {"options": {"steps": [DOOR, MOTION]}}
+    )
+
+    watcher = sequence_module._SequenceWatcher(  # noqa: SLF001
+        hass,
+        sequence_module._Sequence(  # noqa: SLF001
+            steps=validated["options"]["steps"], reset=[], timeout=None
+        ),
+        lambda _collected, duration, _context: reported.append(duration),
+    )
+    stop = await watcher.async_start()
+
+    try:
+        await watcher._async_step_fired(0, {"trigger": {}}, None)  # noqa: SLF001
+        freezer.tick(timedelta(seconds=5))
+
+        real = trigger_helper.async_initialize_triggers
+
+        async def _slow_re_arm(*args: Any, **kwargs: Any):  # noqa: ANN202
+            if args[4].startswith("step 1"):
+                # Time passes while listening starts again.
+                freezer.tick(timedelta(minutes=10))
+            return await real(*args, **kwargs)
+
+        with patch.object(
+            sequence_module.trigger_helper,
+            "async_initialize_triggers",
+            _slow_re_arm,
+        ):
+            await watcher._async_step_fired(1, {"trigger": {}}, None)  # noqa: SLF001
+    finally:
+        stop()
+        await hass.async_block_till_done()
+
+    assert len(reported) == 1
+    assert reported[0] == timedelta(seconds=5), (
+        f"reported {reported[0]}, so re-arming was counted as part of the run"
+    )
+
+
+async def test_a_reset_that_cannot_attach_is_reported(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A sequence that quietly stops being interruptible is worth a line.
+
+    The steps still attach, so the trigger works and reports itself as fine.
+    Only the reset is missing, and nothing else would say so.
+    """
+    await _reset_entities(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass, {"options": {"steps": [DOOR, MOTION], "reset": [DISARMED]}}
+    )
+
+    watcher = sequence_module._SequenceWatcher(  # noqa: SLF001
+        hass,
+        sequence_module._Sequence(  # noqa: SLF001
+            steps=validated["options"]["steps"],
+            reset=validated["options"]["reset"],
+            timeout=None,
+        ),
+        lambda *_args: None,
+    )
+
+    real = trigger_helper.async_initialize_triggers
+
+    async def _reset_fails(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if args[4] == "sequence reset":
+            return None
+        return await real(*args, **kwargs)
+
+    with patch.object(
+        sequence_module.trigger_helper, "async_initialize_triggers", _reset_fails
+    ):
+        stop = await watcher.async_start()
+
+    stop()
+    await hass.async_block_till_done()
+
+    assert "nothing will abandon a run under way" in caplog.text

--- a/tests/ectoplasms/spook/triggers/test_sequence.py
+++ b/tests/ectoplasms/spook/triggers/test_sequence.py
@@ -1,0 +1,510 @@
+"""Tests for the spook.sequence trigger."""
+
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+from homeassistant.core import Context
+from homeassistant.helpers import selector, trigger as trigger_helper
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers import (
+    sequence as sequence_module,
+)
+from custom_components.spook.ectoplasms.spook.triggers.sequence import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+DOOR = {"trigger": "state", "entity_id": "binary_sensor.door", "to": "on"}
+MOTION = {"trigger": "state", "entity_id": "binary_sensor.motion", "to": "on"}
+DISARMED = {"trigger": "state", "entity_id": "input_boolean.armed", "to": "off"}
+
+TWICE = 2
+THRICE = 3
+
+
+async def _automation(
+    hass: HomeAssistant,
+    options: dict[str, Any] | None = None,
+) -> list[dict]:
+    """Set up an automation on the trigger and record every run's variables."""
+    runs: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        runs.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "in order",
+                    "trigger": {
+                        "platform": "spook.sequence",
+                        "options": options or {"steps": [DOOR, MOTION]},
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {
+                                "steps": "{{ trigger.steps | count }}",
+                                "first": "{{ trigger.steps[0].entity_id }}",
+                                "last": "{{ trigger.steps[-1].entity_id }}",
+                            },
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return runs
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger.
+
+    The harness fails a test that leaves a timer or listener behind, and this
+    trigger holds nested triggers and possibly a deadline, so this doubles as
+    a check that it clears all of them up.
+    """
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": "automation.in_order"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+
+async def _settle(hass: HomeAssistant) -> None:
+    """Let the nested triggers finish attaching."""
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+
+async def _move(hass: HomeAssistant, entity_id: str, state: str, **kwargs) -> None:  # noqa: ANN003
+    """Move an entity and let everything settle."""
+    hass.states.async_set(entity_id, state, **kwargs)
+    await _settle(hass)
+
+
+async def _reset_entities(hass: HomeAssistant) -> None:
+    """Put the entities this uses in a known place."""
+    hass.states.async_set("binary_sensor.door", "off")
+    hass.states.async_set("binary_sensor.motion", "off")
+    hass.states.async_set("input_boolean.armed", "on")
+    await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "sequence" in await async_get_triggers(hass)
+
+
+async def test_it_fires_when_the_steps_happen_in_order(hass: HomeAssistant) -> None:
+    """The whole point: door, then motion."""
+    await _reset_entities(hass)
+    runs = await _automation(hass)
+
+    await _move(hass, "binary_sensor.door", "on")
+    assert not runs, "fired on the first step alone"
+
+    await _move(hass, "binary_sensor.motion", "on")
+
+    assert len(runs) == 1
+    assert runs[0]["steps"] == TWICE
+    assert runs[0]["first"] == "binary_sensor.door"
+    assert runs[0]["last"] == "binary_sensor.motion"
+
+    await _detach(hass)
+
+
+async def test_it_does_not_fire_out_of_order(hass: HomeAssistant) -> None:
+    """Motion first is not this sequence, and nothing is listening for it."""
+    await _reset_entities(hass)
+    runs = await _automation(hass)
+
+    await _move(hass, "binary_sensor.motion", "on")
+    await _move(hass, "binary_sensor.door", "on")
+
+    assert not runs, "fired on the steps in the wrong order"
+
+    await _detach(hass)
+
+
+async def test_the_same_step_twice_does_not_advance(hass: HomeAssistant) -> None:
+    """A step is a step, not a counter."""
+    await _reset_entities(hass)
+    runs = await _automation(hass)
+
+    await _move(hass, "binary_sensor.door", "on")
+    await _move(hass, "binary_sensor.door", "off")
+    await _move(hass, "binary_sensor.door", "on")
+
+    assert not runs, "the first step firing twice completed the sequence"
+
+    await _move(hass, "binary_sensor.motion", "on")
+    assert len(runs) == 1
+
+    await _detach(hass)
+
+
+async def test_it_arms_itself_again_afterwards(hass: HomeAssistant) -> None:
+    """Once round is not once ever."""
+    await _reset_entities(hass)
+    runs = await _automation(hass)
+
+    for _ in range(TWICE):
+        await _move(hass, "binary_sensor.door", "on")
+        await _move(hass, "binary_sensor.motion", "on")
+        await _move(hass, "binary_sensor.door", "off")
+        await _move(hass, "binary_sensor.motion", "off")
+
+    assert len(runs) == TWICE
+
+    await _detach(hass)
+
+
+async def test_a_timeout_abandons_the_run(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The deadline runs from the first step, and gives up when it passes."""
+    await _reset_entities(hass)
+    runs = await _automation(hass, {"steps": [DOOR, MOTION], "timeout": {"minutes": 2}})
+
+    await _move(hass, "binary_sensor.door", "on")
+
+    freezer.tick(timedelta(minutes=3))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=3))
+    await _settle(hass)
+
+    await _move(hass, "binary_sensor.motion", "on")
+    assert not runs, "the deadline passed and it still fired"
+
+    # And it is back to waiting for the first step.
+    await _move(hass, "binary_sensor.door", "off")
+    await _move(hass, "binary_sensor.motion", "off")
+    await _move(hass, "binary_sensor.door", "on")
+    await _move(hass, "binary_sensor.motion", "on")
+    assert len(runs) == 1, "it did not arm itself again after the timeout"
+
+    await _detach(hass)
+
+
+async def test_a_timeout_with_room_to_spare_still_fires(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A deadline is a limit, not a wait."""
+    await _reset_entities(hass)
+    runs = await _automation(hass, {"steps": [DOOR, MOTION], "timeout": {"minutes": 2}})
+
+    await _move(hass, "binary_sensor.door", "on")
+    freezer.tick(timedelta(seconds=30))
+    await _move(hass, "binary_sensor.motion", "on")
+
+    assert len(runs) == 1
+
+    await _detach(hass)
+
+
+async def test_a_reset_trigger_abandons_the_run(hass: HomeAssistant) -> None:
+    """Something else happened that means the sequence no longer counts."""
+    await _reset_entities(hass)
+    runs = await _automation(hass, {"steps": [DOOR, MOTION], "reset": [DISARMED]})
+
+    await _move(hass, "binary_sensor.door", "on")
+    await _move(hass, "input_boolean.armed", "off")
+    await _move(hass, "binary_sensor.motion", "on")
+
+    assert not runs, "the reset did not abandon the run"
+
+    await _detach(hass)
+
+
+async def test_a_reset_while_nothing_runs_is_harmless(hass: HomeAssistant) -> None:
+    """Resetting what has not started leaves the first step armed."""
+    await _reset_entities(hass)
+    runs = await _automation(hass, {"steps": [DOOR, MOTION], "reset": [DISARMED]})
+
+    await _move(hass, "input_boolean.armed", "off")
+    await _move(hass, "binary_sensor.door", "on")
+    await _move(hass, "binary_sensor.motion", "on")
+
+    assert len(runs) == 1, "a reset while idle broke the sequence"
+
+    await _detach(hass)
+
+
+async def test_it_carries_the_last_step_user_through(hass: HomeAssistant) -> None:
+    """Whoever completed the sequence is who set the run going."""
+    await _reset_entities(hass)
+    user = await hass.auth.async_create_user("Ghost Hunter")
+
+    ran: list[str] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(call.data["which"])
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": which,
+                    "trigger": {
+                        "platform": "spook.sequence",
+                        "options": {"steps": [DOOR, MOTION]},
+                    },
+                    "condition": [{"condition": f"spook.{which}"}],
+                    "action": [{"action": "test.mark", "data": {"which": which}}],
+                }
+                for which in ("triggered_by_user", "not_triggered_by_user")
+            ]
+        },
+    )
+    await _settle(hass)
+
+    await _move(hass, "binary_sensor.door", "on")
+    await _move(hass, "binary_sensor.motion", "on", context=Context(user_id=user.id))
+
+    assert ran == ["triggered_by_user"]
+
+    for alias in ("triggered_by_user", "not_triggered_by_user"):
+        await hass.services.async_call(
+            "automation",
+            "turn_off",
+            {"entity_id": f"automation.{alias}"},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+
+async def test_it_takes_what_the_trigger_selector_produces(
+    hass: HomeAssistant,
+) -> None:
+    """The shape an automation built in the user interface actually has.
+
+    `TriggerSelector` validates with `cv.TRIGGER_SCHEMA`, which normalises to
+    a list, the same trap the condition selector sets.
+    """
+    await _reset_entities(hass)
+    runs = await _automation(
+        hass, {"steps": selector.TriggerSelector()([DOOR, MOTION])}
+    )
+
+    assert hass.states.get("automation.in_order").state == "on", (
+        "the automation did not load"
+    )
+
+    await _move(hass, "binary_sensor.door", "on")
+    await _move(hass, "binary_sensor.motion", "on")
+    assert len(runs) == 1
+
+    await _detach(hass)
+
+
+async def test_one_step_is_not_a_sequence(hass: HomeAssistant) -> None:
+    """Refused, because there is no order to wait for."""
+    with pytest.raises(vol.Invalid, match="at least 2 steps"):
+        await SpookTrigger.async_validate_config(hass, {"options": {"steps": [DOOR]}})
+
+
+async def test_steps_are_required(hass: HomeAssistant) -> None:
+    """Without them there is nothing to wait for."""
+    with pytest.raises(vol.Invalid, match="required key"):
+        await SpookTrigger.async_validate_config(hass, {"options": {}})
+
+
+async def test_a_bad_step_takes_down_only_its_own_automation(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A nested trigger that cannot be built is reported, not swallowed."""
+    await _reset_entities(hass)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "fine",
+                    "trigger": {
+                        "platform": "spook.sequence",
+                        "options": {"steps": [DOOR, MOTION]},
+                    },
+                    "action": [],
+                },
+                {
+                    "alias": "broken",
+                    "trigger": {
+                        "platform": "spook.sequence",
+                        "options": {
+                            "steps": [DOOR, {"trigger": "not_a_trigger"}],
+                        },
+                    },
+                    "action": [],
+                },
+            ]
+        },
+    )
+    await _settle(hass)
+
+    assert hass.states.get("automation.fine").state == "on"
+    assert hass.states.get("automation.broken").state == "unavailable"
+    assert "not_a_trigger" in caplog.text
+
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": "automation.fine"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+
+async def test_three_steps_all_have_to_land(hass: HomeAssistant) -> None:
+    """Two is the minimum, not the maximum."""
+    await _reset_entities(hass)
+    hass.states.async_set("binary_sensor.window", "off")
+    await hass.async_block_till_done()
+
+    window = {"trigger": "state", "entity_id": "binary_sensor.window", "to": "on"}
+    runs = await _automation(hass, {"steps": [DOOR, MOTION, window]})
+
+    await _move(hass, "binary_sensor.door", "on")
+    await _move(hass, "binary_sensor.motion", "on")
+    assert not runs, "fired before the last step"
+
+    await _move(hass, "binary_sensor.window", "on")
+    assert len(runs) == 1
+    assert runs[0]["steps"] == THRICE
+    assert runs[0]["last"] == "binary_sensor.window"
+
+    await _detach(hass)
+
+
+async def test_a_step_firing_twice_in_one_go_does_not_run_ahead(
+    hass: HomeAssistant,
+) -> None:
+    """Two of the same step arriving together must still be one step.
+
+    Which Home Assistant mostly arranges by itself: it starts the action
+    eagerly, so a step detaches itself while the first event is still being
+    handed out and the second never reaches it. Measured. The test stays
+    because that is an implementation detail of core's, and this is the
+    behaviour that has to hold either way.
+    """
+    await _reset_entities(hass)
+    runs = await _automation(hass)
+
+    # No awaiting in between: both transitions to `on` are queued before the
+    # trigger gets to handle either of them.
+    hass.states.async_set("binary_sensor.door", "on")
+    hass.states.async_set("binary_sensor.door", "off")
+    hass.states.async_set("binary_sensor.door", "on")
+    await _settle(hass)
+
+    assert not runs, "the first step firing twice completed the sequence"
+
+    await _move(hass, "binary_sensor.motion", "on")
+
+    assert len(runs) == 1, "the second firing armed the last step twice"
+    assert runs[0]["steps"] == TWICE, "the same step was collected twice"
+
+    await _detach(hass)
+
+
+async def test_a_reset_while_idle_leaves_the_first_step_alone(
+    hass: HomeAssistant,
+) -> None:
+    """Nothing to abandon means nothing to touch.
+
+    Counted rather than observed, because what re-arming for nothing costs is
+    a gap: detaching and attaching again suspends, and a first step arriving
+    in that window would be missed. Easier to pin the arming than to race it.
+    """
+    await _reset_entities(hass)
+
+    arms = 0
+    real = trigger_helper.async_initialize_triggers
+
+    async def _counting(*args: Any, **kwargs: Any):  # noqa: ANN202
+        nonlocal arms
+        if args[4].startswith("step"):
+            arms += 1
+        return await real(*args, **kwargs)
+
+    with patch.object(
+        sequence_module.trigger_helper, "async_initialize_triggers", _counting
+    ):
+        await _automation(hass, {"steps": [DOOR, MOTION], "reset": [DISARMED]})
+        armed_after_setup = arms
+
+        await _move(hass, "input_boolean.armed", "off")
+        await _move(hass, "input_boolean.armed", "on")
+        await _move(hass, "input_boolean.armed", "off")
+
+        assert arms == armed_after_setup, (
+            f"a reset while idle re-armed the first step {arms - armed_after_setup} time(s)"
+        )
+
+    await _detach(hass)
+
+
+async def test_a_step_answering_late_is_dropped(hass: HomeAssistant) -> None:
+    """A step that queued behind a reset must not be taken when it gets in.
+
+    Driven straight rather than through the event bus. The interleaving that
+    reaches this is a reset or a deadline holding the lock while a step waits
+    behind it, and forcing that through real events is a race, so the sequence
+    is walked by hand instead.
+    """
+    validated = await SpookTrigger.async_validate_config(
+        hass, {"options": {"steps": [DOOR, MOTION]}}
+    )
+    steps = validated["options"]["steps"]
+    completed: list[list[dict]] = []
+
+    watcher = sequence_module._SequenceWatcher(  # noqa: SLF001
+        hass,
+        sequence_module._Sequence(steps=steps, reset=[], timeout=None),  # noqa: SLF001
+        lambda collected, _duration, _context: completed.append(collected),
+    )
+    stop = await watcher.async_start()
+
+    try:
+        # The first step lands, so the second is armed.
+        await watcher._async_step_fired(0, {"trigger": {"entity_id": "a.b"}}, None)  # noqa: SLF001
+        assert not completed
+
+        # The first step answers again, late. It is no longer the step being
+        # waited for, so it counts for nothing.
+        await watcher._async_step_fired(0, {"trigger": {"entity_id": "a.b"}}, None)  # noqa: SLF001
+        assert not completed, "a late first step completed a two step sequence"
+
+        # And the run is still waiting for the second step, not a third one.
+        await watcher._async_step_fired(1, {"trigger": {"entity_id": "c.d"}}, None)  # noqa: SLF001
+        assert len(completed) == 1
+        assert len(completed[0]) == TWICE, "the late step was collected"
+    finally:
+        stop()
+        await hass.async_block_till_done()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Home Assistant fires on one thing happening. It does not fire on one thing happening *after* another, which is most of what a house actually does: the door opened and then somebody moved in the hall, the washing machine started and then went quiet, the alarm armed and then a window opened. Written by hand that needs a helper entity per step and an automation to set each one.

```yaml
trigger: spook.sequence
options:
  timeout: "00:02:00"
  steps:
    - trigger: state
      entity_id: binary_sensor.front_door
      to: "on"
    - trigger: state
      entity_id: binary_sensor.hallway_motion
      to: "on"
  reset:
    - trigger: state
      entity_id: alarm_control_panel.home
      to: disarmed
```

### The semantics, and who chose them

- **Only the step being waited for is attached.** That is what makes the order mean anything, and it keeps the listener count at one no matter how long the sequence is. A later step firing early is not a match, and neither is the same step firing twice.
- **`timeout` covers the whole run**, counted from the first step. Per-step deadlines are a separate feature; nobody has asked for them yet.
- **`reset` triggers abandon a run under way** and stay attached for the watcher's whole life rather than only during a run, because attaching is asynchronous and arming them per run would leave a window where an early reset is missed.
- **Two steps minimum.** One trigger in order is a trigger.
- **Completing arms the first step again**, so it works as many times as you like.

### What it reports

`trigger.steps` holds what each step reported, in order, and `trigger.duration` is how long the run took. The step that completed the sequence is also lifted to the top, so `trigger.entity_id`, `trigger.from_state` and `trigger.to_state` describe the thing that finished it and Spook's context conditions find the person behind it there.

That lift is an allowlist, not a merge, and the reason is worth knowing: `action_payload_builder` puts `**extra_trigger_payload` **last**, so what a trigger reports overrides `trigger_data`. Merging a step wholesale would replace the automation's own `trigger.id`, `idx` and `platform` with the step's and break every `choose` keyed on `trigger.id`.

### Three things measurement caught that reading would not have

1. **`home_assistant_start` on `async_initialize_triggers` is deprecated** and already raises a `RuntimeError` through the frame helper. Removed in 2027.8.
2. **Home Assistant cannot tell that an instance with an async `__call__` is awaitable.** The first version carried the step index on a small callable object, which reads nicely. The coroutine was created, dropped on the floor, and the sequence never advanced past step one. It is a closure now.
3. **`TriggerSelector` normalises to a list**, exactly like `ConditionSelector` did in #1485. The test for that shape goes through the real selector rather than a hand-built list, since assuming the shape is what broke the visual editor path last time.

### Two comments that were wrong until the measurements corrected them

- The lock does not guard against a step firing twice. Home Assistant starts the action eagerly, so a step detaches itself while the first event is still being handed out and a second event never reaches it. The lock guards a step, a reset and a deadline from interleaving, since all three move the same run and all three suspend while re-arming.
- That interleaving is also the only way the stale-step check is reachable, which is why that one test drives the watcher directly: forcing the interleaving through the event bus is a race.

### One thing the linter started and the code finished

A too-many-attributes complaint on the watcher. Rather than suppress it, the run's state moved into a `_Run` that gets replaced wholesale, and what to wait for into a frozen `_Sequence`. Abandoning a run is now one assignment instead of three, with the deadline dropped first because it belongs to the run. Better than what it replaced.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Wave 2 of the triggers and conditions plan, where it is described as the killer feature of the set. Ordered triggers are a standing pattern in Node-RED and a recurring forum request; Home Assistant has no equivalent, native or otherwise.

The glossary gained a `Trigger` entry along the way. It had `Condition` but not its counterpart, which the documentation for this needed.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Eighteen new tests, on top of the existing suite (1153 pass).

Firing in order and not out of order; the first step alone not being enough; the same step twice not advancing; three steps all having to land; arming itself again afterwards; a deadline abandoning a run and the run starting over after it; a deadline with room to spare still firing; a reset abandoning a run; a reset while idle being harmless and, counted separately, not re-arming the first step; the user behind the last step reaching a top-level `spook.triggered_by_user`; the shape the real `TriggerSelector` produces loading and firing; one step and no steps both refused; a step that cannot be attached disabling only its own automation; and a step answering late being dropped.

Nine deliberate defects, each caught: dropping the stale-step guard, arming every step at once, not arming again after completing, never starting the deadline, ignoring the reset triggers, resetting while idle, not lifting the completing step, allowing a single step, and abandoning a run without dropping its timer.

Two of those nine slipped through the first time, and both were my tests rather than the code:

- The "same step twice" test asserted the sequence did not complete, which holds either way, because a stale step re-arms the *next* step rather than completing. It now asserts what actually differs: one step collected once, and the last step armed once.
- The reset-while-idle guard has no observable effect beyond a missed-event window, so it is pinned by counting how often the first step gets armed.

Also ran `ruff check`, `ruff format --check`, `pylint`, and the descriptor gate. The documentation builds with the same 23 warnings as `main`; a first draft added two, both from a `{term}` pointing at a glossary entry that did not exist yet.

One process note. `uv run pylint custom_components tests` reports each target separately, so reading the trailing "rated at 10.00/10" line reports the *second* target's score and hides a finding in the first. It hid this one until pre-commit refused the commit. Checking the exit code is the fix.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
