### PR TITLE
Four from the second stability review

### DIFF
--- a/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
+++ b/custom_components/spook/ectoplasms/automation/repairs/unknown_entity_references.py
@@ -16,6 +16,7 @@ from ....action_extraction import (
 from ....entity_filtering import async_get_all_entity_ids, async_get_all_services
 from ....repairs import AbstractSpookEntityComponentUnknownReferencesRepair
 from ....template_extraction import (
+    KNOWN_DOMAINS,
     async_extract_entities_from_config,
     async_filter_known_entity_ids_with_templates,
 )
@@ -118,6 +119,10 @@ async def _entities_from_reference_fields(
     return entities
 
 
+# Where an event trigger keeps what it matches on, rather than what it needs.
+_EVENT_PAYLOAD_KEYS = frozenset({"event_data", "event_data_template"})
+
+
 async def extract_entities_from_trigger_config(
     hass: HomeAssistant,
     config: dict[str, Any] | list,
@@ -144,14 +149,49 @@ async def extract_entities_from_trigger_config(
 
     entities.update(await _entities_from_reference_fields(hass, config, known_services))
 
+    payload_keys = _payload_keys_to_leave_alone(config)
+
     # Extract from nested configs
-    for value in config.values():
+    for key, value in config.items():
+        if key in payload_keys:
+            continue
+
         if isinstance(value, (dict, list)):
             entities.update(
                 await extract_entities_from_trigger_config(hass, value, known_services)
             )
 
     return entities
+
+
+def _payload_keys_to_leave_alone(config: dict[str, Any]) -> frozenset[str]:
+    """Return the event payload keys that hold data rather than references.
+
+    An `entity_id` inside `event_data` is a reference when the event comes
+    from an integration that means it that way, `timer.finished` being the
+    usual one. On somebody's own event it is whatever the sender put there,
+    and reporting that as a missing entity is a repair about an automation
+    that works perfectly well.
+
+    Told apart by the event type: one named after a domain comes from that
+    integration, anything else is somebody's own.
+    """
+    event_types = config.get("event_type")
+    if event_types is None:
+        return frozenset()
+
+    if isinstance(event_types, str):
+        event_types = [event_types]
+
+    for event_type in event_types:
+        if not isinstance(event_type, str):
+            continue
+
+        domain, dot, _ = event_type.partition(".")
+        if dot and domain in KNOWN_DOMAINS:
+            return frozenset()
+
+    return _EVENT_PAYLOAD_KEYS
 
 
 def extract_event_types_from_trigger_config(config: dict[str, Any] | list) -> set[str]:

--- a/custom_components/spook/ectoplasms/homeassistant/labels.py
+++ b/custom_components/spook/ectoplasms/homeassistant/labels.py
@@ -1,0 +1,30 @@
+"""Spook - Your homie. Shared checks for the label actions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import label_registry as lr
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from homeassistant.core import HomeAssistant
+
+
+@callback
+def async_check_labels_exist(hass: HomeAssistant, label_ids: Iterable[str]) -> None:
+    """Raise unless every one of these labels exists.
+
+    Saying so beats doing nothing quietly: a typo in a label would otherwise
+    come back as a successful call that changed nothing, and the automation
+    that made it would carry on as though it had worked.
+    """
+    label_registry = lr.async_get(hass)
+
+    for label_id in label_ids:
+        if not label_registry.async_get_label(label_id):
+            msg = f"Label {label_id} not found"
+            raise HomeAssistantError(msg)

--- a/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_area.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_area.py
@@ -11,10 +11,10 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     area_registry as ar,
     config_validation as cv,
-    label_registry as lr,
 )
 
 from ....services import AbstractSpookAdminService
+from ..labels import async_check_labels_exist
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -32,15 +32,14 @@ class SpookService(AbstractSpookAdminService):
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
-        label_registry = lr.async_get(self.hass)
-        for label_id in call.data["label_id"]:
-            if not label_registry.async_get_label(label_id):
-                msg = f"Label {label_id} not found"
-                raise HomeAssistantError(msg)
+        async_check_labels_exist(self.hass, call.data["label_id"])
 
         area_registry = ar.async_get(self.hass)
         for area_id in call.data["area_id"]:
-            if area_entry := area_registry.async_get_area(area_id):
-                labels = area_entry.labels.copy()
-                labels.update(call.data["label_id"])
-                area_registry.async_update(area_id, labels=labels)
+            if (area_entry := area_registry.async_get_area(area_id)) is None:
+                msg = f"Area {area_id} not found"
+                raise HomeAssistantError(msg)
+
+            labels = area_entry.labels.copy()
+            labels.update(call.data["label_id"])
+            area_registry.async_update(area_id, labels=labels)

--- a/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_device.py
@@ -11,11 +11,11 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
-    label_registry as lr,
 )
 
 from ....core_compat import async_update_any_device
 from ....services import AbstractSpookAdminService
+from ..labels import async_check_labels_exist
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -33,15 +33,14 @@ class SpookService(AbstractSpookAdminService):
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
-        label_registry = lr.async_get(self.hass)
-        for label_id in call.data["label_id"]:
-            if not label_registry.async_get_label(label_id):
-                msg = f"Label {label_id} not found"
-                raise HomeAssistantError(msg)
+        async_check_labels_exist(self.hass, call.data["label_id"])
 
         device_registry = dr.async_get(self.hass)
         for device_id in call.data["device_id"]:
-            if device_entry := device_registry.async_get(device_id):
-                labels = device_entry.labels.copy()
-                labels.update(call.data["label_id"])
-                async_update_any_device(device_registry, device_id, labels=labels)
+            if (device_entry := device_registry.async_get(device_id)) is None:
+                msg = f"Device {device_id} not found"
+                raise HomeAssistantError(msg)
+
+            labels = device_entry.labels.copy()
+            labels.update(call.data["label_id"])
+            async_update_any_device(device_registry, device_id, labels=labels)

--- a/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_entity.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/add_label_to_entity.py
@@ -11,10 +11,10 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
     entity_registry as er,
-    label_registry as lr,
 )
 
 from ....services import AbstractSpookAdminService
+from ..labels import async_check_labels_exist
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -32,15 +32,14 @@ class SpookService(AbstractSpookAdminService):
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
-        label_registry = lr.async_get(self.hass)
-        for label_id in call.data["label_id"]:
-            if not label_registry.async_get_label(label_id):
-                msg = f"Label {label_id} not found"
-                raise HomeAssistantError(msg)
+        async_check_labels_exist(self.hass, call.data["label_id"])
 
         entity_registry = er.async_get(self.hass)
         for entity_id in call.data["entity_id"]:
-            if entity_entry := entity_registry.async_get(entity_id):
-                labels = entity_entry.labels.copy()
-                labels.update(call.data["label_id"])
-                entity_registry.async_update_entity(entity_id, labels=labels)
+            if (entity_entry := entity_registry.async_get(entity_id)) is None:
+                msg = f"Entity {entity_id} not found"
+                raise HomeAssistantError(msg)
+
+            labels = entity_entry.labels.copy()
+            labels.update(call.data["label_id"])
+            entity_registry.async_update_entity(entity_id, labels=labels)

--- a/custom_components/spook/ectoplasms/homeassistant/services/remove_label_from_area.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/remove_label_from_area.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.components.homeassistant import DOMAIN
-from homeassistant.helpers import area_registry as ar, config_validation as cv
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import (
+    area_registry as ar,
+    config_validation as cv,
+)
 
 from ....services import AbstractSpookAdminService
+from ..labels import async_check_labels_exist
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -27,9 +32,14 @@ class SpookService(AbstractSpookAdminService):
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
+        async_check_labels_exist(self.hass, call.data["label_id"])
+
         area_registry = ar.async_get(self.hass)
         for area_id in call.data["area_id"]:
-            if area_entry := area_registry.async_get_area(area_id):
-                labels = area_entry.labels.copy()
-                labels.difference_update(call.data["label_id"])
-                area_registry.async_update(area_id, labels=labels)
+            if (area_entry := area_registry.async_get_area(area_id)) is None:
+                msg = f"Area {area_id} not found"
+                raise HomeAssistantError(msg)
+
+            labels = area_entry.labels.copy()
+            labels.difference_update(call.data["label_id"])
+            area_registry.async_update(area_id, labels=labels)

--- a/custom_components/spook/ectoplasms/homeassistant/services/remove_label_from_device.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/remove_label_from_device.py
@@ -7,10 +7,15 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.components.homeassistant import DOMAIN
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+)
 
 from ....core_compat import async_update_any_device
 from ....services import AbstractSpookAdminService
+from ..labels import async_check_labels_exist
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -28,9 +33,14 @@ class SpookService(AbstractSpookAdminService):
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
+        async_check_labels_exist(self.hass, call.data["label_id"])
+
         device_registry = dr.async_get(self.hass)
         for device_id in call.data["device_id"]:
-            if device_entry := device_registry.async_get(device_id):
-                labels = device_entry.labels.copy()
-                labels.difference_update(call.data["label_id"])
-                async_update_any_device(device_registry, device_id, labels=labels)
+            if (device_entry := device_registry.async_get(device_id)) is None:
+                msg = f"Device {device_id} not found"
+                raise HomeAssistantError(msg)
+
+            labels = device_entry.labels.copy()
+            labels.difference_update(call.data["label_id"])
+            async_update_any_device(device_registry, device_id, labels=labels)

--- a/custom_components/spook/ectoplasms/homeassistant/services/remove_label_from_entity.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/remove_label_from_entity.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.components.homeassistant import DOMAIN
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import (
+    config_validation as cv,
+    entity_registry as er,
+)
 
 from ....services import AbstractSpookAdminService
+from ..labels import async_check_labels_exist
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
@@ -27,9 +32,14 @@ class SpookService(AbstractSpookAdminService):
 
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
+        async_check_labels_exist(self.hass, call.data["label_id"])
+
         entity_registry = er.async_get(self.hass)
         for entity_id in call.data["entity_id"]:
-            if entity_entry := entity_registry.async_get(entity_id):
-                labels = entity_entry.labels.copy()
-                labels.difference_update(call.data["label_id"])
-                entity_registry.async_update_entity(entity_id, labels=labels)
+            if (entity_entry := entity_registry.async_get(entity_id)) is None:
+                msg = f"Entity {entity_id} not found"
+                raise HomeAssistantError(msg)
+
+            labels = entity_entry.labels.copy()
+            labels.difference_update(call.data["label_id"])
+            entity_registry.async_update_entity(entity_id, labels=labels)

--- a/custom_components/spook/ectoplasms/spook/triggers/sequence.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/sequence.py
@@ -363,6 +363,14 @@ class SpookTrigger(Trigger):
         shaped: ConfigType = _TRIGGER_SCHEMA(config)
         options = shaped[CONF_OPTIONS]
 
+        timeout = options.get(CONF_TIMEOUT)
+        if timeout is not None and timeout.total_seconds() <= 0:
+            msg = (
+                "A sequence with no time to finish in runs out the moment it "
+                "starts, so it never gets past its first step."
+            )
+            raise vol.Invalid(msg)
+
         if len(options[CONF_STEPS]) < _MINIMUM_STEPS:
             msg = (
                 f"A sequence needs at least {_MINIMUM_STEPS} steps to be a "

--- a/custom_components/spook/services.py
+++ b/custom_components/spook/services.py
@@ -103,6 +103,7 @@ class AbstractSpookService(AbstractSpookServiceBase):
                 self.service,
                 self.domain,
             )
+            return
 
         LOGGER.debug(
             "Registering Spook service: %s.%s",

--- a/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
+++ b/tests/ectoplasms/automation/repairs/test_unknown_entity_references.py
@@ -749,3 +749,38 @@ async def test_the_action_walker_filters_service_names_without_being_told(
     )
 
     assert entities == {"input_boolean.gate"}, "the service name was not filtered out"
+
+
+async def test_a_custom_event_payload_is_not_a_reference(
+    hass: HomeAssistant,
+) -> None:
+    """An `entity_id` in somebody's own event is data, not a dependency.
+
+    Home Assistant's own `async_extract_entities` takes nothing from a generic
+    event trigger either. Reporting it would be a repair about an automation
+    that works, which is the worst thing to get wrong.
+    """
+    config = {
+        "platform": "event",
+        "event_type": "my_external_event",
+        "event_data": {"entity_id": "light.whatever_the_sender_calls_it"},
+    }
+
+    assert await extract_entities_from_trigger_config(hass, config) == set()
+
+
+async def test_an_integration_event_payload_still_is_one(
+    hass: HomeAssistant,
+) -> None:
+    """`timer.finished` names a domain, so its payload means an entity.
+
+    That is the line between the two: an event named after an integration
+    comes from it and says what it means.
+    """
+    config = {
+        "platform": "event",
+        "event_type": "timer.finished",
+        "event_data": {"entity_id": "timer.hot_tub"},
+    }
+
+    assert await extract_entities_from_trigger_config(hass, config) == {"timer.hot_tub"}

--- a/tests/ectoplasms/homeassistant/services/test_label_services.py
+++ b/tests/ectoplasms/homeassistant/services/test_label_services.py
@@ -1,0 +1,107 @@
+"""Tests for the label actions saying what they could not find."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
+import pytest
+
+from custom_components.spook.ectoplasms.homeassistant.services import (
+    add_label_to_area,
+    add_label_to_device,
+    add_label_to_entity,
+    remove_label_from_area,
+    remove_label_from_device,
+    remove_label_from_entity,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import (
+        area_registry as ar,
+        entity_registry as er,
+        label_registry as lr,
+    )
+
+_ADD = (add_label_to_entity, add_label_to_area, add_label_to_device)
+_REMOVE = (remove_label_from_entity, remove_label_from_area, remove_label_from_device)
+_FIELD = {
+    "add_label_to_entity": "entity_id",
+    "remove_label_from_entity": "entity_id",
+    "add_label_to_area": "area_id",
+    "remove_label_from_area": "area_id",
+    "add_label_to_device": "device_id",
+    "remove_label_from_device": "device_id",
+}
+
+
+async def _setup(hass: HomeAssistant, module: object) -> None:
+    """Register one label action."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    module.SpookService(hass).async_register()  # type: ignore[attr-defined]
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    "module", [*_ADD, *_REMOVE], ids=lambda m: m.__name__.rsplit(".", 1)[-1]
+)
+async def test_a_target_that_does_not_exist_is_refused(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+    module: object,
+) -> None:
+    """A typo in the target used to come back as a successful no-op.
+
+    Which means an automation carries on as though it had labelled something,
+    and nothing anywhere says otherwise.
+    """
+    label_registry.async_create("Ghosts")
+    await _setup(hass, module)
+
+    service = module.SpookService  # type: ignore[attr-defined]
+    field = _FIELD[module.__name__.rsplit(".", 1)[-1]]
+
+    with pytest.raises(HomeAssistantError, match="not found"):
+        await hass.services.async_call(
+            "homeassistant",
+            service.service,
+            {"label_id": "ghosts", field: "does.not_exist"},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize("module", _REMOVE, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+async def test_a_label_that_does_not_exist_is_refused_on_removal_too(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+    module: object,
+) -> None:
+    """The adding half already said so; removal stayed quiet about it.
+
+    A typo there leaves the label everybody meant to remove exactly where it
+    was, and the call still reports success.
+    """
+    await _setup(hass, module)
+
+    entry = entity_registry.async_get_or_create("light", "test", "1")
+    area = area_registry.async_create("Kitchen")
+    targets = {
+        "entity_id": entry.entity_id,
+        "area_id": area.id,
+        "device_id": "does_not_matter",
+    }
+
+    service = module.SpookService  # type: ignore[attr-defined]
+    field = _FIELD[module.__name__.rsplit(".", 1)[-1]]
+
+    with pytest.raises(HomeAssistantError, match=r"Label .* not found"):
+        await hass.services.async_call(
+            "homeassistant",
+            service.service,
+            {"label_id": "no_such_label", field: targets[field]},
+            blocking=True,
+        )

--- a/tests/ectoplasms/homeassistant/services/test_list_orphaned_database_entities.py
+++ b/tests/ectoplasms/homeassistant/services/test_list_orphaned_database_entities.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import SupportsResponse
 from homeassistant.helpers.recorder import DATA_INSTANCE
+from homeassistant.setup import async_setup_component
 
 from custom_components.spook.ectoplasms.homeassistant.services.list_orphaned_database_entities import (
     SpookService,
@@ -44,6 +45,10 @@ async def test_it_lists_what_the_database_kept_and_the_house_forgot(
     """Recorded entity IDs with no state left are the orphans."""
     ran = _install_fake_recorder(hass)
     hass.states.async_set("sensor.still_here", "1")
+
+    # Set up for real, because Spook does not register a service on somebody
+    # else's domain until that integration is loaded.
+    assert await async_setup_component(hass, "homeassistant", {})
 
     service = SpookService(hass)
     service.async_register()

--- a/tests/ectoplasms/spook/triggers/test_sequence.py
+++ b/tests/ectoplasms/spook/triggers/test_sequence.py
@@ -844,3 +844,18 @@ async def test_stopping_while_attaching_the_reset_leaves_nothing_behind(
 
     watcher.async_stop()
     await hass.async_block_till_done()
+
+
+async def test_a_sequence_with_no_time_to_finish_is_refused(
+    hass: HomeAssistant,
+) -> None:
+    """It would run out the moment it starts, never getting past step one.
+
+    `positive_time_period` counts zero as positive, and the sibling triggers
+    that take a duration already say no to it.
+    """
+    with pytest.raises(vol.Invalid, match="no time to finish"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {"options": {"steps": [DOOR, MOTION], "timeout": {"seconds": 0}}},
+        )

--- a/tests/test_service_registration_errors.py
+++ b/tests/test_service_registration_errors.py
@@ -10,6 +10,7 @@ import pytest
 from custom_components.spook.services import (
     AbstractSpookEntityComponentService,
     AbstractSpookEntityService,
+    AbstractSpookService,
 )
 
 if TYPE_CHECKING:
@@ -71,3 +72,27 @@ def test_missing_component_says_so_in_one_sentence(hass: HomeAssistant) -> None:
         " not_loaded.do_something"
     )
     assert str(caught.value).startswith("Could not find entity component")
+
+
+async def test_a_service_for_an_unloaded_domain_is_not_registered(
+    hass: HomeAssistant,
+) -> None:
+    """Spook does not put an action on somebody else's domain until it is there.
+
+    Registering it anyway would offer an action whose handler reaches for an
+    integration that was never set up, and it would fail there instead of
+    simply not existing.
+    """
+
+    class _Elsewhere(AbstractSpookService):
+        """A service on a domain nobody has loaded."""
+
+        domain = "not_a_loaded_integration"
+        service = "do_something"
+
+        async def async_handle_service(self, call: ServiceCall) -> None:
+            """Handle the service call."""
+
+    _Elsewhere(hass).async_register()
+
+    assert not hass.services.has_service("not_a_loaded_integration", "do_something")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A second outside review of the whole codebase, aimed at the parts the first one did not reach: the trigger platform, the repair machinery, and service registration. Four findings, all verified against the installed core rather than reasoned about.

**An `entity_id` inside a custom event's payload was read as a reference.** An automation listening for somebody's own event with an `entity_id` in its `event_data` was told it points at an entity that does not exist. That is payload matching, not a dependency, and Home Assistant's own `async_extract_entities` takes nothing out of a generic event trigger either. The line between the two is the event type: one named after a domain comes from that integration and means what it says, so `timer.finished` still counts and `my_external_event` does not.

**The six label actions skipped a target they could not find.** `add_label_to_entity` with a typo returned successfully and did nothing, so the automation that called it carried on as though it had worked. Every other registry action in Spook already says "not found"; these do too now. The three removal ones did not validate the label either, which is worse than it sounds: a typo there leaves the label everybody wanted removed exactly where it was, reported as a success.

**`spook.sequence` accepted `timeout: 0`.** `positive_time_period` counts zero as positive, and a sequence with no time to finish in runs out the moment it starts, so the automation loads cleanly and can never fire. `watchdog` and `while` already refuse a zero duration with an explanation; sequence did not.

**A plain service on an unloaded domain logged that it was not being registered, then registered anyway.** The guard had no `return`. The admin variant ten lines further down has always had one.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of the stability round before the next release, after #1496, #1497 and #1500.

The event payload one matters most: a repair telling somebody their working automation is broken is the thing this project cannot afford to get wrong, and this is the second finding of that kind in two review rounds.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Full suite green at 1311, both against the pinned release and against Home Assistant 2026.10.0.dev0 from git.

Each fix has a test that fails when the fix is undone, five in total: a custom event payload collecting nothing while `timer.finished` still does, a missing target being refused, a missing label being refused on removal, a zero timeout being refused, and a service on an unloaded domain not appearing.

Two things worth noting about the shape of the change. Pylint pushed the label check into a shared helper: with the same validation on both halves, the add and remove pairs became similar enough to trip the duplication check, and that check was right. And one test added in #1500 had to be corrected, since it registered a service on `homeassistant` without setting that integration up; with the guard fixed, that no longer works, which is the point.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
