### PR TITLE
Stop the Home Assistant dev canary reading core's built translations

### DIFF
--- a/tests/test_service_translations.py
+++ b/tests/test_service_translations.py
@@ -11,8 +11,8 @@ from typing import TYPE_CHECKING
 import yaml
 
 from homeassistant.helpers.translation import (
+    _async_get_translations_cache,
     async_get_cached_translations,
-    async_get_translations,
 )
 
 from custom_components.spook import services as spook_services
@@ -28,6 +28,21 @@ if TYPE_CHECKING:
 SPOOK_ROOT = Path(__file__).parents[1] / "custom_components" / "spook"
 
 
+def _given_a_cached_translation(hass: HomeAssistant, key: str, value: str) -> None:
+    """Put a Home Assistant translation string in the cache.
+
+    Written by hand rather than loaded, because a Home Assistant installed
+    from git has no built translations: those are generated when a release is
+    built, so only `strings.json` ships in the repository. Reading core's own
+    translations here would tie these tests to how Home Assistant was
+    installed rather than to what Spook does with them.
+    """
+    cache = _async_get_translations_cache(hass).cache_data.cache
+    cache.setdefault("en", {}).setdefault("services", {}).setdefault(
+        "homeassistant", {}
+    )[key] = value
+
+
 class MockSpookService(AbstractSpookService):
     """Mock Spook service."""
 
@@ -40,16 +55,6 @@ class MockSpookService(AbstractSpookService):
 
 async def test_service_translations_are_injected(hass: HomeAssistant) -> None:
     """Test service translation strings are injected for overridden services."""
-    await async_get_translations(hass, "en", "services", {"homeassistant"})
-    translations = async_get_cached_translations(
-        hass,
-        "en",
-        "services",
-        "homeassistant",
-    )
-    original_name = translations["component.homeassistant.services.restart.name"]
-    assert "👻" not in original_name
-
     service = MockSpookService(hass)
     manager = SpookServiceManager(hass)
     manager._services.add(service)
@@ -96,13 +101,12 @@ async def test_service_translation_overrides_are_restored(
     manager._services.add(service)
     manager._service_schemas = {"homeassistant_restart": {}}
 
-    await async_get_translations(hass, "en", "services", {"homeassistant"})
-    original_name = async_get_cached_translations(
+    original_name = "Restart"
+    _given_a_cached_translation(
         hass,
-        "en",
-        "services",
-        "homeassistant",
-    )["component.homeassistant.services.restart.name"]
+        "component.homeassistant.services.restart.name",
+        original_name,
+    )
 
     await manager.async_inject_service_translations()
     translations = async_get_cached_translations(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The Home Assistant dev canary has been red for at least twelve days, failing the same two tests every night. That means the one job watching for "core broke Spook" has been watching nothing, right through a stretch where a lot went in.

Neither test was about core's translations. They read `component.homeassistant.services.restart.name` purely to have something to compare against, and a Home Assistant installed from git does not have it. Built translations are generated when a release is built, so a checkout ships `strings.json` and nothing else: on the canary every integration has zero translations, in every language.

So one test no longer reads a string it never asserted anything about, and the other writes down the value it wants to see restored. That is the better test either way, since it pins what Spook does with a translation rather than what Home Assistant happens to say this month.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A canary nobody can read is worse than no canary: it looks like coverage and is not. This is the first step of a stability round before the next release, so the instrument comes back before the things it is meant to measure.

Ruled out along the way, so this is not papering over a real break:

- `homeassistant.restart` still exists in core dev, with the same fields.
- `homeassistant/helpers/translation.py` is byte-identical between 2026.9.0b1 and 2026.10.0.dev0.
- Spook's own reach into `cache_data.cache` still matches core, and both the injection and the restore already handle a missing key correctly, so nothing here can bite a user: they run releases, which do ship translations.
- This is the only test file that reads core's translations, so nothing else was quietly passing on an empty cache.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The failure was reproduced locally first, against `homeassistant==2026.10.0.dev0` installed from the dev branch exactly as the workflow does. The full suite then passes there, 1284 tests, and equally on the pinned release.

Breaking the restore path still fails `test_service_translation_overrides_are_restored`, so the rewritten test still pins the behaviour it is named for.

One trap worth writing down for anyone reproducing this: `uv pip install "homeassistant @ git+...@dev"` leaves an already-installed version alone, so the first attempt silently kept the release and everything looked fine. It needs `--reinstall-package homeassistant`.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
