### PR TITLE
Add a spook.while trigger

### DIFF
--- a/custom_components/spook/condition_watching.py
+++ b/custom_components/spook/condition_watching.py
@@ -20,13 +20,35 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.template import Template
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Iterator
     from datetime import datetime
+    from typing import Protocol
 
     from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
     from homeassistant.helpers.condition import ConditionChecker
     from homeassistant.helpers.event import EventStateChangedData
     from homeassistant.helpers.typing import ConfigType
+
+    class ConditionTurned(Protocol):  # pylint: disable=too-few-public-methods
+        """Told what a condition now says, and what made it say so.
+
+        Keyword-only, because `on_change(True, event)` at a call site says
+        nothing about what the `True` means.
+        """
+
+        def __call__(
+            self,
+            *,
+            met: bool,
+            event: Event[EventStateChangedData] | None,
+        ) -> None:
+            """Report the turn.
+
+            `event` is there only when the condition turned true and the
+            watcher could be sure which change did it. A turn back to false
+            hands over nothing.
+            """
+
 
 # How often a condition is asked again regardless of anything happening.
 #
@@ -39,6 +61,7 @@ if TYPE_CHECKING:
 # Which is a polling interval, not a bound on how late a turn is noticed: a
 # condition that turns true and false again between two ticks is missed.
 BACKSTOP = timedelta(seconds=30)
+
 
 # Conditions that answer about the run they are asked in: which trigger fired,
 # which automation is running, who pressed the button. Watching is asking over
@@ -239,6 +262,10 @@ class ConditionWatcher:
     can be sure only when every part of the condition announces its own turns;
     see `_announces_every_turn`. Otherwise, and for the backstop, it hands
     over nothing rather than something that might be the wrong thing.
+
+    Both turns are reported, with what the answer now is. Most callers only
+    act on the arrival, and say so by returning; one that keeps doing
+    something for as long as a condition holds needs to know when to stop.
     """
 
     def __init__(
@@ -246,7 +273,7 @@ class ConditionWatcher:
         hass: HomeAssistant,
         checker: ConditionChecker,
         entity_ids: set[str],
-        on_met: Callable[[Event[EventStateChangedData] | None], None],
+        on_change: ConditionTurned,
         *,
         announces_every_turn: bool,
     ) -> None:
@@ -254,7 +281,7 @@ class ConditionWatcher:
         self._hass = hass
         self._checker = checker
         self._entity_ids = entity_ids
-        self._on_met = on_met
+        self._on_change = on_change
         self._announces_every_turn = announces_every_turn
         self._met = False
         self._unsubs: list[CALLBACK_TYPE] = []
@@ -332,14 +359,13 @@ class ConditionWatcher:
 
     @callback
     def _async_look(self, event: Event[EventStateChangedData] | None) -> None:
-        """Ask again, and report only a turn from false to true."""
+        """Ask again, and report a turn either way."""
         met = self._async_ask()
         if met == self._met:
             return
 
         self._met = met
-        if met:
-            self._on_met(event)
+        self._on_change(met=met, event=event if met else None)
 
 
 async def async_validate_condition(
@@ -382,7 +408,7 @@ async def async_validate_condition(
 async def async_condition_watcher(
     hass: HomeAssistant,
     validated: ConfigType,
-    on_met: Callable[[Event[EventStateChangedData] | None], None],
+    on_change: ConditionTurned,
 ) -> ConditionWatcher:
     """Build a watcher for an already validated condition, ready to start."""
     checker = await condition.async_from_config(hass, validated)
@@ -391,6 +417,6 @@ async def async_condition_watcher(
         checker,
         condition.async_extract_entities(validated)
         | set(_threshold_entities(validated)),
-        on_met,
+        on_change,
         announces_every_turn=_announces_every_turn(validated),
     )

--- a/custom_components/spook/ectoplasms/spook/services/wait_for_condition.py
+++ b/custom_components/spook/ectoplasms/spook/services/wait_for_condition.py
@@ -89,15 +89,23 @@ class SpookService(AbstractSpookService):
 
         _reject_static_templates(condition_config)
 
-        met = self.hass.loop.create_future()
+        arrived = self.hass.loop.create_future()
 
-        def condition_met(_event: Event[EventStateChangedData] | None) -> None:
-            """Let the wait finish. What turned it does not matter here."""
-            if not met.done():
-                met.set_result(True)
+        def condition_turned(
+            *,
+            met: bool,
+            event: Event[EventStateChangedData] | None,  # noqa: ARG001  # pylint: disable=unused-argument
+        ) -> None:
+            """Let the wait finish. What turned it does not matter here.
+
+            Going back to false is not something to wake up for: the wait is
+            for the condition arriving, and it has not arrived yet.
+            """
+            if met and not arrived.done():
+                arrived.set_result(True)
 
         watcher = await async_condition_watcher(
-            self.hass, condition_config, condition_met
+            self.hass, condition_config, condition_turned
         )
         stop = watcher.async_start()
 
@@ -115,7 +123,7 @@ class SpookService(AbstractSpookService):
 
         try:
             async with asyncio.timeout(seconds):
-                await met
+                await arrived
         except TimeoutError:
             return {"completed": False}
         finally:

--- a/custom_components/spook/ectoplasms/spook/triggers/condition_met.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/condition_met.py
@@ -74,7 +74,11 @@ class SpookTrigger(Trigger):
     ) -> CALLBACK_TYPE:
         """Attach the trigger to an action runner."""
 
-        def condition_met(event: Event[EventStateChangedData] | None) -> None:
+        def condition_turned(
+            *,
+            met: bool,
+            event: Event[EventStateChangedData] | None,
+        ) -> None:
             """Run the action, now that the condition has turned true.
 
             Reports the state change that turned it, when the watcher can be
@@ -86,6 +90,11 @@ class SpookTrigger(Trigger):
             Empty when there is nothing it can be sure of, rather than naming
             a change that merely happened to be the one noticed.
             """
+            if not met:
+                # Going back to false is not a turn worth firing on, the same
+                # as the template trigger.
+                return
+
             to_state = event.data["new_state"] if event else None
             entity_id = event.data["entity_id"] if event else None
 
@@ -102,6 +111,6 @@ class SpookTrigger(Trigger):
             )
 
         watcher = await async_condition_watcher(
-            self._hass, self._condition, condition_met
+            self._hass, self._condition, condition_turned
         )
         return watcher.async_start()

--- a/custom_components/spook/ectoplasms/spook/triggers/while_.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/while_.py
@@ -1,0 +1,178 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_CONDITION, CONF_OPTIONS
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.trigger import Trigger
+
+from ....condition_watching import async_condition_watcher, async_validate_condition
+
+if TYPE_CHECKING:
+    from datetime import datetime, timedelta
+
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.helpers.event import EventStateChangedData
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_EVERY = "every"
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_CONDITION): vol.Any(dict, list, str),
+            vol.Required(CONF_EVERY): cv.positive_time_period,
+        },
+    }
+)
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that keeps firing for as long as a condition holds.
+
+    The nagging trigger. The garage is open, and you want to hear about it
+    again in ten minutes, and ten minutes after that, until somebody closes
+    it. Home Assistant can do that inside a script with a `repeat` and a
+    `delay`, but that holds a run open for as long as the garage is open, so
+    the automation's mode has to allow for it and a reload ends it.
+
+    As a trigger it holds nothing open. It fires the moment the condition
+    arrives, keeps firing on the interval while it holds, and stops when it
+    stops holding.
+    """
+
+    trigger = "while"
+
+    _condition: ConfigType
+    _every: timedelta
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config, condition and all."""
+        shaped: ConfigType = _TRIGGER_SCHEMA(config)
+        options = shaped[CONF_OPTIONS]
+
+        if options[CONF_EVERY].total_seconds() <= 0:
+            msg = (
+                "A repeat interval of zero would fire as fast as Home "
+                "Assistant can run it, for as long as the condition holds."
+            )
+            raise vol.Invalid(msg)
+
+        options[CONF_CONDITION] = await async_validate_condition(
+            hass, options[CONF_CONDITION]
+        )
+        return shaped
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._condition = options[CONF_CONDITION]
+        self._every = options[CONF_EVERY]
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+        unsub_repeat: CALLBACK_TYPE | None = None
+        times = 0
+
+        @callback
+        def fire(event: Event[EventStateChangedData] | None) -> None:
+            """Run the action, saying how many times it has now run."""
+            nonlocal times
+            times += 1
+
+            to_state = event.data["new_state"] if event else None
+            entity_id = event.data["entity_id"] if event else None
+            # Lifted out of the change that turned the condition true, so
+            # `trigger.to_state` and friends mean here what they mean
+            # everywhere else, and so a condition asking who is behind the run
+            # finds the person there. Named one by one rather than merged: what
+            # is handed to `run_action` overrides the automation's own
+            # `trigger.id` and `platform`.
+            carried = (
+                {"from_state": event.data["old_state"], "to_state": to_state}
+                if event
+                else {}
+            )
+
+            run_action(
+                {
+                    "entity_id": entity_id,
+                    **carried,
+                    "times": times,
+                    "every": self._every,
+                },
+                f"a condition held, run {times}",
+                to_state.context if to_state else None,
+            )
+
+        @callback
+        def stop_repeating() -> None:
+            """Drop the interval, if one is running."""
+            nonlocal unsub_repeat, times
+            if unsub_repeat is not None:
+                unsub_repeat()
+                unsub_repeat = None
+            times = 0
+
+        @callback
+        def repeat(_now: datetime) -> None:
+            """Fire again, the condition still holding."""
+            fire(None)
+
+        @callback
+        def condition_turned(
+            *,
+            met: bool,
+            event: Event[EventStateChangedData] | None,
+        ) -> None:
+            """Start or stop repeating, depending on which way it turned."""
+            nonlocal unsub_repeat
+
+            if not met:
+                stop_repeating()
+                return
+
+            fire(event)
+            unsub_repeat = async_track_time_interval(
+                self._hass,
+                repeat,
+                self._every,
+                # Nothing should still be nagging while Home Assistant is
+                # shutting down, and a timer that outlives the run it belongs
+                # to is a leak whether anyone notices or not.
+                cancel_on_shutdown=True,
+            )
+
+        watcher = await async_condition_watcher(
+            self._hass, self._condition, condition_turned
+        )
+        stop_watching = watcher.async_start()
+
+        @callback
+        def stop() -> None:
+            """Stop watching, and stop repeating."""
+            stop_watching()
+            stop_repeating()
+
+        return stop

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -18,6 +18,20 @@
         }
       }
     },
+    "while": {
+      "name": "While a condition holds",
+      "description": "Fires when a condition turns true, and keeps firing on an interval for as long as it stays true.",
+      "fields": {
+        "condition": {
+          "name": "Condition",
+          "description": "The condition to watch. Firing starts when it turns true and stops when it stops being true."
+        },
+        "every": {
+          "name": "Every",
+          "description": "How long to wait between one firing and the next, for as long as the condition holds."
+        }
+      }
+    },
     "condition_met": {
       "name": "Condition turned true",
       "description": "Fires when a condition goes from false to true, using the same condition building blocks as anywhere else.",

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -74,3 +74,14 @@ sequence:
       required: false
       selector:
         trigger:
+while:
+  fields:
+    condition:
+      required: true
+      selector:
+        condition:
+    every:
+      required: true
+      example: "00:10:00"
+      selector:
+        duration:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1029,6 +1029,78 @@ options:
 - A later step that cannot be attached is a different matter, because the automation is already running by then. That run stalls where it stands and the log is the only place it says so. Same for a `reset` that cannot be attached: the steps keep working, so nothing else gives it away.
   :::
 
+### While a condition holds
+
+Fires when a condition turns true, and keeps firing on an interval for as long as it stays true.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - While a condition holds
+* - Trigger name
+  - `spook.while`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `condition`
+  - {term}`condition <condition>`
+  - Yes
+  - Any condition, built the ordinary way
+* - `every`
+  - {term}`string <string>`
+  - Yes
+  - `00:10:00`
+```
+
+The nagging trigger. The garage is open and you want to hear about it again in ten minutes, and ten minutes after that, until somebody closes it.
+
+Home Assistant can already do this inside a script, with a `repeat` holding a `while` and a `delay`. What that costs is a script run held open for as long as the garage is open: the automation's `mode` has to allow for it, a reload ends it, and core stops a loop that has gone round ten thousand times. As a trigger none of that applies, because nothing is being held open between one firing and the next.
+
+It fires the moment the condition arrives, not while it already holds, so loading an automation whose condition happens to be true does not set it off. Counting starts again at one each time the condition comes back.
+
+When it fires, `trigger.times` is how many times it has fired this spell, starting at one, and `trigger.every` is the interval. The first firing also carries the state change that made the condition turn, in the same way [Condition turned true](#condition-turned-true) does, so `spook.triggered_by_user` finds the person who caused it there. The firings after that carry nobody, because nobody makes a clock come round.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Remind me every ten minutes while the garage is open and nobody is home:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.while
+options:
+  every: "00:10:00"
+  condition:
+    - condition: state
+      entity_id: cover.garage
+      state: open
+      for: "00:10:00"
+    - condition: numeric_state
+      entity_id: zone.home
+      below: 1
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- The first firing happens the moment the condition turns true, and the interval starts from there. To wait before the first reminder, put a `for:` on the condition itself, as the example does.
+- A spell is abandoned when Home Assistant restarts, along with everything else in memory. A condition that is still true after the restart is not a new arrival, so it will not start nagging again until it goes false and true once more.
+- Everything [Condition turned true](#condition-turned-true) says about what can and cannot be watched applies here as well, including the 30-second polling pass and the conditions that are refused.
+  :::
+
+(condition-turned-true)=
+
 ### Condition turned true
 
 Fires when a condition goes from false to true.

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -50,3 +50,9 @@ Fires when a condition goes from false to true, using the same condition buildin
 Fires when several triggers happen one after another, in the order given, optionally within a time limit. _#sequence_ _#order_ _#timeout_
 
 `spook.sequence`, [documentation](other-features#triggers-in-order) 📚
+
+## While a condition holds
+
+Fires when a condition turns true and keeps firing on an interval for as long as it stays true, without holding a script run open. _#condition_ _#repeat_ _#reminder_
+
+`spook.while`, [documentation](other-features#while-a-condition-holds) 📚

--- a/tests/ectoplasms/spook/triggers/test_while.py
+++ b/tests/ectoplasms/spook/triggers/test_while.py
@@ -1,0 +1,356 @@
+"""Tests for the spook.while trigger."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import Context
+from homeassistant.helpers import selector
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers.while_ import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+OPEN = {"condition": "state", "entity_id": "cover.garage", "state": "open"}
+EVERY = timedelta(minutes=10)
+
+TWICE = 2
+THRICE = 3
+
+
+async def _automation(
+    hass: HomeAssistant,
+    options: dict[str, Any] | None = None,
+) -> list[dict]:
+    """Set up an automation on the trigger and record every run."""
+    runs: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        runs.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "nagging",
+                    "trigger": {
+                        "platform": "spook.while",
+                        "options": options
+                        or {"condition": OPEN, "every": {"minutes": 10}},
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {"times": "{{ trigger.times }}"},
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return runs
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger.
+
+    The harness fails a test that leaves a timer or listener behind, and this
+    trigger holds both, so this doubles as a check that it clears up.
+    """
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": "automation.nagging"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+
+async def _tick(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
+    """Let one interval pass."""
+    freezer.tick(EVERY)
+    async_fire_time_changed(hass, dt_util.utcnow() + EVERY)
+    await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "while" in await async_get_triggers(hass)
+
+
+async def test_it_fires_on_arrival_and_keeps_going(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The whole point: it arrives, and then it nags."""
+    hass.states.async_set("cover.garage", "closed")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    assert not runs, "fired while the condition was false"
+
+    hass.states.async_set("cover.garage", "open")
+    await hass.async_block_till_done()
+    assert len(runs) == 1, "did not fire when the condition arrived"
+
+    await _tick(hass, freezer)
+    assert len(runs) == TWICE
+
+    await _tick(hass, freezer)
+    assert len(runs) == THRICE
+
+    await _detach(hass)
+
+
+async def test_it_stops_when_the_condition_stops(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A nag about something that is no longer true is just noise."""
+    hass.states.async_set("cover.garage", "closed")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    hass.states.async_set("cover.garage", "open")
+    await hass.async_block_till_done()
+    await _tick(hass, freezer)
+    assert len(runs) == TWICE
+
+    hass.states.async_set("cover.garage", "closed")
+    await hass.async_block_till_done()
+
+    await _tick(hass, freezer)
+    await _tick(hass, freezer)
+    assert len(runs) == TWICE, "it kept nagging after the condition let go"
+
+    await _detach(hass)
+
+
+async def test_it_starts_over_the_next_time(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Counting from one again, because this is a new spell of it."""
+    hass.states.async_set("cover.garage", "closed")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    hass.states.async_set("cover.garage", "open")
+    await hass.async_block_till_done()
+    await _tick(hass, freezer)
+    hass.states.async_set("cover.garage", "closed")
+    await hass.async_block_till_done()
+
+    hass.states.async_set("cover.garage", "open")
+    await hass.async_block_till_done()
+
+    assert [run["times"] for run in runs] == [1, TWICE, 1]
+
+    await _detach(hass)
+
+
+async def test_it_does_not_fire_for_a_condition_already_true(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Loading an automation is not the condition arriving.
+
+    The same call `condition_met` makes, and for the same reason: every
+    reload would otherwise set off every automation whose condition holds.
+    """
+    hass.states.async_set("cover.garage", "open")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    assert not runs
+
+    await _tick(hass, freezer)
+    assert not runs, "it started nagging about a condition that was already true"
+
+    await _detach(hass)
+
+
+async def test_it_carries_the_user_through_on_arrival(
+    hass: HomeAssistant,
+) -> None:
+    """Whoever caused the condition to arrive set the first run going."""
+    user = await hass.auth.async_create_user("Ghost Hunter")
+    hass.states.async_set("cover.garage", "closed")
+    await hass.async_block_till_done()
+
+    ran: list[str] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(call.data["which"])
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": which,
+                    "trigger": {
+                        "platform": "spook.while",
+                        "options": {"condition": OPEN, "every": {"minutes": 10}},
+                    },
+                    "condition": [{"condition": f"spook.{which}"}],
+                    "action": [{"action": "test.mark", "data": {"which": which}}],
+                }
+                for which in ("triggered_by_user", "not_triggered_by_user")
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("cover.garage", "open", context=Context(user_id=user.id))
+    await hass.async_block_till_done()
+
+    assert ran == ["triggered_by_user"]
+
+    for alias in ("triggered_by_user", "not_triggered_by_user"):
+        await hass.services.async_call(
+            "automation",
+            "turn_off",
+            {"entity_id": f"automation.{alias}"},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+
+async def test_a_repeat_names_nobody(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Nobody causes the clock to come round, so nobody is behind a repeat."""
+    hass.states.async_set("cover.garage", "closed")
+    await hass.async_block_till_done()
+
+    ran: list[str] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(call.data["which"])
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "not_triggered_by_user",
+                    "trigger": {
+                        "platform": "spook.while",
+                        "options": {"condition": OPEN, "every": {"minutes": 10}},
+                    },
+                    "condition": [{"condition": "spook.not_triggered_by_user"}],
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {"which": "{{ trigger.times }}"},
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set(
+        "cover.garage", "open", context=Context(user_id="ghost-hunter")
+    )
+    await hass.async_block_till_done()
+    assert not ran, "the arrival was attributed to nobody"
+
+    await _tick(hass, freezer)
+    assert ran == [TWICE], "the repeat was attributed to somebody"
+
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.not_triggered_by_user"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_it_takes_what_the_condition_selector_produces(
+    hass: HomeAssistant,
+) -> None:
+    """The shape an automation built in the user interface actually has."""
+    hass.states.async_set("cover.garage", "closed")
+    await hass.async_block_till_done()
+
+    runs = await _automation(
+        hass,
+        {
+            "condition": selector.ConditionSelector()(OPEN),
+            "every": {"minutes": 10},
+        },
+    )
+
+    assert hass.states.get("automation.nagging").state == "on", (
+        "the automation did not load"
+    )
+
+    hass.states.async_set("cover.garage", "open")
+    await hass.async_block_till_done()
+    assert len(runs) == 1
+
+    await _detach(hass)
+
+
+async def test_an_interval_is_required(hass: HomeAssistant) -> None:
+    """Without one this is just `condition_met`."""
+    with pytest.raises(vol.Invalid, match="required key"):
+        await SpookTrigger.async_validate_config(hass, {"options": {"condition": OPEN}})
+
+
+async def test_a_zero_interval_is_refused(hass: HomeAssistant) -> None:
+    """It would fire as fast as Home Assistant can run it."""
+    with pytest.raises(vol.Invalid, match="as fast as"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"condition": OPEN, "every": {"seconds": 0}}}
+        )
+
+
+async def test_a_condition_is_required(hass: HomeAssistant) -> None:
+    """Without one there is nothing to hold."""
+    with pytest.raises(vol.Invalid, match="required key"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"every": {"minutes": 10}}}
+        )
+
+
+async def test_a_run_dependent_condition_is_refused(hass: HomeAssistant) -> None:
+    """The same refusal the other condition watchers make."""
+    with pytest.raises(vol.Invalid, match="no run here"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {
+                "options": {
+                    "condition": {"condition": "trigger", "id": "abc"},
+                    "every": {"minutes": 10},
+                }
+            },
+        )

--- a/tests/test_condition_watching.py
+++ b/tests/test_condition_watching.py
@@ -30,8 +30,11 @@ import custom_components.spook
 if TYPE_CHECKING:
     from freezegun.api import FrozenDateTimeFactory
 
-    from homeassistant.core import HomeAssistant
+    from homeassistant.core import Event, HomeAssistant
+    from homeassistant.helpers.event import EventStateChangedData
     from homeassistant.helpers.typing import ConfigType
+
+    from custom_components.spook.condition_watching import ConditionTurned
 
 GATE = {"condition": "state", "entity_id": "input_boolean.gate", "state": "on"}
 GATE_TEMPLATE = {
@@ -43,6 +46,16 @@ TWICE = 2
 FIVE = 5.0
 
 
+def _record(turns: list[Context | None]) -> ConditionTurned:
+    """Return a callback that records the context of every turn to true."""
+
+    def _turned(*, met: bool, event: Event[EventStateChangedData] | None) -> None:
+        if met:
+            turns.append(event.context if event else None)
+
+    return _turned
+
+
 async def _watching(
     hass: HomeAssistant,
     config: ConfigType,
@@ -52,7 +65,7 @@ async def _watching(
     watcher = await async_condition_watcher(
         hass,
         await async_validate_condition(hass, config),
-        lambda event: turns.append(event.context if event else None),
+        _record(turns),
     )
     watcher.async_start()
     return watcher, turns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The nagging trigger. The garage is open and you want to hear about it again in ten minutes, and ten minutes after that, until somebody closes it.

```yaml
trigger: spook.while
options:
  every: "00:10:00"
  condition:
    - condition: state
      entity_id: cover.garage
      state: open
      for: "00:10:00"
    - condition: numeric_state
      entity_id: zone.home
      below: 1
```

### Why this is not already possible

It nearly is, and that is worth being precise about rather than hand-waving. Home Assistant can do this inside a script:

```yaml
repeat:
  while:
    - condition: state
      entity_id: cover.garage
      state: open
  sequence:
    - action: notify.mobile_app
    - delay: "00:10:00"
```

Read `_async_step_repeat` and it genuinely re-evaluates the conditions before each pass and breaks when they stop holding, so this works and stops on time. What it costs is a run held open for as long as the condition holds:

- The automation's `mode` has to allow for a run that lasts hours.
- A reload or a restart ends it, and nothing brings it back.
- `REPEAT_WARN_ITERATIONS` warns at 5000 passes and `REPEAT_TERMINATE_ITERATIONS` kills the run at 10000. At ten minutes you never reach that; at ten seconds you do, inside a day.

As a trigger, none of that applies, because nothing is held open between one firing and the next.

An action form was considered and deliberately left out: it would inherit every one of those costs, because it would still be a script run.

### Semantics

- Fires when the condition **arrives**, not while it already holds. Loading an automation whose condition happens to be true does not set it off, the same call `spook.condition_met` makes and for the same reason.
- Then fires every `every` for as long as it holds, and stops when it stops holding.
- Counting starts again at one the next time it comes back.
- A zero interval is refused: it would fire as fast as Home Assistant can run it.
- To wait before the *first* reminder, put a `for:` on the condition, as the example does. That falls out of using conditions rather than a target and a state, which is what makes this composable at all: "open, and nobody home, and after sunset" is one condition.

### What it reports

`trigger.times` (from one, per spell) and `trigger.every`. The first firing also carries `entity_id`, `from_state` and `to_state` from the change that turned the condition, so `spook.triggered_by_user` finds the person there. The repeats carry nobody, because nobody makes a clock come round.

Named one by one rather than merged, for the reason #1489 found the hard way: what is handed to `run_action` overrides `trigger_data`, so merging a payload wholesale would replace the automation's own `trigger.id`.

### The watcher change

`ConditionWatcher` reported only the arrival. Something that keeps going for as long as a condition holds needs to know when to stop, so it reports both turns now.

That is one `on_change(met=..., event=...)` rather than an added `on_unmet`. Two callbacks pushed both the argument count and the attribute count over their limits, and collapsing them turned out to read better anyway: the two existing callers now say out loud that they only act on the arrival, instead of the watcher deciding that for them.

Keyword-only, through a `Protocol`, because `on_change(True, event)` at a call site says nothing about what the `True` means. That also settles ruff's boolean-positional-argument complaint honestly rather than with a suppression.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Wave 2 of the triggers and conditions plan, where it is listed as repeat-while. The plan described it in terms of a target and a state; conditions turned out to be the better shape, and cheaper, since `condition_watching.py` already exists.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Twelve new tests, on top of the existing suite (1171 pass).

Discovery; firing on arrival and then on the interval; stopping when the condition lets go; counting from one again the next time; not firing for a condition that was already true when the automation loaded; the user carried through on arrival and nobody carried on a repeat; the shape the real `ConditionSelector` produces; and four refusals (no interval, zero interval, no condition, a run-dependent condition).

Seven deliberate defects, each caught: never starting the interval, never stopping it, no firing on arrival, the counter never resetting, a zero interval allowed, the state change not carried, and the watcher going quiet on the turn back to false.

Also ran `ruff check`, `ruff format --check`, `pylint` (by exit code), and the descriptor gate. The documentation builds with the same 23 warnings as `main`. A first draft added three of its own: two implicit heading links, fixed by giving "Condition turned true" an explicit anchor, and a `{term}` pointing at a glossary entry that does not exist.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
