### PR TITLE
Add a spook.watchdog trigger

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/sequence.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/sequence.py
@@ -125,13 +125,22 @@ class _SequenceWatcher:
         early is missed, and ignoring them while idle costs nothing.
         """
         if self._sequence.reset:
-            self._unsub_reset = await async_attach_nested(
+            unsub_reset = await async_attach_nested(
                 self._hass,
                 self._sequence.reset,
                 self._async_reset_fired,
                 "the reset triggers of a sequence trigger",
                 "so nothing will abandon a run under way",
             )
+
+            if self._stopped:
+                # Stopped while this was suspended, the same window every
+                # attach in Spook has. Nobody is holding the handle any more.
+                if unsub_reset is not None:
+                    unsub_reset()
+                return self.async_stop
+
+            self._unsub_reset = unsub_reset
 
         await self._async_arm(0)
 

--- a/custom_components/spook/ectoplasms/spook/triggers/sequence.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/sequence.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.trigger import Trigger
 from homeassistant.util import dt as dt_util
 
-from ....const import DOMAIN, LOGGER
+from ....trigger_nesting import async_attach_nested
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -58,17 +58,6 @@ _TRIGGER_SCHEMA = vol.Schema(
         },
     }
 )
-
-
-@callback
-def _log(level: int, message: str, **kwargs: Any) -> None:
-    """Take the log line Home Assistant writes about a nested trigger.
-
-    `async_initialize_triggers` insists on somewhere to write, and what it
-    writes is about a trigger the user did not attach themselves, so it goes
-    to Spook's logger rather than an automation's.
-    """
-    LOGGER.log(level, "Spook sequence trigger: %s", message, **kwargs)
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,23 +125,15 @@ class _SequenceWatcher:
         early is missed, and ignoring them while idle costs nothing.
         """
         if self._sequence.reset:
-            self._unsub_reset = await trigger_helper.async_initialize_triggers(
+            # Nothing to add when this fails: `async_attach_nested` says so.
+            # A sequence whose reset never arrives keeps working, it has just
+            # quietly stopped being interruptible.
+            self._unsub_reset = await async_attach_nested(
                 self._hass,
                 self._sequence.reset,
                 self._async_reset_fired,
-                DOMAIN,
-                "sequence reset",
-                _log,
+                "the reset triggers of a sequence trigger",
             )
-
-            if self._unsub_reset is None:
-                # Nothing attached, and it has already logged why. Worth
-                # repeating, because a sequence whose reset never arrives is
-                # one that quietly stops being interruptible.
-                LOGGER.warning(
-                    "Spook could not attach the reset triggers of a sequence "
-                    "trigger, so nothing will abandon a run under way"
-                )
 
         await self._async_arm(0)
 
@@ -206,13 +187,11 @@ class _SequenceWatcher:
             """
             await self._async_step_fired(index, variables, context)
 
-        unsub = await trigger_helper.async_initialize_triggers(
+        unsub = await async_attach_nested(
             self._hass,
             [self._sequence.steps[index]],
             _fired,
-            DOMAIN,
-            f"step {index + 1}",
-            _log,
+            f"step {index + 1} of a sequence trigger",
         )
 
         if self._stopped:
@@ -222,22 +201,10 @@ class _SequenceWatcher:
                 unsub()
             return
 
+        # `async_start` turns a failure here into a refusal for the first step,
+        # where there is still somebody to refuse to. From a step landing there
+        # is not, so the line `async_attach_nested` logged is all there is.
         self._run.unsub_step = unsub
-
-        if unsub is None:
-            # `async_initialize_triggers` hands back nothing when it could not
-            # attach anything, having logged why. Say so as well: a sequence
-            # stuck on a step it cannot listen for is a trigger that never
-            # fires, and that is the failure mode worth being loud about.
-            #
-            # `async_start` turns this into a refusal for the first step, where
-            # there is still somebody to refuse to. From a step landing there
-            # is not, so a line in the log is all there is.
-            LOGGER.warning(
-                "Spook could not attach step %s of a sequence trigger, "
-                "so it will not fire",
-                index + 1,
-            )
 
     @callback
     def _async_disarm_step(self) -> None:

--- a/custom_components/spook/ectoplasms/spook/triggers/sequence.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/sequence.py
@@ -125,14 +125,12 @@ class _SequenceWatcher:
         early is missed, and ignoring them while idle costs nothing.
         """
         if self._sequence.reset:
-            # Nothing to add when this fails: `async_attach_nested` says so.
-            # A sequence whose reset never arrives keeps working, it has just
-            # quietly stopped being interruptible.
             self._unsub_reset = await async_attach_nested(
                 self._hass,
                 self._sequence.reset,
                 self._async_reset_fired,
                 "the reset triggers of a sequence trigger",
+                "so nothing will abandon a run under way",
             )
 
         await self._async_arm(0)
@@ -192,6 +190,7 @@ class _SequenceWatcher:
             [self._sequence.steps[index]],
             _fired,
             f"step {index + 1} of a sequence trigger",
+            "so it will not fire",
         )
 
         if self._stopped:

--- a/custom_components/spook/ectoplasms/spook/triggers/watchdog.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/watchdog.py
@@ -94,9 +94,16 @@ class _Watchdog:
 
     async def async_start(self) -> CALLBACK_TYPE:
         """Listen for both halves, and hand back the way to stop."""
+        # The expected half goes on first, and the order is not arbitrary.
+        # Attaching suspends, so whichever goes on second leaves a window where
+        # the first is already listening. Arming in that window would start a
+        # watch with nothing listening for what it is waiting for, and the
+        # thing arriving would be missed and barked about. The other way round
+        # is harmless, because the expected trigger arriving while nothing is
+        # armed is inert by design.
         for configs, action, name in (
-            (self._watch.arm, self._async_armed, "the arming triggers"),
             (self._watch.expect, self._async_expected, "the expected triggers"),
+            (self._watch.arm, self._async_armed, "the arming triggers"),
         ):
             unsub = await async_attach_nested(
                 self._hass,

--- a/custom_components/spook/ectoplasms/spook/triggers/watchdog.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/watchdog.py
@@ -99,8 +99,20 @@ class _Watchdog:
             (self._watch.expect, self._async_expected, "the expected triggers"),
         ):
             unsub = await async_attach_nested(
-                self._hass, configs, action, f"{name} of a watchdog trigger"
+                self._hass,
+                configs,
+                action,
+                f"{name} of a watchdog trigger",
+                "so it will not fire",
             )
+
+            if self._stopped:
+                # Stopped while this was suspended. Nobody is holding the
+                # handle any more, so let go of it here, and do not go on to
+                # attach the other half.
+                if unsub is not None:
+                    unsub()
+                return self.async_stop
 
             if unsub is None:
                 # Half a watchdog is not a watchdog: without the arming half it

--- a/custom_components/spook/ectoplasms/spook/triggers/watchdog.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/watchdog.py
@@ -1,0 +1,274 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, trigger as trigger_helper
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.trigger import Trigger
+
+from ....trigger_nesting import async_attach_nested
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime, timedelta
+
+    from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_ARM = "arm"
+CONF_EXPECT = "expect"
+CONF_WITHIN = "within"
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_ARM): cv.TRIGGER_SCHEMA,
+            vol.Required(CONF_EXPECT): cv.TRIGGER_SCHEMA,
+            vol.Required(CONF_WITHIN): cv.positive_time_period,
+        },
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Watch:
+    """What to wait for, and how long to give it."""
+
+    arm: list[ConfigType]
+    expect: list[ConfigType]
+    within: timedelta
+
+
+@dataclass(slots=True)
+class _Armed:
+    """One spell of waiting, and the clock running on it.
+
+    Together because they end together, and because the deadline callback
+    checks whether this is still the spell it was set for by identity.
+    """
+
+    by: dict[str, Any]
+    unsub_deadline: CALLBACK_TYPE | None = None
+
+
+class _Watchdog:
+    """Starts a clock when something happens, and barks if nothing follows.
+
+    Armed or not, and nothing in between. Arming again while already armed
+    restarts the clock rather than starting a second one: the arming event is
+    what the wait is measured from, so the latest one is the one that counts.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        watch: _Watch,
+        on_bark: Callable[[dict[str, Any]], None],
+    ) -> None:
+        """Initialize the watchdog."""
+        self._hass = hass
+        self._watch = watch
+        self._on_bark = on_bark
+
+        self._armed: _Armed | None = None
+        self._unsubs: list[CALLBACK_TYPE] = []
+
+        # Arming, the expected thing arriving and the deadline passing all move
+        # the same watch, and arming suspends. One at a time.
+        self._lock = asyncio.Lock()
+        self._stopped = False
+
+    async def async_start(self) -> CALLBACK_TYPE:
+        """Listen for both halves, and hand back the way to stop."""
+        for configs, action, name in (
+            (self._watch.arm, self._async_armed, "the arming triggers"),
+            (self._watch.expect, self._async_expected, "the expected triggers"),
+        ):
+            unsub = await async_attach_nested(
+                self._hass, configs, action, f"{name} of a watchdog trigger"
+            )
+
+            if unsub is None:
+                # Half a watchdog is not a watchdog: without the arming half it
+                # never starts, and without the other half it always barks.
+                # Refusing is what gets the automation marked unavailable
+                # rather than leaving it looking healthy.
+                self.async_stop()
+                msg = f"Could not attach {name} of a watchdog trigger"
+                raise HomeAssistantError(msg)
+
+            self._unsubs.append(unsub)
+
+        return self.async_stop
+
+    @callback
+    def async_stop(self) -> None:
+        """Stop listening, and drop the clock."""
+        self._stopped = True
+
+        self._async_disarm()
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+
+    async def _async_armed(
+        self,
+        variables: dict[str, Any] | None = None,
+        _context: Context | None = None,
+    ) -> None:
+        """Something worth watching for happened. Start the clock."""
+        async with self._lock:
+            if self._stopped:
+                return
+
+            self._async_disarm()
+            self._armed = _Armed(by=(variables or {}).get("trigger", {}))
+            self._async_start_deadline()
+
+    async def _async_expected(
+        self,
+        _variables: dict[str, Any] | None = None,
+        _context: Context | None = None,
+    ) -> None:
+        """Stand down, what was being waited for arrived."""
+        async with self._lock:
+            if self._stopped or self._armed is None:
+                # Not armed, so this is just something happening.
+                return
+
+            self._async_disarm()
+
+    @callback
+    def _async_start_deadline(self) -> None:
+        """Give it until the deadline, and bark if it gets there.
+
+        The deadline belongs to the arming that set it. Arming again replaces
+        it, and a callback that was already on its way when that happened has
+        nothing left to say.
+        """
+        armed = self._armed
+        if armed is None:
+            return
+
+        async def _due(_now: datetime) -> None:
+            """Bark, nothing having arrived in time."""
+            async with self._lock:
+                if self._stopped or self._armed is not armed:
+                    return
+
+                armed.unsub_deadline = None
+                self._async_disarm()
+                self._on_bark(armed.by)
+
+        armed.unsub_deadline = async_call_later(
+            self._hass, self._watch.within.total_seconds(), _due
+        )
+
+    @callback
+    def _async_disarm(self) -> None:
+        """Stop waiting, whatever the reason.
+
+        Dropping the clock first, because forgetting the spell would otherwise
+        lose the handle to it and leave a timer behind.
+        """
+        self._async_drop_deadline()
+        self._armed = None
+
+    @callback
+    def _async_drop_deadline(self) -> None:
+        """Drop the clock, if one is running."""
+        if self._armed is not None and self._armed.unsub_deadline is not None:
+            self._armed.unsub_deadline()
+            self._armed.unsub_deadline = None
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when something expected does not happen.
+
+    Every trigger Home Assistant has fires because something happened. The
+    interesting failures are the other kind: the back door opened and nobody
+    walked into the hall, the washing machine started and never finished, the
+    nightly backup began and never reported in.
+
+    Written by hand that is a helper entity, a timer, and two automations to
+    keep them in step. Here it is one trigger: arm on this, expect that,
+    within so long.
+    """
+
+    trigger = "watchdog"
+
+    _watch: _Watch
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config, nested triggers and all."""
+        shaped: ConfigType = _TRIGGER_SCHEMA(config)
+        options = shaped[CONF_OPTIONS]
+
+        if options[CONF_WITHIN].total_seconds() <= 0:
+            msg = (
+                "A watchdog with no time to wait barks the moment it is armed, "
+                "which is a trigger on the arming half alone."
+            )
+            raise vol.Invalid(msg)
+
+        for key in (CONF_ARM, CONF_EXPECT):
+            options[key] = await trigger_helper.async_validate_trigger_config(
+                hass, options[key]
+            )
+
+        return shaped
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._watch = _Watch(
+            arm=options[CONF_ARM],
+            expect=options[CONF_EXPECT],
+            within=options[CONF_WITHIN],
+        )
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def bark(armed_by: dict[str, Any]) -> None:
+            """Run the action, the wait having run out.
+
+            No context handed over. A watchdog fires because nothing happened,
+            at a moment a clock came round, and nobody makes a clock come
+            round. Whoever armed it is in `trigger.armed_by` for an automation
+            that wants to say so itself.
+            """
+            description = armed_by.get("description", "something")
+
+            run_action(
+                {"armed_by": armed_by, "within": self._watch.within},
+                f"nothing followed {description} within {self._watch.within}",
+            )
+
+        watchdog = _Watchdog(self._hass, self._watch, bark)
+        return await watchdog.async_start()

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -32,6 +32,24 @@
         }
       }
     },
+    "watchdog": {
+      "name": "Watchdog",
+      "description": "Fires when something that was expected to happen does not happen in time.",
+      "fields": {
+        "arm": {
+          "name": "Arm",
+          "description": "What starts the watch. The wait is measured from here, and arming again while already waiting starts the wait over."
+        },
+        "expect": {
+          "name": "Expect",
+          "description": "What is expected to follow. Arriving in time calls the watch off, and nothing fires."
+        },
+        "within": {
+          "name": "Within",
+          "description": "How long the expected thing has to arrive. This fires when that time passes and it has not."
+        }
+      }
+    },
     "condition_met": {
       "name": "Condition turned true",
       "description": "Fires when a condition goes from false to true, using the same condition building blocks as anywhere else.",

--- a/custom_components/spook/trigger_nesting.py
+++ b/custom_components/spook/trigger_nesting.py
@@ -32,16 +32,20 @@ async def async_attach_nested(
     configs: list[ConfigType],
     action: Callable,
     name: str,
+    consequence: str,
 ) -> CALLBACK_TYPE | None:
     """Attach triggers on behalf of a Spook trigger, and say if it worked.
 
     Returns `None` when nothing could be attached, having said so in the log.
-    Home Assistant already logs why, but a Spook trigger waiting for something
-    it could not listen for never fires, and that is the failure mode worth
-    being loud about.
+    Home Assistant already logs why; what it cannot know is what that costs
+    the trigger asking, and going quiet about that is how a trigger ends up
+    looking healthy while it can no longer do its job.
 
-    `name` is read straight into that line, so it wants to be a noun phrase:
-    "step 2 of a sequence trigger".
+    `name` and `consequence` are read straight into that line: "Spook could
+    not attach {name}, {consequence}". Which is why the consequence comes from
+    the caller. A sequence missing a step never fires again, while one missing
+    its optional reset triggers fires perfectly well and has only stopped
+    being interruptible.
 
     `action` has to be a function, not an object with an async `__call__`.
     Home Assistant decides whether to await an action by inspecting it, and an
@@ -54,6 +58,6 @@ async def async_attach_nested(
     )
 
     if unsub is None:
-        LOGGER.warning("Spook could not attach %s, so it will not fire", name)
+        LOGGER.warning("Spook could not attach %s, %s", name, consequence)
 
     return unsub

--- a/custom_components/spook/trigger_nesting.py
+++ b/custom_components/spook/trigger_nesting.py
@@ -1,0 +1,59 @@
+"""Spook - Your homie. Attaching triggers on behalf of another trigger."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import callback
+from homeassistant.helpers import trigger as trigger_helper
+
+from .const import DOMAIN, LOGGER
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+    from homeassistant.helpers.typing import ConfigType
+
+
+@callback
+def _log(level: int, message: str, **kwargs: Any) -> None:
+    """Take the log line Home Assistant writes about a nested trigger.
+
+    `async_initialize_triggers` insists on somewhere to write, and what it
+    writes is about a trigger the user did not attach themselves, so it goes
+    to Spook's logger rather than an automation's.
+    """
+    LOGGER.log(level, "Spook nested trigger: %s", message, **kwargs)
+
+
+async def async_attach_nested(
+    hass: HomeAssistant,
+    configs: list[ConfigType],
+    action: Callable,
+    name: str,
+) -> CALLBACK_TYPE | None:
+    """Attach triggers on behalf of a Spook trigger, and say if it worked.
+
+    Returns `None` when nothing could be attached, having said so in the log.
+    Home Assistant already logs why, but a Spook trigger waiting for something
+    it could not listen for never fires, and that is the failure mode worth
+    being loud about.
+
+    `name` is read straight into that line, so it wants to be a noun phrase:
+    "step 2 of a sequence trigger".
+
+    `action` has to be a function, not an object with an async `__call__`.
+    Home Assistant decides whether to await an action by inspecting it, and an
+    instance is not recognised as awaitable: the coroutine gets created,
+    dropped, and the trigger never hears anything. Measured, at the cost of an
+    afternoon.
+    """
+    unsub = await trigger_helper.async_initialize_triggers(
+        hass, configs, action, DOMAIN, name, _log
+    )
+
+    if unsub is None:
+        LOGGER.warning("Spook could not attach %s, so it will not fire", name)
+
+    return unsub

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -85,3 +85,18 @@ while:
       example: "00:10:00"
       selector:
         duration:
+watchdog:
+  fields:
+    arm:
+      required: true
+      selector:
+        trigger:
+    expect:
+      required: true
+      selector:
+        trigger:
+    within:
+      required: true
+      example: "00:02:00"
+      selector:
+        duration:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1099,6 +1099,80 @@ options:
 - Everything [Condition turned true](#condition-turned-true) says about what can and cannot be watched applies here as well, including the 30-second polling pass and the conditions that are refused.
   :::
 
+### Watchdog
+
+Fires when something that was expected to happen does not happen in time.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Watchdog
+* - Trigger name
+  - `spook.watchdog`
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `arm`
+  - {term}`trigger <trigger>`
+  - Yes
+  - What starts the watch
+* - `expect`
+  - {term}`trigger <trigger>`
+  - Yes
+  - What is expected to follow
+* - `within`
+  - {term}`string <string>`
+  - Yes
+  - `00:02:00`
+```
+
+Every trigger Home Assistant has fires because something happened. The interesting failures are the other kind: the back door opened and nobody walked into the hall, the washing machine started and never finished, the nightly backup began and never reported in. Written by hand that is a helper entity, a timer, and two automations to keep them in step.
+
+Arming starts a clock. The expected trigger arriving before it runs out calls the watch off and nothing fires. The clock running out is what fires it.
+
+Arming again while already waiting starts the wait over rather than running a second one, because the wait is measured from the arming and the latest one is the one that counts. The expected trigger arriving while nothing is being waited for does nothing at all.
+
+When it fires, `trigger.armed_by` is what the arming trigger reported and `trigger.within` is the wait it was given. Nothing else is carried, and no user: a watchdog fires because nothing happened, at a moment a clock came round, and nobody makes a clock come round. An automation that wants to name the person can read `trigger.armed_by`.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+The back door opened and nobody came into the hall within two minutes:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.watchdog
+options:
+  within: "00:02:00"
+  arm:
+    - trigger: state
+      entity_id: binary_sensor.back_door
+      to: "on"
+  expect:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- A watch under way is abandoned when Home Assistant restarts, along with everything else in memory. Something armed before a restart is not waited for after it.
+- A watchdog that cannot attach either half is refused, which disables that automation and says why in the log. Half a watchdog would either never start or always fire, and neither is worth leaving running.
+- The automation's `trigger_variables` do not reach the arming and expected triggers, for the same reason they do not reach a sequence's steps: Home Assistant hands those to a trigger platform, not to a trigger like this one.
+  :::
+
 (condition-turned-true)=
 
 ### Condition turned true

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -56,3 +56,9 @@ Fires when several triggers happen one after another, in the order given, option
 Fires when a condition turns true and keeps firing on an interval for as long as it stays true, without holding a script run open. _#condition_ _#repeat_ _#reminder_
 
 `spook.while`, [documentation](other-features#while-a-condition-holds) 📚
+
+## Watchdog
+
+Fires when something that was expected to happen does not happen in time, without needing a helper entity and a timer to arrange it. _#absence_ _#timeout_ _#watchdog_
+
+`spook.watchdog`, [documentation](other-features#watchdog) 📚

--- a/tests/ectoplasms/spook/triggers/test_sequence.py
+++ b/tests/ectoplasms/spook/triggers/test_sequence.py
@@ -12,7 +12,6 @@ from homeassistant.core import Context
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector, trigger as trigger_helper
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 import pytest
 import voluptuous as vol
@@ -194,7 +193,7 @@ async def test_a_timeout_abandons_the_run(
     await _move(hass, "binary_sensor.door", "on")
 
     freezer.tick(timedelta(minutes=3))
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=3))
+    async_fire_time_changed(hass)
     await _settle(hass)
 
     await _move(hass, "binary_sensor.motion", "on")
@@ -654,7 +653,7 @@ async def test_a_reset_that_cannot_attach_is_reported(
     real = trigger_helper.async_initialize_triggers
 
     async def _reset_fails(*args: Any, **kwargs: Any):  # noqa: ANN202
-        if args[4] == "sequence reset":
+        if args[4].startswith("the reset triggers"):
             return None
         return await real(*args, **kwargs)
 
@@ -666,7 +665,7 @@ async def test_a_reset_that_cannot_attach_is_reported(
     stop()
     await hass.async_block_till_done()
 
-    assert "nothing will abandon a run under way" in caplog.text
+    assert "could not attach the reset triggers" in caplog.text
 
 
 async def test_a_deadline_only_ends_the_run_it_was_set_for(
@@ -725,7 +724,7 @@ async def test_a_deadline_only_ends_the_run_it_was_set_for(
         # And only then does the first run's deadline come due, joining the
         # back of the queue.
         freezer.tick(timedelta(seconds=31))
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+        async_fire_time_changed(hass)
         await asyncio.sleep(0)
 
         watcher._lock.release()  # noqa: SLF001

--- a/tests/ectoplasms/spook/triggers/test_sequence.py
+++ b/tests/ectoplasms/spook/triggers/test_sequence.py
@@ -16,6 +16,7 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 import pytest
 import voluptuous as vol
 
+from custom_components.spook import trigger_nesting
 from custom_components.spook.ectoplasms.spook.triggers import (
     sequence as sequence_module,
 )
@@ -788,4 +789,58 @@ async def test_a_first_step_that_cannot_attach_is_refused(
     # And it took the reset triggers back down on its way out, because nobody
     # was handed a way to do it.
     assert watcher._unsub_reset is None, "the reset triggers were left attached"  # noqa: SLF001
+    await hass.async_block_till_done()
+
+
+async def test_stopping_while_attaching_the_reset_leaves_nothing_behind(
+    hass: HomeAssistant,
+) -> None:
+    """The third attach in this codebase with the same window.
+
+    Two of them were found by review, one after the other, so this one is
+    covered by the same shape of test rather than waiting to be the third.
+    """
+    await _reset_entities(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass, {"options": {"steps": [DOOR, MOTION], "reset": [DISARMED]}}
+    )
+
+    watcher = sequence_module._SequenceWatcher(  # noqa: SLF001
+        hass,
+        sequence_module._Sequence(  # noqa: SLF001
+            steps=validated["options"]["steps"],
+            reset=validated["options"]["reset"],
+            timeout=None,
+        ),
+        lambda *_args: None,
+    )
+
+    real = trigger_helper.async_initialize_triggers
+    hold = asyncio.Event()
+    attaching = asyncio.Event()
+
+    async def _suspending(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if "reset" in args[4]:
+            attaching.set()
+            await hold.wait()
+        return await real(*args, **kwargs)
+
+    with patch.object(
+        trigger_nesting.trigger_helper, "async_initialize_triggers", _suspending
+    ):
+        starting = hass.async_create_task(watcher.async_start())
+        async with asyncio.timeout(5):
+            await attaching.wait()
+
+        watcher.async_stop()
+
+        hold.set()
+        async with asyncio.timeout(5):
+            await starting
+        await hass.async_block_till_done()
+
+    assert watcher._unsub_reset is None, "a reset listener was left behind"  # noqa: SLF001
+    assert watcher._run.unsub_step is None, "a step listener was left behind"  # noqa: SLF001
+
+    watcher.async_stop()
     await hass.async_block_till_done()

--- a/tests/ectoplasms/spook/triggers/test_sequence.py
+++ b/tests/ectoplasms/spook/triggers/test_sequence.py
@@ -666,6 +666,9 @@ async def test_a_reset_that_cannot_attach_is_reported(
     await hass.async_block_till_done()
 
     assert "could not attach the reset triggers" in caplog.text
+    assert "nothing will abandon a run under way" in caplog.text, (
+        "the line says a healthy sequence will not fire"
+    )
 
 
 async def test_a_deadline_only_ends_the_run_it_was_set_for(

--- a/tests/ectoplasms/spook/triggers/test_watchdog.py
+++ b/tests/ectoplasms/spook/triggers/test_watchdog.py
@@ -373,8 +373,18 @@ async def test_stopping_while_attaching_leaves_nothing_behind(
     await hass.async_block_till_done()
 
 
-async def test_half_a_watchdog_is_refused(hass: HomeAssistant) -> None:
-    """Without one half it either never starts or always barks."""
+@pytest.mark.parametrize("failing", ["expected", "arming"])
+async def test_half_a_watchdog_is_refused(
+    hass: HomeAssistant,
+    failing: str,
+) -> None:
+    """Without one half it either never starts or always barks.
+
+    Both halves, because they are not the same path. The expected half is
+    attached first, so failing it leaves nothing to clean up; failing the
+    arming half means a listener has already been stored and stopping has to
+    let go of it. Covering only the first would let that leak back in.
+    """
     await _reset(hass)
     validated = await SpookTrigger.async_validate_config(
         hass,
@@ -392,20 +402,22 @@ async def test_half_a_watchdog_is_refused(hass: HomeAssistant) -> None:
 
     real = trigger_helper.async_initialize_triggers
 
-    async def _expect_fails(*args: Any, **kwargs: Any):  # noqa: ANN202
-        if "expected" in args[4]:
+    async def _one_half_fails(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if failing in args[4]:
             return None
         return await real(*args, **kwargs)
 
     with (
         patch.object(
-            watchdog_module.trigger_helper,
+            trigger_nesting.trigger_helper,
             "async_initialize_triggers",
-            _expect_fails,
+            _one_half_fails,
         ),
-        pytest.raises(HomeAssistantError, match="expected triggers"),
+        pytest.raises(HomeAssistantError, match=f"{failing} triggers"),
     ):
         await watchdog.async_start()
+
+    assert not watchdog._unsubs, "the half that did attach was left behind"
 
     await hass.async_block_till_done()
 

--- a/tests/ectoplasms/spook/triggers/test_watchdog.py
+++ b/tests/ectoplasms/spook/triggers/test_watchdog.py
@@ -18,6 +18,7 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 import pytest
 import voluptuous as vol
 
+from custom_components.spook import trigger_nesting
 from custom_components.spook.ectoplasms.spook.triggers import (
     watchdog as watchdog_module,
 )
@@ -308,31 +309,67 @@ async def test_a_deadline_only_ends_the_arming_it_was_set_for(
         await hass.async_block_till_done()
 
 
-async def test_stopping_while_arming_leaves_nothing_behind(
+async def test_stopping_while_attaching_leaves_nothing_behind(
     hass: HomeAssistant,
 ) -> None:
-    """Attaching suspends and stopping does not, the same as everywhere."""
+    """Stopping is synchronous and attaching is not.
+
+    Overlapped on purpose. An earlier version of this test awaited
+    `async_start` before stopping, which never puts the two at the same time
+    and passed against a watchdog that leaked its listener. Review caught
+    that, so this one holds the attach open and stops while it waits.
+    """
     await _reset(hass)
     validated = await SpookTrigger.async_validate_config(
         hass,
         {"options": {"arm": [DOOR], "expect": [MOTION], "within": {"minutes": 2}}},
     )
     options = validated["options"]
+    barks: list[dict] = []
 
     watchdog = watchdog_module._Watchdog(
         hass,
         watchdog_module._Watch(
             arm=options["arm"], expect=options["expect"], within=options["within"]
         ),
-        lambda _armed_by: None,
+        barks.append,
     )
-    stop = await watchdog.async_start()
-    stop()
 
-    # An arming that was already on its way must not start a clock.
-    await watchdog._async_armed({"trigger": {}}, None)
+    real = trigger_helper.async_initialize_triggers
+    hold = asyncio.Event()
+    attaching = asyncio.Event()
+
+    async def _suspending(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if "arming" in args[4]:
+            attaching.set()
+            await hold.wait()
+        return await real(*args, **kwargs)
+
+    with patch.object(
+        trigger_nesting.trigger_helper,
+        "async_initialize_triggers",
+        _suspending,
+    ):
+        starting = hass.async_create_task(watchdog.async_start())
+        async with asyncio.timeout(5):
+            await attaching.wait()
+
+        # The automation is turned off while the arming half is being
+        # attached.
+        watchdog.async_stop()
+
+        hold.set()
+        async with asyncio.timeout(5):
+            await starting
+        await hass.async_block_till_done()
+
+    assert not watchdog._unsubs, "a listener was left behind"
+
+    # And it really is deaf: arming it does nothing.
+    await _move(hass, "binary_sensor.door", "on")
     assert watchdog._armed is None, "a stopped watchdog armed itself"
 
+    watchdog.async_stop()
     await hass.async_block_till_done()
 
 

--- a/tests/ectoplasms/spook/triggers/test_watchdog.py
+++ b/tests/ectoplasms/spook/triggers/test_watchdog.py
@@ -1,0 +1,436 @@
+"""Tests for the spook.watchdog trigger."""
+
+# The watchdog's own state is what several of these are about, and there is no
+# public way at it.
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import selector, trigger as trigger_helper
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers import (
+    watchdog as watchdog_module,
+)
+from custom_components.spook.ectoplasms.spook.triggers.watchdog import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+DOOR = {"trigger": "state", "entity_id": "binary_sensor.door", "to": "on"}
+MOTION = {"trigger": "state", "entity_id": "binary_sensor.motion", "to": "on"}
+WITHIN = timedelta(minutes=2)
+
+TWICE = 2
+
+
+async def _automation(
+    hass: HomeAssistant,
+    options: dict[str, Any] | None = None,
+) -> list[dict]:
+    """Set up an automation on the trigger and record every bark."""
+    barks: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        barks.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "watching",
+                    "trigger": {
+                        "platform": "spook.watchdog",
+                        "options": options
+                        or {
+                            "arm": [DOOR],
+                            "expect": [MOTION],
+                            "within": {"minutes": 2},
+                        },
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {"armed_by": "{{ trigger.armed_by.entity_id }}"},
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    return barks
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its triggers.
+
+    The harness fails a test that leaves a timer or listener behind, and this
+    trigger holds both, so this doubles as a check that it clears up.
+    """
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": "automation.watching"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+
+async def _reset(hass: HomeAssistant) -> None:
+    """Put the entities this uses in a known place."""
+    hass.states.async_set("binary_sensor.door", "off")
+    hass.states.async_set("binary_sensor.motion", "off")
+    await hass.async_block_till_done()
+
+
+async def _move(hass: HomeAssistant, entity_id: str, state: str) -> None:
+    """Move an entity and let everything settle."""
+    hass.states.async_set(entity_id, state)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+
+async def _wait_out(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
+    """Let the whole wait pass."""
+    # `freezer.tick` moves the clock, so the time to fire at is simply the
+    # time it now is. Adding the same stretch again, which reads as the
+    # obvious thing, moves twice as far and sets off deadlines that should
+    # still be pending.
+    freezer.tick(WITHIN + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "watchdog" in await async_get_triggers(hass)
+
+
+async def test_it_barks_when_nothing_follows(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The whole point: the door opened and nobody came in."""
+    await _reset(hass)
+    barks = await _automation(hass)
+
+    await _move(hass, "binary_sensor.door", "on")
+    assert not barks, "barked the moment it was armed"
+
+    await _wait_out(hass, freezer)
+
+    assert len(barks) == 1
+    assert barks[0]["armed_by"] == "binary_sensor.door"
+
+    await _detach(hass)
+
+
+async def test_it_stays_quiet_when_the_expected_thing_arrives(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Which is the case it exists to tell apart from the other one."""
+    await _reset(hass)
+    barks = await _automation(hass)
+
+    await _move(hass, "binary_sensor.door", "on")
+    await _move(hass, "binary_sensor.motion", "on")
+    await _wait_out(hass, freezer)
+
+    assert not barks, "barked even though the expected thing arrived"
+
+    await _detach(hass)
+
+
+async def test_the_expected_thing_on_its_own_does_nothing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Nothing is being waited for, so there is nothing to call off."""
+    await _reset(hass)
+    barks = await _automation(hass)
+
+    await _move(hass, "binary_sensor.motion", "on")
+    await _wait_out(hass, freezer)
+
+    assert not barks
+
+    await _detach(hass)
+
+
+async def test_arming_again_starts_the_wait_over(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The wait is measured from the arming, so the latest one counts."""
+    await _reset(hass)
+    barks = await _automation(hass)
+
+    await _move(hass, "binary_sensor.door", "on")
+
+    # Most of the wait passes, and then it is armed again.
+    freezer.tick(WITHIN - timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert not barks
+
+    await _move(hass, "binary_sensor.door", "off")
+    await _move(hass, "binary_sensor.door", "on")
+
+    # The old wait would have run out by now. The new one has not.
+    freezer.tick(timedelta(seconds=20))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert not barks, "the wait was not started over"
+
+    await _wait_out(hass, freezer)
+    assert len(barks) == 1
+
+    await _detach(hass)
+
+
+async def test_it_can_bark_more_than_once(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Barking is not the end of it: the next arming starts a new watch."""
+    await _reset(hass)
+    barks = await _automation(hass)
+
+    for _ in range(TWICE):
+        await _move(hass, "binary_sensor.door", "on")
+        await _wait_out(hass, freezer)
+        await _move(hass, "binary_sensor.door", "off")
+
+    assert len(barks) == TWICE
+
+    await _detach(hass)
+
+
+async def test_it_takes_what_the_trigger_selector_produces(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The shape an automation built in the user interface actually has."""
+    await _reset(hass)
+    barks = await _automation(
+        hass,
+        {
+            "arm": selector.TriggerSelector()(DOOR),
+            "expect": selector.TriggerSelector()(MOTION),
+            "within": {"minutes": 2},
+        },
+    )
+
+    assert hass.states.get("automation.watching").state == "on", (
+        "the automation did not load"
+    )
+
+    await _move(hass, "binary_sensor.door", "on")
+    await _wait_out(hass, freezer)
+    assert len(barks) == 1
+
+    await _detach(hass)
+
+
+async def test_a_deadline_only_ends_the_arming_it_was_set_for(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A due deadline waits for the lock like everything else.
+
+    Arranged in order, because waiters on a lock are served in order: hold it,
+    queue the re-arm, then let the first arming's deadline come due behind it.
+    Barking then would be barking about a wait that was replaced.
+    """
+    await _reset(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass,
+        {"options": {"arm": [DOOR], "expect": [MOTION], "within": {"minutes": 2}}},
+    )
+    options = validated["options"]
+    barks: list[dict] = []
+
+    watchdog = watchdog_module._Watchdog(
+        hass,
+        watchdog_module._Watch(
+            arm=options["arm"], expect=options["expect"], within=options["within"]
+        ),
+        barks.append,
+    )
+    stop = await watchdog.async_start()
+
+    try:
+        await watchdog._async_armed({"trigger": {"entity_id": "a.b"}}, None)
+        first = watchdog._armed
+        assert first is not None
+
+        await watchdog._lock.acquire()
+
+        rearm = hass.async_create_task(
+            watchdog._async_armed({"trigger": {"entity_id": "c.d"}}, None)
+        )
+        await asyncio.sleep(0)
+
+        freezer.tick(WITHIN + timedelta(seconds=1))
+        async_fire_time_changed(hass)
+        await asyncio.sleep(0)
+
+        watchdog._lock.release()
+        async with asyncio.timeout(5):
+            await rearm
+        await hass.async_block_till_done()
+
+        assert not barks, "the replaced arming's deadline still barked"
+        assert watchdog._armed is not None, "the new watch was called off"
+        assert watchdog._armed is not first
+    finally:
+        stop()
+        await hass.async_block_till_done()
+
+
+async def test_stopping_while_arming_leaves_nothing_behind(
+    hass: HomeAssistant,
+) -> None:
+    """Attaching suspends and stopping does not, the same as everywhere."""
+    await _reset(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass,
+        {"options": {"arm": [DOOR], "expect": [MOTION], "within": {"minutes": 2}}},
+    )
+    options = validated["options"]
+
+    watchdog = watchdog_module._Watchdog(
+        hass,
+        watchdog_module._Watch(
+            arm=options["arm"], expect=options["expect"], within=options["within"]
+        ),
+        lambda _armed_by: None,
+    )
+    stop = await watchdog.async_start()
+    stop()
+
+    # An arming that was already on its way must not start a clock.
+    await watchdog._async_armed({"trigger": {}}, None)
+    assert watchdog._armed is None, "a stopped watchdog armed itself"
+
+    await hass.async_block_till_done()
+
+
+async def test_half_a_watchdog_is_refused(hass: HomeAssistant) -> None:
+    """Without one half it either never starts or always barks."""
+    await _reset(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass,
+        {"options": {"arm": [DOOR], "expect": [MOTION], "within": {"minutes": 2}}},
+    )
+    options = validated["options"]
+
+    watchdog = watchdog_module._Watchdog(
+        hass,
+        watchdog_module._Watch(
+            arm=options["arm"], expect=options["expect"], within=options["within"]
+        ),
+        lambda _armed_by: None,
+    )
+
+    real = trigger_helper.async_initialize_triggers
+
+    async def _expect_fails(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if "expected" in args[4]:
+            return None
+        return await real(*args, **kwargs)
+
+    with (
+        patch.object(
+            watchdog_module.trigger_helper,
+            "async_initialize_triggers",
+            _expect_fails,
+        ),
+        pytest.raises(HomeAssistantError, match="expected triggers"),
+    ):
+        await watchdog.async_start()
+
+    await hass.async_block_till_done()
+
+
+async def test_a_zero_wait_is_refused(hass: HomeAssistant) -> None:
+    """It would bark the moment it was armed."""
+    with pytest.raises(vol.Invalid, match="no time to wait"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {"options": {"arm": [DOOR], "expect": [MOTION], "within": {"seconds": 0}}},
+        )
+
+
+async def test_both_halves_are_required(hass: HomeAssistant) -> None:
+    """A watchdog is two triggers and a duration, or it is not one."""
+    for options in (
+        {"expect": [MOTION], "within": {"minutes": 2}},
+        {"arm": [DOOR], "within": {"minutes": 2}},
+        {"arm": [DOOR], "expect": [MOTION]},
+    ):
+        with pytest.raises(vol.Invalid, match="required key"):
+            await SpookTrigger.async_validate_config(hass, {"options": options})
+
+
+async def test_barking_ends_the_watch(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Once it has barked there is nothing left to wait for.
+
+    Checked on the watchdog itself, because what it costs to get this wrong is
+    stale state rather than a wrong bark: the clock is gone either way, so the
+    next arming works regardless. Pinning it keeps a later change from
+    building on a watch that was supposed to be over.
+    """
+    await _reset(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass,
+        {"options": {"arm": [DOOR], "expect": [MOTION], "within": {"minutes": 2}}},
+    )
+    options = validated["options"]
+    barks: list[dict] = []
+
+    watchdog = watchdog_module._Watchdog(
+        hass,
+        watchdog_module._Watch(
+            arm=options["arm"], expect=options["expect"], within=options["within"]
+        ),
+        barks.append,
+    )
+    stop = await watchdog.async_start()
+
+    try:
+        await watchdog._async_armed({"trigger": {"entity_id": "a.b"}}, None)
+        assert watchdog._armed is not None
+
+        freezer.tick(WITHIN + timedelta(seconds=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert len(barks) == 1
+        assert watchdog._armed is None, "it is still waiting for something"
+    finally:
+        stop()
+        await hass.async_block_till_done()

--- a/tests/ectoplasms/spook/triggers/test_watchdog.py
+++ b/tests/ectoplasms/spook/triggers/test_watchdog.py
@@ -471,3 +471,60 @@ async def test_barking_ends_the_watch(
     finally:
         stop()
         await hass.async_block_till_done()
+
+
+async def test_nothing_is_missed_while_the_halves_are_attaching(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Attaching suspends, so one half listens before the other does.
+
+    Arming in that window would start a watch with nothing listening for what
+    it waits for, and the thing arriving would be missed and barked about. So
+    the expected half goes on first, and this drives both events through the
+    window to say so.
+    """
+    await _reset(hass)
+    validated = await SpookTrigger.async_validate_config(
+        hass,
+        {"options": {"arm": [DOOR], "expect": [MOTION], "within": {"minutes": 2}}},
+    )
+    options = validated["options"]
+    barks: list[dict] = []
+
+    watchdog = watchdog_module._Watchdog(
+        hass,
+        watchdog_module._Watch(
+            arm=options["arm"], expect=options["expect"], within=options["within"]
+        ),
+        barks.append,
+    )
+
+    real = trigger_helper.async_initialize_triggers
+    attached = 0
+
+    async def _busy_window(*args: Any, **kwargs: Any):  # noqa: ANN202
+        nonlocal attached
+        unsub = await real(*args, **kwargs)
+        attached += 1
+
+        if attached == 1:
+            # One half is listening and the other is not. Both halves of a
+            # perfectly ordinary run happen right now.
+            hass.states.async_set("binary_sensor.door", "on")
+            hass.states.async_set("binary_sensor.motion", "on")
+            await hass.async_block_till_done()
+
+        return unsub
+
+    with patch.object(
+        trigger_nesting.trigger_helper, "async_initialize_triggers", _busy_window
+    ):
+        stop = await watchdog.async_start()
+
+    try:
+        await _wait_out(hass, freezer)
+        assert not barks, "it barked about something it was not listening for"
+    finally:
+        stop()
+        await hass.async_block_till_done()

--- a/tests/ectoplasms/spook/triggers/test_while.py
+++ b/tests/ectoplasms/spook/triggers/test_while.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import Context
 from homeassistant.helpers import selector
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 import pytest
 import voluptuous as vol
@@ -86,7 +85,7 @@ async def _detach(hass: HomeAssistant) -> None:
 async def _tick(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
     """Let one interval pass."""
     freezer.tick(EVERY)
-    async_fire_time_changed(hass, dt_util.utcnow() + EVERY)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
 

--- a/tests/test_condition_watching.py
+++ b/tests/test_condition_watching.py
@@ -438,7 +438,7 @@ async def test_the_backstop_has_nothing_to_carry(
 
     hass.states.async_set("input_boolean.gate", "on")
     freezer.tick(BACKSTOP)
-    async_fire_time_changed(hass, dt_util.utcnow() + BACKSTOP)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     watcher.async_stop()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Every trigger Home Assistant has fires because something happened. The interesting failures are the other kind: the back door opened and nobody walked into the hall, the washing machine started and never finished, the nightly backup began and never reported in.

```yaml
trigger: spook.watchdog
options:
  within: "00:02:00"
  arm:
    - trigger: state
      entity_id: binary_sensor.back_door
      to: "on"
  expect:
    - trigger: state
      entity_id: binary_sensor.hallway_motion
      to: "on"
```

Written by hand that is a helper entity, a timer, and two automations to keep them in step.

### The semantics, and who chose them

- **Arming starts a clock.** The expected trigger arriving before it runs out calls the watch off. The clock running out is what fires.
- **Arming again while already waiting starts the wait over**, rather than running a second one, because the wait is measured from the arming and the latest one is the one that counts.
- **The expected trigger arriving while nothing is being waited for does nothing.** There is no watch to call off.
- **Barking ends the watch.** The next arming starts a new one.
- **A zero wait is refused**: it would fire the moment it was armed, which is a trigger on the arming half alone.
- **Half a watchdog is refused**, not logged. Without the arming half it never starts, without the other half it always fires, and an automation that can only be wrong should be marked unavailable rather than left looking healthy.

### What it reports

`trigger.armed_by`, which is what the arming trigger reported, and `trigger.within`.

No context. A watchdog fires because nothing happened, at a moment a clock came round, and nobody makes a clock come round. That is the same call `spook.while` makes for its repeats. An automation that wants to name the person can read it out of `trigger.armed_by`.

### The nested plumbing moves out

`sequence` was already attaching triggers on behalf of a trigger by hand, and the watchdog is the second to need it, so it moves to `trigger_nesting.py`. Forty lines carrying three lessons that cost the sequence branch real time:

- The action has to be a **function**, not an object with an async `__call__`. Home Assistant decides whether to await it by inspecting it, and an instance is not recognised: the coroutine is created, dropped, and nothing ever advances.
- `async_initialize_triggers` returning `None` means nothing attached, which for a Spook trigger means one that never fires.
- That deserves a line in the log naming what could not be attached.

Sequence calls it now. Its behaviour is unchanged and its tests pass untouched, except for the name one of them matches on.

### A clock that lied

Four test helpers, here and in the sequence, while and condition watcher tests, moved time twice as far as they claimed:

```python
freezer.tick(WITHIN)
async_fire_time_changed(hass, dt_util.utcnow() + WITHIN)   # utcnow() already moved
```

Checked whether it was hiding anything by running all sixty-three of those tests with the single advance before changing anything: all still pass, so it was not. But a watchdog cannot be tested against a clock that lies, and this is exactly where it showed: the "arming again starts the wait over" test fired the first deadline it was supposed to leave pending.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Wave 2 of the triggers and conditions plan, where it is described as the canonical Node-RED pattern with no Home Assistant equivalent.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Thirteen new tests, on top of the existing suite (1186 pass).

Barking when nothing follows; staying quiet when the expected thing arrives; the expected thing on its own doing nothing; arming again starting the wait over; barking more than once; the shape the real `TriggerSelector` produces; a stale deadline leaving the arming that replaced it alone; stopping while attaching leaving nothing behind; half a watchdog refused; a zero wait refused; both halves required; and barking ending the watch.

Ten deliberate defects, eight caught: the expected trigger ignored, arming again not restarting, a stale deadline accepted, the deadline never set, half a watchdog allowed, a zero wait allowed, `async_stop` setting nothing, and the watch left standing after a bark.

The two that survive are worth naming rather than papering over. Both are early returns with no observable effect: disarming when nothing is armed is inert, because dropping a deadline that does not exist does nothing and clearing an empty watch clears nothing. They are kept because they state the domain fact at the point a reader needs it, not because they change behaviour, and no test is added to pretend otherwise.

Also ran `ruff check`, `ruff format --check`, `pylint` (by exit code), and the descriptor gate. The documentation builds with the same 23 warnings as `main`.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
