### PR TITLE
Tie a sequence deadline to the run that set it

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/sequence.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/sequence.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_OPTIONS, CONF_TIMEOUT
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, trigger as trigger_helper
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.trigger import Trigger
@@ -154,6 +155,17 @@ class _SequenceWatcher:
                 )
 
         await self._async_arm(0)
+
+        if self._run.unsub_step is None:
+            # Nothing to wait for, so this trigger can never fire. Raising is
+            # what gets the automation marked unavailable instead of leaving
+            # it looking healthy and silent, which is what the documentation
+            # promises. Detach the reset triggers first: nobody is going to be
+            # handed a way to do it.
+            self.async_stop()
+            msg = "Could not attach the first step of a sequence trigger"
+            raise HomeAssistantError(msg)
+
         return self.async_stop
 
     @callback
@@ -217,6 +229,10 @@ class _SequenceWatcher:
             # attach anything, having logged why. Say so as well: a sequence
             # stuck on a step it cannot listen for is a trigger that never
             # fires, and that is the failure mode worth being loud about.
+            #
+            # `async_start` turns this into a refusal for the first step, where
+            # there is still somebody to refuse to. From a step landing there
+            # is not, so a line in the log is all there is.
             LOGGER.warning(
                 "Spook could not attach step %s of a sequence trigger, "
                 "so it will not fire",
@@ -296,24 +312,36 @@ class _SequenceWatcher:
 
     @callback
     def _async_start_timeout(self) -> None:
-        """Put a deadline on the whole run, if one was configured."""
+        """Put a deadline on the whole run, if one was configured.
+
+        The deadline is tied to the run that set it. A due callback has to
+        wait for the lock like everything else, and by the time it gets in the
+        run it belongs to may have finished or been abandoned and a fresh one
+        started. Giving up on that one would end a run that had barely begun.
+        """
         if self._sequence.timeout is None:
             return
 
-        self._run.unsub_timeout = async_call_later(
-            self._hass, self._sequence.timeout.total_seconds(), self._async_timed_out
+        run = self._run
+
+        async def _due(_now: datetime) -> None:
+            """Give up on the run, if it is still the run this was set for."""
+            async with self._lock:
+                if self._stopped or self._run is not run:
+                    return
+
+                # Cleared inside the lock, and on the run this belongs to, so
+                # it cannot wipe a newer run's handle and leave that timer
+                # behind.
+                run.unsub_timeout = None
+
+                self._async_disarm_step()
+                self._async_abandon()
+                await self._async_arm(0)
+
+        run.unsub_timeout = async_call_later(
+            self._hass, self._sequence.timeout.total_seconds(), _due
         )
-
-    async def _async_timed_out(self, _now: datetime) -> None:
-        """Give up on the run, the deadline passed."""
-        self._run.unsub_timeout = None
-        async with self._lock:
-            if self._stopped:
-                return
-
-            self._async_disarm_step()
-            self._async_abandon()
-            await self._async_arm(0)
 
     @callback
     def _async_abandon(self) -> None:

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -306,7 +306,7 @@ Template test function
 Trigger
 : A trigger is what sets an {term}`automation <automation>` going. Something happens, a state changes, a time comes round, an event is fired, and the automation runs. An automation can have several, and any one of them firing is enough.
 : A trigger is not a {term}`condition <condition>`. A trigger is a moment; a condition is a question asked at that moment.
-: {term}`Integrations <integration>` can provide their own triggers, which is how Spook adds some. Those are named after the integration providing them, like `sun.sunset` or `spook.sequence`, while the ones built into Home Assistant itself, `state` or `time`, carry no prefix at all.
+: {term}`Integrations <integration>` can provide their own triggers, which is how Spook adds some. Newer ones are named after the integration and the thing they fire on, like `sun.sunset` or `spook.sequence`. Older ones are named after the integration alone and take the detail as an option, like `mqtt` or `sun` with an `event`. Both spellings work.
 : [Learn more in the official Home Assistant documentation](https://www.home-assistant.io/docs/automation/trigger/)
 :::
 

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1025,7 +1025,8 @@ options:
 - The `timeout` covers the whole run, counted from the first step. There is no per-step deadline.
 - A run under way is abandoned when Home Assistant restarts, along with everything else in memory. A sequence half-finished before a restart starts again from the first step.
 - The automation's `trigger_variables` do not reach the steps. Home Assistant hands those to a trigger platform, not to a trigger like this one, so a step whose own configuration is written as a template referring to them has nothing to render from. Steps written the ordinary way are unaffected.
-- A step that cannot be attached disables that automation and says why in the log, rather than sitting there never firing. That covers both a step Home Assistant refuses to accept and one it accepts but then cannot listen for. A `reset` that cannot be attached leaves the steps working, so that one only says so in the log.
+- A step Home Assistant refuses to accept disables that automation, and so does a first step it accepts but then cannot listen for. Both are caught while the automation loads, and both say why in the log, rather than leaving it sitting there never firing.
+- A later step that cannot be attached is a different matter, because the automation is already running by then. That run stalls where it stands and the log is the only place it says so. Same for a `reset` that cannot be attached: the steps keep working, so nothing else gives it away.
   :::
 
 ### Condition turned true

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1025,7 +1025,7 @@ options:
 - The `timeout` covers the whole run, counted from the first step. There is no per-step deadline.
 - A run under way is abandoned when Home Assistant restarts, along with everything else in memory. A sequence half-finished before a restart starts again from the first step.
 - The automation's `trigger_variables` do not reach the steps. Home Assistant hands those to a trigger platform, not to a trigger like this one, so a step whose own configuration is written as a template referring to them has nothing to render from. Steps written the ordinary way are unaffected.
-- A step that cannot be attached at all disables that automation and says why in the log, rather than sitting there never firing. A `reset` that cannot be attached leaves the steps working, so that one only says so in the log.
+- A step that cannot be attached disables that automation and says why in the log, rather than sitting there never firing. That covers both a step Home Assistant refuses to accept and one it accepts but then cannot listen for. A `reset` that cannot be attached leaves the steps working, so that one only says so in the log.
   :::
 
 ### Condition turned true

--- a/tests/ectoplasms/spook/triggers/test_sequence.py
+++ b/tests/ectoplasms/spook/triggers/test_sequence.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from homeassistant.core import Context
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector, trigger as trigger_helper
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -666,3 +667,123 @@ async def test_a_reset_that_cannot_attach_is_reported(
     await hass.async_block_till_done()
 
     assert "nothing will abandon a run under way" in caplog.text
+
+
+async def test_a_deadline_only_ends_the_run_it_was_set_for(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A due deadline waits for the lock like everything else.
+
+    Built deliberately, because the interleaving is narrow and only the narrow
+    version shows anything. A deadline abandoning a run that has not started
+    yet leaves exactly what it found, so what has to be arranged is a deadline
+    from a finished run arriving after the next one has already got somewhere.
+
+    Waiters on a lock are served in order, so holding it and queueing three
+    things behind it puts them in that order every time: the step that
+    completes the first run, the first step of the second, and then the stale
+    deadline.
+    """
+    await _reset_entities(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass,
+        {"options": {"steps": [DOOR, MOTION], "timeout": {"seconds": 30}}},
+    )
+    completed: list[list[dict]] = []
+
+    watcher = sequence_module._SequenceWatcher(  # noqa: SLF001
+        hass,
+        sequence_module._Sequence(  # noqa: SLF001
+            steps=validated["options"]["steps"],
+            reset=[],
+            timeout=validated["options"]["timeout"],
+        ),
+        lambda collected, _duration, _context: completed.append(collected),
+    )
+    stop = await watcher.async_start()
+
+    try:
+        # A run starts, so a deadline is set for it.
+        await watcher._async_step_fired(0, {"trigger": {}}, None)  # noqa: SLF001
+        assert watcher._run.unsub_timeout is not None  # noqa: SLF001
+
+        await watcher._lock.acquire()  # noqa: SLF001
+
+        # The last step of that run lands, and waits for the lock.
+        landing = hass.async_create_task(
+            watcher._async_step_fired(1, {"trigger": {}}, None)  # noqa: SLF001
+        )
+        await asyncio.sleep(0)
+
+        # So does the first step of the run after it.
+        next_run = hass.async_create_task(
+            watcher._async_step_fired(0, {"trigger": {}}, None)  # noqa: SLF001
+        )
+        await asyncio.sleep(0)
+
+        # And only then does the first run's deadline come due, joining the
+        # back of the queue.
+        freezer.tick(timedelta(seconds=31))
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+        await asyncio.sleep(0)
+
+        watcher._lock.release()  # noqa: SLF001
+        async with asyncio.timeout(5):
+            await landing
+            await next_run
+        await hass.async_block_till_done()
+
+        assert len(completed) == 1, "the first run did not complete"
+        assert watcher._run.armed == 1, (  # noqa: SLF001
+            "a finished run's deadline abandoned the run that followed it"
+        )
+        assert len(watcher._run.collected) == 1  # noqa: SLF001
+    finally:
+        stop()
+        await hass.async_block_till_done()
+
+
+async def test_a_first_step_that_cannot_attach_is_refused(
+    hass: HomeAssistant,
+) -> None:
+    """An automation that can never fire must not look healthy.
+
+    Refusing is what gets Home Assistant to mark it unavailable. A line in the
+    log alone would leave it enabled, silent, and indistinguishable from one
+    that is simply waiting.
+    """
+    await _reset_entities(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass, {"options": {"steps": [DOOR, MOTION], "reset": [DISARMED]}}
+    )
+
+    watcher = sequence_module._SequenceWatcher(  # noqa: SLF001
+        hass,
+        sequence_module._Sequence(  # noqa: SLF001
+            steps=validated["options"]["steps"],
+            reset=validated["options"]["reset"],
+            timeout=None,
+        ),
+        lambda *_args: None,
+    )
+
+    real = trigger_helper.async_initialize_triggers
+
+    async def _steps_fail(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if args[4].startswith("step"):
+            return None
+        return await real(*args, **kwargs)
+
+    with (
+        patch.object(
+            sequence_module.trigger_helper, "async_initialize_triggers", _steps_fail
+        ),
+        pytest.raises(HomeAssistantError, match="first step"),
+    ):
+        await watcher.async_start()
+
+    # And it took the reset triggers back down on its way out, because nobody
+    # was handed a way to do it.
+    assert watcher._unsub_reset is None, "the reset triggers were left attached"  # noqa: SLF001
+    await hass.async_block_till_done()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Follow-up to #1489. Three findings from that review's last round arrived after it was merged, and one of them is a real race now sitting on `main`.

### A deadline could end the wrong run

A deadline waits for the watcher's lock like everything else. Coming due while the last step is completing the run puts it in the queue behind that step, so by the time it gets in, the run it belongs to has finished and the next one has started. It then abandoned that one. Clearing `unsub_timeout` before taking the lock could also wipe a newer run's handle and leave its timer running.

The deadline now belongs to the run that set it and does nothing once that run is over.

This is not a corner case for a sequence that completes near its own deadline, which is exactly the shape people write: "the door opened and then motion within two minutes", over and over.

### A first step that cannot be attached now refuses

The documentation said an unattachable step disables its automation. That was true only for a step Home Assistant rejects outright, which fails validation. A step it accepts and then cannot listen for logged a warning and carried on, leaving the automation enabled, silent, and indistinguishable from one that is simply waiting.

`async_start` raises now, which is what gets the automation marked unavailable. A later re-arm has nobody to raise to, so that still warns, and the documentation says which is which.

### The glossary entry was half wrong

The review said `sun.sunset` is not a valid trigger key. Measured through the real validation, on this version of Home Assistant:

```
{'trigger': 'sun.sunset'}: valid
{'trigger': 'sun', 'event': 'sunset'}: valid
{'trigger': 'mqtt', 'topic': 'x/y'}: valid
```

So that half does not hold: the sun platform exposes `sunset` as a key and `_` for the bare `sun`. The other half does: the entry implied integration triggers always carry a prefix, and `mqtt` does not. Rewritten to name both spellings.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Review findings on #1489 that landed after the merge.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two new tests, on top of the existing suite (1158 pass).

The deadline test took three attempts, and the first two pinned nothing, because I had the race wrong. A deadline abandoning a run that has not started yet leaves exactly what it found, so nothing is observable. It only does damage once the next run has got somewhere. The test therefore holds the lock and queues three things behind it in order: the step that completes the first run, the first step of the second, and only then the stale deadline. Waiters on a lock are served in order, so that is reproducible rather than hopeful.

The refusal test fails every step's attachment and requires both that `async_start` raises and that it took the reset triggers back down on its way out, since nobody is handed a way to do it.

Eleven deliberate defects, each caught: the stale deadline accepted, the first step not refusing, the stop flag gone, `async_stop` not setting it, a silent reset failure, the stale-step guard dropped, every step armed at once, the deadline never started, the completing step not lifted into the payload, a single step allowed, and a run abandoned without dropping its timer.

Also ran `ruff check`, `ruff format --check`, `pylint` (by exit code), and the descriptor gate. The documentation builds with the same 23 warnings as `main`.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
