### PR TITLE
Add an automation.snooze action

### DIFF
--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -80,6 +80,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Forward async_setup_entry to ectoplasms
     await async_forward_setup_entry(hass, entry)
 
+    # Before the services, because `automation.snooze` reaches for this the
+    # moment it is called, and registering the action first leaves a window
+    # where calling it finds nothing there.
+    #
+    # This also picks up automations snoozed before the last restart. An
+    # automation that is off stays off, so without it a snooze that spanned a
+    # restart would be a disable nobody remembers making.
+    entry.async_on_unload(await async_setup_snoozing(hass))
+
     # Set up services
     services = SpookServiceManager(hass)
     await services.async_setup()
@@ -121,11 +130,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # And when they ran, for the conditions that count runs rather than
     # contexts. Same reason it cannot wait to be asked.
     entry.async_on_unload(async_setup_run_history(hass))
-
-    # Pick up any automations that were snoozed before the last restart. An
-    # automation that is off stays off, so without this a snooze that spanned
-    # a restart would be a disable nobody remembers making.
-    entry.async_on_unload(await async_setup_snoozing(hass))
 
     # Yay, we didn't got spooked!
     return True

--- a/custom_components/spook/__init__.py
+++ b/custom_components/spook/__init__.py
@@ -25,6 +25,7 @@ from .repairs import SpookRepairManager
 from .run_history import async_setup_run_history
 from .services import SpookServiceManager
 from .setup_helpers import async_forward_setup_entry
+from .snoozing import async_setup_snoozing
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -120,6 +121,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # And when they ran, for the conditions that count runs rather than
     # contexts. Same reason it cannot wait to be asked.
     entry.async_on_unload(async_setup_run_history(hass))
+
+    # Pick up any automations that were snoozed before the last restart. An
+    # automation that is off stays off, so without this a snooze that spanned
+    # a restart would be a disable nobody remembers making.
+    entry.async_on_unload(await async_setup_snoozing(hass))
 
     # Yay, we didn't got spooked!
     return True

--- a/custom_components/spook/ectoplasms/automation/services/__init__.py
+++ b/custom_components/spook/ectoplasms/automation/services/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/automation/services/snooze.py
+++ b/custom_components/spook/ectoplasms/automation/services/snooze.py
@@ -1,0 +1,43 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.automation import DOMAIN, BaseAutomationEntity
+from homeassistant.helpers import config_validation as cv
+
+from ....services import AbstractSpookEntityComponentService
+from ....snoozing import async_get_snoozing
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_DURATION = "duration"
+
+
+class SpookService(AbstractSpookEntityComponentService[BaseAutomationEntity]):
+    """Automation service that turns one off for a while, not for good.
+
+    Turning an automation off is the only way to make it stop for an hour,
+    and an automation turned off stays off: past the restart, past the
+    weekend, until somebody notices. The usual way round it is a helper
+    entity and a second automation to turn the first one back on, which is
+    two moving parts for something that should be one.
+    """
+
+    domain = DOMAIN
+    service = "snooze"
+    schema = {vol.Required(CONF_DURATION): cv.positive_time_period}
+
+    async def async_handle_service(
+        self,
+        entity: BaseAutomationEntity,
+        call: ServiceCall,
+    ) -> None:
+        """Handle the service call."""
+        await async_get_snoozing(self.hass).async_snooze(
+            entity.entity_id, call.data[CONF_DURATION]
+        )

--- a/custom_components/spook/ectoplasms/automation/services/snooze.py
+++ b/custom_components/spook/ectoplasms/automation/services/snooze.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
@@ -13,9 +13,27 @@ from ....services import AbstractSpookEntityComponentService
 from ....snoozing import async_get_snoozing
 
 if TYPE_CHECKING:
+    from datetime import timedelta
+
     from homeassistant.core import ServiceCall
 
 CONF_DURATION = "duration"
+
+
+def _a_stretch_of_time(value: Any) -> timedelta:
+    """Validate a duration that is actually a duration.
+
+    `cv.positive_time_period` counts nothing at all as positive, and a snooze
+    of nothing is an automation turned off and straight back on: a pulse
+    through everything watching it, in exchange for no quiet whatsoever.
+    """
+    period = cv.positive_time_period(value)
+
+    if not period:
+        msg = "duration must be longer than nothing"
+        raise vol.Invalid(msg)
+
+    return period
 
 
 class SpookService(AbstractSpookEntityComponentService[BaseAutomationEntity]):
@@ -30,7 +48,7 @@ class SpookService(AbstractSpookEntityComponentService[BaseAutomationEntity]):
 
     domain = DOMAIN
     service = "snooze"
-    schema = {vol.Required(CONF_DURATION): cv.positive_time_period}
+    schema = {vol.Required(CONF_DURATION): _a_stretch_of_time}
 
     async def async_handle_service(
         self,

--- a/custom_components/spook/ectoplasms/automation/services/snooze.py
+++ b/custom_components/spook/ectoplasms/automation/services/snooze.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components.automation import DOMAIN, BaseAutomationEntity
 from homeassistant.helpers import config_validation as cv
+from homeassistant.util import dt as dt_util
 
 from ....services import AbstractSpookEntityComponentService
 from ....snoozing import async_get_snoozing
@@ -32,6 +33,15 @@ def _a_stretch_of_time(value: Any) -> timedelta:
     if not period:
         msg = "duration must be longer than nothing"
         raise vol.Invalid(msg)
+
+    try:
+        dt_util.utcnow() + period
+    except OverflowError as err:
+        # Time periods run further than datetimes do, so a big enough number
+        # of days lands past the end of the calendar. Better said here than
+        # thrown halfway through turning an automation off.
+        msg = "duration must end at a time that exists"
+        raise vol.Invalid(msg) from err
 
     return period
 

--- a/custom_components/spook/ectoplasms/automation/services/snooze.py
+++ b/custom_components/spook/ectoplasms/automation/services/snooze.py
@@ -39,5 +39,10 @@ class SpookService(AbstractSpookEntityComponentService[BaseAutomationEntity]):
     ) -> None:
         """Handle the service call."""
         await async_get_snoozing(self.hass).async_snooze(
-            entity.entity_id, call.data[CONF_DURATION]
+            entity.entity_id,
+            call.data[CONF_DURATION],
+            # Carried through, so an automation watching this one switch off
+            # can still tell who asked for it. Spook's own context conditions
+            # read the person off exactly that.
+            context=call.context,
         )

--- a/custom_components/spook/ectoplasms/automation/services/snooze.py
+++ b/custom_components/spook/ectoplasms/automation/services/snooze.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 
 from homeassistant.components.automation import DOMAIN, BaseAutomationEntity
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import dt as dt_util
 
 from ....services import AbstractSpookEntityComponentService
 from ....snoozing import async_get_snoozing
@@ -33,15 +32,6 @@ def _a_stretch_of_time(value: Any) -> timedelta:
     if not period:
         msg = "duration must be longer than nothing"
         raise vol.Invalid(msg)
-
-    try:
-        dt_util.utcnow() + period
-    except OverflowError as err:
-        # Time periods run further than datetimes do, so a big enough number
-        # of days lands past the end of the calendar. Better said here than
-        # thrown halfway through turning an automation off.
-        msg = "duration must end at a time that exists"
-        raise vol.Invalid(msg) from err
 
     return period
 

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -2,6 +2,7 @@
   "domain": "spook",
   "name": "Spook",
   "after_dependencies": [
+    "automation",
     "blueprint",
     "cloud",
     "counter",

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -20,6 +20,24 @@ blueprint_import:
       selector:
         text:
 
+automation_snooze:
+  name: Snooze 👻
+  description: >-
+    Turns an automation off for a while, and turns it back on when the time is
+    up. Surviving a restart of Home Assistant, so a snooze does not quietly
+    become a disable.
+  target:
+    entity:
+      domain: automation
+  fields:
+    duration:
+      name: Duration
+      description: How long the automation stays off.
+      required: true
+      example: "01:00:00"
+      selector:
+        duration:
+
 homeassistant_create_area:
   name: Create an area 👻
   description: >-

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -24,7 +24,7 @@ automation_snooze:
   name: Snooze 👻
   description: >-
     Turns an automation off for a while, and turns it back on when the time is
-    up. Surviving a restart of Home Assistant, so a snooze does not quietly
+    up. It survives a restart of Home Assistant, so a snooze does not quietly
     become a disable.
   target:
     entity:

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -186,12 +186,21 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
                 context=context,
             )
         except HomeAssistantError:
-            # The deadline is written down either way, and a record with
-            # nothing waiting on it is an automation that stays as it is until
-            # a restart. Extending a snooze is where that bites: it is already
-            # off, and the wait it had was let go to make room for this one.
             if self._until.get(entity_id) == deadline:
-                self._async_rearm(entity_id)
+                state = self._hass.states.get(entity_id)
+
+                if state is not None and state.state == STATE_ON:
+                    # Still running, so nothing was snoozed and there is
+                    # nothing to wake later. Keeping the record would have
+                    # Spook turn on an automation that somebody else turned
+                    # off in the meantime.
+                    self._async_forget(entity_id)
+                else:
+                    # Off already, from the snooze this one was extending. The
+                    # deadline is written down, and a record with nothing
+                    # waiting on it is an automation off until a restart: the
+                    # wait it had was let go to make room for this one.
+                    self._async_rearm(entity_id)
 
             raise
 
@@ -306,6 +315,11 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         down, and an automation off with nothing written down is the
         disable-nobody-remembers this whole thing exists to prevent.
         """
+        if self._stopped:
+            # A second chance is handed to a task, and unloading can happen
+            # between that task being made and it getting to run.
+            return
+
         self._async_cancel_timer(entity_id)
 
         # Marked rather than removed, so this wake-up call is not read as
@@ -464,7 +478,12 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         if (until := self._until.get(entity_id)) is None or until > dt_util.utcnow():
             return
 
-        self._hass.async_create_task(self._async_wake(entity_id, until))
+        # Handed to the loop rather than started here and now, so that
+        # unloading in this same breath is seen before anything is turned on.
+        self._hass.async_create_task(
+            self._async_wake(entity_id, until),
+            eager_start=False,
+        )
 
     @callback
     def _async_cancel_timer(self, entity_id: str) -> None:

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_ON,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -318,6 +319,18 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         finally:
             self._waking.discard(entity_id)
 
+        state = self._hass.states.get(entity_id)
+        if state is None or state.state != STATE_ON:
+            # Entity services quietly pass over whatever is unavailable and
+            # come back as though all was well, so a wake landing in the
+            # middle of a reload turns nothing on. The record stays, and the
+            # watch below has another go once the automation is back.
+            LOGGER.debug(
+                "Spook could not wake %s, which is not there at the moment",
+                entity_id,
+            )
+            return
+
         if self._until.get(entity_id) != until:
             # Asked for again while that was happening, so the wait this woke
             # belongs to nobody and the new one stands.
@@ -364,42 +377,44 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
 
     @callback
     def _async_watch(self) -> None:
-        """Listen for anything asleep being turned on by somebody else.
+        """Listen to everything that is asleep.
 
-        Which cancels the snooze: turning it on is a clearer statement of what
-        somebody wants than a wake-up time they set earlier.
-
-        The record is dropped before this trigger's own wake-up call, so the
-        entity is no longer being watched by the time that arrives and it does
-        not cancel itself.
+        For two things. Somebody turning one on, which cancels the snooze: it
+        is a clearer statement of what they want than a wake-up time set
+        earlier. And one coming back from wherever it was, which is the second
+        chance for a wake-up call that arrived while it was away.
         """
         previous = self._unsub_watching
         self._unsub_watching = None
 
         if self._until and not self._stopped:
             self._unsub_watching = async_track_state_change_event(
-                self._hass, list(self._until), self._async_woken_by_hand
+                self._hass, list(self._until), self._async_state_changed
             )
 
         if previous is not None:
             previous()
 
     @callback
-    def _async_woken_by_hand(self, event: Event[EventStateChangedData]) -> None:
-        """Forget a snooze for an automation somebody has turned back on.
+    def _async_state_changed(self, event: Event[EventStateChangedData]) -> None:
+        """Deal with something asleep changing state.
 
         A state that is gone says nothing here: a rename takes the old one
         away as surely as a delete does, and telling those apart is what the
         registry is for.
         """
         new_state = event.data["new_state"]
-        if new_state is None or new_state.state != STATE_ON:
+        if new_state is None:
             return
 
         entity_id = event.data[ATTR_ENTITY_ID]
         if entity_id in self._waking:
-            # Spook's own wake-up call, which is not somebody changing
-            # their mind about it.
+            # Spook's own wake-up call, which is neither somebody changing
+            # their mind nor an automation coming back.
+            return
+
+        if new_state.state != STATE_ON:
+            self._async_try_again(entity_id, new_state.state)
             return
 
         if self._until.pop(entity_id, None) is None:
@@ -408,6 +423,22 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         self._async_cancel_timer(entity_id)
         self._async_watch()
         self._hass.async_create_task(self._async_save())
+
+    @callback
+    def _async_try_again(self, entity_id: str, state: str) -> None:
+        """Wake an automation that was away when its time came.
+
+        Its wake-up call found nothing to turn on and left the record alone,
+        so this is where it gets its second chance: the automation is back,
+        and it is still owed a waking.
+        """
+        if state == STATE_UNAVAILABLE:
+            return
+
+        if (until := self._until.get(entity_id)) is None or until > dt_util.utcnow():
+            return
+
+        self._hass.async_create_task(self._async_wake(entity_id, until))
 
     @callback
     def _async_cancel_timer(self, entity_id: str) -> None:

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -195,6 +195,12 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         """Sort out everything that was asleep when the lights went out."""
         now = dt_util.utcnow()
 
+        # Watched from the outset rather than only at the end, because the
+        # end is a store write and somebody turning an automation on during it
+        # would go unseen, leaving a record counting down for something that
+        # is already running.
+        self._async_watch()
+
         for entity_id, until in list(self._until.items()):
             if self._stopped:
                 # Unloaded partway through, waking one of them.

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -130,8 +130,16 @@ class Snoozing:
             )
             return
 
-        self._until[entity_id] = dt_util.utcnow() + duration
+        deadline = dt_util.utcnow() + duration
+        self._until[entity_id] = deadline
         await self._async_save()
+
+        if self._until.get(entity_id) != deadline:
+            # Somebody turned the automation on while that was saving, which
+            # cancels a snooze. Extending one already asleep is where that can
+            # happen, the automation being off and watched at the time.
+            # Turning it off now would leave it off with nothing to wake it.
+            return
 
         # Unloaded while that was saving leaves both of these refusing, and
         # the automation is still turned off below: it is written down, so the
@@ -213,10 +221,13 @@ class Snoozing:
         recall a callback already on its way. One that arrives after somebody
         asked for longer would otherwise drop the new wait and wake the
         automation at the old time.
+
+        Nor does cancelling recall one that came due in the same breath as the
+        unload, which is why the flag is worth another look here.
         """
 
         async def _wake(_now: datetime) -> None:
-            if self._until.get(entity_id) != until:
+            if self._stopped or self._until.get(entity_id) != until:
                 return
 
             self._timers.pop(entity_id, None)
@@ -255,6 +266,11 @@ class Snoozing:
             if entity_id not in self._until:
                 self._until[entity_id] = until
                 self._async_watch()
+
+                # Written down again as well: a save for some other automation
+                # may have gone by while this one was failing, and that one
+                # wrote out a register this record had already left.
+                await self._async_save()
 
             return
 

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import CoreState, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
@@ -58,6 +58,7 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         self._unsub_watching: CALLBACK_TYPE | None = None
         self._unsub_started: CALLBACK_TYPE | None = None
         self._unsub_registry: CALLBACK_TYPE | None = None
+        self._waking: set[str] = set()
         self._stopped = False
 
     async def async_start(self) -> CALLBACK_TYPE:
@@ -145,7 +146,16 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
             )
             return
 
-        deadline = dt_util.utcnow() + duration
+        try:
+            deadline = dt_util.utcnow() + duration
+        except OverflowError as err:
+            # Time periods run further than datetimes do, so a big enough
+            # number of days lands past the end of the calendar. Worked out
+            # here rather than at the door, because the answer depends on what
+            # time it is by the time the snooze actually happens.
+            msg = f"Cannot snooze {entity_id} until a time that does not exist"
+            raise ServiceValidationError(msg) from err
+
         self._until[entity_id] = deadline
         await self._async_save()
 
@@ -174,12 +184,25 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
             context=context,
         )
 
+        if self._until.get(entity_id) != deadline:
+            # Turned on by hand between the check above and that call landing,
+            # which cancels the snooze. The turning-off went through anyway,
+            # so it is taken back here: leaving it would be an automation off
+            # with nothing left to wake it.
+            await self._hass.services.async_call(
+                AUTOMATION_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+                context=context,
+            )
+            return
+
         # And only now the waiting, because a snooze short enough to come due
         # while that was happening would otherwise wake the automation before
         # this turned it off, leaving it off with nothing to wake it. A
         # deadline that has already passed by this point simply fires at once.
-        if self._until.get(entity_id) == deadline:
-            self._async_rearm(entity_id)
+        self._async_rearm(entity_id)
 
     @callback
     def async_until(self, entity_id: str) -> datetime | None:
@@ -265,14 +288,18 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
     async def _async_wake(self, entity_id: str, until: datetime) -> None:
         """Put an automation back on, its time being up.
 
-        The record goes first, so this wake-up call is not read as somebody
-        turning the automation on by hand, and comes back if turning it on
-        fails. An automation left off with nothing written down is the
+        The record stays put until the automation is actually on, and is only
+        marked as being seen to. Removing it first and putting it back on
+        failure reads the same most of the time, but not when the failure is
+        the process going away: a cancellation partway leaves nothing written
+        down, and an automation off with nothing written down is the
         disable-nobody-remembers this whole thing exists to prevent.
         """
-        self._until.pop(entity_id, None)
         self._async_cancel_timer(entity_id)
-        self._async_watch()
+
+        # Marked rather than removed, so this wake-up call is not read as
+        # somebody turning the automation on by hand.
+        self._waking.add(entity_id)
 
         try:
             await self._hass.services.async_call(
@@ -287,21 +314,18 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
                 "to try again after a restart",
                 entity_id,
             )
+            return
+        finally:
+            self._waking.discard(entity_id)
 
-            # Unless somebody asked for a fresh one while that was failing,
-            # in which case theirs is the newer word on it.
-            if entity_id not in self._until:
-                self._until[entity_id] = until
-                self._async_watch()
-
-                # Written down again as well: a save for some other automation
-                # may have gone by while this one was failing, and that one
-                # wrote out a register this record had already left.
-                await self._async_save()
-
+        if self._until.get(entity_id) != until:
+            # Asked for again while that was happening, so the wait this woke
+            # belongs to nobody and the new one stands.
             return
 
+        del self._until[entity_id]
         await self._async_save()
+        self._async_watch()
 
     @callback
     def _async_registry_changed(
@@ -373,6 +397,11 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
             return
 
         entity_id = event.data[ATTR_ENTITY_ID]
+        if entity_id in self._waking:
+            # Spook's own wake-up call, which is not somebody changing
+            # their mind about it.
+            return
+
         if self._until.pop(entity_id, None) is None:
             return
 

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import CoreState, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
     async_track_state_change_event,
@@ -26,7 +27,7 @@ from .const import DOMAIN, LOGGER
 if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
-    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.core import CALLBACK_TYPE, Context, Event, HomeAssistant
     from homeassistant.helpers.event import EventStateChangedData
 
 DATA_SNOOZING: HassKey[Snoozing] = HassKey("spook_snoozing")
@@ -92,7 +93,12 @@ class Snoozing:
             self._unsub_started()
             self._unsub_started = None
 
-    async def async_snooze(self, entity_id: str, duration: timedelta) -> None:
+    async def async_snooze(
+        self,
+        entity_id: str,
+        duration: timedelta,
+        context: Context | None = None,
+    ) -> None:
         """Turn an automation off, and arrange for it to come back on.
 
         Asking again for one already asleep moves its wake-up time, rather
@@ -128,6 +134,7 @@ class Snoozing:
             SERVICE_TURN_OFF,
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,
+            context=context,
         )
 
     @callback
@@ -156,7 +163,7 @@ class Snoozing:
                 # what they want than the snooze does.
                 self._until.pop(entity_id, None)
             elif until <= now:
-                await self._async_wake(entity_id)
+                await self._async_wake(entity_id, until)
             else:
                 self._async_rearm(entity_id)
 
@@ -176,36 +183,63 @@ class Snoozing:
             return
 
         self._timers[entity_id] = async_track_point_in_utc_time(
-            self._hass, self._async_due(entity_id), until
+            self._hass, self._async_due(entity_id, until), until
         )
 
     @callback
-    def _async_due(self, entity_id: str) -> CALLBACK_TYPE:
-        """Return the callback that wakes one automation.
+    def _async_due(self, entity_id: str, until: datetime) -> CALLBACK_TYPE:
+        """Return the callback that wakes one automation at this time.
 
-        A closure rather than a `partial` on a method, so the entity it
-        belongs to is not something the caller can get wrong.
+        Carrying the time it was set for, because cancelling a wait does not
+        recall a callback already on its way. One that arrives after somebody
+        asked for longer would otherwise drop the new wait and wake the
+        automation at the old time.
         """
 
         async def _wake(_now: datetime) -> None:
+            if self._until.get(entity_id) != until:
+                return
+
             self._timers.pop(entity_id, None)
-            await self._async_wake(entity_id)
+            await self._async_wake(entity_id, until)
 
         return _wake
 
-    async def _async_wake(self, entity_id: str) -> None:
-        """Put an automation back on, its time being up."""
+    async def _async_wake(self, entity_id: str, until: datetime) -> None:
+        """Put an automation back on, its time being up.
+
+        The record goes first, so this wake-up call is not read as somebody
+        turning the automation on by hand, and comes back if turning it on
+        fails. An automation left off with nothing written down is the
+        disable-nobody-remembers this whole thing exists to prevent.
+        """
         self._until.pop(entity_id, None)
         self._async_cancel_timer(entity_id)
-        await self._async_save()
         self._async_watch()
 
-        await self._hass.services.async_call(
-            AUTOMATION_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id},
-            blocking=True,
-        )
+        try:
+            await self._hass.services.async_call(
+                AUTOMATION_DOMAIN,
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
+        except HomeAssistantError:
+            LOGGER.exception(
+                "Spook could not wake %s and left the snooze on the books, "
+                "to try again after a restart",
+                entity_id,
+            )
+
+            # Unless somebody asked for a fresh one while that was failing,
+            # in which case theirs is the newer word on it.
+            if entity_id not in self._until:
+                self._until[entity_id] = until
+                self._async_watch()
+
+            return
+
+        await self._async_save()
 
     @callback
     def _async_watch(self) -> None:
@@ -231,9 +265,15 @@ class Snoozing:
 
     @callback
     def _async_woken_by_hand(self, event: Event[EventStateChangedData]) -> None:
-        """Forget a snooze for an automation somebody has turned back on."""
+        """Forget a snooze for an automation somebody has turned back on.
+
+        Or removed entirely. A reload only makes an automation unavailable for
+        a moment, so a state that is gone for good means the automation is, and
+        a record for something that no longer exists is dead weight in the
+        store.
+        """
         new_state = event.data["new_state"]
-        if new_state is None or new_state.state != STATE_ON:
+        if new_state is not None and new_state.state != STATE_ON:
             return
 
         entity_id = event.data[ATTR_ENTITY_ID]
@@ -266,4 +306,16 @@ def async_get_snoozing(hass: HomeAssistant) -> Snoozing:
 async def async_setup_snoozing(hass: HomeAssistant) -> CALLBACK_TYPE:
     """Start keeping track of what is asleep, and return the way to stop."""
     snoozing = hass.data[DATA_SNOOZING] = Snoozing(hass)
-    return await snoozing.async_start()
+    stop = await snoozing.async_start()
+
+    @callback
+    def _unload() -> None:
+        """Stop, and take the register with it.
+
+        Leaving a stopped register behind would hand the next thing that asks
+        one that no longer keeps time.
+        """
+        stop()
+        hass.data.pop(DATA_SNOOZING, None)
+
+    return _unload

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -177,13 +177,23 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         # automation on by hand cancels the snooze through a state event, and
         # a fresh snooze arriving before that event lands would find it still
         # written down as asleep and leave it running with a wake-up time.
-        await self._hass.services.async_call(
-            AUTOMATION_DOMAIN,
-            SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: entity_id},
-            blocking=True,
-            context=context,
-        )
+        try:
+            await self._hass.services.async_call(
+                AUTOMATION_DOMAIN,
+                SERVICE_TURN_OFF,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+                context=context,
+            )
+        except HomeAssistantError:
+            # The deadline is written down either way, and a record with
+            # nothing waiting on it is an automation that stays as it is until
+            # a restart. Extending a snooze is where that bites: it is already
+            # off, and the wait it had was let go to make room for this one.
+            if self._until.get(entity_id) == deadline:
+                self._async_rearm(entity_id)
+
+            raise
 
         if self._until.get(entity_id) != deadline:
             # Turned on by hand between the check above and that call landing,
@@ -367,22 +377,26 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
 
         if data["action"] == "remove":
             # Nothing left to wake, so the record is dead weight in the store.
-            if self._until.pop(entity_id, None) is None:
-                return
+            self._async_forget(entity_id)
+            return
 
-            self._async_cancel_timer(entity_id)
-
-        elif old_entity_id := data.get("old_entity_id"):
+        if old_entity_id := data.get("old_entity_id"):
             if (until := self._until.pop(old_entity_id, None)) is None:
                 return
 
             self._async_cancel_timer(old_entity_id)
             self._until[entity_id] = until
             self._async_rearm(entity_id)
+            self._async_watch()
+            self._hass.async_create_task(self._async_save())
 
-        else:
+    @callback
+    def _async_forget(self, entity_id: str) -> None:
+        """Drop a record, there being no automation left to wake."""
+        if self._until.pop(entity_id, None) is None:
             return
 
+        self._async_cancel_timer(entity_id)
         self._async_watch()
         self._hass.async_create_task(self._async_save())
 
@@ -410,15 +424,21 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
     def _async_state_changed(self, event: Event[EventStateChangedData]) -> None:
         """Deal with something asleep changing state.
 
-        A state that is gone says nothing here: a rename takes the old one
-        away as surely as a delete does, and telling those apart is what the
-        registry is for.
+        A state that is gone usually says nothing here: a rename takes the old
+        one away as surely as a delete does, and telling those apart is what
+        the registry is for. Usually, because a YAML automation written
+        without an `id` has no registry entry to be renamed in, and for those
+        a state gone for good is the only word there is.
         """
+        entity_id = event.data[ATTR_ENTITY_ID]
+
         new_state = event.data["new_state"]
         if new_state is None:
+            if er.async_get(self._hass).async_get(entity_id) is None:
+                self._async_forget(entity_id)
+
             return
 
-        entity_id = event.data[ATTR_ENTITY_ID]
         if entity_id in self._waking:
             # Spook's own wake-up call, which is neither somebody changing
             # their mind nor an automation coming back.
@@ -428,12 +448,7 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
             self._async_try_again(entity_id, new_state.state)
             return
 
-        if self._until.pop(entity_id, None) is None:
-            return
-
-        self._async_cancel_timer(entity_id)
-        self._async_watch()
-        self._hass.async_create_task(self._async_save())
+        self._async_forget(entity_id)
 
     @callback
     def _async_try_again(self, entity_id: str, state: str) -> None:

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -1,0 +1,269 @@
+"""Spook - Your homie. Automations that are off for a while, not off for good."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_STARTED,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
+from homeassistant.core import CoreState, callback
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time,
+    async_track_state_change_event,
+)
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+from homeassistant.util.hass_dict import HassKey
+
+from .const import DOMAIN, LOGGER
+
+if TYPE_CHECKING:
+    from datetime import datetime, timedelta
+
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.helpers.event import EventStateChangedData
+
+DATA_SNOOZING: HassKey[Snoozing] = HassKey("spook_snoozing")
+
+STORAGE_KEY = f"{DOMAIN}.snoozing"
+STORAGE_VERSION = 1
+
+
+class Snoozing:
+    """Keeps automations off until their time is up, restarts included.
+
+    An automation that is off stays off across a restart, which is the whole
+    reason this has to be written down rather than left in a timer. Home
+    Assistant coming back up with an automation still asleep and nothing left
+    to wake it is how a snooze becomes a disable nobody remembers making.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the register."""
+        self._hass = hass
+        self._store: Store[dict[str, str]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._until: dict[str, datetime] = {}
+        self._timers: dict[str, CALLBACK_TYPE] = {}
+        self._unsub_watching: CALLBACK_TYPE | None = None
+        self._unsub_started: CALLBACK_TYPE | None = None
+
+    async def async_start(self) -> CALLBACK_TYPE:
+        """Read back what was asleep, and take it from there."""
+        stored = await self._store.async_load() or {}
+        self._until = {
+            entity_id: parsed
+            for entity_id, until in stored.items()
+            if (parsed := dt_util.parse_datetime(until)) is not None
+        }
+
+        # Waking things up needs the automations to exist, and at setup they
+        # may not yet. Anything already asleep waits for Home Assistant to say
+        # it has finished starting.
+        if self._hass.state is CoreState.running:
+            await self._async_catch_up()
+        else:
+            self._unsub_started = self._hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED, self._async_started
+            )
+
+        return self.async_stop
+
+    @callback
+    def async_stop(self) -> None:
+        """Stop waiting, without waking anything.
+
+        What is asleep stays written down, so it is picked up again next time
+        rather than left off for good.
+        """
+        for entity_id in list(self._timers):
+            self._async_cancel_timer(entity_id)
+
+        if self._unsub_watching is not None:
+            self._unsub_watching()
+            self._unsub_watching = None
+
+        if self._unsub_started is not None:
+            self._unsub_started()
+            self._unsub_started = None
+
+    async def async_snooze(self, entity_id: str, duration: timedelta) -> None:
+        """Turn an automation off, and arrange for it to come back on.
+
+        Asking again for one already asleep moves its wake-up time, rather
+        than being turned away for being off: it is off because of this, and
+        asking for longer is the ordinary way to use it.
+        """
+        asleep = entity_id in self._until
+        state = self._hass.states.get(entity_id)
+
+        if not asleep and (state is None or state.state != STATE_ON):
+            # Turning it on later would be a change nobody asked for: it was
+            # off before this, and this is not the thing that put it there.
+            LOGGER.warning(
+                "Spook did not snooze %s because it is not on, "
+                "and waking it would turn it on",
+                entity_id,
+            )
+            return
+
+        self._until[entity_id] = dt_util.utcnow() + duration
+        await self._async_save()
+
+        self._async_rearm(entity_id)
+        self._async_watch()
+
+        # Turned off every time, including one already asleep. Skipping it
+        # would save nothing observable and opens a gap: somebody turning the
+        # automation on by hand cancels the snooze through a state event, and
+        # a fresh snooze arriving before that event lands would find it still
+        # written down as asleep and leave it running with a wake-up time.
+        await self._hass.services.async_call(
+            AUTOMATION_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    @callback
+    def async_until(self, entity_id: str) -> datetime | None:
+        """Return when an automation is due to wake, if it is asleep."""
+        return self._until.get(entity_id)
+
+    async def _async_started(self, _event: Event) -> None:
+        """Home Assistant has finished starting, so the automations are here."""
+        self._unsub_started = None
+        await self._async_catch_up()
+
+    async def _async_catch_up(self) -> None:
+        """Sort out everything that was asleep when the lights went out."""
+        now = dt_util.utcnow()
+
+        for entity_id, until in list(self._until.items()):
+            state = self._hass.states.get(entity_id)
+
+            if state is None:
+                # Gone while Home Assistant was down. Nothing to wake.
+                LOGGER.debug("Spook forgot a snooze for missing %s", entity_id)
+                self._until.pop(entity_id, None)
+            elif state.state == STATE_ON:
+                # Somebody turned it on in the meantime, which says more about
+                # what they want than the snooze does.
+                self._until.pop(entity_id, None)
+            elif until <= now:
+                await self._async_wake(entity_id)
+            else:
+                self._async_rearm(entity_id)
+
+        await self._async_save()
+        self._async_watch()
+
+    @callback
+    def _async_rearm(self, entity_id: str) -> None:
+        """Wait until this one is due.
+
+        In UTC, because the wait is a fixed instant and adding a duration to a
+        local time is wall-clock arithmetic: an hour out, twice a year.
+        """
+        self._async_cancel_timer(entity_id)
+
+        if (until := self._until.get(entity_id)) is None:
+            return
+
+        self._timers[entity_id] = async_track_point_in_utc_time(
+            self._hass, self._async_due(entity_id), until
+        )
+
+    @callback
+    def _async_due(self, entity_id: str) -> CALLBACK_TYPE:
+        """Return the callback that wakes one automation.
+
+        A closure rather than a `partial` on a method, so the entity it
+        belongs to is not something the caller can get wrong.
+        """
+
+        async def _wake(_now: datetime) -> None:
+            self._timers.pop(entity_id, None)
+            await self._async_wake(entity_id)
+
+        return _wake
+
+    async def _async_wake(self, entity_id: str) -> None:
+        """Put an automation back on, its time being up."""
+        self._until.pop(entity_id, None)
+        self._async_cancel_timer(entity_id)
+        await self._async_save()
+        self._async_watch()
+
+        await self._hass.services.async_call(
+            AUTOMATION_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    @callback
+    def _async_watch(self) -> None:
+        """Listen for anything asleep being turned on by somebody else.
+
+        Which cancels the snooze: turning it on is a clearer statement of what
+        somebody wants than a wake-up time they set earlier.
+
+        The record is dropped before this trigger's own wake-up call, so the
+        entity is no longer being watched by the time that arrives and it does
+        not cancel itself.
+        """
+        previous = self._unsub_watching
+        self._unsub_watching = None
+
+        if self._until:
+            self._unsub_watching = async_track_state_change_event(
+                self._hass, list(self._until), self._async_woken_by_hand
+            )
+
+        if previous is not None:
+            previous()
+
+    @callback
+    def _async_woken_by_hand(self, event: Event[EventStateChangedData]) -> None:
+        """Forget a snooze for an automation somebody has turned back on."""
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state != STATE_ON:
+            return
+
+        entity_id = event.data[ATTR_ENTITY_ID]
+        if self._until.pop(entity_id, None) is None:
+            return
+
+        self._async_cancel_timer(entity_id)
+        self._async_watch()
+        self._hass.async_create_task(self._async_save())
+
+    @callback
+    def _async_cancel_timer(self, entity_id: str) -> None:
+        """Drop the pending wait for one automation, if there is one."""
+        if (timer := self._timers.pop(entity_id, None)) is not None:
+            timer()
+
+    async def _async_save(self) -> None:
+        """Write down what is asleep."""
+        await self._store.async_save(
+            {entity_id: until.isoformat() for entity_id, until in self._until.items()}
+        )
+
+
+@callback
+def async_get_snoozing(hass: HomeAssistant) -> Snoozing:
+    """Return the shared register."""
+    return hass.data[DATA_SNOOZING]
+
+
+async def async_setup_snoozing(hass: HomeAssistant) -> CALLBACK_TYPE:
+    """Start keeping track of what is asleep, and return the way to stop."""
+    snoozing = hass.data[DATA_SNOOZING] = Snoozing(hass)
+    return await snoozing.async_start()

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -53,10 +53,20 @@ class Snoozing:
         self._timers: dict[str, CALLBACK_TYPE] = {}
         self._unsub_watching: CALLBACK_TYPE | None = None
         self._unsub_started: CALLBACK_TYPE | None = None
+        self._stopped = False
 
     async def async_start(self) -> CALLBACK_TYPE:
         """Read back what was asleep, and take it from there."""
         stored = await self._store.async_load() or {}
+
+        if self._stopped:
+            # Unloaded while the store was being read. Stopping cannot reach
+            # into a coroutine that is waiting, so anything arming something
+            # after an `await` has to look for itself. Here that is the
+            # listener below; the timers and the state watch refuse on their
+            # own.
+            return self.async_stop
+
         self._until = {
             entity_id: parsed
             for entity_id, until in stored.items()
@@ -82,6 +92,8 @@ class Snoozing:
         What is asleep stays written down, so it is picked up again next time
         rather than left off for good.
         """
+        self._stopped = True
+
         for entity_id in list(self._timers):
             self._async_cancel_timer(entity_id)
 
@@ -121,6 +133,9 @@ class Snoozing:
         self._until[entity_id] = dt_util.utcnow() + duration
         await self._async_save()
 
+        # Unloaded while that was saving leaves both of these refusing, and
+        # the automation is still turned off below: it is written down, so the
+        # next start picks it up. Only the waiting goes.
         self._async_rearm(entity_id)
         self._async_watch()
 
@@ -152,6 +167,10 @@ class Snoozing:
         now = dt_util.utcnow()
 
         for entity_id, until in list(self._until.items()):
+            if self._stopped:
+                # Unloaded partway through, waking one of them.
+                return
+
             state = self._hass.states.get(entity_id)
 
             if state is None:
@@ -179,7 +198,7 @@ class Snoozing:
         """
         self._async_cancel_timer(entity_id)
 
-        if (until := self._until.get(entity_id)) is None:
+        if self._stopped or (until := self._until.get(entity_id)) is None:
             return
 
         self._timers[entity_id] = async_track_point_in_utc_time(
@@ -255,7 +274,7 @@ class Snoozing:
         previous = self._unsub_watching
         self._unsub_watching = None
 
-        if self._until:
+        if self._until and not self._stopped:
             self._unsub_watching = async_track_state_change_event(
                 self._hass, list(self._until), self._async_woken_by_hand
             )

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -156,10 +156,9 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
             # Turning it off now would leave it off with nothing to wake it.
             return
 
-        # Unloaded while that was saving leaves both of these refusing, and
-        # the automation is still turned off below: it is written down, so the
+        # Unloaded while that was saving leaves this refusing, and the
+        # automation is still turned off below: it is written down, so the
         # next start picks it up. Only the waiting goes.
-        self._async_rearm(entity_id)
         self._async_watch()
 
         # Turned off every time, including one already asleep. Skipping it
@@ -174,6 +173,13 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
             blocking=True,
             context=context,
         )
+
+        # And only now the waiting, because a snooze short enough to come due
+        # while that was happening would otherwise wake the automation before
+        # this turned it off, leaving it off with nothing to wake it. A
+        # deadline that has already passed by this point simply fires at once.
+        if self._until.get(entity_id) == deadline:
+            self._async_rearm(entity_id)
 
     @callback
     def async_until(self, entity_id: str) -> datetime | None:

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -160,6 +160,12 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         self._until[entity_id] = deadline
         await self._async_save()
 
+        if not asleep and not self._is_on(entity_id):
+            # Turned off by somebody else while that was saving, and Spook
+            # does not wake what it did not put to sleep.
+            self._async_forget(entity_id)
+            return
+
         if self._until.get(entity_id) != deadline:
             # Somebody turned the automation on while that was saving, which
             # cancels a snooze. Extending one already asleep is where that can
@@ -187,9 +193,7 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
             )
         except HomeAssistantError:
             if self._until.get(entity_id) == deadline:
-                state = self._hass.states.get(entity_id)
-
-                if state is not None and state.state == STATE_ON:
+                if self._is_on(entity_id):
                     # Still running, so nothing was snoozed and there is
                     # nothing to wake later. Keeping the record would have
                     # Spook turn on an automation that somebody else turned
@@ -223,6 +227,12 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         # this turned it off, leaving it off with nothing to wake it. A
         # deadline that has already passed by this point simply fires at once.
         self._async_rearm(entity_id)
+
+    @callback
+    def _is_on(self, entity_id: str) -> bool:
+        """Return whether an automation is running right now."""
+        state = self._hass.states.get(entity_id)
+        return state is not None and state.state == STATE_ON
 
     @callback
     def async_until(self, entity_id: str) -> datetime | None:
@@ -315,9 +325,10 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         down, and an automation off with nothing written down is the
         disable-nobody-remembers this whole thing exists to prevent.
         """
-        if self._stopped:
-            # A second chance is handed to a task, and unloading can happen
-            # between that task being made and it getting to run.
+        if self._stopped or self._until.get(entity_id) != until:
+            # A second chance is handed to the loop, so both unloading and
+            # somebody turning the automation on can happen between that being
+            # arranged and this getting to run.
             return
 
         self._async_cancel_timer(entity_id)
@@ -343,8 +354,7 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
         finally:
             self._waking.discard(entity_id)
 
-        state = self._hass.states.get(entity_id)
-        if state is None or state.state != STATE_ON:
+        if not self._is_on(entity_id):
             # Entity services quietly pass over whatever is unavailable and
             # come back as though all was well, so a wake landing in the
             # middle of a reload turns nothing on. The record stays, and the

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
     async_track_state_change_event,
@@ -36,7 +37,10 @@ STORAGE_KEY = f"{DOMAIN}.snoozing"
 STORAGE_VERSION = 1
 
 
-class Snoozing:
+# Three of the attributes below are subscriptions, each cancelled in its own
+# way and at its own moment, so folding them into one bag would cost more than
+# the count saves.
+class Snoozing:  # pylint: disable=too-many-instance-attributes
     """Keeps automations off until their time is up, restarts included.
 
     An automation that is off stays off across a restart, which is the whole
@@ -53,6 +57,7 @@ class Snoozing:
         self._timers: dict[str, CALLBACK_TYPE] = {}
         self._unsub_watching: CALLBACK_TYPE | None = None
         self._unsub_started: CALLBACK_TYPE | None = None
+        self._unsub_registry: CALLBACK_TYPE | None = None
         self._stopped = False
 
     async def async_start(self) -> CALLBACK_TYPE:
@@ -72,6 +77,12 @@ class Snoozing:
             for entity_id, until in stored.items()
             if (parsed := dt_util.parse_datetime(until)) is not None
         }
+
+        # Records are filed under an entity ID, so the register has to hear
+        # about the ones that change or go away.
+        self._unsub_registry = self._hass.bus.async_listen(
+            er.EVENT_ENTITY_REGISTRY_UPDATED, self._async_registry_changed
+        )
 
         # Waking things up needs the automations to exist, and at setup they
         # may not yet. Anything already asleep waits for Home Assistant to say
@@ -104,6 +115,10 @@ class Snoozing:
         if self._unsub_started is not None:
             self._unsub_started()
             self._unsub_started = None
+
+        if self._unsub_registry is not None:
+            self._unsub_registry()
+            self._unsub_registry = None
 
     async def async_snooze(
         self,
@@ -277,6 +292,41 @@ class Snoozing:
         await self._async_save()
 
     @callback
+    def _async_registry_changed(
+        self,
+        event: Event[er.EventEntityRegistryUpdatedData],
+    ) -> None:
+        """Follow a renamed automation, and let go of a removed one.
+
+        The record is filed under an entity ID, and an entity ID is something
+        people change. Following it here keeps the snooze on the automation
+        rather than on the name it happened to have.
+        """
+        data = event.data
+        entity_id = data["entity_id"]
+
+        if data["action"] == "remove":
+            # Nothing left to wake, so the record is dead weight in the store.
+            if self._until.pop(entity_id, None) is None:
+                return
+
+            self._async_cancel_timer(entity_id)
+
+        elif old_entity_id := data.get("old_entity_id"):
+            if (until := self._until.pop(old_entity_id, None)) is None:
+                return
+
+            self._async_cancel_timer(old_entity_id)
+            self._until[entity_id] = until
+            self._async_rearm(entity_id)
+
+        else:
+            return
+
+        self._async_watch()
+        self._hass.async_create_task(self._async_save())
+
+    @callback
     def _async_watch(self) -> None:
         """Listen for anything asleep being turned on by somebody else.
 
@@ -302,13 +352,12 @@ class Snoozing:
     def _async_woken_by_hand(self, event: Event[EventStateChangedData]) -> None:
         """Forget a snooze for an automation somebody has turned back on.
 
-        Or removed entirely. A reload only makes an automation unavailable for
-        a moment, so a state that is gone for good means the automation is, and
-        a record for something that no longer exists is dead weight in the
-        store.
+        A state that is gone says nothing here: a rename takes the old one
+        away as surely as a delete does, and telling those apart is what the
+        registry is for.
         """
         new_state = event.data["new_state"]
-        if new_state is not None and new_state.state != STATE_ON:
+        if new_state is None or new_state.state != STATE_ON:
             return
 
         entity_id = event.data[ATTR_ENTITY_ID]

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
@@ -191,7 +192,10 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
                 blocking=True,
                 context=context,
             )
-        except HomeAssistantError:
+        except HomeAssistantError, asyncio.CancelledError:
+            # Cancelled counts here too. A script calling this can be stopped
+            # mid-call, and that is not a shutdown: Home Assistant carries on
+            # without ever coming back to pick the record up.
             if self._until.get(entity_id) == deadline:
                 if self._is_on(entity_id):
                     # Still running, so nothing was snoozed and there is

--- a/custom_components/spook/snoozing.py
+++ b/custom_components/spook/snoozing.py
@@ -332,8 +332,19 @@ class Snoozing:  # pylint: disable=too-many-instance-attributes
             return
 
         if self._until.get(entity_id) != until:
-            # Asked for again while that was happening, so the wait this woke
-            # belongs to nobody and the new one stands.
+            # Asked for again while this was waking it, so theirs is the newer
+            # word on it and the automation belongs off. It was just turned
+            # on, so that has to be put back.
+            #
+            # There being a record at all is not in doubt here: the only way
+            # to lose one mid-wake is for the automation to go, and the check
+            # above has already turned back for that.
+            await self._hass.services.async_call(
+                AUTOMATION_DOMAIN,
+                SERVICE_TURN_OFF,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=True,
+            )
             return
 
         del self._until[entity_id]

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -825,6 +825,16 @@
         }
       }
     },
+    "automation_snooze": {
+      "name": "Snooze",
+      "description": "Turns an automation off for a while, and turns it back on when the time is up.",
+      "fields": {
+        "duration": {
+          "name": "Duration",
+          "description": "How long the automation stays off. It comes back on by itself when this is up, a restart of Home Assistant in between included."
+        }
+      }
+    },
     "homeassistant_create_area": {
       "name": "Create an area",
       "description": "Creates a new area on the fly.",

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -66,7 +66,7 @@ Dynamically remove an entity from an area. _#AaaaandItIsGone_
 
 ## Automation: Snooze
 
-Turns an automation off for a while, and turns it back on when the time is up. Surviving a restart, so a snooze does not quietly become a disable. _#automation_ _#quiet_ _#temporary_
+Turns an automation off for a while, and turns it back on when the time is up. It survives a restart, so a snooze does not quietly become a disable. _#automation_ _#quiet_ _#temporary_
 
 `automation.snooze`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.snooze), [documentation](integrations/automation#snooze) 📚
 

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -64,6 +64,12 @@ Dynamically remove an entity from an area. _#AaaaandItIsGone_
 
 `homeassistant.remove_entity_from_area`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_entity_from_area), [documentation](areas#remove-an-entity-from-an-area)
 
+## Automation: Snooze
+
+Turns an automation off for a while, and turns it back on when the time is up. Surviving a restart, so a snooze does not quietly become a disable. _#automation_ _#quiet_ _#temporary_
+
+`automation.snooze`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.snooze), [documentation](integrations/automation#snooze) 📚
+
 ## Blueprint: Import Blueprint
 
 Downloads and imports an automation/script blueprint, directly from the URL you pass into this action. _#noquestionsasked_

--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -34,7 +34,83 @@ Spook does not provide any new devices or entities for this integration.
 
 ## Actions
 
-Spook does not provide action enhancements for this integration.
+Spook adds the following new actions to your Home Assistant instance:
+
+### Snooze
+
+Turns an automation off for a while, and turns it back on when the time is up.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Automation: Snooze 👻
+* - {term}`Action name`
+  - `automation.snooze`
+* - {term}`Action targets`
+  - Yes, `automation` entities
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action
+* - {term}`Developer tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.snooze)
+    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.snooze)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `duration`
+  - {term}`string <string>`
+  - Yes
+  - `01:00:00`
+```
+
+Turning an automation off is the only way to make it stop for an hour, and an automation turned off stays off: past the restart, past the weekend, until somebody notices. The usual way around that is a helper entity and a second automation to turn the first one back on, which is two moving parts for something that should be one.
+
+This is that, in one action. It survives a restart of Home Assistant, because the time it is due back is written down rather than left in a timer that dies with the process.
+
+Turning the automation back on yourself cancels the snooze. Saying so is a clearer statement of what you want than a wake-up time set earlier, so Spook takes it that way and forgets the rest.
+
+:::{seealso} Example actions in {term}`YAML`
+:class: dropdown
+
+Quiet the doorbell for an hour:
+
+```{code-block} yaml
+:linenos:
+action: automation.snooze
+target:
+  entity_id: automation.doorbell_announce
+data:
+  duration: "01:00:00"
+```
+
+Everything in the bedroom, until the morning:
+
+```{code-block} yaml
+:linenos:
+action: automation.snooze
+target:
+  area_id: bedroom
+data:
+  duration: "08:00:00"
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- An automation that is already off is left alone, and Spook says so in the log. Waking it would turn on something you turned off, which is not what snoozing asks for.
+- Snoozing one that is already asleep moves its wake-up time rather than starting a second one.
+- The automation is off while it sleeps, so anything reading its state sees exactly that. There is no third state between on and off.
+  :::
 
 ## Repairs
 

--- a/tests/ectoplasms/automation/services/__init__.py
+++ b/tests/ectoplasms/automation/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook."""

--- a/tests/ectoplasms/automation/services/test_snooze.py
+++ b/tests/ectoplasms/automation/services/test_snooze.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from homeassistant.core import CoreState
+from homeassistant.core import Context, CoreState
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 import pytest
@@ -94,6 +94,31 @@ async def test_it_snoozes_several_at_once(
 
     assert hass.states.get(SLEEPER).state == "on"
     assert hass.states.get(OTHER).state == "on"
+
+    hass.data["spook_snoozing"].async_stop()
+
+
+async def test_the_caller_travels_with_the_switching_off(
+    hass: HomeAssistant,
+) -> None:
+    """An automation watching this one switch off can still tell who asked.
+
+    Which is the business Spook's own context conditions are in, so the action
+    dropping the caller here would be an odd thing for it to do.
+    """
+    await _setup(hass)
+
+    asked = Context()
+    await hass.services.async_call(
+        "automation",
+        "snooze",
+        {"entity_id": SLEEPER, "duration": {"hours": 1}},
+        blocking=True,
+        context=asked,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).context.id == asked.id
 
     hass.data["spook_snoozing"].async_stop()
 

--- a/tests/ectoplasms/automation/services/test_snooze.py
+++ b/tests/ectoplasms/automation/services/test_snooze.py
@@ -145,6 +145,30 @@ async def test_a_snooze_of_nothing_is_refused(hass: HomeAssistant) -> None:
     hass.data["spook_snoozing"].async_stop()
 
 
+async def test_a_duration_past_the_end_of_the_calendar_is_refused(
+    hass: HomeAssistant,
+) -> None:
+    """Time periods run further than datetimes do.
+
+    So a big enough number of days lands past the end of the calendar, and
+    that is a validation error rather than an overflow thrown halfway through
+    turning an automation off.
+    """
+    await _setup(hass)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            "automation",
+            "snooze",
+            {"entity_id": SLEEPER, "duration": {"days": 999999999}},
+            blocking=True,
+        )
+
+    assert hass.states.get(SLEEPER).state == "on"
+
+    hass.data["spook_snoozing"].async_stop()
+
+
 async def test_a_duration_is_required(hass: HomeAssistant) -> None:
     """Without one there is no snooze, only an off switch."""
     await _setup(hass)

--- a/tests/ectoplasms/automation/services/test_snooze.py
+++ b/tests/ectoplasms/automation/services/test_snooze.py
@@ -1,0 +1,112 @@
+"""Tests for the automation.snooze action."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.core import CoreState
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.automation.services.snooze import SpookService
+from custom_components.spook.snoozing import async_setup_snoozing
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+SLEEPER = "automation.sleeper"
+OTHER = "automation.other"
+AN_HOUR = timedelta(hours=1)
+
+CONFIG = {
+    "automation": [
+        {
+            "id": name,
+            "alias": name.title(),
+            "triggers": [{"trigger": "state", "entity_id": "input_boolean.x"}],
+            "actions": [],
+        }
+        for name in ("sleeper", "other")
+    ]
+}
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    """Set up the automations, the register and the action."""
+    assert await async_setup_component(hass, "automation", CONFIG)
+    await hass.async_block_till_done()
+
+    hass.set_state(CoreState.running)
+    await async_setup_snoozing(hass)
+    SpookService(hass).async_register()
+    await hass.async_block_till_done()
+
+
+async def test_it_snoozes_the_targeted_automation(hass: HomeAssistant) -> None:
+    """The action is what a person or an automation actually calls."""
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "automation",
+        "snooze",
+        {"entity_id": SLEEPER, "duration": {"hours": 1}},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "off"
+    assert hass.states.get(OTHER).state == "on", "it snoozed something else too"
+
+    hass.data["spook_snoozing"].async_stop()
+
+
+async def test_it_snoozes_several_at_once(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Home Assistant expands the target, so a list is a list."""
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "automation",
+        "snooze",
+        {"entity_id": [SLEEPER, OTHER], "duration": {"hours": 1}},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "off"
+    assert hass.states.get(OTHER).state == "off"
+
+    freezer.tick(AN_HOUR + timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "on"
+    assert hass.states.get(OTHER).state == "on"
+
+    hass.data["spook_snoozing"].async_stop()
+
+
+async def test_a_duration_is_required(hass: HomeAssistant) -> None:
+    """Without one there is no snooze, only an off switch."""
+    await _setup(hass)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            "automation", "snooze", {"entity_id": SLEEPER}, blocking=True
+        )
+
+    assert hass.states.get(SLEEPER).state == "on"
+
+    hass.data["spook_snoozing"].async_stop()

--- a/tests/ectoplasms/automation/services/test_snooze.py
+++ b/tests/ectoplasms/automation/services/test_snooze.py
@@ -123,6 +123,28 @@ async def test_the_caller_travels_with_the_switching_off(
     hass.data["spook_snoozing"].async_stop()
 
 
+async def test_a_snooze_of_nothing_is_refused(hass: HomeAssistant) -> None:
+    """It would turn an automation off and straight back on, for nothing.
+
+    Anything watching that automation would see the pulse, so this is a
+    mistake worth saying out loud rather than carrying out.
+    """
+    await _setup(hass)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            "automation",
+            "snooze",
+            {"entity_id": SLEEPER, "duration": {"seconds": 0}},
+            blocking=True,
+        )
+
+    assert hass.states.get(SLEEPER).state == "on"
+    assert hass.data["spook_snoozing"].async_until(SLEEPER) is None
+
+    hass.data["spook_snoozing"].async_stop()
+
+
 async def test_a_duration_is_required(hass: HomeAssistant) -> None:
     """Without one there is no snooze, only an off switch."""
     await _setup(hass)

--- a/tests/ectoplasms/automation/services/test_snooze.py
+++ b/tests/ectoplasms/automation/services/test_snooze.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.core import Context, CoreState
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 import pytest
@@ -156,7 +157,7 @@ async def test_a_duration_past_the_end_of_the_calendar_is_refused(
     """
     await _setup(hass)
 
-    with pytest.raises(vol.Invalid):
+    with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             "automation",
             "snooze",

--- a/tests/test_ectoplasm_discovery.py
+++ b/tests/test_ectoplasm_discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -11,7 +12,10 @@ import yaml
 
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.repairs import AbstractSpookRepairBase
-from custom_components.spook.services import AbstractSpookServiceBase
+from custom_components.spook.services import (
+    AbstractSpookEntityComponentService,
+    AbstractSpookServiceBase,
+)
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -79,6 +83,37 @@ def test_repair_modules_expose_spook_repair(module_file: Path) -> None:
     assert hasattr(module, "SpookRepair")
     assert isinstance(module.SpookRepair, type)
     assert issubclass(module.SpookRepair, AbstractSpookRepairBase)
+
+
+def test_entity_component_services_wait_for_their_component() -> None:
+    """Every service on somebody else's entity component is waited for.
+
+    Registering one needs that component already set up. If it is not, the
+    service is skipped with a log line and never tried again, so the action
+    is simply missing until the next restart. Naming the domain in the
+    manifest is what makes the order certain.
+    """
+    manifest = json.loads((SPOOK_ROOT / "manifest.json").read_text())
+    waited_for = {
+        *manifest["dependencies"],
+        *manifest["after_dependencies"],
+        DOMAIN,
+    }
+
+    unwaited = set()
+    for module_file in SERVICE_MODULES:
+        service_class = _import_module(module_file).SpookService
+
+        if not issubclass(service_class, AbstractSpookEntityComponentService):
+            continue
+
+        if service_class.domain not in waited_for:
+            unwaited.add(service_class.domain)
+
+    assert not unwaited, (
+        f"Entity component services for {sorted(unwaited)}, which the manifest "
+        f"does not wait for. Spook may be set up first and skip them for good."
+    )
 
 
 def test_service_modules_have_service_descriptions() -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -26,6 +26,7 @@ from custom_components import spook
 from custom_components.spook.automation_runs import async_get_automation_runs
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.run_history import async_get_run_history
+from custom_components.spook.snoozing import DATA_SNOOZING
 from custom_components.spook.integration_linking import (
     link_sub_integrations,
     unlink_sub_integrations,
@@ -67,6 +68,23 @@ class _NoopSpookRepairManager:
 
     async def async_on_unload(self) -> None:
         """Unload no repairs."""
+
+
+class _SnoozeCheckingServiceManager:
+    """Service manager that records what was in place before it registered."""
+
+    had_snoozing: bool | None = None
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the checking service manager."""
+        self.hass = hass
+
+    async def async_setup(self) -> None:
+        """Record whether the snooze register was already there."""
+        type(self).had_snoozing = DATA_SNOOZING in self.hass.data
+
+    def async_on_unload(self) -> None:
+        """Unload no services."""
 
 
 class _RecordingSpookRepairManager:
@@ -197,6 +215,47 @@ async def test_setup_entry_starts_and_stops_the_automation_run_register(
 
     assert EVENT_AUTOMATION_TRIGGERED not in hass.bus.async_listeners()
     assert runs.async_which("a-run") is None, "kept remembering after unloading"
+
+
+async def test_setup_entry_has_the_snooze_register_before_the_actions(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the snooze register is in place before any action can be called.
+
+    `automation.snooze` reaches for it the moment somebody calls it, so
+    registering the actions first leaves a window where the action exists and
+    the register does not. That window is a real one: an automation set off by
+    Home Assistant starting can call it.
+    """
+
+    async def async_forward_no_platforms(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+    ) -> None:
+        """Forward no ectoplasm setup during the lifecycle smoke test."""
+
+    monkeypatch.setattr(spook, "PLATFORMS", [])
+    monkeypatch.setattr(spook, "link_sub_integrations", _link_sub_integrations_noop)
+    monkeypatch.setattr(spook, "async_forward_setup_entry", async_forward_no_platforms)
+    monkeypatch.setattr(spook, "SpookServiceManager", _SnoozeCheckingServiceManager)
+    monkeypatch.setattr(spook, "SpookRepairManager", _NoopSpookRepairManager)
+    monkeypatch.setattr(_SnoozeCheckingServiceManager, "had_snoozing", None)
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _SnoozeCheckingServiceManager.had_snoozing is True, (
+        "the actions were registered before the register they reach for"
+    )
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert DATA_SNOOZING not in hass.data, "the register outlived the entry"
 
 
 async def test_setup_entry_starts_and_stops_the_run_history(

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -830,6 +830,9 @@ async def test_snoozing_again_during_a_wake_survives_that_wake(
     assert snoozing.async_until(SLEEPER) == asked_for, (
         "the wake-up call was read as somebody cancelling the new snooze"
     )
+    assert hass.states.get(SLEEPER).state == "off", (
+        "the wake-up call left it running against the snooze that replaced it"
+    )
 
     snoozing.async_stop()
 

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -13,8 +13,9 @@ from unittest.mock import patch
 
 from homeassistant.components.automation import AutomationEntity
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE
-from homeassistant.core import Context, CoreState, State
+from homeassistant.core import Context, CoreState, State, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.storage import Store
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -40,7 +41,8 @@ if TYPE_CHECKING:
 
     from homeassistant.helpers import entity_registry as er
 
-    from homeassistant.core import HomeAssistant
+    from homeassistant.core import Event, HomeAssistant
+    from homeassistant.helpers.event import EventStateChangedData
 
 SLEEPER = "automation.sleeper"
 OTHER = "automation.other"
@@ -568,6 +570,64 @@ async def test_unloading_while_the_store_is_read_leaves_nothing_behind(
     assert hass.states.get(SLEEPER).state == "off", (
         "it woke an automation after Spook was unloaded"
     )
+
+
+async def test_a_snooze_shorter_than_its_own_turning_off_still_ends_on(
+    hass: HomeAssistant,
+) -> None:
+    """A wake must not overtake the disable it belongs to.
+
+    The turning-off is held open here and the snooze made shorter than it, so
+    the deadline is certain to pass while the automation is still being turned
+    off. Arming the timer before that would wake it first and disable it
+    second: off, with nothing written down.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    turning_off = asyncio.Event()
+    let_go = asyncio.Event()
+    back_on = asyncio.Event()
+    real_turn_off = AutomationEntity.async_turn_off
+
+    @callback
+    def _woken(event: Event[EventStateChangedData]) -> None:
+        new_state = event.data["new_state"]
+        if new_state is not None and new_state.state == "on":
+            back_on.set()
+
+    unsub = async_track_state_change_event(hass, [SLEEPER], _woken)
+
+    async def _held_open(self: AutomationEntity, **kwargs: object) -> None:
+        turning_off.set()
+        await let_go.wait()
+
+        await real_turn_off(self, **kwargs)
+
+    with patch.object(AutomationEntity, "async_turn_off", _held_open):
+        snoozed = hass.async_create_task(
+            snoozing.async_snooze(SLEEPER, timedelta(milliseconds=1))
+        )
+
+        async with asyncio.timeout(5):
+            await turning_off.wait()
+
+        # Well past a millisecond, so the deadline is behind us by the time
+        # the automation is actually off.
+        await asyncio.sleep(0.05)
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await snoozed
+
+    async with asyncio.timeout(5):
+        await back_on.wait()
+
+    unsub()
+
+    assert snoozing.async_until(SLEEPER) is None, "it left a wake-up time behind"
+
+    snoozing.async_stop()
 
 
 async def test_turning_it_on_while_a_longer_snooze_saves_wins(

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.storage import Store
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
+import pytest
 from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
     mock_restore_cache,
@@ -38,8 +39,6 @@ import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
 
 if TYPE_CHECKING:
     from freezegun.api import FrozenDateTimeFactory
-    import pytest
-
     from homeassistant.helpers import entity_registry as er
 
     from homeassistant.core import Event, HomeAssistant
@@ -65,6 +64,19 @@ CONFIG = {
         },
     ]
 }
+
+
+NAMELESS = {
+    "automation": [
+        {"alias": "Nameless", "triggers": [], "actions": [{"delay": 1}]},
+        {"alias": "Also nameless", "triggers": [], "actions": [{"delay": 1}]},
+    ]
+}
+
+
+def _without_the_nameless_one() -> dict:
+    """Return the same config with the first one taken out."""
+    return {"automation": NAMELESS["automation"][1:]}
 
 
 async def _automations(hass: HomeAssistant) -> None:
@@ -392,6 +404,42 @@ async def test_the_caller_is_carried_into_the_turning_off(
     snoozing.async_stop()
 
 
+async def test_an_extension_whose_turning_off_fails_still_wakes(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The deadline is written down, so something has to be waiting on it.
+
+    Extending a snooze lets go of the wait it had to make room for the new
+    one, and that new wait is only set up once the automation is off. A
+    failure in between used to leave a record with nothing waiting on it: an
+    automation off until somebody restarts Home Assistant.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    with (
+        patch.object(
+            AutomationEntity,
+            "async_turn_off",
+            side_effect=HomeAssistantError("no"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await snoozing.async_snooze(SLEEPER, AN_HOUR * 2)
+
+    assert snoozing.async_until(SLEEPER) is not None
+
+    await _pass(hass, freezer, AN_HOUR * 2 + timedelta(minutes=1))
+
+    assert hass.states.get(SLEEPER).state == "on", "nothing was waiting on it"
+    assert snoozing.async_until(SLEEPER) is None
+
+    snoozing.async_stop()
+
+
 async def test_a_wake_that_fails_keeps_the_record(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
@@ -443,6 +491,66 @@ async def test_an_automation_that_is_deleted_takes_its_snooze_with_it(
     await hass.async_block_till_done()
 
     assert snoozing.async_until(SLEEPER) is None, "the snooze outlived its automation"
+
+    snoozing.async_stop()
+
+
+async def test_an_automation_without_an_id_takes_its_snooze_with_it(
+    hass: HomeAssistant,
+) -> None:
+    """A YAML automation written without an `id` has no registry entry.
+
+    So there is no removal event to read, and a state gone for good is the
+    only word there is. Measured: deleting one of these takes its state
+    straight to nothing, where an automation with an `id` would linger as
+    unavailable.
+    """
+    assert await async_setup_component(hass, "automation", NAMELESS)
+    await hass.async_block_till_done()
+
+    snoozing = await _register(hass)
+
+    nameless = "automation.nameless"
+    await snoozing.async_snooze(nameless, AN_HOUR)
+    assert snoozing.async_until(nameless) is not None
+
+    with patch(
+        "homeassistant.config.async_hass_config_yaml",
+        return_value=_without_the_nameless_one(),
+    ):
+        await hass.services.async_call("automation", "reload", blocking=True)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(nameless) is None
+    assert snoozing.async_until(nameless) is None, (
+        "the snooze outlived the automation it was for"
+    )
+
+    snoozing.async_stop()
+
+
+async def test_a_state_that_goes_while_the_entity_stays_keeps_the_snooze(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A missing state is not proof on its own that an automation is gone.
+
+    An entity that still has its registry entry is still an automation, and
+    its snooze outlives whatever took the state away.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    until = snoozing.async_until(SLEEPER)
+
+    assert entity_registry.async_get(SLEEPER) is not None
+    hass.states.async_remove(SLEEPER)
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) == until, (
+        "it read a missing state as an automation that no longer exists"
+    )
 
     snoozing.async_stop()
 

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -864,6 +864,76 @@ async def test_an_automation_woken_once_can_still_be_woken_by_hand(
     snoozing.async_stop()
 
 
+async def test_a_wake_that_finds_nothing_there_tries_again_later(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Entity services pass over what is unavailable and say nothing about it.
+
+    So a wake-up call landing in the middle of a reload turns nothing on, and
+    dropping the record there would leave the automation off for good. It
+    keeps the record and has another go when the automation is back.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    # What a skipped entity looks like: the call comes back, nothing happened.
+    async def _skipped(_self: AutomationEntity, **_kwargs: object) -> None:
+        return
+
+    with patch.object(AutomationEntity, "async_turn_on", _skipped):
+        await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+    assert hass.states.get(SLEEPER).state == "off"
+    assert snoozing.async_until(SLEEPER) is not None, (
+        "it dropped the record for an automation it never woke"
+    )
+
+    # Away, and then back.
+    hass.states.async_set(SLEEPER, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    hass.states.async_set(SLEEPER, "off")
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "on", "it never had another go"
+    assert snoozing.async_until(SLEEPER) is None
+
+    snoozing.async_stop()
+
+
+async def test_one_that_is_away_is_left_alone_until_it_is_back(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Going unavailable is not the automation coming back.
+
+    Trying to wake it there would be the same call failing the same way, and
+    it is exactly the moment the state watch hears from most.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    async def _skipped(_self: AutomationEntity, **_kwargs: object) -> None:
+        return
+
+    with patch.object(AutomationEntity, "async_turn_on", _skipped):
+        await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+        hass.states.async_set(SLEEPER, STATE_UNAVAILABLE)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == STATE_UNAVAILABLE, (
+        "it tried to wake one that was still away"
+    )
+    assert snoozing.async_until(SLEEPER) is not None
+
+    snoozing.async_stop()
+
+
 async def test_a_wake_cancelled_partway_keeps_the_record(
     hass: HomeAssistant,
     hass_storage: dict,

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -1,0 +1,360 @@
+"""Tests for snoozing automations."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, State
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    async_fire_time_changed,
+    mock_restore_cache,
+)
+
+from custom_components.spook.snoozing import (
+    STORAGE_KEY,
+    STORAGE_VERSION,
+    Snoozing,
+    async_setup_snoozing,
+)
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+    import pytest
+
+    from homeassistant.core import HomeAssistant
+
+SLEEPER = "automation.sleeper"
+OTHER = "automation.other"
+AN_HOUR = timedelta(hours=1)
+
+CONFIG = {
+    "automation": [
+        {
+            "id": "sleeper",
+            "alias": "Sleeper",
+            "triggers": [{"trigger": "state", "entity_id": "input_boolean.x"}],
+            "actions": [],
+        },
+        {
+            "id": "other",
+            "alias": "Other",
+            "triggers": [{"trigger": "state", "entity_id": "input_boolean.x"}],
+            "actions": [],
+        },
+    ]
+}
+
+
+async def _automations(hass: HomeAssistant) -> None:
+    """Set up the automations these tests snooze."""
+    assert await async_setup_component(hass, "automation", CONFIG)
+    await hass.async_block_till_done()
+
+
+async def _register(hass: HomeAssistant) -> Snoozing:
+    """Start a register, the way the config entry does."""
+    hass.set_state(CoreState.running)
+    await async_setup_snoozing(hass)
+    return hass.data["spook_snoozing"]
+
+
+async def _pass(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, amount: timedelta
+) -> None:
+    """Let a stretch of time go by.
+
+    `freezer.tick` moves the clock, so the moment to fire at is the moment it
+    now is. Adding the same stretch again moves twice as far.
+    """
+    freezer.tick(amount)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+async def test_it_turns_the_automation_off(hass: HomeAssistant) -> None:
+    """Which is the only way to make an automation stop for a while."""
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    assert hass.states.get(SLEEPER).state == "off"
+    assert snoozing.async_until(SLEEPER) is not None
+
+    snoozing.async_stop()
+
+
+async def test_it_turns_the_automation_back_on(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """And that is the half an automation cannot do for itself."""
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    assert hass.states.get(SLEEPER).state == "off"
+
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+    assert hass.states.get(SLEEPER).state == "on"
+    assert snoozing.async_until(SLEEPER) is None
+
+    snoozing.async_stop()
+
+
+async def test_it_leaves_others_alone(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Snoozing one automation is not snoozing the house."""
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    assert hass.states.get(OTHER).state == "on"
+
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+    assert hass.states.get(OTHER).state == "on"
+
+    snoozing.async_stop()
+
+
+async def test_an_automation_already_off_is_not_snoozed(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Waking it would turn on something somebody deliberately turned off."""
+    await _automations(hass)
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": SLEEPER}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    snoozing = await _register(hass)
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    assert snoozing.async_until(SLEEPER) is None
+    assert "did not snooze" in caplog.text, "it went quiet about doing nothing"
+
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+    assert hass.states.get(SLEEPER).state == "off", "it turned on anyway"
+
+    snoozing.async_stop()
+
+
+async def test_turning_it_on_by_hand_cancels_the_snooze(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Somebody turning it on says more than a wake-up time set earlier."""
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    await hass.services.async_call(
+        "automation", "turn_on", {"entity_id": SLEEPER}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) is None, "it is still counting down"
+
+    # And it is not turned off again, nor woken a second time.
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": SLEEPER}, blocking=True
+    )
+    await hass.async_block_till_done()
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+    assert hass.states.get(SLEEPER).state == "off", "the cancelled snooze woke it"
+
+    snoozing.async_stop()
+
+
+async def test_snoozing_again_replaces_the_time(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Asking for longer means longer, not two answers."""
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    first = snoozing.async_until(SLEEPER)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR * 3)
+    second = snoozing.async_until(SLEEPER)
+    assert second > first
+
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+    assert hass.states.get(SLEEPER).state == "off", "the first wait still woke it"
+
+    await _pass(hass, freezer, AN_HOUR * 2)
+    assert hass.states.get(SLEEPER).state == "on"
+
+    snoozing.async_stop()
+
+
+async def test_it_is_written_down(hass: HomeAssistant, hass_storage: dict) -> None:
+    """Because the automation stays off across a restart and this must not."""
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    stored = hass_storage[STORAGE_KEY]
+    assert stored["version"] == STORAGE_VERSION
+    assert SLEEPER in stored["data"]
+
+    snoozing.async_stop()
+
+
+async def test_a_snooze_that_outlived_the_restart_is_picked_up(
+    hass: HomeAssistant,
+    hass_storage: dict,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Still asleep, and still owed a wake-up call."""
+    until = dt_util.utcnow() + AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {SLEEPER: until.isoformat()},
+    }
+    mock_restore_cache(hass, (State(SLEEPER, "off"),))
+    await _automations(hass)
+
+    snoozing = await _register(hass)
+    assert hass.states.get(SLEEPER).state == "off"
+
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+    assert hass.states.get(SLEEPER).state == "on", "it never woke up"
+
+    snoozing.async_stop()
+
+
+async def test_a_snooze_that_expired_while_down_wakes_at_once(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """The time passed with nobody watching, which still counts."""
+    until = dt_util.utcnow() - AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {SLEEPER: until.isoformat()},
+    }
+    mock_restore_cache(hass, (State(SLEEPER, "off"),))
+    await _automations(hass)
+
+    snoozing = await _register(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "on", "it slept through its alarm"
+    assert snoozing.async_until(SLEEPER) is None
+
+    snoozing.async_stop()
+
+
+async def test_a_snooze_for_something_turned_on_while_down_is_dropped(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """Somebody turned it on, which settles it."""
+    until = dt_util.utcnow() + AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {SLEEPER: until.isoformat()},
+    }
+    await _automations(hass)
+    assert hass.states.get(SLEEPER).state == "on"
+
+    snoozing = await _register(hass)
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) is None, "it is still counting down"
+    assert hass.states.get(SLEEPER).state == "on"
+
+    snoozing.async_stop()
+
+
+async def test_a_snooze_for_something_that_is_gone_is_dropped(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """An automation deleted while Home Assistant was down."""
+    until = dt_util.utcnow() + AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {"automation.deleted": until.isoformat()},
+    }
+    await _automations(hass)
+
+    snoozing = await _register(hass)
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until("automation.deleted") is None
+
+    snoozing.async_stop()
+
+
+async def test_it_waits_for_home_assistant_to_finish_starting(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """The automations have to exist before anything can be woken.
+
+    Set up during startup, the register holds off until Home Assistant says it
+    has finished, because turning on an automation that is not there yet does
+    nothing at all.
+    """
+    until = dt_util.utcnow() - AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {SLEEPER: until.isoformat()},
+    }
+    mock_restore_cache(hass, (State(SLEEPER, "off"),))
+
+    hass.set_state(CoreState.starting)
+    await async_setup_snoozing(hass)
+    snoozing = hass.data["spook_snoozing"]
+
+    # Nothing has happened yet: the automations are not up.
+    assert snoozing.async_until(SLEEPER) is not None
+
+    await _automations(hass)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "on", "it never caught up"
+
+    snoozing.async_stop()
+
+
+async def test_stopping_leaves_the_snooze_written_down(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """Unloading Spook is not a reason to wake everything up.
+
+    It is also not a reason to forget: the automation is still off, so the
+    record is what brings it back next time.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    snoozing.async_stop()
+
+    assert hass.states.get(SLEEPER).state == "off"
+    assert SLEEPER in hass_storage[STORAGE_KEY]["data"]

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -404,6 +404,47 @@ async def test_the_caller_is_carried_into_the_turning_off(
     snoozing.async_stop()
 
 
+async def test_a_fresh_snooze_whose_turning_off_fails_leaves_no_record(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Nothing was snoozed, so there is nothing to wake later.
+
+    Keeping the record would have Spook turn on an automation that somebody
+    else turned off in the meantime, which is the one thing it promises not
+    to do.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    with (
+        patch.object(
+            AutomationEntity,
+            "async_turn_off",
+            side_effect=HomeAssistantError("no"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    assert hass.states.get(SLEEPER).state == "on"
+    assert snoozing.async_until(SLEEPER) is None, (
+        "it wrote down a snooze for an automation it never turned off"
+    )
+
+    # Somebody turns it off themselves, and it is not Spook's to turn back on.
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": SLEEPER}, blocking=True
+    )
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+    assert hass.states.get(SLEEPER).state == "off", (
+        "it woke an automation it had not put to sleep"
+    )
+
+    snoozing.async_stop()
+
+
 async def test_an_extension_whose_turning_off_fails_still_wakes(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
@@ -1012,6 +1053,43 @@ async def test_a_wake_that_finds_nothing_there_tries_again_later(
     assert snoozing.async_until(SLEEPER) is None
 
     snoozing.async_stop()
+
+
+async def test_a_second_chance_queued_at_the_unload_does_nothing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The second chance is handed to a task, which runs a moment later.
+
+    Unloading in between has to leave that task with nothing to do, or an
+    automation gets turned on by a register nobody is running.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    until = snoozing.async_until(SLEEPER)
+
+    async def _skipped(_self: AutomationEntity, **_kwargs: object) -> None:
+        return
+
+    with patch.object(AutomationEntity, "async_turn_on", _skipped):
+        await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+    assert snoozing.async_until(SLEEPER) == until
+
+    # Back again, which queues the second chance, and gone before it runs.
+    hass.states.async_set(SLEEPER, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    hass.states.async_set(SLEEPER, "off")
+    snoozing.async_stop()
+
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "off", (
+        "it woke an automation after Spook was unloaded"
+    )
+    assert snoozing.async_until(SLEEPER) == until, "and forgot the snooze doing it"
 
 
 async def test_one_that_is_away_is_left_alone_until_it_is_back(

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import asyncio
+import contextlib
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -572,6 +573,56 @@ async def test_unloading_while_the_store_is_read_leaves_nothing_behind(
     )
 
 
+async def test_turning_it_on_while_the_snooze_turns_it_off_takes_it_back(
+    hass: HomeAssistant,
+) -> None:
+    """The turning-off can be in flight when the snooze is cancelled.
+
+    Extending a snooze checks the record before it turns the automation off,
+    and somebody can turn it on between that check and the call landing. The
+    disable then goes through against a snooze that no longer exists, so it
+    has to be taken back: an automation off with nothing to wake it is the
+    whole failure this prevents.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    turning_off = asyncio.Event()
+    let_go = asyncio.Event()
+    real_turn_off = AutomationEntity.async_turn_off
+
+    async def _held_open(self: AutomationEntity, **kwargs: object) -> None:
+        turning_off.set()
+        await let_go.wait()
+
+        await real_turn_off(self, **kwargs)
+
+    with patch.object(AutomationEntity, "async_turn_off", _held_open):
+        extending = hass.async_create_task(snoozing.async_snooze(SLEEPER, AN_HOUR * 3))
+
+        async with asyncio.timeout(5):
+            await turning_off.wait()
+
+        await hass.services.async_call(
+            "automation", "turn_on", {"entity_id": SLEEPER}, blocking=True
+        )
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await extending
+
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "on", (
+        "the disable went through against a snooze that had been cancelled"
+    )
+    assert snoozing.async_until(SLEEPER) is None
+
+    snoozing.async_stop()
+
+
 async def test_a_snooze_shorter_than_its_own_turning_off_still_ends_on(
     hass: HomeAssistant,
 ) -> None:
@@ -681,16 +732,15 @@ async def test_turning_it_on_while_a_longer_snooze_saves_wins(
     snoozing.async_stop()
 
 
-async def test_a_wake_that_fails_writes_the_record_back_down(
+async def test_a_wake_in_progress_stays_in_the_register(
     hass: HomeAssistant,
     hass_storage: dict,
 ) -> None:
-    """In memory is not enough, because somebody else may save in between.
+    """Because somebody else may write the register out while it is waking.
 
-    A snooze for another automation writes out the whole register, and by then
-    this record has already left it. Putting it back only in memory means a
-    restart loses it, and the automation is off for good: the exact thing this
-    is here to prevent.
+    A snooze for another automation saves the lot, and a record taken out
+    early would not be in what got saved. Waking is marked rather than
+    removed for exactly this.
     """
     await _automations(hass)
     snoozing = await _register(hass)
@@ -716,9 +766,11 @@ async def test_a_wake_that_fails_writes_the_record_back_down(
         async with asyncio.timeout(5):
             await waking.wait()
 
-        # Writes out a register that no longer has the one being woken in it.
         await snoozing.async_snooze(OTHER, AN_HOUR)
-        assert SLEEPER not in hass_storage[STORAGE_KEY]["data"]
+
+        assert SLEEPER in hass_storage[STORAGE_KEY]["data"], (
+            "somebody else's save wrote out a register without it"
+        )
 
         let_go.set()
 
@@ -728,9 +780,126 @@ async def test_a_wake_that_fails_writes_the_record_back_down(
     await hass.async_block_till_done()
 
     assert snoozing.async_until(SLEEPER) is not None
-    assert SLEEPER in hass_storage[STORAGE_KEY]["data"], (
-        "the record lives only in memory, so a restart would lose it"
+
+    snoozing.async_stop()
+
+
+async def test_snoozing_again_during_a_wake_survives_that_wake(
+    hass: HomeAssistant,
+) -> None:
+    """Spook's own wake-up call is not somebody changing their mind.
+
+    Asking for a fresh snooze while one is being woken leaves a new record,
+    and the turning-on that follows must not be read as a person cancelling
+    it. The mark on the entity is what tells those two apart.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    until = snoozing.async_until(SLEEPER)
+
+    waking = asyncio.Event()
+    let_go = asyncio.Event()
+    real_turn_on = AutomationEntity.async_turn_on
+
+    async def _held_open(self: AutomationEntity, **kwargs: object) -> None:
+        waking.set()
+        await let_go.wait()
+
+        await real_turn_on(self, **kwargs)
+
+    with patch.object(AutomationEntity, "async_turn_on", _held_open):
+        woken = hass.async_create_task(snoozing._async_wake(SLEEPER, until))
+
+        async with asyncio.timeout(5):
+            await waking.wait()
+
+        # Somebody wants longer, while it is being woken.
+        await snoozing.async_snooze(SLEEPER, AN_HOUR * 3)
+        asked_for = snoozing.async_until(SLEEPER)
+        assert asked_for is not None
+
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await woken
+
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) == asked_for, (
+        "the wake-up call was read as somebody cancelling the new snooze"
     )
+
+    snoozing.async_stop()
+
+
+async def test_an_automation_woken_once_can_still_be_woken_by_hand(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The mark on a waking automation has to come off again.
+
+    Left on, it would go on excusing every turning-on as Spook's own for the
+    rest of the run, and a person cancelling a later snooze would be ignored.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+    assert hass.states.get(SLEEPER).state == "on"
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    await hass.services.async_call(
+        "automation", "turn_on", {"entity_id": SLEEPER}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) is None, (
+        "it went on treating a person as itself"
+    )
+
+    snoozing.async_stop()
+
+
+async def test_a_wake_cancelled_partway_keeps_the_record(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """A shutdown can cancel a wake mid-call, and it must leave no trace.
+
+    Nothing is removed until the automation is actually on, so a cancellation
+    lands on a register that still has the record, on disk as well as in
+    memory. The next start sees to it.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    until = snoozing.async_until(SLEEPER)
+
+    waking = asyncio.Event()
+
+    async def _never_finishes(_self: AutomationEntity, **_kwargs: object) -> None:
+        waking.set()
+        await asyncio.Event().wait()
+
+    with patch.object(AutomationEntity, "async_turn_on", _never_finishes):
+        cancelled = hass.async_create_task(snoozing._async_wake(SLEEPER, until))
+
+        async with asyncio.timeout(5):
+            await waking.wait()
+
+        cancelled.cancel()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await cancelled
+
+    assert snoozing.async_until(SLEEPER) == until, "the record went with the wake"
+    assert SLEEPER in hass_storage[STORAGE_KEY]["data"]
+    assert hass.states.get(SLEEPER).state == "off"
 
     snoozing.async_stop()
 

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -762,6 +762,63 @@ async def test_a_wake_up_call_that_came_due_at_the_unload_does_nothing(
     assert snoozing.async_until(SLEEPER) == until, "and forgot the snooze on the way"
 
 
+async def test_turning_one_on_while_catching_up_cancels_its_snooze(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """Catching up ends in a store write, and somebody may act during it.
+
+    Nothing here is overdue, so no wake sets up the watch along the way, and
+    the write at the end is the whole window. Turning an automation on cancels
+    its snooze, and a start still tidying up must not be the moment that
+    stops being true.
+    """
+    later = dt_util.utcnow() + AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {SLEEPER: later.isoformat()},
+    }
+    mock_restore_cache(hass, (State(SLEEPER, "off"),))
+    await _automations(hass)
+
+    hass.set_state(CoreState.running)
+    snoozing = Snoozing(hass)
+
+    saving = asyncio.Event()
+    let_go = asyncio.Event()
+    real_save = Store.async_save
+
+    async def _held_open(self: Store, data: dict) -> None:
+        saving.set()
+        await let_go.wait()
+
+        await real_save(self, data)
+
+    with patch.object(Store, "async_save", _held_open):
+        starting = hass.async_create_task(snoozing.async_start())
+
+        async with asyncio.timeout(5):
+            await saving.wait()
+
+        # Somebody decides they want it running again.
+        await hass.services.async_call(
+            "automation", "turn_on", {"entity_id": SLEEPER}, blocking=True
+        )
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await starting
+
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) is None, (
+        "it kept counting down for one somebody had turned back on"
+    )
+    assert SLEEPER not in snoozing._timers, "and left its wake-up call armed"
+
+    snoozing.async_stop()
+
+
 async def test_unloading_partway_through_catching_up_stops_there(
     hass: HomeAssistant,
     hass_storage: dict,

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -541,6 +541,138 @@ async def test_unloading_while_the_store_is_read_leaves_nothing_behind(
     )
 
 
+async def test_turning_it_on_while_a_longer_snooze_saves_wins(
+    hass: HomeAssistant,
+) -> None:
+    """Extending a snooze is the one moment the automation is off and watched.
+
+    Turning it on there cancels the snooze, and the extension must not then
+    turn it off again: that is an automation left off with nothing written
+    down to wake it, which is the whole failure this exists to prevent.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    assert hass.states.get(SLEEPER).state == "off"
+
+    saving = asyncio.Event()
+    let_go = asyncio.Event()
+    real_save = Store.async_save
+
+    async def _held_open(self: Store, data: dict) -> None:
+        saving.set()
+        await let_go.wait()
+        await real_save(self, data)
+
+    with patch.object(Store, "async_save", _held_open):
+        extending = hass.async_create_task(snoozing.async_snooze(SLEEPER, AN_HOUR * 3))
+
+        async with asyncio.timeout(5):
+            await saving.wait()
+
+        # Not waited on any further than the call itself: the listener that
+        # cancels the snooze is a callback, so it has already run, and its own
+        # save is queued behind the one being held open here.
+        await hass.services.async_call(
+            "automation", "turn_on", {"entity_id": SLEEPER}, blocking=True
+        )
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await extending
+
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "on", (
+        "the extension turned it off again after being cancelled"
+    )
+    assert snoozing.async_until(SLEEPER) is None, "and left a wake-up time behind"
+
+    snoozing.async_stop()
+
+
+async def test_a_wake_that_fails_writes_the_record_back_down(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """In memory is not enough, because somebody else may save in between.
+
+    A snooze for another automation writes out the whole register, and by then
+    this record has already left it. Putting it back only in memory means a
+    restart loses it, and the automation is off for good: the exact thing this
+    is here to prevent.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    until = snoozing.async_until(SLEEPER)
+
+    waking = asyncio.Event()
+    let_go = asyncio.Event()
+
+    async def _refuse(_self: AutomationEntity, **_kwargs: object) -> None:
+        waking.set()
+        await let_go.wait()
+
+        msg = "no"
+        raise HomeAssistantError(msg)
+
+    with patch.object(AutomationEntity, "async_turn_on", _refuse):
+        # Driven straight rather than through the clock, so the failing wake
+        # and the snooze below genuinely overlap.
+        failing = hass.async_create_task(snoozing._async_wake(SLEEPER, until))
+
+        async with asyncio.timeout(5):
+            await waking.wait()
+
+        # Writes out a register that no longer has the one being woken in it.
+        await snoozing.async_snooze(OTHER, AN_HOUR)
+        assert SLEEPER not in hass_storage[STORAGE_KEY]["data"]
+
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await failing
+
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) is not None
+    assert SLEEPER in hass_storage[STORAGE_KEY]["data"], (
+        "the record lives only in memory, so a restart would lose it"
+    )
+
+    snoozing.async_stop()
+
+
+async def test_a_wake_up_call_that_came_due_at_the_unload_does_nothing(
+    hass: HomeAssistant,
+) -> None:
+    """Cancelling a timer does not recall a callback that already fired.
+
+    Driven straight, because a callback firing in the same breath as the
+    unload is a race, and a test that lets the two miss each other would pass
+    against exactly the leak it is named for. The snooze keeps its record, so
+    the next start sees to it.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    until = snoozing.async_until(SLEEPER)
+    already_going = snoozing._async_due(SLEEPER, until)
+
+    snoozing.async_stop()
+    await already_going(dt_util.utcnow())
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "off", (
+        "it woke an automation after Spook was unloaded"
+    )
+    assert snoozing.async_until(SLEEPER) == until, "and forgot the snooze on the way"
+
+
 async def test_unloading_partway_through_catching_up_stops_there(
     hass: HomeAssistant,
     hass_storage: dict,

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -1,13 +1,19 @@
 """Tests for snoozing automations."""
 
-# pylint: disable=wrong-import-order
+# The register's own bookkeeping is what one of these is about, and there is no
+# public way at it.
+# ruff: noqa: SLF001
+# pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
-from homeassistant.core import CoreState, State
+from homeassistant.components.automation import AutomationEntity
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE
+from homeassistant.core import Context, CoreState, State
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
@@ -29,6 +35,8 @@ import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
 if TYPE_CHECKING:
     from freezegun.api import FrozenDateTimeFactory
     import pytest
+
+    from homeassistant.helpers import entity_registry as er
 
     from homeassistant.core import HomeAssistant
 
@@ -358,3 +366,123 @@ async def test_stopping_leaves_the_snooze_written_down(
 
     assert hass.states.get(SLEEPER).state == "off"
     assert SLEEPER in hass_storage[STORAGE_KEY]["data"]
+
+
+async def test_the_caller_is_carried_into_the_turning_off(
+    hass: HomeAssistant,
+) -> None:
+    """Whoever asked for the snooze is who turned the automation off.
+
+    The action passing its caller down is pinned where the action lives; this
+    is the half underneath it.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    asked = Context()
+    await snoozing.async_snooze(SLEEPER, AN_HOUR, context=asked)
+
+    assert hass.states.get(SLEEPER).context.id == asked.id
+
+    snoozing.async_stop()
+
+
+async def test_a_wake_that_fails_keeps_the_record(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Because forgetting it is what turns a snooze into a disable.
+
+    An automation left off with nothing written down is exactly the failure
+    this whole thing exists to prevent, so the record only goes once turning
+    it on has actually worked.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    with patch.object(
+        AutomationEntity,
+        "async_turn_on",
+        side_effect=HomeAssistantError("no"),
+    ):
+        await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+    assert snoozing.async_until(SLEEPER) is not None, (
+        "the record went even though it never woke"
+    )
+    assert hass.states.get(SLEEPER).state == "off"
+    assert "could not wake" in caplog.text, "it failed quietly"
+
+    snoozing.async_stop()
+
+
+async def test_an_automation_that_is_deleted_takes_its_snooze_with_it(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Because a record for something that no longer exists is dead weight.
+
+    A reload only makes an automation unavailable for a moment, which is why
+    this waits for the state to be gone for good rather than merely away.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    assert snoozing.async_until(SLEEPER) is not None
+
+    entity_registry.async_remove(SLEEPER)
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) is None, "the snooze outlived its automation"
+
+    snoozing.async_stop()
+
+
+async def test_an_automation_that_is_merely_away_keeps_its_snooze(
+    hass: HomeAssistant,
+) -> None:
+    """A reload passes through unavailable, and must not read as a delete."""
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    until = snoozing.async_until(SLEEPER)
+
+    hass.states.async_set(SLEEPER, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) == until, "a reload cancelled the snooze"
+
+    snoozing.async_stop()
+
+
+async def test_a_stale_wake_up_call_leaves_the_new_wait_alone(
+    hass: HomeAssistant,
+) -> None:
+    """Cancelling a wait does not recall a callback already on its way.
+
+    Driven straight, because arranging for a timer to fire after it was
+    cancelled is a race. The callback is asked for at one time and then the
+    wait is moved, which is what asking for longer does.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    first = snoozing.async_until(SLEEPER)
+    stale = snoozing._async_due(SLEEPER, first)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR * 3)
+    later = snoozing.async_until(SLEEPER)
+
+    # The wait it belonged to is gone, so it has nothing to say.
+    await stale(dt_util.utcnow())
+
+    assert snoozing.async_until(SLEEPER) == later, "it dropped the newer wait"
+    assert hass.states.get(SLEEPER).state == "off", "it woke at the old time"
+
+    snoozing.async_stop()

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -491,6 +491,49 @@ async def test_a_second_chance_overtaken_by_a_person_does_nothing(
     snoozing.async_stop()
 
 
+async def test_a_snooze_cancelled_after_it_took_still_wakes(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A script calling this can be stopped mid-call, which is not a shutdown.
+
+    Home Assistant carries on and never comes back to pick the record up, so
+    an automation turned off by a cancelled snooze would stay off until a
+    restart if nothing were waiting on its deadline.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    turned_off = asyncio.Event()
+    real_turn_off = AutomationEntity.async_turn_off
+
+    async def _then_hang(self: AutomationEntity, **kwargs: object) -> None:
+        await real_turn_off(self, **kwargs)
+        turned_off.set()
+
+        await asyncio.Event().wait()
+
+    with patch.object(AutomationEntity, "async_turn_off", _then_hang):
+        snoozed = hass.async_create_task(snoozing.async_snooze(SLEEPER, AN_HOUR))
+
+        async with asyncio.timeout(5):
+            await turned_off.wait()
+
+        snoozed.cancel()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await snoozed
+
+    assert hass.states.get(SLEEPER).state == "off"
+    assert snoozing.async_until(SLEEPER) is not None
+
+    await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+    assert hass.states.get(SLEEPER).state == "on", "nothing was waiting on it"
+
+    snoozing.async_stop()
+
+
 async def test_a_fresh_snooze_whose_turning_off_fails_leaves_no_record(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -404,6 +404,93 @@ async def test_the_caller_is_carried_into_the_turning_off(
     snoozing.async_stop()
 
 
+async def test_turning_it_off_while_a_fresh_snooze_saves_gives_it_up(
+    hass: HomeAssistant,
+) -> None:
+    """Spook does not wake what it did not put to sleep.
+
+    A fresh snooze checks the automation is running before it writes anything
+    down, and somebody can turn it off during that write. The turning-off
+    below then changes nothing, and keeping the deadline would have Spook turn
+    on an automation that a person deliberately disabled.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    saving = asyncio.Event()
+    let_go = asyncio.Event()
+    real_save = Store.async_save
+
+    async def _held_open(self: Store, data: dict) -> None:
+        saving.set()
+        await let_go.wait()
+
+        await real_save(self, data)
+
+    with patch.object(Store, "async_save", _held_open):
+        snoozed = hass.async_create_task(snoozing.async_snooze(SLEEPER, AN_HOUR))
+
+        async with asyncio.timeout(5):
+            await saving.wait()
+
+        await hass.services.async_call(
+            "automation", "turn_off", {"entity_id": SLEEPER}, blocking=True
+        )
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await snoozed
+
+    await hass.async_block_till_done()
+
+    assert snoozing.async_until(SLEEPER) is None, (
+        "it claimed an automation somebody else turned off"
+    )
+
+    snoozing.async_stop()
+
+
+async def test_a_second_chance_overtaken_by_a_person_does_nothing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The second chance waits its turn, and things happen while it waits.
+
+    Somebody turning the automation on cancels the snooze, and the wake that
+    was queued before that must not go on to hand it back off.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+
+    async def _skipped(_self: AutomationEntity, **_kwargs: object) -> None:
+        return
+
+    with patch.object(AutomationEntity, "async_turn_on", _skipped):
+        await _pass(hass, freezer, AN_HOUR + timedelta(minutes=1))
+
+    assert snoozing.async_until(SLEEPER) is not None
+
+    # Back again, which queues the second chance, and a person gets there
+    # first.
+    hass.states.async_set(SLEEPER, STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    hass.states.async_set(SLEEPER, "off")
+    await hass.services.async_call(
+        "automation", "turn_on", {"entity_id": SLEEPER}, blocking=True
+    )
+
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "on", (
+        "the queued wake handed it back off against the person who wanted it on"
+    )
+    assert snoozing.async_until(SLEEPER) is None
+
+    snoozing.async_stop()
+
+
 async def test_a_fresh_snooze_whose_turning_off_fails_leaves_no_record(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
@@ -667,6 +754,9 @@ async def test_a_stale_wake_up_call_leaves_the_new_wait_alone(
 
     assert snoozing.async_until(SLEEPER) == later, "it dropped the newer wait"
     assert hass.states.get(SLEEPER).state == "off", "it woke at the old time"
+    assert SLEEPER in snoozing._timers, (
+        "it dropped the newer wait's timer, leaving nothing able to cancel it"
+    )
 
     snoozing.async_stop()
 

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import asyncio
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -14,6 +15,7 @@ from homeassistant.components.automation import AutomationEntity
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE
 from homeassistant.core import Context, CoreState, State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.storage import Store
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
@@ -486,3 +488,194 @@ async def test_a_stale_wake_up_call_leaves_the_new_wait_alone(
     assert hass.states.get(SLEEPER).state == "off", "it woke at the old time"
 
     snoozing.async_stop()
+
+
+async def test_unloading_while_the_store_is_read_leaves_nothing_behind(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """Stopping cannot reach into a coroutine that is waiting on something.
+
+    So the two are made to genuinely overlap here: the read is held open, the
+    register is stopped, and only then is the read let go. A test that awaits
+    the start first would pass against exactly the leak it is named for.
+    """
+    until = dt_util.utcnow() - AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {SLEEPER: until.isoformat()},
+    }
+    mock_restore_cache(hass, (State(SLEEPER, "off"),))
+    await _automations(hass)
+
+    hass.set_state(CoreState.running)
+    snoozing = Snoozing(hass)
+
+    reading = asyncio.Event()
+    let_go = asyncio.Event()
+    real_load = Store.async_load
+
+    async def _held_open(self: Store) -> dict | None:
+        reading.set()
+        await let_go.wait()
+        return await real_load(self)
+
+    with patch.object(Store, "async_load", _held_open):
+        starting = hass.async_create_task(snoozing.async_start())
+
+        async with asyncio.timeout(5):
+            await reading.wait()
+
+        snoozing.async_stop()
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await starting
+
+    await hass.async_block_till_done()
+
+    assert not snoozing._timers, "it armed a timer on a stopped register"
+    assert snoozing._unsub_watching is None, "it left a listener behind"
+    assert hass.states.get(SLEEPER).state == "off", (
+        "it woke an automation after Spook was unloaded"
+    )
+
+
+async def test_unloading_partway_through_catching_up_stops_there(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """Two overdue snoozes, and Spook goes while the first is being woken.
+
+    The second must stay asleep rather than be turned on by a register that
+    is no longer running. It keeps its record, so the next start sees to it.
+    """
+    until = dt_util.utcnow() - AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {SLEEPER: until.isoformat(), OTHER: until.isoformat()},
+    }
+    mock_restore_cache(hass, (State(SLEEPER, "off"), State(OTHER, "off")))
+    await _automations(hass)
+
+    hass.set_state(CoreState.running)
+    snoozing = Snoozing(hass)
+
+    waking = asyncio.Event()
+    let_go = asyncio.Event()
+    real_turn_on = AutomationEntity.async_turn_on
+
+    async def _held_open(self: AutomationEntity, **kwargs: object) -> None:
+        if self.entity_id == SLEEPER:
+            waking.set()
+            await let_go.wait()
+
+        await real_turn_on(self, **kwargs)
+
+    with patch.object(AutomationEntity, "async_turn_on", _held_open):
+        starting = hass.async_create_task(snoozing.async_start())
+
+        async with asyncio.timeout(5):
+            await waking.wait()
+
+        snoozing.async_stop()
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await starting
+
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SLEEPER).state == "on", "the one it was on never woke"
+    assert hass.states.get(OTHER).state == "off", (
+        "it kept waking automations after Spook was unloaded"
+    )
+    assert snoozing.async_until(OTHER) is not None, "and forgot the one it skipped"
+
+
+async def test_unloading_while_the_store_is_read_before_the_start(
+    hass: HomeAssistant,
+    hass_storage: dict,
+) -> None:
+    """Same overlap, with Home Assistant not up yet.
+
+    A register that is still reading its store when Spook goes would otherwise
+    sit down to wait for a start event nobody is going to unsubscribe it from.
+    """
+    until = dt_util.utcnow() + AN_HOUR
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "data": {SLEEPER: until.isoformat()},
+    }
+    await _automations(hass)
+
+    hass.set_state(CoreState.not_running)
+    snoozing = Snoozing(hass)
+
+    reading = asyncio.Event()
+    let_go = asyncio.Event()
+    real_load = Store.async_load
+
+    async def _held_open(self: Store) -> dict | None:
+        reading.set()
+        await let_go.wait()
+        return await real_load(self)
+
+    with patch.object(Store, "async_load", _held_open):
+        starting = hass.async_create_task(snoozing.async_start())
+
+        async with asyncio.timeout(5):
+            await reading.wait()
+
+        snoozing.async_stop()
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await starting
+
+    assert snoozing._unsub_started is None, "it waited for a start after unloading"
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert not snoozing._timers, "the start it waited for armed a timer"
+
+
+async def test_unloading_while_a_snooze_is_saved_still_leaves_nothing_behind(
+    hass: HomeAssistant,
+) -> None:
+    """The other side of the same thing: a call in flight when the entry goes.
+
+    The automation is still turned off, because the snooze is written down by
+    then and the next start picks it up. Only the waiting is dropped, there
+    being nobody left to do it.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    saving = asyncio.Event()
+    let_go = asyncio.Event()
+    real_save = Store.async_save
+
+    async def _held_open(self: Store, data: dict) -> None:
+        saving.set()
+        await let_go.wait()
+        await real_save(self, data)
+
+    with patch.object(Store, "async_save", _held_open):
+        snoozed = hass.async_create_task(snoozing.async_snooze(SLEEPER, AN_HOUR))
+
+        async with asyncio.timeout(5):
+            await saving.wait()
+
+        snoozing.async_stop()
+        let_go.set()
+
+        async with asyncio.timeout(5):
+            await snoozed
+
+    await hass.async_block_till_done()
+
+    assert not snoozing._timers, "it armed a timer on a stopped register"
+    assert snoozing._unsub_watching is None, "it left a listener behind"
+    assert hass.states.get(SLEEPER).state == "off", "it did not turn it off at all"

--- a/tests/test_snoozing.py
+++ b/tests/test_snoozing.py
@@ -427,8 +427,8 @@ async def test_an_automation_that_is_deleted_takes_its_snooze_with_it(
 ) -> None:
     """Because a record for something that no longer exists is dead weight.
 
-    A reload only makes an automation unavailable for a moment, which is why
-    this waits for the state to be gone for good rather than merely away.
+    Read off the registry rather than off a state going missing, which a
+    rename does just as thoroughly as a delete.
     """
     await _automations(hass)
     snoozing = await _register(hass)
@@ -440,6 +440,35 @@ async def test_an_automation_that_is_deleted_takes_its_snooze_with_it(
     await hass.async_block_till_done()
 
     assert snoozing.async_until(SLEEPER) is None, "the snooze outlived its automation"
+
+    snoozing.async_stop()
+
+
+async def test_renaming_an_automation_leaves_no_record_under_either_name(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A snooze follows the automation, not the name it had that day.
+
+    Measured rather than assumed: Home Assistant brings a renamed automation
+    back on, because the new entity ID has nothing to restore from. So the
+    snooze ends there anyway, the way any other turning-on ends one. What the
+    registry buys is that nothing stays filed under the old name, counting
+    down towards an entity nobody uses.
+    """
+    await _automations(hass)
+    snoozing = await _register(hass)
+
+    await snoozing.async_snooze(SLEEPER, AN_HOUR)
+    assert snoozing.async_until(SLEEPER) is not None
+
+    renamed = "automation.now_called_this"
+    entity_registry.async_update_entity(SLEEPER, new_entity_id=renamed)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(renamed).state == "on"
+    assert snoozing.async_until(SLEEPER) is None, "a record left under the old name"
+    assert snoozing.async_until(renamed) is None
 
     snoozing.async_stop()
 
@@ -810,4 +839,5 @@ async def test_unloading_while_a_snooze_is_saved_still_leaves_nothing_behind(
 
     assert not snoozing._timers, "it armed a timer on a stopped register"
     assert snoozing._unsub_watching is None, "it left a listener behind"
+    assert snoozing._unsub_registry is None, "it kept watching the registry"
     assert hass.states.get(SLEEPER).state == "off", "it did not turn it off at all"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Turning an automation off is the only way to make it stop for an hour, and an automation turned off stays off: past the restart, past the weekend, until somebody notices. The usual way around it is a helper entity and a second automation to turn the first one back on, which is two moving parts for something that should be one.

```yaml
action: automation.snooze
target:
  area_id: bedroom
data:
  duration: "08:00:00"
```

### Why the writing down is the feature

Measured rather than assumed: an automation restores its own on/off state across a restart. So one snoozed before a restart comes back off, with nothing left to wake it. A snooze kept only in a timer is a disable nobody remembers making.

This is Spook's first `Store`. The turn-on-for-duration action in the same phase of the plan wants the same restart-surviving machinery, so it is written to be lifted.

### The awkward cases, all decided rather than left to happen

- **Already off**: left alone, and said so in the log. Waking it would turn on something somebody deliberately turned off, which is not what snoozing asks for.
- **Already asleep**: the wake-up time moves rather than a second wait starting. Asking for longer is the ordinary way to use this, and the first version of this refused it, because the already-off guard fired on an automation that was off *because of the snooze*. My own test caught that.
- **Turned on by hand**: the snooze is forgotten. Somebody turning it on is a clearer statement of what they want than a time they set earlier.
- **Restart, time already passed**: woken at once. **Still to come**: the wait carries on. **Turned on while Home Assistant was down**: dropped.
- **Automation deleted**: the record goes with it.
- **Spook unloaded**: nothing woken, nothing forgotten. The automation is still off, and the record is what brings it back next time.

The catch-up waits for `EVENT_HOMEASSISTANT_STARTED` when Spook sets up during startup, because turning on an automation that has not been created yet does nothing at all.

### A guard that went

`turn_off` was skipped for an automation already asleep. It survived mutation testing, which is the tell: skipping it saves nothing observable, and it opens a gap. Turning the automation on by hand cancels the snooze through a state event, so a fresh snooze arriving before that event lands would find it still written down as asleep, skip the turn off, and leave it running with a wake-up time. Calling `turn_off` every time is idempotent and closes that, so the guard is gone rather than wrapped in a test.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Phase 5A.2 of the plan. `home-assistant/feature-requests` #2735 (14 votes) and #3956 ask for exactly this, and the plan's note that the timer must survive restarts turned out to be the whole design rather than a detail.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Sixteen new tests, on top of the existing suite (1228 pass).

The register, thirteen: turning it off and back on again; leaving other automations alone; refusing one already off and saying so; a manual turn-on cancelling the snooze and not waking it later; snoozing again replacing the time; the snooze being written down; a snooze that outlived a restart being picked up, one that expired while down waking at once, one whose automation was turned on while down being dropped, and one whose automation is gone being forgotten; waiting for Home Assistant to finish starting before catching up; and unloading leaving the record alone.

The action, three: snoozing what it targets and nothing else, several at once through the target expansion, and a duration being required.

Ten deliberate defects, each caught: never waking, never storing, never catching up after a restart, an expired snooze not woken, snoozing automations that were already off, ignoring a manual turn-on, re-arming without replacing the previous wait, not dropping a snooze for something turned on while down, and stopping waking everything up.

Also ran `ruff check`, `ruff format --check`, `pylint` (by exit code), and the descriptor gate. The documentation builds with the same 23 warnings as `main`.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
