### PR TITLE
Three more from the stability review

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/services/list_orphaned_database_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/list_orphaned_database_entities.py
@@ -4,18 +4,31 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 
 from homeassistant.components.homeassistant import DOMAIN
-from homeassistant.components.recorder import (
-    get_instance,
-)
+from homeassistant.components.recorder import get_instance
 from homeassistant.core import ServiceResponse, SupportsResponse
+from homeassistant.helpers.recorder import session_scope
 
 from ....services import AbstractSpookService
 
 if TYPE_CHECKING:
-    from homeassistant.core import ServiceCall
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+_RECORDED_ENTITY_IDS = text("SELECT DISTINCT(entity_id) FROM states_meta")
+
+
+def _recorded_entity_ids(hass: HomeAssistant) -> set[str]:
+    """Return every entity ID the recorder has ever written down.
+
+    Runs on the recorder's own thread, on the connection it already has.
+    Opening a second engine here would put the whole query on the event loop,
+    where a large or remote database stalls everything else in the house
+    while it reads, and would leave a connection pool behind afterwards.
+    """
+    with session_scope(hass=hass, read_only=True) as session:
+        return {row[0] for row in session.execute(_RECORDED_ENTITY_IDS)}
 
 
 class SpookService(AbstractSpookService):
@@ -27,21 +40,14 @@ class SpookService(AbstractSpookService):
 
     async def async_handle_service(self, call: ServiceCall) -> ServiceResponse:
         """Handle the service call."""
-        query = text(
-            """
-            SELECT DISTINCT(entity_id) FROM states_meta
-            """
+        recorded = await get_instance(self.hass).async_add_executor_job(
+            _recorded_entity_ids, self.hass
         )
-        db_url = get_instance(self.hass).db_url
-        engine = create_engine(db_url)
-        with engine.connect() as conn:
-            response = conn.execute(query)
-            db_list = [e[0] for e in response]
-        states_list = self.hass.states.async_entity_ids()
-        compared_list = set(db_list).difference(states_list)
+        orphaned = recorded.difference(self.hass.states.async_entity_ids())
+
         if call.return_response:
             return {
-                "count": len(compared_list),
-                "entities": list(compared_list),
+                "count": len(orphaned),
+                "entities": list(orphaned),
             }
         return None

--- a/custom_components/spook/ectoplasms/lovelace/dashboards.py
+++ b/custom_components/spook/ectoplasms/lovelace/dashboards.py
@@ -1,0 +1,50 @@
+"""Spook - Your homie. Reading dashboards without one bad one stopping the rest."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.lovelace.const import ConfigNotFound
+from homeassistant.exceptions import HomeAssistantError
+
+from ...const import LOGGER
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Mapping
+
+    from homeassistant.components.lovelace.dashboard import (
+        LovelaceStorage,
+        LovelaceYAML,
+    )
+
+type Dashboard = LovelaceStorage | LovelaceYAML
+
+
+async def async_dashboard_configs(
+    dashboards: Mapping[str, Dashboard],
+) -> AsyncIterator[tuple[Dashboard, str, dict[str, Any] | None]]:
+    """Yield every dashboard, its URL path, and its config where there is one.
+
+    A dashboard that cannot be read comes back with `None` rather than being
+    skipped, so the caller still counts it among the things it looked at and
+    can clean up issues it raised for it earlier.
+    """
+    for dashboard in dashboards.values():
+        url_path = dashboard.url_path or "lovelace"
+
+        try:
+            config = await dashboard.async_load(force=False)
+        except ConfigNotFound:
+            LOGGER.debug("Config for dashboard %s not found, skipping", url_path)
+            yield dashboard, url_path, None
+        except HomeAssistantError:
+            # A dashboard that will not load at all: broken YAML, or a secret
+            # it cannot resolve. That is a problem of its own and not one
+            # Spook reports on, but letting it out would stop every other
+            # dashboard from being checked.
+            LOGGER.warning(
+                "Spook could not read dashboard %s, so it was skipped", url_path
+            )
+            yield dashboard, url_path, None
+        else:
+            yield dashboard, url_path, config

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_area_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_area_references.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.lovelace import DOMAIN
-from homeassistant.components.lovelace.const import ConfigNotFound
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
 from homeassistant.core import callback
 from homeassistant.helpers import area_registry as ar
@@ -14,6 +13,7 @@ from ....const import LOGGER
 from ....dashboard_extraction import extract_areas_from_dashboard_node
 from ....entity_filtering import async_filter_known_area_ids, async_get_all_area_ids
 from ....repairs import AbstractSpookRepair
+from ..dashboards import async_dashboard_configs
 
 if TYPE_CHECKING:
     from homeassistant.components.lovelace.dashboard import (
@@ -49,13 +49,11 @@ class SpookRepair(AbstractSpookRepair):
 
         known_area_ids = async_get_all_area_ids(self.hass)
 
-        for dashboard in self._dashboards.values():
-            url_path = dashboard.url_path or "lovelace"
+        async for dashboard, url_path, config in async_dashboard_configs(
+            self._dashboards
+        ):
             self.possible_issue_ids.add(url_path)
-            try:
-                config = await dashboard.async_load(force=False)
-            except ConfigNotFound:
-                LOGGER.debug("Config for dashboard %s not found, skipping", url_path)
+            if config is None:
                 continue
 
             extracted_areas = self.__async_extract_areas(config)

--- a/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/unknown_entity_references.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.lovelace import DOMAIN
-from homeassistant.components.lovelace.const import ConfigNotFound
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
     EVENT_LOVELACE_UPDATED,
@@ -19,6 +18,7 @@ from ....dashboard_extraction import extract_entities_from_dashboard_node
 from ....entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
+from ..dashboards import async_dashboard_configs
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -79,13 +79,11 @@ class SpookRepair(AbstractSpookRepair):
 
         # Loop over all dashboards and check if there are unknown entities
         # referenced in the dashboards.
-        for dashboard in self._dashboards.values():
-            url_path = dashboard.url_path or "lovelace"
+        async for dashboard, url_path, config in async_dashboard_configs(
+            self._dashboards
+        ):
             self.possible_issue_ids.add(url_path)
-            try:
-                config = await dashboard.async_load(force=False)
-            except ConfigNotFound:
-                LOGGER.debug("Config for dashboard %s not found, skipping", url_path)
+            if config is None:
                 continue
 
             extracted_entities = self.__async_extract_entities(config)

--- a/custom_components/spook/reference_extraction.py
+++ b/custom_components/spook/reference_extraction.py
@@ -14,6 +14,7 @@ never to replace it.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import re
 from typing import Any
 
 from homeassistant.const import ENTITY_MATCH_ALL, ENTITY_MATCH_NONE
@@ -21,6 +22,11 @@ from homeassistant.const import ENTITY_MATCH_ALL, ENTITY_MATCH_NONE
 from .template_extraction import is_template_string
 
 # Direct reference keys, mapped to their reference type.
+# What the device registry hands out: `random_uuid_hex`, so 32 hex characters.
+# Should that ever change, this errs towards reporting less rather than
+# reporting a good automation as broken.
+_DEVICE_REGISTRY_ID = re.compile(r"[0-9a-f]{32}")
+
 _REFERENCE_KEYS = (
     "area_id",
     "device_id",
@@ -85,8 +91,20 @@ def _walk(config: Any, targets: ExtractedTargets) -> None:
         return
 
     for key in _REFERENCE_KEYS:
-        if key in config:
-            getattr(targets, f"{key}s").update(_collect_ids(config[key]))
+        if key not in config:
+            continue
+
+        ids = _collect_ids(config[key])
+
+        if key == "device_id":
+            # Some integrations take a `device_id` of their own making as
+            # plain action data, RFLink's protocol IDs among them, and those
+            # are not registry IDs and never will be. Reporting one as a
+            # missing device would be a repair about a perfectly good
+            # automation, which is worse than missing a real one.
+            ids = {value for value in ids if _DEVICE_REGISTRY_ID.fullmatch(value)}
+
+        getattr(targets, f"{key}s").update(ids)
 
     for key, value in config.items():
         if key in _EXCLUDED_KEYS:

--- a/tests/ectoplasms/homeassistant/services/test_list_orphaned_database_entities.py
+++ b/tests/ectoplasms/homeassistant/services/test_list_orphaned_database_entities.py
@@ -1,0 +1,68 @@
+"""Tests for the homeassistant.list_orphaned_database_entities action."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import SupportsResponse
+from homeassistant.helpers.recorder import DATA_INSTANCE
+
+from custom_components.spook.ectoplasms.homeassistant.services.list_orphaned_database_entities import (
+    SpookService,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_RECORDED = {"sensor.still_here", "sensor.long_gone", "sensor.also_gone"}
+
+
+def _install_fake_recorder(hass: HomeAssistant) -> list[Any]:
+    """Install a recorder whose executor hands back a fixed set of entity IDs.
+
+    Returns the list the executor records what it was asked to run in, so a
+    test can tell the query went to the recorder rather than to a database
+    connection of Spook's own making.
+    """
+    ran: list[Any] = []
+
+    async def _async_add_executor_job(func: Any, *_args: Any) -> Any:
+        ran.append(func)
+        return _RECORDED
+
+    hass.data[DATA_INSTANCE] = SimpleNamespace(
+        async_add_executor_job=_async_add_executor_job,
+    )
+    return ran
+
+
+async def test_it_lists_what_the_database_kept_and_the_house_forgot(
+    hass: HomeAssistant,
+) -> None:
+    """Recorded entity IDs with no state left are the orphans."""
+    ran = _install_fake_recorder(hass)
+    hass.states.async_set("sensor.still_here", "1")
+
+    service = SpookService(hass)
+    service.async_register()
+
+    response = await hass.services.async_call(
+        "homeassistant",
+        "list_orphaned_database_entities",
+        blocking=True,
+        return_response=True,
+    )
+
+    orphaned = {"sensor.long_gone", "sensor.also_gone"}
+    assert set(response["entities"]) == orphaned
+    assert response["count"] == len(orphaned)
+    assert ran, "the query did not go through the recorder"
+
+
+async def test_the_action_answers_only_when_asked(hass: HomeAssistant) -> None:
+    """It is a response-only action, so a call without one gets nothing back."""
+    _install_fake_recorder(hass)
+
+    assert SpookService.supports_response is SupportsResponse.ONLY

--- a/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/lovelace/repairs/test_unknown_entity_references.py
@@ -13,6 +13,9 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.lovelace.repairs.unknown_entity_references import (
     SpookRepair,
 )
@@ -20,6 +23,7 @@ import pytest
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
 
 
 @pytest.fixture(name="repair")
@@ -195,3 +199,46 @@ def test_dashboard_covers_custom_card_structures(repair: SpookRepair) -> None:
         ]
     }
     assert _extract(repair, config) == {"sensor.custom": "home"}
+
+
+async def test_one_unreadable_dashboard_does_not_stop_the_rest(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A dashboard that will not load must not take the inspection down.
+
+    Home Assistant turns a missing file into `ConfigNotFound`, but a dashboard
+    whose YAML does not parse raises straight out of the loader. Letting that
+    out left every dashboard after it unchecked, and the repair erroring on
+    every pass from then on.
+    """
+    hass.states.async_set("light.known", "on")
+
+    async def _will_not_load(**_kwargs: Any) -> dict[str, Any]:
+        msg = "mapping values are not allowed here"
+        raise HomeAssistantError(msg)
+
+    async def _loads_fine(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "views": [
+                {"path": "home", "cards": [{"type": "entity", "entity": "light.gone"}]}
+            ]
+        }
+
+    repair = SpookRepair(hass)
+    repair._dashboards = {  # noqa: SLF001
+        "broken": SimpleNamespace(
+            url_path="broken", config=None, async_load=_will_not_load
+        ),
+        "fine": SimpleNamespace(
+            url_path="fine", config={"title": "Fine"}, async_load=_loads_fine
+        ),
+    }
+
+    await repair.async_inspect()
+
+    assert issue_registry.async_get_issue(
+        DOMAIN, "lovelace_unknown_entity_references_fine"
+    ), "the dashboard after the broken one was never checked"
+    assert "could not read dashboard broken" in caplog.text

--- a/tests/test_reference_extraction.py
+++ b/tests/test_reference_extraction.py
@@ -271,3 +271,33 @@ def test_device_extraction_ignores_non_device_templates() -> None:
     config = {"value_template": "{{ states('sensor.x') }}"}
 
     assert extract_device_ids_from_config(config) == set()
+
+
+def test_a_device_id_that_is_not_a_registry_id_is_not_a_reference() -> None:
+    """Some integrations take a `device_id` of their own making.
+
+    RFLink's `send_command` wants a protocol ID like `newkaku_0000c6c2_1`,
+    which is action data rather than a reference to anything in the device
+    registry. Collecting it means telling somebody their working automation
+    points at a device that does not exist.
+    """
+    targets = extract_targets_from_config(
+        {
+            "action": "rflink.send_command",
+            "data": {"device_id": "newkaku_0000c6c2_1", "command": "on"},
+        }
+    )
+
+    assert targets.device_ids == set()
+
+
+def test_a_real_device_id_in_action_data_is_still_a_reference() -> None:
+    """Actions that target devices write them there too, and those count."""
+    targets = extract_targets_from_config(
+        {
+            "action": "light.turn_on",
+            "data": {"device_id": "abcdef0123456789abcdef0123456789"},
+        }
+    )
+
+    assert targets.device_ids == {"abcdef0123456789abcdef0123456789"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The last three findings from the stability review, all verified against the installed core rather than reasoned about.

**One bad dashboard stopped the Lovelace inspection dead.** Home Assistant turns a missing file into `ConfigNotFound`, which was handled, but a dashboard whose YAML does not parse raises `HomeAssistantError` straight out of the loader. That took every dashboard after it down with it, and put an error in the log on every inspection from then on. Both Lovelace repairs walked dashboards identically, so that walk now lives in one place and reads what it can, warning about what it cannot. A dashboard that fails to load is still counted among the things looked at, so issues raised for it earlier are still cleaned up.

**A `device_id` in action data is not always a device.** RFLink's `send_command` wants a protocol ID like `newkaku_0000c6c2_1` there, and `xiaomi_aqara.remove_device` does something similar; those are the two in core, and custom integrations may well do the same. Spook collected every `device_id` it found anywhere and reported those as missing devices, which means telling somebody their working automation is broken. Device registry IDs come from `random_uuid_hex`, so 32 hex characters, and anything that is not one is somebody else's data. Should core ever change that shape, this errs towards reporting less rather than reporting a good automation as broken.

**Listing orphaned database entities ran on the event loop.** It opened its own SQLAlchemy engine, connected, queried and iterated, all synchronously inside an async handler, so a large or remote database stalled everything else in the house while it read. The engine was never disposed either, leaving a connection pool behind on every call. It goes through the recorder now, on the connection already open and the thread meant for it, which takes the second engine out of the picture entirely.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of a stability round before the next release, alongside #1496 and #1497.

The `device_id` one is the worst of the three by some distance. A repair that misses something is a shame; a repair that tells somebody their perfectly good automation references a deleted device is the thing this project cannot afford to get wrong.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Full suite green at 1290, and equally against Home Assistant 2026.10.0.dev0 from git.

Each fix has a test that fails when the fix is undone:

- A broken dashboard next to a good one, where the good one still has to be checked and the log has to say which one could not be read.
- An RFLink-shaped `device_id` in action data collecting nothing, while a real registry ID in the same position still counts.
- The query going through the recorder's executor rather than a connection of Spook's own.

`list_orphaned_database_entities` had no test at all before this; it has two now. The existing reference extraction tests already used real 32-character device IDs, so nothing had to be adjusted there.

Pylint is what pushed the shared dashboard walk into its own module: after the second `except` the two repairs were similar enough to trip the duplication check, and it was right.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
