### PR TITLE
Add a spook.flapping trigger

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/flapping.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/flapping.py
@@ -15,11 +15,9 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
 from homeassistant.helpers.trigger import Trigger
-from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from datetime import datetime
 
     from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
     from homeassistant.helpers.event import EventStateChangedData
@@ -112,9 +110,14 @@ class _Recent:
     oldest one falls off by itself and the question is only ever whether the
     ones still in hand happened close enough together. No pruning, and no
     growth on an entity that changes all day.
+
+    Moments are the timestamps the events carry, in seconds, rather than
+    datetimes built from them. Cheaper on an entity that changes a lot, and
+    it is when the change happened rather than when this got round to hearing
+    about it.
     """
 
-    seen: deque[datetime]
+    seen: deque[float]
     reported: bool = False
 
 
@@ -144,7 +147,7 @@ class _FlappingEntityTracker(TargetEntityChangeTracker):
         """Initialize the tracker."""
         super().__init__(hass, target_selection, entity_filter=lambda ids: ids)
         self._changes = changes
-        self._within = within
+        self._within = within.total_seconds()
         self._on_flapping = on_flapping
         self._tracked: set[str] = set()
         self._recent: dict[str, _Recent] = {}
@@ -210,7 +213,7 @@ class _FlappingEntityTracker(TargetEntityChangeTracker):
         if recent is None:
             recent = self._recent[entity_id] = _Recent(seen=deque(maxlen=self._changes))
 
-        recent.seen.append(dt_util.utcnow())
+        recent.seen.append(event.time_fired_timestamp)
 
         if len(recent.seen) < self._changes or (
             recent.seen[-1] - recent.seen[0] > self._within

--- a/custom_components/spook/ectoplasms/spook/triggers/flapping.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/flapping.py
@@ -37,6 +37,13 @@ CONF_WITHIN = "within"
 # back and forth.
 _MINIMUM_CHANGES = 2
 
+# And an upper end, because the count is also how many moments are kept per
+# entity. A thousand changes inside one window is already far past anything
+# that could be called a health problem, and the number selector offers the
+# same ceiling, so the two agree rather than the interface quietly promising
+# a limit that written configuration walks around.
+_MAXIMUM_CHANGES = 1000
+
 
 def _flapping_count(value: Any) -> int:
     """Validate the number of changes, and refuse one that is not flapping."""
@@ -45,6 +52,12 @@ def _flapping_count(value: Any) -> int:
         message = (
             f"It takes at least {_MINIMUM_CHANGES} changes to be going back "
             f"and forth, and this asks for {changes}"
+        )
+        raise vol.Invalid(message)
+    if changes > _MAXIMUM_CHANGES:
+        message = (
+            f"Looking for more than {_MAXIMUM_CHANGES} changes is not looking "
+            f"for a flapping entity, and this asks for {changes}"
         )
         raise vol.Invalid(message)
     return changes

--- a/custom_components/spook/ectoplasms/spook/triggers/flapping.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/flapping.py
@@ -1,0 +1,298 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS, CONF_TARGET
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.helpers.event import EventStateChangedData
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_CHANGES = "changes"
+CONF_WITHIN = "within"
+
+# One change is a change. Two in a row is the least that can be called going
+# back and forth.
+_MINIMUM_CHANGES = 2
+
+
+def _flapping_count(value: Any) -> int:
+    """Validate the number of changes, and refuse one that is not flapping."""
+    changes = cv.positive_int(value)
+    if changes < _MINIMUM_CHANGES:
+        message = (
+            f"It takes at least {_MINIMUM_CHANGES} changes to be going back "
+            f"and forth, and this asks for {changes}"
+        )
+        raise vol.Invalid(message)
+    return changes
+
+
+def _window(value: Any) -> timedelta:
+    """Validate the window, and refuse one nothing can happen inside."""
+    within = cv.positive_time_period(value)
+    if within <= timedelta(0):
+        message = "The window must be longer than zero"
+        raise vol.Invalid(message)
+    return within
+
+
+# `TARGET_FIELDS` is a plain mapping of schema fields, so it needs compiling
+# before it can validate anything.
+_TARGET_SCHEMA = vol.Schema(cv.TARGET_FIELDS)
+
+
+def _watchable_target(value: Any) -> ConfigType:
+    """Validate the target, and refuse one that names nothing.
+
+    An empty target passes the field validation happily and then watches
+    nothing at all: a trigger that loads and can never fire. Core's own target
+    tracking helper raises on this for the same reason.
+    """
+    target: ConfigType = _TARGET_SCHEMA(value)
+    if not TargetSelection(target).has_any_target:
+        message = (
+            "The target must name at least one entity, device, area, floor or label"
+        )
+        raise vol.Invalid(message)
+    return target
+
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TARGET): _watchable_target,
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_CHANGES): _flapping_count,
+            vol.Required(CONF_WITHIN): _window,
+        },
+    }
+)
+
+
+@dataclass(slots=True)
+class _Recent:
+    """The last few changes to one entity, and whether it has been reported.
+
+    The deque is capped at the number of changes being looked for, so the
+    oldest one falls off by itself and the question is only ever whether the
+    ones still in hand happened close enough together. No pruning, and no
+    growth on an entity that changes all day.
+    """
+
+    seen: deque[datetime]
+    reported: bool = False
+
+
+# Everything here is called by the base class or by an event, so there is
+# nothing public to count.
+# pylint: disable-next=too-few-public-methods
+class _FlappingEntityTracker(TargetEntityChangeTracker):
+    """Watch a target's entities and report the ones that will not settle.
+
+    Changes of state, not writes: an entity reporting the same value over and
+    over is chatty, not flapping. Going to `unavailable` and back does count,
+    which is the case this exists for.
+
+    The registry listening and target re-expansion come from the base class,
+    which calls back into `_handle_entities_update` whenever the set of
+    targeted entities moves.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        target_selection: TargetSelection,
+        changes: int,
+        within: timedelta,
+        on_flapping: Callable[[str, Event[EventStateChangedData]], None],
+    ) -> None:
+        """Initialize the tracker."""
+        super().__init__(hass, target_selection, entity_filter=lambda ids: ids)
+        self._changes = changes
+        self._within = within
+        self._on_flapping = on_flapping
+        self._tracked: set[str] = set()
+        self._recent: dict[str, _Recent] = {}
+        self._unsub_changes: list[CALLBACK_TYPE] = []
+
+    @callback
+    def _handle_entities_update(self, tracked_entities: set[str]) -> None:
+        """Re-aim at the entities the target now covers.
+
+        The base class re-expands the target on every entity, device and area
+        registry event anywhere in the system, and almost none of those move
+        this target. Tearing down and rebuilding the listeners each time would
+        be work for nothing.
+        """
+        if tracked_entities == self._tracked:
+            return
+
+        for entity_id in self._tracked - tracked_entities:
+            self._recent.pop(entity_id, None)
+
+        self._tracked = tracked_entities
+        self._relisten()
+
+    @callback
+    def _relisten(self) -> None:
+        """Listen for changes to exactly the entities being tracked.
+
+        The new listener goes on before the old one comes off. Home Assistant
+        keeps one shared tracker per event type: drop the last subscriber and
+        it is torn down, taking with it events that have fired but not been
+        dispatched yet. Core's own target tracker orders it this way for the
+        same reason.
+        """
+        previous = self._unsub_changes
+        self._unsub_changes = []
+
+        if self._tracked:
+            self._unsub_changes = [
+                async_track_state_change_event(
+                    self._hass, list(self._tracked), self._entity_changed
+                )
+            ]
+
+        for unsub in previous:
+            unsub()
+
+    @callback
+    def _entity_changed(self, event: Event[EventStateChangedData]) -> None:
+        """Count a change, and report an entity that has had too many."""
+        old_state = event.data["old_state"]
+        new_state = event.data["new_state"]
+
+        if old_state is None or new_state is None:
+            # An entity arriving or leaving is not it going back and forth.
+            return
+
+        if old_state.state == new_state.state:
+            # An attribute moved and the state did not. Chatty, not flapping.
+            return
+
+        entity_id = event.data["entity_id"]
+        recent = self._recent.get(entity_id)
+        if recent is None:
+            recent = self._recent[entity_id] = _Recent(seen=deque(maxlen=self._changes))
+
+        recent.seen.append(dt_util.utcnow())
+
+        if len(recent.seen) < self._changes or (
+            recent.seen[-1] - recent.seen[0] > self._within
+        ):
+            # Not enough changes in hand, or the oldest of them is too long
+            # ago. Either way it has settled since, so it can be reported
+            # again when it starts up.
+            recent.reported = False
+            return
+
+        if recent.reported:
+            # Already said so. Reporting every further change would be a
+            # storm of alerts about a storm.
+            return
+
+        recent.reported = True
+        self._on_flapping(entity_id, event)
+
+    def _unsubscribe(self) -> None:
+        """Unsubscribe from everything, the base class' listeners included."""
+        super()._unsubscribe()
+
+        for unsub in self._unsub_changes:
+            unsub()
+        self._unsub_changes.clear()
+
+        self._recent.clear()
+        self._tracked = set()
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when an entity will not settle.
+
+    A sensor that goes on and off and on again, a device that drops off the
+    network and comes back, a binary sensor sitting right on its threshold.
+    Each change on its own looks fine, and Home Assistant has no way to say
+    "this one has changed five times in five minutes and something is wrong
+    with it".
+    """
+
+    trigger = "flapping"
+
+    _changes: int
+    _within: timedelta
+    _target: ConfigType
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        return _TRIGGER_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._changes = options[CONF_CHANGES]
+        self._within = options[CONF_WITHIN]
+        self._target = config.target or {}
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def entity_is_flapping(
+            entity_id: str,
+            event: Event[EventStateChangedData],
+        ) -> None:
+            """Run the action for the entity that will not settle."""
+            to_state = event.data["new_state"]
+
+            run_action(
+                {
+                    "entity_id": entity_id,
+                    "from_state": event.data["old_state"],
+                    "to_state": to_state,
+                    "changes": self._changes,
+                    "within": self._within,
+                },
+                f"{entity_id} changed {self._changes} times in {self._within}",
+                to_state.context if to_state else None,
+            )
+
+        tracker = _FlappingEntityTracker(
+            self._hass,
+            TargetSelection(self._target),
+            self._changes,
+            self._within,
+            entity_is_flapping,
+        )
+        return await tracker.async_setup()

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -50,6 +50,20 @@
         }
       }
     },
+    "flapping": {
+      "name": "Entity will not settle",
+      "description": "Fires when an entity changes state more often than it should within a stretch of time.",
+      "fields": {
+        "changes": {
+          "name": "Changes",
+          "description": "How many changes of state it takes before this fires. Changes of attribute do not count, and neither does an entity appearing or disappearing."
+        },
+        "within": {
+          "name": "Within",
+          "description": "The stretch of time those changes have to fall inside. It slides along, so this is always about the most recent changes."
+        }
+      }
+    },
     "condition_met": {
       "name": "Condition turned true",
       "description": "Fires when a condition goes from false to true, using the same condition building blocks as anywhere else.",

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -100,3 +100,20 @@ watchdog:
       example: "00:02:00"
       selector:
         duration:
+flapping:
+  target:
+    entity:
+  fields:
+    changes:
+      required: true
+      example: 5
+      selector:
+        number:
+          min: 2
+          max: 1000
+          mode: box
+    within:
+      required: true
+      example: "00:05:00"
+      selector:
+        duration:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1200,7 +1200,7 @@ Fires when an entity changes state more often than it should within a stretch of
 * - `changes`
   - {term}`integer <integer>`
   - Yes
-  - At least 2
+  - Between 2 and 1000
 * - `within`
   - {term}`string <string>`
   - Yes
@@ -1213,7 +1213,7 @@ Changes of state, not writes. An entity reporting the same value over and over i
 
 The window slides, so this is always about the most recent changes rather than a fresh count every five minutes.
 
-It reports once per spell. Once it has said an entity will not settle it stays quiet until that entity does settle, because a storm of alerts about a storm helps nobody. Settling means the last few changes no longer fall inside the window; the next time it starts up is news again.
+It reports once per spell. Once it has said an entity will not settle it stays quiet until that entity does settle, because a storm of alerts about a storm helps nobody. Settling means the last few changes no longer fall inside the window, and the next time it starts up is news again. A change that still leaves the last few inside the window is the same spell carrying on, however long it has been since the one before it.
 
 When it fires, `trigger.entity_id` names the entity, `trigger.from_state` and `trigger.to_state` are the change that tipped it over, and `trigger.changes` and `trigger.within` are what was asked for.
 
@@ -1251,7 +1251,7 @@ options:
 
 - Counting starts when the automation loads. Changes from before that are not known, so an entity that has been flapping all afternoon is reported the next time it changes enough, not immediately.
 - Each entity is counted on its own. Ten entities changing twice each is not one entity changing twenty times, which is the point, but it does mean a target full of entities that each flap a little goes unreported.
-- What is remembered is the last `changes` moments per entity, and no more, so a large target costs little. It is forgotten entirely when Home Assistant restarts or the entity leaves the target.
+- What is remembered is the last `changes` moments per entity, and no more, so a large target costs little. That is also why `changes` stops at a thousand: past that it is not describing a flapping entity any more. It is forgotten entirely when Home Assistant restarts or the entity leaves the target.
   :::
 
 (condition-turned-true)=

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1173,6 +1173,87 @@ options:
 - The automation's `trigger_variables` do not reach the arming and expected triggers, for the same reason they do not reach a sequence's steps: Home Assistant hands those to a trigger platform, not to a trigger like this one.
   :::
 
+### Entity will not settle
+
+Fires when an entity changes state more often than it should within a stretch of time.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Entity will not settle
+* - Trigger name
+  - `spook.flapping`
+* - Targets
+  - {term}`Entities <entity>`, {term}`devices <device>`, {term}`areas <area>`, floors and labels
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `changes`
+  - {term}`integer <integer>`
+  - Yes
+  - At least 2
+* - `within`
+  - {term}`string <string>`
+  - Yes
+  - `00:05:00`
+```
+
+A sensor that goes on and off and on again, a device that drops off the network and comes back, a binary sensor sitting right on its threshold. Each change on its own looks perfectly fine, and Home Assistant has no way to say "this one has changed five times in five minutes and something is wrong with it".
+
+Changes of state, not writes. An entity reporting the same value over and over is chatty, not unsettled, so attribute changes do not count. Going to `unavailable` and back does count, which is the case this exists for. An entity appearing or disappearing does not: that is not it going back and forth.
+
+The window slides, so this is always about the most recent changes rather than a fresh count every five minutes.
+
+It reports once per spell. Once it has said an entity will not settle it stays quiet until that entity does settle, because a storm of alerts about a storm helps nobody. Settling means the last few changes no longer fall inside the window; the next time it starts up is news again.
+
+When it fires, `trigger.entity_id` names the entity, `trigger.from_state` and `trigger.to_state` are the change that tipped it over, and `trigger.changes` and `trigger.within` are what was asked for.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Tell me about a door sensor that cannot make up its mind:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.flapping
+target:
+  entity_id: binary_sensor.back_door
+options:
+  changes: 5
+  within: "00:05:00"
+```
+
+Or watch everything with a label, and hear about whichever one starts misbehaving:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.flapping
+target:
+  label_id: battery_powered
+options:
+  changes: 10
+  within: "00:15:00"
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Counting starts when the automation loads. Changes from before that are not known, so an entity that has been flapping all afternoon is reported the next time it changes enough, not immediately.
+- Each entity is counted on its own. Ten entities changing twice each is not one entity changing twenty times, which is the point, but it does mean a target full of entities that each flap a little goes unreported.
+- What is remembered is the last `changes` moments per entity, and no more, so a large target costs little. It is forgotten entirely when Home Assistant restarts or the entity leaves the target.
+  :::
+
 (condition-turned-true)=
 
 ### Condition turned true

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -62,3 +62,9 @@ Fires when a condition turns true and keeps firing on an interval for as long as
 Fires when something that was expected to happen does not happen in time, without needing a helper entity and a timer to arrange it. _#absence_ _#timeout_ _#watchdog_
 
 `spook.watchdog`, [documentation](other-features#watchdog) 📚
+
+## Entity will not settle
+
+Fires when an entity changes state more often than it should within a stretch of time, which is how a failing device usually announces itself. _#flapping_ _#device-health_ _#unavailable_
+
+`spook.flapping`, [documentation](other-features#entity-will-not-settle) 📚

--- a/tests/ectoplasms/spook/triggers/test_flapping.py
+++ b/tests/ectoplasms/spook/triggers/test_flapping.py
@@ -1,0 +1,396 @@
+"""Tests for the spook.flapping trigger."""
+
+# The tracker's own bookkeeping is what one of these is about, and there is
+# no public way at it.
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import Context
+from homeassistant.helpers.target import TargetSelection
+from homeassistant.setup import async_setup_component
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers import (
+    flapping as flapping_module,
+)
+from custom_components.spook.ectoplasms.spook.triggers.flapping import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+FLAPPER = "binary_sensor.dodgy"
+WITHIN = timedelta(minutes=5)
+
+TWICE = 2
+THRICE = 3
+
+
+async def _automation(
+    hass: HomeAssistant,
+    target: dict | None = None,
+    options: dict[str, Any] | None = None,
+) -> list[dict]:
+    """Set up an automation on the trigger and record every run."""
+    runs: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        runs.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "unsettled",
+                    "trigger": {
+                        "platform": "spook.flapping",
+                        "target": target or {"entity_id": FLAPPER},
+                        "options": options or {"changes": 3, "within": "00:05:00"},
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {
+                                "entity_id": "{{ trigger.entity_id }}",
+                                "changes": "{{ trigger.changes }}",
+                                "to_state": "{{ trigger.to_state.state }}",
+                            },
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return runs
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger.
+
+    The harness fails a test that leaves a listener behind, so this doubles as
+    a check that it clears up.
+    """
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": "automation.unsettled"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+
+async def _flap(
+    hass: HomeAssistant,
+    times: int,
+    entity_id: str = FLAPPER,
+    **kwargs: Any,
+) -> None:
+    """Change an entity's state `times` times.
+
+    Toggling from wherever it is now, rather than from a fixed first value.
+    Starting from "on" when it is already on writes the same state, which is
+    not a change at all, and a test that thinks it made three changes and
+    made two is a test that lies about what it proved.
+    """
+    for _ in range(times):
+        current = hass.states.get(entity_id)
+        following = "off" if current is not None and current.state == "on" else "on"
+        hass.states.async_set(entity_id, following, **kwargs)
+        await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "flapping" in await async_get_triggers(hass)
+
+
+async def test_it_fires_on_the_change_that_tips_it_over(
+    hass: HomeAssistant,
+) -> None:
+    """Three changes in five minutes, and the third is the one."""
+    hass.states.async_set(FLAPPER, "off")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    await _flap(hass, 2)
+    assert not runs, "fired before it had seen enough"
+
+    await _flap(hass, 1)
+
+    assert len(runs) == 1
+    assert runs[0]["entity_id"] == FLAPPER
+    assert runs[0]["changes"] == THRICE
+
+    await _detach(hass)
+
+
+async def test_changes_spread_out_are_not_flapping(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The window slides, so old changes stop counting."""
+    hass.states.async_set(FLAPPER, "off")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    for _ in range(4):
+        await _flap(hass, 1)
+        freezer.tick(WITHIN)
+
+    assert not runs, "changes minutes apart were called flapping"
+
+    await _detach(hass)
+
+
+async def test_it_does_not_report_the_same_spell_twice(
+    hass: HomeAssistant,
+) -> None:
+    """A storm of alerts about a storm is worse than the storm."""
+    hass.states.async_set(FLAPPER, "off")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    await _flap(hass, 10)
+
+    assert len(runs) == 1, "it reported every change once it got going"
+
+    await _detach(hass)
+
+
+async def test_it_reports_again_once_it_has_settled(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Settling down and starting again is news a second time."""
+    hass.states.async_set(FLAPPER, "off")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    await _flap(hass, 3)
+    assert len(runs) == 1
+
+    # Quiet for long enough that the old changes fall outside the window.
+    freezer.tick(WITHIN * 2)
+    await _flap(hass, 3)
+
+    assert len(runs) == TWICE, "it never reported the second spell"
+
+    await _detach(hass)
+
+
+async def test_attribute_changes_do_not_count(hass: HomeAssistant) -> None:
+    """Chatty is not the same as unsettled."""
+    hass.states.async_set(FLAPPER, "on")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    for value in range(5):
+        hass.states.async_set(FLAPPER, "on", {"brightness": value})
+        await hass.async_block_till_done()
+
+    assert not runs, "an entity holding one state was called flapping"
+
+    await _detach(hass)
+
+
+async def test_going_unavailable_and_back_counts(hass: HomeAssistant) -> None:
+    """Which is the case this exists for."""
+    hass.states.async_set(FLAPPER, "on")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    for state in ("unavailable", "on", "unavailable"):
+        hass.states.async_set(FLAPPER, state)
+        await hass.async_block_till_done()
+
+    assert len(runs) == 1
+    assert runs[0]["to_state"] == "unavailable"
+
+    await _detach(hass)
+
+
+async def test_an_entity_appearing_is_not_flapping(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Nor is one being removed, however often it happens.
+
+    The log is checked as well as the runs, because those two failures look
+    the same from the outside. Reading the state off a removal, where there is
+    none to read, raises inside the event dispatch; Home Assistant swallows
+    that and the trigger stays quiet, so "it did not fire" is true either way.
+    """
+    runs = await _automation(hass)
+
+    for _ in range(5):
+        hass.states.async_set(FLAPPER, "on")
+        await hass.async_block_till_done()
+        hass.states.async_remove(FLAPPER)
+        await hass.async_block_till_done()
+
+    assert not runs, "an entity coming and going was called flapping"
+    assert not [
+        record for record in caplog.records if record.levelno >= logging.ERROR
+    ], "it went looking for a state that was not there"
+
+    await _detach(hass)
+
+
+async def test_an_entity_leaving_the_target_is_forgotten(
+    hass: HomeAssistant,
+) -> None:
+    """Otherwise what it did is remembered for as long as the trigger lives.
+
+    Checked on the tracker, because a target losing an entity is a registry
+    event away and what it costs is memory rather than a wrong answer.
+    """
+    hass.states.async_set(FLAPPER, "off")
+    await hass.async_block_till_done()
+
+    tracker = flapping_module._FlappingEntityTracker(  # noqa: SLF001
+        hass,
+        TargetSelection({"entity_id": FLAPPER}),
+        3,
+        WITHIN,
+        lambda _entity_id, _event: None,
+    )
+    stop = await tracker.async_setup()
+
+    try:
+        await _flap(hass, 2)
+        assert FLAPPER in tracker._recent, "nothing was counted"  # noqa: SLF001
+
+        tracker._handle_entities_update(set())  # noqa: SLF001
+        assert not tracker._recent, (  # noqa: SLF001
+            "it still remembers an entity it stopped watching"
+        )
+    finally:
+        stop()
+        await hass.async_block_till_done()
+
+
+async def test_entities_are_counted_apart(hass: HomeAssistant) -> None:
+    """Two entities each changing twice is not one changing four times."""
+    other = "binary_sensor.also_dodgy"
+    hass.states.async_set(FLAPPER, "off")
+    hass.states.async_set(other, "off")
+    await hass.async_block_till_done()
+
+    runs = await _automation(hass, target={"entity_id": [FLAPPER, other]})
+
+    await _flap(hass, 2)
+    await _flap(hass, 2, entity_id=other)
+    assert not runs, "changes to different entities were added together"
+
+    await _flap(hass, 1)
+    assert len(runs) == 1
+    assert runs[0]["entity_id"] == FLAPPER
+
+    await _detach(hass)
+
+
+async def test_it_carries_the_change_that_tipped_it_over(
+    hass: HomeAssistant,
+) -> None:
+    """Whoever made that change set the run going."""
+    user = await hass.auth.async_create_user("Ghost Hunter")
+    hass.states.async_set(FLAPPER, "off")
+    await hass.async_block_till_done()
+
+    ran: list[str] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(call.data["which"])
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": which,
+                    "trigger": {
+                        "platform": "spook.flapping",
+                        "target": {"entity_id": FLAPPER},
+                        "options": {"changes": 3, "within": "00:05:00"},
+                    },
+                    "condition": [{"condition": f"spook.{which}"}],
+                    "action": [{"action": "test.mark", "data": {"which": which}}],
+                }
+                for which in ("triggered_by_user", "not_triggered_by_user")
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    await _flap(hass, 2)
+    hass.states.async_set(FLAPPER, "on", context=Context(user_id=user.id))
+    await hass.async_block_till_done()
+
+    assert ran == ["triggered_by_user"]
+
+    for alias in ("triggered_by_user", "not_triggered_by_user"):
+        await hass.services.async_call(
+            "automation",
+            "turn_off",
+            {"entity_id": f"automation.{alias}"},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+
+async def test_one_change_is_not_flapping(hass: HomeAssistant) -> None:
+    """It takes going back and forth, which needs at least two."""
+    with pytest.raises(vol.Invalid, match="at least 2 changes"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {
+                "target": {"entity_id": FLAPPER},
+                "options": {"changes": 1, "within": "00:05:00"},
+            },
+        )
+
+
+async def test_a_zero_window_is_refused(hass: HomeAssistant) -> None:
+    """Nothing can happen inside no time at all."""
+    with pytest.raises(vol.Invalid, match="longer than zero"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {
+                "target": {"entity_id": FLAPPER},
+                "options": {"changes": 3, "within": {"seconds": 0}},
+            },
+        )
+
+
+async def test_an_empty_target_is_refused(hass: HomeAssistant) -> None:
+    """It would load and then watch nothing at all."""
+    with pytest.raises(vol.Invalid, match="at least one entity"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {"target": {}, "options": {"changes": 3, "within": "00:05:00"}},
+        )
+
+
+async def test_both_options_are_required(hass: HomeAssistant) -> None:
+    """Neither has a sensible default to fall back on."""
+    for options in ({"changes": 3}, {"within": "00:05:00"}):
+        with pytest.raises(vol.Invalid, match="required key"):
+            await SpookTrigger.async_validate_config(
+                hass, {"target": {"entity_id": FLAPPER}, "options": options}
+            )

--- a/tests/ectoplasms/spook/triggers/test_flapping.py
+++ b/tests/ectoplasms/spook/triggers/test_flapping.py
@@ -394,3 +394,77 @@ async def test_both_options_are_required(hass: HomeAssistant) -> None:
             await SpookTrigger.async_validate_config(
                 hass, {"target": {"entity_id": FLAPPER}, "options": options}
             )
+
+
+async def test_an_absurd_number_of_changes_is_refused(hass: HomeAssistant) -> None:
+    """The count is also how many moments are kept per entity.
+
+    The number selector offers a thousand as its ceiling, so written
+    configuration has to stop there too, or the interface promises a limit
+    that YAML walks straight around.
+    """
+    with pytest.raises(vol.Invalid, match="not looking for a flapping entity"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {
+                "target": {"entity_id": FLAPPER},
+                "options": {"changes": 1001, "within": "00:05:00"},
+            },
+        )
+
+
+async def test_a_second_spell_that_starts_straight_away_is_reported(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Settling and starting again inside one window's worth of quiet.
+
+    Three changes, then quiet for long enough that they no longer count, then
+    three more in quick succession. The third of those completes a window of
+    its own and is a spell in its own right.
+    """
+    hass.states.async_set(FLAPPER, "off")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    await _flap(hass, 3)
+    assert len(runs) == 1
+
+    freezer.tick(WITHIN * 3)
+
+    # The first two of the new spell still have an old change in hand, so it
+    # is the third that completes a window made only of new ones.
+    await _flap(hass, 2)
+    assert len(runs) == 1, "it reported before it had a whole new window"
+
+    await _flap(hass, 1)
+    assert len(runs) == TWICE, "the second spell went unreported"
+
+    await _detach(hass)
+
+
+async def test_carrying_on_flapping_is_still_one_spell(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A change late in the window continues a spell rather than starting one.
+
+    Three changes a minute apart fire once. A fourth four minutes later still
+    leaves the last three inside a five minute window, so the entity has not
+    settled and there is nothing new to say.
+    """
+    hass.states.async_set(FLAPPER, "off")
+    await hass.async_block_till_done()
+    runs = await _automation(hass)
+
+    for _ in range(3):
+        await _flap(hass, 1)
+        freezer.tick(timedelta(minutes=1))
+    assert len(runs) == 1
+
+    freezer.tick(timedelta(minutes=3))
+    await _flap(hass, 1)
+
+    assert len(runs) == 1, "a spell that never let up was reported twice"
+
+    await _detach(hass)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A sensor that goes on and off and on again, a device that drops off the network and comes back, a binary sensor sitting right on its threshold. Each change looks perfectly fine on its own, and Home Assistant has no way to say "this one has changed five times in five minutes and something is wrong with it".

```yaml
trigger: spook.flapping
target:
  label_id: battery_powered
options:
  changes: 10
  within: "00:15:00"
```

### The semantics

- **Changes of state, not writes.** An entity repeating one value is chatty, not unsettled, so attribute changes do not count. Going to `unavailable` and back does, which is the case this exists for. An entity appearing or disappearing does not: that is not it going back and forth.
- **The window slides**, so it is always about the most recent changes rather than a fresh count every five minutes.
- **Once per spell.** Once it has said an entity will not settle it stays quiet until that entity does, because a storm of alerts about a storm helps nobody. Settling means the changes in hand no longer fall inside the window, and the next time it starts up is news again.
- **Each entity is counted on its own.** Ten entities changing twice each is not one entity changing twenty times.
- Fewer than two changes is not going back and forth, and a zero window is a stretch nothing can happen inside. Both refused.

### No timers

Which is the pleasant part, and worth saying because the other triggers on this branch each had to be taught about deadlines the hard way.

What is kept per entity is a deque capped at the number of changes being looked for. The oldest falls off by itself, so there is no pruning, no growth on an entity that changes all day, and the only question at each change is whether the ones still in hand happened close enough together. Bounded memory and no clock to get wrong.

The target expansion, registry rewiring and attach-before-detach ordering come from `TargetEntityChangeTracker`, the same base `spook.stale` uses.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Wave 2 of the triggers and conditions plan, where it is listed as the device-health case no automation system covers first class.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Fifteen new tests, on top of the existing suite (1205 pass).

Firing on the change that tips it over; changes spread out not counting; not reporting the same spell twice; reporting again once it has settled; attribute changes not counting; `unavailable` and back counting; an entity appearing not counting; entities counted apart; the change that tipped it over carrying its user; an entity leaving the target being forgotten; and four refusals.

Eleven deliberate defects, each caught: the window ignored, every change reported, never reporting again, attribute changes counted, appearing counted, all entities sharing one count, the change not carried into the payload, a single change allowed, a zero window allowed, an empty target allowed, and an entity leaving the target not forgotten.

Two of those eleven escaped the first time, and both were my tests rather than the code:

- **The helper that made an entity flap started from `"on"` every time**, so a second spell in the same test began by writing the state it was already in. That is not a change at all, and a test that thinks it made three changes and made two is a test that lies about what it proved. It toggles from wherever the entity is now.
- **The "appearing is not flapping" test passed under its own mutation for the wrong reason.** Without the guard, reading the state off a removal raises inside the event dispatch; Home Assistant swallows that and the trigger stays quiet, so "it did not fire" is true either way. Measured the exception, then made the test check the log as well as the runs.

Also ran `ruff check`, `ruff format --check`, `pylint` (by exit code), and the descriptor gate. The documentation builds with the same 23 warnings as `main`; a first draft added one, from a `{term}` pointing at a glossary entry that does not exist.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
