### PR TITLE
Fix two repairs that had quietly stopped looking

### DIFF
--- a/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
@@ -56,6 +56,13 @@ class SpookRepair(AbstractSpookRepair):
         if (resources := self.hass.data[DOMAIN].resources) is None:
             return
 
+        # Storage-mode resources are loaded the first time somebody asks for
+        # them, which is normally the dashboard, and Spook inspects long
+        # before that. Reading them straight would see an empty collection and
+        # report nothing at all. In YAML mode this is already loaded and the
+        # call costs nothing.
+        await resources.async_get_info()
+
         to_check: dict[str, Path] = {}
         for item in resources.async_items() or []:
             if (url := item.get("url")) and (

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_ignored_zones.py
@@ -36,21 +36,21 @@ class SpookRepair(AbstractSpookRepair):
         """Trigger a inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
-        coordinators: list[ProximityDataUpdateCoordinator] | None
-        if not (coordinators := self.hass.data.get(self.domain)):
-            return  # Nothing to do, proximity is not loaded
-
         known_entity_ids = async_get_all_entity_ids(self.hass)
 
-        for entry_id, coordinator in coordinators.items():
-            self.possible_issue_ids.add(entry_id)
+        # Read off the config entries rather than `hass.data`. Proximity has
+        # kept its coordinator on the entry since it became a config entry
+        # integration, and only a loaded entry has one at all.
+        for entry in self.hass.config_entries.async_loaded_entries(self.domain):
+            coordinator: ProximityDataUpdateCoordinator = entry.runtime_data
+            self.possible_issue_ids.add(entry.entry_id)
             if unknown_entities := async_filter_known_entity_ids(
                 self.hass,
                 entity_ids=coordinator.ignored_zone_ids,
                 known_entity_ids=known_entity_ids,
             ):
                 self.async_create_issue(
-                    issue_id=entry_id,
+                    issue_id=entry.entry_id,
                     translation_placeholders={
                         "name": coordinator.name,
                         "zones": async_describe_unknown_entities(

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_tracked_entities.py
@@ -36,21 +36,21 @@ class SpookRepair(AbstractSpookRepair):
         """Trigger a inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
-        coordinators: list[ProximityDataUpdateCoordinator] | None
-        if not (coordinators := self.hass.data.get(self.domain)):
-            return  # Nothing to do, proximity is not loaded
-
         known_entity_ids = async_get_all_entity_ids(self.hass)
 
-        for entry_id, coordinator in coordinators.items():
-            self.possible_issue_ids.add(entry_id)
+        # Read off the config entries rather than `hass.data`. Proximity has
+        # kept its coordinator on the entry since it became a config entry
+        # integration, and only a loaded entry has one at all.
+        for entry in self.hass.config_entries.async_loaded_entries(self.domain):
+            coordinator: ProximityDataUpdateCoordinator = entry.runtime_data
+            self.possible_issue_ids.add(entry.entry_id)
             if unknown_entities := async_filter_known_entity_ids(
                 self.hass,
                 entity_ids=coordinator.tracked_entities,
                 known_entity_ids=known_entity_ids,
             ):
                 self.async_create_issue(
-                    issue_id=entry_id,
+                    issue_id=entry.entry_id,
                     translation_placeholders={
                         "name": coordinator.name,
                         "entities": async_describe_unknown_entities(

--- a/custom_components/spook/ectoplasms/proximity/repairs/unknown_zone.py
+++ b/custom_components/spook/ectoplasms/proximity/repairs/unknown_zone.py
@@ -34,17 +34,17 @@ class SpookRepair(AbstractSpookRepair):
         """Trigger a inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
-        coordinators: list[ProximityDataUpdateCoordinator] | None
-        if not (coordinators := self.hass.data.get(self.domain)):
-            return  # Nothing to do, proximity is not loaded
-
         known_entity_ids = async_get_all_entity_ids(self.hass)
 
-        for entry_id, coordinator in coordinators.items():
-            self.possible_issue_ids.add(entry_id)
+        # Read off the config entries rather than `hass.data`. Proximity has
+        # kept its coordinator on the entry since it became a config entry
+        # integration, and only a loaded entry has one at all.
+        for entry in self.hass.config_entries.async_loaded_entries(self.domain):
+            coordinator: ProximityDataUpdateCoordinator = entry.runtime_data
+            self.possible_issue_ids.add(entry.entry_id)
             if coordinator.proximity_zone_id not in known_entity_ids:
                 self.async_create_issue(
-                    issue_id=entry_id,
+                    issue_id=entry.entry_id,
                     translation_placeholders={
                         "name": coordinator.name,
                         "zone": coordinator.proximity_zone_id,

--- a/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+from homeassistant.components.lovelace.resources import RESOURCE_STORAGE_KEY
+from homeassistant.setup import async_setup_component
+
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.lovelace.repairs.missing_resources import (
     SpookRepair,
@@ -26,11 +29,17 @@ def _make_www_file(hass: HomeAssistant, name: str) -> None:
     (www / name).write_text("// here", encoding="utf-8")
 
 
+async def _no_loading_needed() -> dict[str, int]:
+    """Stand in for the loading the real collection does on first use."""
+    return {"resources": 0}
+
+
 def _set_resources(hass: HomeAssistant, urls: list[str]) -> None:
     """Install a fake resource collection with the given URLs."""
     hass.data["lovelace"] = SimpleNamespace(
         resources=SimpleNamespace(
             async_items=lambda: [{"url": url, "type": "module"} for url in urls],
+            async_get_info=_no_loading_needed,
         ),
     )
 
@@ -88,3 +97,33 @@ async def test_no_resource_collection_is_a_no_op(
     await SpookRepair(hass).async_inspect()
 
     assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_storage_resources_are_loaded_before_they_are_read(
+    hass: HomeAssistant,
+    hass_storage: dict,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the real resource collection is loaded rather than read empty.
+
+    Storage-mode resources load the first time somebody asks for them, which
+    is normally the dashboard, and Spook inspects long before that. Read
+    straight, the collection is empty and a missing resource goes unreported.
+    """
+    hass_storage[RESOURCE_STORAGE_KEY] = {
+        "version": 1,
+        "key": RESOURCE_STORAGE_KEY,
+        "data": {"items": [{"id": "1", "type": "module", "url": "/local/gone.js"}]},
+    }
+    assert await async_setup_component(hass, "lovelace", {})
+    await hass.async_block_till_done()
+
+    resources = hass.data["lovelace"].resources
+    assert not resources.loaded, "core changed when it loads these"
+    assert resources.async_items() == [], "and what an unloaded one holds"
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert "/local/gone.js" in issue.translation_placeholders["resources"]

--- a/tests/ectoplasms/proximity/__init__.py
+++ b/tests/ectoplasms/proximity/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook proximity ectoplasm."""

--- a/tests/ectoplasms/proximity/repairs/__init__.py
+++ b/tests/ectoplasms/proximity/repairs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook proximity repairs."""

--- a/tests/ectoplasms/proximity/repairs/conftest.py
+++ b/tests/ectoplasms/proximity/repairs/conftest.py
@@ -1,0 +1,54 @@
+"""Shared setup for the proximity repair tests."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.proximity.const import (
+    CONF_IGNORED_ZONES,
+    CONF_TOLERANCE,
+    CONF_TRACKED_ENTITIES,
+)
+from homeassistant.const import CONF_ZONE
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+
+async def async_set_up_proximity(
+    hass: HomeAssistant,
+    *,
+    zone: str = "zone.home",
+    tracked: list[str] | None = None,
+    ignored_zones: list[str] | None = None,
+) -> ConfigEntry:
+    """Set up a real proximity config entry.
+
+    Set up rather than faked, because what these repairs read is exactly the
+    thing a fake would have to guess at: proximity keeps its coordinator on
+    the config entry, and only a loaded entry has one.
+    """
+    assert await async_setup_component(hass, "zone", {})
+    await hass.async_block_till_done()
+
+    entry = MockConfigEntry(
+        domain="proximity",
+        title="Home",
+        data={
+            CONF_ZONE: zone,
+            CONF_TRACKED_ENTITIES: tracked if tracked is not None else [],
+            CONF_IGNORED_ZONES: ignored_zones if ignored_zones is not None else [],
+            CONF_TOLERANCE: 1,
+        },
+        unique_id="home",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    return entry

--- a/tests/ectoplasms/proximity/repairs/test_unknown_ignored_zones.py
+++ b/tests/ectoplasms/proximity/repairs/test_unknown_ignored_zones.py
@@ -1,0 +1,47 @@
+"""Tests for the proximity unknown ignored zones repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.proximity.repairs.unknown_ignored_zones import (
+    SpookRepair,
+)
+
+from .conftest import async_set_up_proximity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def test_unknown_ignored_zone_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test proximity ignoring a zone that no longer exists is reported."""
+    entry = await async_set_up_proximity(hass, ignored_zones=["zone.demolished"])
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN, f"proximity_unknown_ignored_zones_{entry.entry_id}"
+    )
+    assert issue
+    assert "zone.demolished" in issue.translation_placeholders["zones"]
+
+
+async def test_ignored_zones_that_exist_are_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test proximity ignoring only real zones is left alone."""
+    entry = await async_set_up_proximity(hass, ignored_zones=["zone.home"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.async_get_issue(
+        DOMAIN, f"proximity_unknown_ignored_zones_{entry.entry_id}"
+    )

--- a/tests/ectoplasms/proximity/repairs/test_unknown_tracked_entities.py
+++ b/tests/ectoplasms/proximity/repairs/test_unknown_tracked_entities.py
@@ -1,0 +1,56 @@
+"""Tests for the proximity unknown tracked entities repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.proximity.repairs.unknown_tracked_entities import (
+    SpookRepair,
+)
+
+from .conftest import async_set_up_proximity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def test_unknown_tracked_entity_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test proximity tracking something that no longer exists is reported.
+
+    People rather than device trackers, since a device tracker comes and goes
+    by nature and Spook never reports those as missing.
+    """
+    hass.states.async_set("person.here", "home")
+    entry = await async_set_up_proximity(
+        hass, tracked=["person.here", "person.moved_out"]
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN, f"proximity_unknown_tracked_entities_{entry.entry_id}"
+    )
+    assert issue
+    assert "person.moved_out" in issue.translation_placeholders["entities"]
+    assert "person.here" not in issue.translation_placeholders["entities"]
+
+
+async def test_tracked_entities_that_exist_are_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test proximity tracking only real entities is left alone."""
+    hass.states.async_set("person.here", "home")
+    entry = await async_set_up_proximity(hass, tracked=["person.here"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.async_get_issue(
+        DOMAIN, f"proximity_unknown_tracked_entities_{entry.entry_id}"
+    )

--- a/tests/ectoplasms/proximity/repairs/test_unknown_zone.py
+++ b/tests/ectoplasms/proximity/repairs/test_unknown_zone.py
@@ -1,0 +1,47 @@
+"""Tests for the proximity unknown zone repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.proximity.repairs.unknown_zone import (
+    SpookRepair,
+)
+
+from .conftest import async_set_up_proximity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+
+async def test_unknown_zone_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test proximity watching a zone that no longer exists is reported."""
+    entry = await async_set_up_proximity(hass, zone="zone.demolished")
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(
+        DOMAIN, f"proximity_unknown_zone_{entry.entry_id}"
+    )
+    assert issue
+    assert issue.translation_placeholders["zone"] == "zone.demolished"
+
+
+async def test_a_zone_that_exists_is_not_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test proximity watching a real zone is left alone."""
+    entry = await async_set_up_proximity(hass, zone="zone.home")
+
+    await SpookRepair(hass).async_inspect()
+
+    assert not issue_registry.async_get_issue(
+        DOMAIN, f"proximity_unknown_zone_{entry.entry_id}"
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Two repairs that run, find nothing, and report nothing, which looks exactly like everything being fine. Both came out of an outside review of the whole codebase as part of a stability round.

**The three proximity repairs read `hass.data["proximity"]` and give up when it is empty.** It is always empty. Proximity keeps its coordinator on the config entry, and core writes nothing to `hass.data` at all: a `grep` for it across the whole integration comes back with nothing. So a proximity watching a deleted zone, tracking somebody who no longer exists, or ignoring a zone that is gone has gone unreported for as long as proximity has been a config entry integration. They read `async_loaded_entries()` and `entry.runtime_data` now, which is where the coordinator has been all along, and only a loaded entry has one.

**Storage-mode Lovelace resources are loaded lazily**, the first time somebody asks for them, which is normally the dashboard. Spook inspects long before that and read the collection straight, so it saw an empty list and reported nothing. Both collection types expose `async_get_info()`, which loads on demand and costs nothing in YAML mode where the resources are already there.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A repair that has quietly stopped looking is worse than one that is obviously broken: nothing points at it, and the absence of issues reads as good news.

Neither of these had a test that could have caught it. Proximity had no tests at all. The Lovelace resource tests replaced core's collection with a fake that is always populated, which is precisely the thing that needed checking.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Both claims were driven rather than reasoned about. A test that sets up a real proximity config entry shows `hass.data["proximity"]` absent while the coordinator sits on the entry. A test that sets up the real Lovelace resource collection shows `loaded` false and `async_items()` empty, then both filled after the load.

Six new proximity tests, three of which fail against the old `hass.data` lookup. One new Lovelace test, which fails without the load. The full suite passes at 1291, and equally against Home Assistant 2026.10.0.dev0 from git.

One thing worth knowing for anybody reading the proximity tests: `device_tracker.` is on Spook's ignored-domains list, since those come and go by nature, so a missing device tracker can never be reported. The tests track people instead, which is the realistic case anyway.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
