### PR TITLE
Add light actions that adjust rather than switch

### DIFF
--- a/custom_components/spook/ectoplasms/light/__init__.py
+++ b/custom_components/spook/ectoplasms/light/__init__.py
@@ -4,15 +4,22 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant.components.light import ATTR_BRIGHTNESS, DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, STATE_ON
+from homeassistant.components.light import DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_GROUP_ENTITIES,
+    STATE_ON,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, State
 
-# A group standing for itself, or a group of groups, would otherwise go round
-# forever. Nobody nests lights this deep on purpose.
-_MOST_NESTING = 10
+# Where a light keeps its members, depending on what kind of group it is. A
+# helper group lists entity IDs under `entity_id`; a group belonging to one
+# integration, like the ones MQTT builds, gets `group_entities` from Home
+# Assistant itself. Reading only the first sort means adjusting the second
+# sort's group entity, which is the thing these actions exist to avoid.
+_MEMBER_KEYS = (ATTR_ENTITY_ID, ATTR_GROUP_ENTITIES)
 
 
 def async_lights_that_are_on(hass: HomeAssistant, entity_id: str) -> list[State]:
@@ -28,15 +35,23 @@ def async_lights_that_are_on(hass: HomeAssistant, entity_id: str) -> list[State]
     treats an off light as brightness zero and turns it on from there, so
     dimming a room would light up everything somebody had deliberately
     switched off.
+
+    What comes back is every light that is on, whatever it can do. Each action
+    keeps only the ones it has something to say to, since a light with no
+    dimmer has no brightness to step and one with no colour has no colour to
+    set.
     """
     found: list[State] = []
     seen: set[str] = set()
-    todo: list[tuple[str, int]] = [(entity_id, 0)]
+    todo = [entity_id]
 
     while todo:
-        current, depth = todo.pop()
+        current = todo.pop()
 
-        if current in seen or depth > _MOST_NESTING:
+        # Groups can hold groups, and nothing stops one holding itself. The
+        # set is what makes that terminate, so there is no depth limit to
+        # trip over.
+        if current in seen:
             continue
 
         seen.add(current)
@@ -44,18 +59,35 @@ def async_lights_that_are_on(hass: HomeAssistant, entity_id: str) -> list[State]
         if (state := hass.states.get(current)) is None:
             continue
 
-        if members := state.attributes.get(ATTR_ENTITY_ID):
-            todo.extend(
-                (member, depth + 1)
-                for member in members
-                if isinstance(member, str) and member.startswith(f"{DOMAIN}.")
-            )
+        if (members := _async_members(state)) is not None:
+            todo.extend(members)
             continue
 
-        if (
-            state.state == STATE_ON
-            and state.attributes.get(ATTR_BRIGHTNESS) is not None
-        ):
+        if state.state == STATE_ON:
             found.append(state)
 
     return found
+
+
+def _async_members(state: State) -> list[str] | None:
+    """Return the lights a group holds, or `None` if it is not a group.
+
+    Told apart by whether the attribute is there rather than by whether it
+    holds anything, because a group that is empty is still a group and has no
+    brightness of its own worth setting.
+    """
+    for key in _MEMBER_KEYS:
+        if key not in state.attributes:
+            continue
+
+        members = state.attributes[key]
+        if not isinstance(members, (list, tuple)):
+            continue
+
+        return [
+            member
+            for member in members
+            if isinstance(member, str) and member.startswith(f"{DOMAIN}.")
+        ]
+
+    return None

--- a/custom_components/spook/ectoplasms/light/__init__.py
+++ b/custom_components/spook/ectoplasms/light/__init__.py
@@ -1,0 +1,61 @@
+"""Spook - Your homie. Adjusting lights that are already on."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ON
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, State
+
+# A group standing for itself, or a group of groups, would otherwise go round
+# forever. Nobody nests lights this deep on purpose.
+_MOST_NESTING = 10
+
+
+def async_lights_that_are_on(hass: HomeAssistant, entity_id: str) -> list[State]:
+    """Return the lights behind an entity that are on right now.
+
+    A light group is a light like any other, so one target can stand for one
+    light or for twenty. Adjusting the group entity itself is what makes Home
+    Assistant average its members and then set every one of them to that
+    average: the dim one jumps up, the bright one drops. Working per member is
+    the whole point of these actions.
+
+    Lights that are off are left out, which is the other half. Home Assistant
+    treats an off light as brightness zero and turns it on from there, so
+    dimming a room would light up everything somebody had deliberately
+    switched off.
+    """
+    found: list[State] = []
+    seen: set[str] = set()
+    todo: list[tuple[str, int]] = [(entity_id, 0)]
+
+    while todo:
+        current, depth = todo.pop()
+
+        if current in seen or depth > _MOST_NESTING:
+            continue
+
+        seen.add(current)
+
+        if (state := hass.states.get(current)) is None:
+            continue
+
+        if members := state.attributes.get(ATTR_ENTITY_ID):
+            todo.extend(
+                (member, depth + 1)
+                for member in members
+                if isinstance(member, str) and member.startswith(f"{DOMAIN}.")
+            )
+            continue
+
+        if (
+            state.state == STATE_ON
+            and state.attributes.get(ATTR_BRIGHTNESS) is not None
+        ):
+            found.append(state)
+
+    return found

--- a/custom_components/spook/ectoplasms/light/services/__init__.py
+++ b/custom_components/spook/ectoplasms/light/services/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/light/services/decrease_brightness.py
+++ b/custom_components/spook/ectoplasms/light/services/decrease_brightness.py
@@ -1,0 +1,16 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from ..stepping import AbstractStepBrightnessService
+
+
+class SpookService(AbstractStepBrightnessService):
+    """Light service that turns down what is already lit.
+
+    It stops at the dimmest a light goes rather than switching it off, so
+    holding a dim-down button leaves the room lit rather than dark.
+    """
+
+    service = "decrease_brightness"
+    direction = -1

--- a/custom_components/spook/ectoplasms/light/services/increase_brightness.py
+++ b/custom_components/spook/ectoplasms/light/services/increase_brightness.py
@@ -1,0 +1,17 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from ..stepping import AbstractStepBrightnessService
+
+
+class SpookService(AbstractStepBrightnessService):
+    """Light service that turns up what is already lit.
+
+    Lights that are off stay off: Home Assistant reads an off light as
+    brightness zero and turns it on from there, so asking a room for more
+    light would switch on everything somebody had deliberately turned off.
+    """
+
+    service = "increase_brightness"
+    direction = 1

--- a/custom_components/spook/ectoplasms/light/services/set_brightness.py
+++ b/custom_components/spook/ectoplasms/light/services/set_brightness.py
@@ -1,0 +1,62 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS_PCT,
+    ATTR_TRANSITION,
+    DOMAIN,
+    LightEntity,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.helpers import config_validation as cv
+
+from ....services import AbstractSpookEntityComponentService
+from .. import async_lights_that_are_on
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_BRIGHTNESS_PCT = "brightness_pct"
+
+
+class SpookService(AbstractSpookEntityComponentService[LightEntity]):
+    """Light service that sets brightness on what is already lit.
+
+    `light.turn_on` with a brightness does two things at once: it sets the
+    level and it switches the light on. Most of the time somebody adjusting a
+    room means the first without the second, and there is no way to ask for
+    that.
+    """
+
+    domain = DOMAIN
+    service = "set_brightness"
+    schema = {
+        vol.Required(CONF_BRIGHTNESS_PCT): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=100)
+        ),
+        vol.Optional(ATTR_TRANSITION): cv.positive_float,
+    }
+
+    async def async_handle_service(
+        self,
+        entity: LightEntity,
+        call: ServiceCall,
+    ) -> None:
+        """Handle the service call."""
+        for light in async_lights_that_are_on(self.hass, entity.entity_id):
+            data = {
+                ATTR_ENTITY_ID: light.entity_id,
+                ATTR_BRIGHTNESS_PCT: call.data[CONF_BRIGHTNESS_PCT],
+            }
+
+            if (transition := call.data.get(ATTR_TRANSITION)) is not None:
+                data[ATTR_TRANSITION] = transition
+
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=call.context
+            )

--- a/custom_components/spook/ectoplasms/light/services/set_brightness.py
+++ b/custom_components/spook/ectoplasms/light/services/set_brightness.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT,
     ATTR_TRANSITION,
     DOMAIN,
@@ -48,15 +49,27 @@ class SpookService(AbstractSpookEntityComponentService[LightEntity]):
         call: ServiceCall,
     ) -> None:
         """Handle the service call."""
-        for light in async_lights_that_are_on(self.hass, entity.entity_id):
-            data = {
-                ATTR_ENTITY_ID: light.entity_id,
-                ATTR_BRIGHTNESS_PCT: call.data[CONF_BRIGHTNESS_PCT],
-            }
+        # A light with no dimmer has no level to set, and it is still a light:
+        # it lands in a group and in an area target like any other.
+        lights = [
+            light
+            for light in async_lights_that_are_on(self.hass, entity.entity_id)
+            if light.attributes.get(ATTR_BRIGHTNESS) is not None
+        ]
+        if not lights:
+            return
 
-            if (transition := call.data.get(ATTR_TRANSITION)) is not None:
-                data[ATTR_TRANSITION] = transition
+        # One call for all of them, rather than one call each: they are all
+        # going to the same level, and this way Home Assistant fans it out
+        # with the concurrency and per-platform limits it already has.
+        data = {
+            ATTR_ENTITY_ID: [light.entity_id for light in lights],
+            ATTR_BRIGHTNESS_PCT: call.data[CONF_BRIGHTNESS_PCT],
+        }
 
-            await self.hass.services.async_call(
-                DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=call.context
-            )
+        if (transition := call.data.get(ATTR_TRANSITION)) is not None:
+            data[ATTR_TRANSITION] = transition
+
+        await self.hass.services.async_call(
+            DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=call.context
+        )

--- a/custom_components/spook/ectoplasms/light/services/set_color.py
+++ b/custom_components/spook/ectoplasms/light/services/set_color.py
@@ -1,0 +1,77 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_COLOR_NAME,
+    ATTR_RGB_COLOR,
+    ATTR_SUPPORTED_COLOR_MODES,
+    ATTR_TRANSITION,
+    DOMAIN,
+    LightEntity,
+    color_supported,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+
+from ....services import AbstractSpookEntityComponentService
+from .. import async_lights_that_are_on
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookEntityComponentService[LightEntity]):
+    """Light service that colours what is already lit.
+
+    Lights that cannot do colour are passed over rather than turned on white,
+    which is what `light.turn_on` with a colour does to them.
+    """
+
+    domain = DOMAIN
+    service = "set_color"
+    schema = {
+        vol.Exclusive(ATTR_RGB_COLOR, "colour"): vol.All(
+            vol.Length(min=3, max=3), [vol.All(vol.Coerce(int), vol.Range(0, 255))]
+        ),
+        vol.Exclusive(ATTR_COLOR_NAME, "colour"): cv.string,
+        vol.Optional(ATTR_TRANSITION): cv.positive_float,
+    }
+
+    async def async_handle_service(
+        self,
+        entity: LightEntity,
+        call: ServiceCall,
+    ) -> None:
+        """Handle the service call."""
+        if not (call.data.keys() & {ATTR_RGB_COLOR, ATTR_COLOR_NAME}):
+            # Checked here rather than in the schema: an entity service takes
+            # a plain field mapping, so there is nowhere in it to say that one
+            # of two optional keys has to be there.
+            msg = f"Set what colour, {ATTR_RGB_COLOR} or {ATTR_COLOR_NAME}?"
+            raise ServiceValidationError(msg)
+
+        lights = [
+            light
+            for light in async_lights_that_are_on(self.hass, entity.entity_id)
+            if color_supported(light.attributes.get(ATTR_SUPPORTED_COLOR_MODES))
+        ]
+        if not lights:
+            return
+
+        data: dict[str, object] = {
+            ATTR_ENTITY_ID: [light.entity_id for light in lights]
+        }
+
+        for key in (ATTR_RGB_COLOR, ATTR_COLOR_NAME, ATTR_TRANSITION):
+            if key in call.data:
+                data[key] = call.data[key]
+
+        await self.hass.services.async_call(
+            DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=call.context
+        )

--- a/custom_components/spook/ectoplasms/light/services/set_color.py
+++ b/custom_components/spook/ectoplasms/light/services/set_color.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.components.light import (
-    ATTR_COLOR_NAME,
     ATTR_RGB_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
     ATTR_TRANSITION,
@@ -16,7 +15,6 @@ from homeassistant.components.light import (
     color_supported,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 
 from ....services import AbstractSpookEntityComponentService
@@ -36,10 +34,9 @@ class SpookService(AbstractSpookEntityComponentService[LightEntity]):
     domain = DOMAIN
     service = "set_color"
     schema = {
-        vol.Exclusive(ATTR_RGB_COLOR, "colour"): vol.All(
+        vol.Required(ATTR_RGB_COLOR): vol.All(
             vol.Length(min=3, max=3), [vol.All(vol.Coerce(int), vol.Range(0, 255))]
         ),
-        vol.Exclusive(ATTR_COLOR_NAME, "colour"): cv.string,
         vol.Optional(ATTR_TRANSITION): cv.positive_float,
     }
 
@@ -49,13 +46,6 @@ class SpookService(AbstractSpookEntityComponentService[LightEntity]):
         call: ServiceCall,
     ) -> None:
         """Handle the service call."""
-        if not (call.data.keys() & {ATTR_RGB_COLOR, ATTR_COLOR_NAME}):
-            # Checked here rather than in the schema: an entity service takes
-            # a plain field mapping, so there is nowhere in it to say that one
-            # of two optional keys has to be there.
-            msg = f"Set what colour, {ATTR_RGB_COLOR} or {ATTR_COLOR_NAME}?"
-            raise ServiceValidationError(msg)
-
         lights = [
             light
             for light in async_lights_that_are_on(self.hass, entity.entity_id)
@@ -68,7 +58,7 @@ class SpookService(AbstractSpookEntityComponentService[LightEntity]):
             ATTR_ENTITY_ID: [light.entity_id for light in lights]
         }
 
-        for key in (ATTR_RGB_COLOR, ATTR_COLOR_NAME, ATTR_TRANSITION):
+        for key in (ATTR_RGB_COLOR, ATTR_TRANSITION):
             if key in call.data:
                 data[key] = call.data[key]
 

--- a/custom_components/spook/ectoplasms/light/services/set_color_temperature.py
+++ b/custom_components/spook/ectoplasms/light/services/set_color_temperature.py
@@ -1,0 +1,84 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_MAX_COLOR_TEMP_KELVIN,
+    ATTR_MIN_COLOR_TEMP_KELVIN,
+    ATTR_SUPPORTED_COLOR_MODES,
+    ATTR_TRANSITION,
+    DOMAIN,
+    LightEntity,
+    color_temp_supported,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.helpers import config_validation as cv
+
+from ....services import AbstractSpookEntityComponentService
+from .. import async_lights_that_are_on
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
+    from homeassistant.core import ServiceCall, State
+
+CONF_KELVIN = "kelvin"
+
+
+class SpookService(AbstractSpookEntityComponentService[LightEntity]):
+    """Light service that sets colour temperature on what is already lit.
+
+    Kept inside each light's own range, because warm white on one lamp is a
+    number another one cannot reach, and a group is rarely all the same model.
+    """
+
+    domain = DOMAIN
+    service = "set_color_temperature"
+    schema = {
+        vol.Required(CONF_KELVIN): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.Optional(ATTR_TRANSITION): cv.positive_float,
+    }
+
+    async def async_handle_service(
+        self,
+        entity: LightEntity,
+        call: ServiceCall,
+    ) -> None:
+        """Handle the service call."""
+        kelvin = call.data[CONF_KELVIN]
+        transition = call.data.get(ATTR_TRANSITION)
+
+        def _call(light: State) -> Coroutine[Any, Any, Any]:
+            """Return the call that sets one light, within what it can do."""
+            coolest = light.attributes.get(ATTR_MAX_COLOR_TEMP_KELVIN, kelvin)
+            warmest = light.attributes.get(ATTR_MIN_COLOR_TEMP_KELVIN, kelvin)
+
+            data: dict[str, Any] = {
+                ATTR_ENTITY_ID: light.entity_id,
+                ATTR_COLOR_TEMP_KELVIN: min(max(kelvin, warmest), coolest),
+            }
+
+            if transition is not None:
+                data[ATTR_TRANSITION] = transition
+
+            return self.hass.services.async_call(
+                DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=call.context
+            )
+
+        # One call each, since each light is held to its own range, and all at
+        # once, since waiting for them in turn adds up over a room.
+        await asyncio.gather(
+            *(
+                _call(light)
+                for light in async_lights_that_are_on(self.hass, entity.entity_id)
+                if color_temp_supported(
+                    light.attributes.get(ATTR_SUPPORTED_COLOR_MODES)
+                )
+            )
+        )

--- a/custom_components/spook/ectoplasms/light/services/set_effect.py
+++ b/custom_components/spook/ectoplasms/light/services/set_effect.py
@@ -1,0 +1,62 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_EFFECT,
+    ATTR_EFFECT_LIST,
+    DOMAIN,
+    LightEntity,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.helpers import config_validation as cv
+
+from ....services import AbstractSpookEntityComponentService
+from .. import async_lights_that_are_on
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+
+class SpookService(AbstractSpookEntityComponentService[LightEntity]):
+    """Light service that sets an effect on what is already lit.
+
+    Only on lights that have the effect asked for. Effect names are per
+    manufacturer and rarely agree, so a room is usually a mix of lights that
+    know "Colorloop" and lights that have never heard of it.
+    """
+
+    domain = DOMAIN
+    service = "set_effect"
+    schema = {vol.Required(ATTR_EFFECT): cv.string}
+
+    async def async_handle_service(
+        self,
+        entity: LightEntity,
+        call: ServiceCall,
+    ) -> None:
+        """Handle the service call."""
+        effect = call.data[ATTR_EFFECT]
+
+        lights = [
+            light
+            for light in async_lights_that_are_on(self.hass, entity.entity_id)
+            if effect in (light.attributes.get(ATTR_EFFECT_LIST) or ())
+        ]
+        if not lights:
+            return
+
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: [light.entity_id for light in lights],
+                ATTR_EFFECT: effect,
+            },
+            blocking=True,
+            context=call.context,
+        )

--- a/custom_components/spook/ectoplasms/light/stepping.py
+++ b/custom_components/spook/ectoplasms/light/stepping.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
@@ -19,7 +20,9 @@ from ...services import AbstractSpookEntityComponentService
 from . import async_lights_that_are_on
 
 if TYPE_CHECKING:
-    from homeassistant.core import ServiceCall
+    from collections.abc import Coroutine
+
+    from homeassistant.core import ServiceCall, State
 
 CONF_STEP_PCT = "step_pct"
 
@@ -57,17 +60,33 @@ class AbstractStepBrightnessService(AbstractSpookEntityComponentService[LightEnt
     ) -> None:
         """Handle the service call."""
         step = round(_FULL * call.data[CONF_STEP_PCT] / 100) * self.direction
+        transition = call.data.get(ATTR_TRANSITION)
 
-        for light in async_lights_that_are_on(self.hass, entity.entity_id):
+        def _call(light: State) -> Coroutine[Any, Any, Any]:
+            """Return the call that steps one light from where it is."""
             brightness = light.attributes[ATTR_BRIGHTNESS] + step
-            data = {
+            data: dict[str, Any] = {
                 ATTR_ENTITY_ID: light.entity_id,
                 ATTR_BRIGHTNESS: min(max(brightness, _DIMMEST), _FULL),
             }
 
-            if (transition := call.data.get(ATTR_TRANSITION)) is not None:
+            if transition is not None:
                 data[ATTR_TRANSITION] = transition
 
-            await self.hass.services.async_call(
+            return self.hass.services.async_call(
                 DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=call.context
             )
+
+        # Every light lands on a different level, so this cannot be one call.
+        # Waiting for each in turn can, though: a room full of lights would
+        # take as long as all of them added together, and slow ones are
+        # exactly what somebody is dimming.
+        # A light with no dimmer has no level to step, and it is still a
+        # light: it lands in a group and in an area target like any other.
+        await asyncio.gather(
+            *(
+                _call(light)
+                for light in async_lights_that_are_on(self.hass, entity.entity_id)
+                if light.attributes.get(ATTR_BRIGHTNESS) is not None
+            )
+        )

--- a/custom_components/spook/ectoplasms/light/stepping.py
+++ b/custom_components/spook/ectoplasms/light/stepping.py
@@ -1,0 +1,73 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_TRANSITION,
+    DOMAIN,
+    LightEntity,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.helpers import config_validation as cv
+
+from ...services import AbstractSpookEntityComponentService
+from . import async_lights_that_are_on
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_STEP_PCT = "step_pct"
+
+# Full brightness in the numbers the light platform actually uses.
+_FULL = 255
+
+# One, not zero, because zero is off and these actions do not switch lights.
+_DIMMEST = 1
+
+
+class AbstractStepBrightnessService(AbstractSpookEntityComponentService[LightEntity]):
+    """Shared half of stepping brightness up and down.
+
+    The whole point is doing it per light. Stepping a group entity has Home
+    Assistant average its members, apply the step to that average, and then
+    set every member to the result, so a room with one lamp at 10% and one at
+    100% ends up with both at 65% after asking for a little more light.
+    """
+
+    domain = DOMAIN
+    schema = {
+        vol.Required(CONF_STEP_PCT): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=100)
+        ),
+        vol.Optional(ATTR_TRANSITION): cv.positive_float,
+    }
+
+    #: Which way this one goes.
+    direction: int
+
+    async def async_handle_service(
+        self,
+        entity: LightEntity,
+        call: ServiceCall,
+    ) -> None:
+        """Handle the service call."""
+        step = round(_FULL * call.data[CONF_STEP_PCT] / 100) * self.direction
+
+        for light in async_lights_that_are_on(self.hass, entity.entity_id):
+            brightness = light.attributes[ATTR_BRIGHTNESS] + step
+            data = {
+                ATTR_ENTITY_ID: light.entity_id,
+                ATTR_BRIGHTNESS: min(max(brightness, _DIMMEST), _FULL),
+            }
+
+            if (transition := call.data.get(ATTR_TRANSITION)) is not None:
+                data[ATTR_TRANSITION] = transition
+
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_TURN_ON, data, blocking=True, context=call.context
+            )

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -8,6 +8,7 @@
     "counter",
     "energy",
     "group",
+    "light",
     "proximity",
     "timer"
   ],

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -56,6 +56,95 @@ automation_turn_on_for:
       selector:
         duration:
 
+light_set_brightness:
+  name: Set brightness 👻
+  description: >-
+    Sets the brightness of lights that are already on, and leaves the ones
+    that are off alone. Groups are adjusted light by light rather than by
+    their average.
+  target:
+    entity:
+      domain: light
+  fields:
+    brightness_pct:
+      name: Brightness
+      description: The brightness to set, as a percentage.
+      required: true
+      example: 50
+      selector:
+        number:
+          min: 1
+          max: 100
+          unit_of_measurement: "%"
+    transition:
+      name: Transition
+      description: How long the change should take.
+      example: 2
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: seconds
+
+light_increase_brightness:
+  name: Increase brightness 👻
+  description: >-
+    Turns up the lights that are already on, and leaves the ones that are off
+    alone. Each light steps from its own level, so a group keeps its shape
+    instead of levelling out.
+  target:
+    entity:
+      domain: light
+  fields:
+    step_pct:
+      name: Step
+      description: How much brighter to go, as a percentage.
+      required: true
+      example: 10
+      selector:
+        number:
+          min: 1
+          max: 100
+          unit_of_measurement: "%"
+    transition:
+      name: Transition
+      description: How long the change should take.
+      example: 2
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: seconds
+
+light_decrease_brightness:
+  name: Decrease brightness 👻
+  description: >-
+    Turns down the lights that are already on, stopping at the dimmest they go
+    rather than switching them off. Each light steps from its own level.
+  target:
+    entity:
+      domain: light
+  fields:
+    step_pct:
+      name: Step
+      description: How much dimmer to go, as a percentage.
+      required: true
+      example: 10
+      selector:
+        number:
+          min: 1
+          max: 100
+          unit_of_measurement: "%"
+    transition:
+      name: Transition
+      description: How long the change should take.
+      example: 2
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: seconds
+
 homeassistant_create_area:
   name: Create an area 👻
   description: >-

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -145,6 +145,83 @@ light_decrease_brightness:
           max: 300
           unit_of_measurement: seconds
 
+light_set_color:
+  name: Set color 👻
+  description: >-
+    Sets the color of lights that are already on, and leaves alone the ones
+    that are off or cannot do color.
+  target:
+    entity:
+      domain: light
+  fields:
+    rgb_color:
+      name: Color
+      description: The color to set.
+      example: "[255, 100, 100]"
+      selector:
+        color_rgb:
+    color_name:
+      name: Color name
+      description: A named color, such as "coral" or "midnightblue".
+      example: coral
+      selector:
+        text:
+    transition:
+      name: Transition
+      description: How long the change should take.
+      example: 2
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: seconds
+
+light_set_color_temperature:
+  name: Set color temperature 👻
+  description: >-
+    Sets the color temperature of lights that are already on, each within the
+    range it can actually reach.
+  target:
+    entity:
+      domain: light
+  fields:
+    kelvin:
+      name: Color temperature
+      description: The color temperature to set.
+      required: true
+      example: 2700
+      selector:
+        color_temp:
+          unit: kelvin
+          min: 2000
+          max: 6500
+    transition:
+      name: Transition
+      description: How long the change should take.
+      example: 2
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: seconds
+
+light_set_effect:
+  name: Set effect 👻
+  description: >-
+    Sets an effect on the lights that are already on and actually have it.
+    Effect names differ per manufacturer, so a room is usually a mix.
+  target:
+    entity:
+      domain: light
+  fields:
+    effect:
+      name: Effect
+      description: The name of the effect to set.
+      required: true
+      example: Colorloop
+      selector:
+        text:
+
 homeassistant_create_area:
   name: Create an area 👻
   description: >-

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -157,15 +157,10 @@ light_set_color:
     rgb_color:
       name: Color
       description: The color to set.
+      required: true
       example: "[255, 100, 100]"
       selector:
         color_rgb:
-    color_name:
-      name: Color name
-      description: A named color, such as "coral" or "midnightblue".
-      example: coral
-      selector:
-        text:
     transition:
       name: Transition
       description: How long the change should take.

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -887,6 +887,48 @@
         }
       }
     },
+    "light_set_color": {
+      "name": "Set color",
+      "description": "Sets the color of lights that are already on, and leaves alone the ones that are off or cannot do color.",
+      "fields": {
+        "rgb_color": {
+          "name": "Color",
+          "description": "The color to set. Lights that cannot do color are passed over rather than turned white."
+        },
+        "color_name": {
+          "name": "Color name",
+          "description": "A named color, such as \"coral\" or \"midnightblue\"."
+        },
+        "transition": {
+          "name": "Transition",
+          "description": "How long the change should take, in seconds."
+        }
+      }
+    },
+    "light_set_color_temperature": {
+      "name": "Set color temperature",
+      "description": "Sets the color temperature of lights that are already on, each within the range it can actually reach.",
+      "fields": {
+        "kelvin": {
+          "name": "Color temperature",
+          "description": "The color temperature to set. Every light is held to its own range, since warm white on one lamp is a number another cannot reach."
+        },
+        "transition": {
+          "name": "Transition",
+          "description": "How long the change should take, in seconds."
+        }
+      }
+    },
+    "light_set_effect": {
+      "name": "Set effect",
+      "description": "Sets an effect on the lights that are already on and actually have it.",
+      "fields": {
+        "effect": {
+          "name": "Effect",
+          "description": "The name of the effect to set. Effect names differ per manufacturer, so lights that do not have this one are left as they are."
+        }
+      }
+    },
     "homeassistant_create_area": {
       "name": "Create an area",
       "description": "Creates a new area on the fly.",

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -895,10 +895,6 @@
           "name": "Color",
           "description": "The color to set. Lights that cannot do color are passed over rather than turned white."
         },
-        "color_name": {
-          "name": "Color name",
-          "description": "A named color, such as \"coral\" or \"midnightblue\"."
-        },
         "transition": {
           "name": "Transition",
           "description": "How long the change should take, in seconds."

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -845,6 +845,48 @@
         }
       }
     },
+    "light_set_brightness": {
+      "name": "Set brightness",
+      "description": "Sets the brightness of lights that are already on, and leaves the ones that are off alone.",
+      "fields": {
+        "brightness_pct": {
+          "name": "Brightness",
+          "description": "The brightness to set, as a percentage. Groups are adjusted light by light, so a light that is off stays off."
+        },
+        "transition": {
+          "name": "Transition",
+          "description": "How long the change should take, in seconds."
+        }
+      }
+    },
+    "light_increase_brightness": {
+      "name": "Increase brightness",
+      "description": "Turns up the lights that are already on, and leaves the ones that are off alone.",
+      "fields": {
+        "step_pct": {
+          "name": "Step",
+          "description": "How much brighter to go, as a percentage. Each light steps from its own level, so a group keeps its shape instead of levelling out."
+        },
+        "transition": {
+          "name": "Transition",
+          "description": "How long the change should take, in seconds."
+        }
+      }
+    },
+    "light_decrease_brightness": {
+      "name": "Decrease brightness",
+      "description": "Turns down the lights that are already on, stopping at the dimmest they go rather than switching them off.",
+      "fields": {
+        "step_pct": {
+          "name": "Step",
+          "description": "How much dimmer to go, as a percentage. Each light steps from its own level, so a group keeps its shape instead of levelling out."
+        },
+        "transition": {
+          "name": "Transition",
+          "description": "How long the change should take, in seconds."
+        }
+      }
+    },
     "homeassistant_create_area": {
       "name": "Create an area",
       "description": "Creates a new area on the fly.",

--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -40,6 +40,7 @@ parts:
       - file: integrations/homeassistant
       - file: integrations/input_number
       - file: integrations/input_select
+      - file: integrations/light
       - file: integrations/notify
       - file: integrations/number
       - file: integrations/person

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -82,6 +82,24 @@ Downloads and imports an automation/script blueprint, directly from the URL you 
 
 `blueprint.import`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=blueprint.import), [documentation](integrations/blueprint#import-blueprint) 📚
 
+## Light: Set brightness
+
+Sets the brightness of lights that are already on, and leaves the ones that are off alone. _#light_ _#adjust_
+
+`light.set_brightness`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_brightness), [documentation](integrations/light#set-brightness) 📚
+
+## Light: Increase brightness
+
+Turns up the lights that are already on, stepping each from its own level instead of the group average. _#light_ _#adjust_
+
+`light.increase_brightness`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.increase_brightness), [documentation](integrations/light#increase-brightness) 📚
+
+## Light: Decrease brightness
+
+Turns down the lights that are already on, stopping at the dimmest they go rather than switching them off. _#light_ _#adjust_
+
+`light.decrease_brightness`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.decrease_brightness), [documentation](integrations/light#decrease-brightness) 📚
+
 ## Wait for a condition
 
 Waits until a condition is true, and carries on straight away if it already is. Takes the ordinary condition building blocks, so it needs no template. _#wait_ _#condition_

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -100,6 +100,24 @@ Turns down the lights that are already on, stopping at the dimmest they go rathe
 
 `light.decrease_brightness`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.decrease_brightness), [documentation](integrations/light#decrease-brightness) 📚
 
+## Light: Set color
+
+Sets the color of lights that are already on, and passes over the ones that cannot do color. _#light_ _#adjust_
+
+`light.set_color`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color), [documentation](integrations/light#set-color) 📚
+
+## Light: Set color temperature
+
+Sets the color temperature of lights that are already on, each within the range it can actually reach. _#light_ _#adjust_
+
+`light.set_color_temperature`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color_temperature), [documentation](integrations/light#set-color-temperature) 📚
+
+## Light: Set effect
+
+Sets an effect on the lights that are already on and actually have it. _#light_ _#adjust_
+
+`light.set_effect`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_effect), [documentation](integrations/light#set-effect) 📚
+
 ## Wait for a condition
 
 Waits until a condition is true, and carries on straight away if it already is. Takes the ordinary condition building blocks, so it needs no template. _#wait_ _#condition_

--- a/documentation/integrations/light.md
+++ b/documentation/integrations/light.md
@@ -16,7 +16,7 @@ date: 2026-08-29T14:00:00+02:00
 
 The light {term}`integration <integration>` is how {term}`Home Assistant` controls anything that lights up a room.
 
-Spook adds actions for adjusting lights, rather than switching them. `light.turn_on` does two things at once: it sets a level and it turns the light on. Most of the time somebody adjusting a room means the first without the second, and there is no way to ask for that.
+Spook adds actions for adjusting lights, rather than switching them: brightness, color, color temperature and effects. `light.turn_on` does two things at once: it sets a level and it turns the light on. Most of the time somebody adjusting a room means the first without the second, and there is no way to ask for that.
 
 There is a second half to it. A light group is a light like any other, so asking one for a little more brightness has Home Assistant average its members, apply the step to that average, and then set every member to the result. A room with a lamp at 10% and one at 100% ends up with both at 65%: not brighter, just flatter. Spook's actions work through to the members and step each from its own level.
 
@@ -192,12 +192,172 @@ data:
 
 :::
 
+### Set color
+
+Set the color of the lights that are already on. Lights that cannot do color are passed over, rather than being turned white the way `light.turn_on` does to them.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Light: Set color 👻
+* - {term}`Action name`
+  - `light.set_color`
+* - {term}`Action targets`
+  - Yes, `light` entities
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Added action
+* - {term}`Developer tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color)
+    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `rgb_color`
+  - {term}`list <list>`
+  - One of the two
+  - [255, 127, 80]
+* - `color_name`
+  - {term}`string <string>`
+  - One of the two
+  - coral
+* - `transition`
+  - {term}`number <number>`
+  - No
+  - 2
+```
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: light.set_color
+target:
+  area_id: living_room
+data:
+  color_name: coral
+```
+
+:::
+
+### Set color temperature
+
+Set the color temperature of the lights that are already on, each within the range it can actually reach. Warm white on one lamp is a number another one cannot manage, and a room is rarely all the same model.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Light: Set color temperature 👻
+* - {term}`Action name`
+  - `light.set_color_temperature`
+* - {term}`Action targets`
+  - Yes, `light` entities
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Added action
+* - {term}`Developer tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color_temperature)
+    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color_temperature)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `kelvin`
+  - {term}`number <number>`
+  - Yes
+  - 2700
+* - `transition`
+  - {term}`number <number>`
+  - No
+  - 2
+```
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: light.set_color_temperature
+target:
+  area_id: living_room
+data:
+  kelvin: 2700
+  transition: 2
+```
+
+:::
+
+### Set effect
+
+Set an effect on the lights that are already on and actually have it. Effect names are per manufacturer and rarely agree, so a room is usually a mix of lights that know this one and lights that have never heard of it.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Light: Set effect 👻
+* - {term}`Action name`
+  - `light.set_effect`
+* - {term}`Action targets`
+  - Yes, `light` entities
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Added action
+* - {term}`Developer tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_effect)
+    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_effect)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `effect`
+  - {term}`string <string>`
+  - Yes
+  - Colorloop
+```
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: light.set_effect
+target:
+  entity_id: light.kitchen
+data:
+  effect: Colorloop
+```
+
+:::
+
 :::{attention} Known limitations
 :class: dropdown
 
 - Lights that are off are left alone. These actions adjust, they do not switch: turning the room up should not light up whatever somebody deliberately turned off.
 - Decreasing stops at the dimmest a light goes rather than switching it off, so holding a dim-down button leaves the room lit rather than dark.
-- A light that reports no brightness at all, an on-or-off light, is skipped. There is nothing to adjust.
+- A light that cannot do what is being asked is skipped rather than turned on regardless: an on-or-off light has no brightness to set, a white-only light has no color, and a light without a given effect has never heard of it.
   :::
 
 ## Repairs

--- a/documentation/integrations/light.md
+++ b/documentation/integrations/light.md
@@ -1,0 +1,205 @@
+---
+subject: Enhanced integrations
+title: Light
+subtitle: Turn it down a bit, would you 💡
+description: Spook adds actions that adjust the lights that are already on, leaving the ones that are off alone, and stepping every light in a group from its own level instead of from the group average.
+date: 2026-08-29T14:00:00+02:00
+---
+
+```{image} https://brands.home-assistant.io/light/icon.png
+:alt: The Home Assistant light icon
+:width: 250px
+:align: center
+```
+
+<br><br>
+
+The light {term}`integration <integration>` is how {term}`Home Assistant` controls anything that lights up a room.
+
+Spook adds actions for adjusting lights, rather than switching them. `light.turn_on` does two things at once: it sets a level and it turns the light on. Most of the time somebody adjusting a room means the first without the second, and there is no way to ask for that.
+
+There is a second half to it. A light group is a light like any other, so asking one for a little more brightness has Home Assistant average its members, apply the step to that average, and then set every member to the result. A room with a lamp at 10% and one at 100% ends up with both at 65%: not brighter, just flatter. Spook's actions work through to the members and step each from its own level.
+
+## Devices & entities
+
+Spook does not provide any new devices or entities for this integration.
+
+## Actions
+
+Spook adds the following new actions to your Home Assistant instance:
+
+### Set brightness
+
+Set the brightness of the lights that are already on.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Light: Set brightness 👻
+* - {term}`Action name`
+  - `light.set_brightness`
+* - {term}`Action targets`
+  - Yes, `light` entities
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Added action
+* - {term}`Developer tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_brightness)
+    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_brightness)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `brightness_pct`
+  - {term}`number <number>`
+  - Yes
+  - 50
+* - `transition`
+  - {term}`number <number>`
+  - No
+  - 2
+```
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+Half brightness in the living room, without waking up whatever is off in there:
+
+```{code-block} yaml
+:linenos:
+action: light.set_brightness
+target:
+  area_id: living_room
+data:
+  brightness_pct: 50
+  transition: 2
+```
+
+:::
+
+### Increase brightness
+
+Turn up the lights that are already on.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Light: Increase brightness 👻
+* - {term}`Action name`
+  - `light.increase_brightness`
+* - {term}`Action targets`
+  - Yes, `light` entities
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Added action
+* - {term}`Developer tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.increase_brightness)
+    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.increase_brightness)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `step_pct`
+  - {term}`number <number>`
+  - Yes
+  - 10
+* - `transition`
+  - {term}`number <number>`
+  - No
+  - 2
+```
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+A dim-up button that does what the one on a Hue remote does:
+
+```{code-block} yaml
+:linenos:
+action: light.increase_brightness
+target:
+  entity_id: light.kitchen
+data:
+  step_pct: 10
+```
+
+:::
+
+### Decrease brightness
+
+Turn down the lights that are already on, stopping at the dimmest they go.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Light: Decrease brightness 👻
+* - {term}`Action name`
+  - `light.decrease_brightness`
+* - {term}`Action targets`
+  - Yes, `light` entities
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Added action
+* - {term}`Developer tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.decrease_brightness)
+    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.decrease_brightness)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `step_pct`
+  - {term}`number <number>`
+  - Yes
+  - 10
+* - `transition`
+  - {term}`number <number>`
+  - No
+  - 2
+```
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: light.decrease_brightness
+target:
+  area_id: bedroom
+data:
+  step_pct: 20
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Lights that are off are left alone. These actions adjust, they do not switch: turning the room up should not light up whatever somebody deliberately turned off.
+- Decreasing stops at the dimmest a light goes rather than switching it off, so holding a dim-down button leaves the room lit rather than dark.
+- A light that reports no brightness at all, an on-or-off light, is skipped. There is nothing to adjust.
+  :::
+
+## Repairs
+
+Spook has no repair detections for this integration.

--- a/documentation/integrations/light.md
+++ b/documentation/integrations/light.md
@@ -223,12 +223,8 @@ Set the color of the lights that are already on. Lights that cannot do color are
   - Default / Example
 * - `rgb_color`
   - {term}`list <list>`
-  - One of the two
+  - Yes
   - [255, 127, 80]
-* - `color_name`
-  - {term}`string <string>`
-  - One of the two
-  - coral
 * - `transition`
   - {term}`number <number>`
   - No
@@ -244,7 +240,7 @@ action: light.set_color
 target:
   area_id: living_room
 data:
-  color_name: coral
+  rgb_color: [255, 127, 80]
 ```
 
 :::

--- a/tests/ectoplasms/light/__init__.py
+++ b/tests/ectoplasms/light/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook light ectoplasm."""

--- a/tests/ectoplasms/light/services/__init__.py
+++ b/tests/ectoplasms/light/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Spook light services."""

--- a/tests/ectoplasms/light/services/conftest.py
+++ b/tests/ectoplasms/light/services/conftest.py
@@ -1,0 +1,139 @@
+"""Lights to adjust, and a group of them."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.light import ColorMode, LightEntity, LightEntityFeature
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.const import Platform
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import (
+        AddConfigEntryEntitiesCallback,
+    )
+
+DIM = "light.dim"
+BRIGHT = "light.bright"
+OFF = "light.off"
+PLAIN = "light.plain"
+GROUP = "light.kitchen"
+
+
+class OnOffLight(LightEntity):
+    """A light with no dimmer, the kind a relay drives."""
+
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_should_poll = False
+
+    def __init__(self, name: str, *, on: bool) -> None:
+        """Initialize the light."""
+        self._attr_name = name
+        self._attr_unique_id = name
+        self._attr_is_on = on
+
+    async def async_turn_on(self, **_kwargs: Any) -> None:
+        """Turn the light on."""
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """Turn the light off."""
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+class FakeLight(LightEntity):
+    """A light that remembers what it was told."""
+
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_features = LightEntityFeature.TRANSITION
+    _attr_should_poll = False
+
+    def __init__(self, name: str, brightness: int, *, on: bool) -> None:
+        """Initialize the light."""
+        self._attr_name = name
+        self._attr_unique_id = name
+        self._attr_brightness = brightness
+        self._attr_is_on = on
+        self.transitions: list[float | None] = []
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on, at a brightness if one was given."""
+        self._attr_is_on = True
+
+        if "brightness" in kwargs:
+            self._attr_brightness = kwargs["brightness"]
+
+        self.transitions.append(kwargs.get("transition"))
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **_kwargs: Any) -> None:
+        """Turn the light off."""
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+async def async_set_up_lights(hass: HomeAssistant) -> None:
+    """Set up three lights: one dim, one bright, one off."""
+
+    async def _setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+        await hass.config_entries.async_forward_entry_setups(entry, [Platform.LIGHT])
+        return True
+
+    async def _setup_platform(
+        _hass: HomeAssistant,
+        _entry: ConfigEntry,
+        add: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        add(
+            [
+                FakeLight("dim", 26, on=True),
+                FakeLight("bright", 255, on=True),
+                FakeLight("off", 128, on=False),
+                OnOffLight("plain", on=True),
+            ]
+        )
+
+    mock_integration(hass, MockModule("fake", async_setup_entry=_setup_entry))
+    mock_platform(hass, "fake.config_flow")
+    mock_platform(hass, "fake.light", MockPlatform(async_setup_entry=_setup_platform))
+
+    class _Flow(ConfigFlow, domain="fake"):
+        """A config flow that does nothing."""
+
+    with mock_config_flow("fake", _Flow):
+        entry = MockConfigEntry(domain="fake")
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def async_set_up_group(hass: HomeAssistant, members: list[str]) -> None:
+    """Put the given lights behind a light group helper."""
+    entry = MockConfigEntry(
+        domain="group",
+        data={},
+        options={
+            "group_type": "light",
+            "name": "Kitchen",
+            "entities": members,
+            "hide_members": False,
+        },
+        title="Kitchen",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/ectoplasms/light/services/conftest.py
+++ b/tests/ectoplasms/light/services/conftest.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.light import ColorMode, LightEntity, LightEntityFeature
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import Platform
+from homeassistant.helpers.group import IntegrationSpecificGroup
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     MockModule,
@@ -28,6 +29,10 @@ BRIGHT = "light.bright"
 OFF = "light.off"
 PLAIN = "light.plain"
 GROUP = "light.kitchen"
+OWNED_GROUP = "light.theset"
+EMPTY_GROUP = "light.nobody"
+COLOUR = "light.colour"
+WHITES = "light.whites"
 
 
 class OnOffLight(LightEntity):
@@ -86,6 +91,72 @@ class FakeLight(LightEntity):
         self.async_write_ha_state()
 
 
+class ColourLight(FakeLight):
+    """A light that can do colour and effects."""
+
+    _attr_supported_color_modes = {ColorMode.RGB}
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_features = LightEntityFeature.TRANSITION | LightEntityFeature.EFFECT
+    _attr_effect_list = ["Colorloop", "Random"]
+
+    def __init__(self, name: str) -> None:
+        """Initialize the light."""
+        super().__init__(name, 255, on=True)
+        self._attr_rgb_color = (255, 255, 255)
+        self.calls: list[dict[str, Any]] = []
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on, remembering everything it was asked for."""
+        self.calls.append(dict(kwargs))
+
+        if "rgb_color" in kwargs:
+            self._attr_rgb_color = kwargs["rgb_color"]
+
+        if "effect" in kwargs:
+            self._attr_effect = kwargs["effect"]
+
+        await super().async_turn_on(**kwargs)
+
+
+class ColourTemperatureLight(FakeLight):
+    """A light that only does whites, with a range of its own."""
+
+    _attr_supported_color_modes = {ColorMode.COLOR_TEMP}
+    _attr_color_mode = ColorMode.COLOR_TEMP
+    _attr_supported_features = LightEntityFeature.TRANSITION
+    _attr_min_color_temp_kelvin = 2202
+    _attr_max_color_temp_kelvin = 4000
+
+    def __init__(self, name: str) -> None:
+        """Initialize the light."""
+        super().__init__(name, 255, on=True)
+        self._attr_color_temp_kelvin = 3000
+        self.calls: list[dict[str, Any]] = []
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on, remembering everything it was asked for."""
+        self.calls.append(dict(kwargs))
+
+        if "color_temp_kelvin" in kwargs:
+            self._attr_color_temp_kelvin = kwargs["color_temp_kelvin"]
+
+        await super().async_turn_on(**kwargs)
+
+
+class IntegrationGroupLight(FakeLight):
+    """A group an integration owns, like the ones MQTT builds.
+
+    Home Assistant gives these members under `group_entities` rather than
+    `entity_id`, and it does so from `helpers/entity.py` for any entity with
+    a group at all.
+    """
+
+    def __init__(self, name: str, member_unique_ids: list[str]) -> None:
+        """Initialize the group."""
+        super().__init__(name, 26, on=True)
+        self.group = IntegrationSpecificGroup(self, member_unique_ids)
+
+
 async def async_set_up_lights(hass: HomeAssistant) -> None:
     """Set up three lights: one dim, one bright, one off."""
 
@@ -104,6 +175,10 @@ async def async_set_up_lights(hass: HomeAssistant) -> None:
                 FakeLight("bright", 255, on=True),
                 FakeLight("off", 128, on=False),
                 OnOffLight("plain", on=True),
+                IntegrationGroupLight("theset", ["dim", "bright"]),
+                IntegrationGroupLight("nobody", []),
+                ColourLight("colour"),
+                ColourTemperatureLight("whites"),
             ]
         )
 

--- a/tests/ectoplasms/light/services/test_colour.py
+++ b/tests/ectoplasms/light/services/test_colour.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.setup import async_setup_component
 import pytest
+import voluptuous as vol
 
 from custom_components.spook.ectoplasms.light.services.set_color import (
     SpookService as ColourService,
@@ -76,7 +76,7 @@ async def test_colour_leaves_a_light_that_is_off_alone(hass: HomeAssistant) -> N
     await hass.services.async_call(
         "light",
         "set_color",
-        {"entity_id": "light.kitchen", "color_name": "coral"},
+        {"entity_id": "light.kitchen", "rgb_color": _CORAL},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -85,10 +85,10 @@ async def test_colour_leaves_a_light_that_is_off_alone(hass: HomeAssistant) -> N
 
 
 async def test_a_colour_is_required(hass: HomeAssistant) -> None:
-    """One of the two ways of naming one, at least."""
+    """Without one there is nothing to set."""
     await _setup(hass)
 
-    with pytest.raises(ServiceValidationError):
+    with pytest.raises(vol.Invalid):
         await hass.services.async_call(
             "light", "set_color", {"entity_id": COLOUR}, blocking=True
         )

--- a/tests/ectoplasms/light/services/test_colour.py
+++ b/tests/ectoplasms/light/services/test_colour.py
@@ -1,0 +1,171 @@
+"""Tests for the light colour, colour temperature and effect actions."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.setup import async_setup_component
+import pytest
+
+from custom_components.spook.ectoplasms.light.services.set_color import (
+    SpookService as ColourService,
+)
+from custom_components.spook.ectoplasms.light.services.set_color_temperature import (
+    SpookService as TemperatureService,
+)
+from custom_components.spook.ectoplasms.light.services.set_effect import (
+    SpookService as EffectService,
+)
+
+from .conftest import COLOUR, DIM, OFF, WHITES, async_set_up_group, async_set_up_lights
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_CORAL = [255, 127, 80]
+_WARM = 2700
+_TOO_COOL = 6500
+_COOLEST_IT_GOES = 4000
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    """Set up the lights and the three actions."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await async_set_up_lights(hass)
+    ColourService(hass).async_register()
+    TemperatureService(hass).async_register()
+    EffectService(hass).async_register()
+    await hass.async_block_till_done()
+
+
+def _light(hass: HomeAssistant, entity_id: str):  # noqa: ANN202
+    """Return the entity object behind an entity ID."""
+    return hass.data["entity_components"]["light"].get_entity(entity_id)
+
+
+async def test_colour_skips_lights_that_cannot_do_colour(
+    hass: HomeAssistant,
+) -> None:
+    """`light.turn_on` with a colour turns a white-only light on white instead.
+
+    Which is a visible change to a light somebody was not asking about, in a
+    room where one lamp happens to do colour and the rest do not.
+    """
+    await _setup(hass)
+    await async_set_up_group(hass, [COLOUR, WHITES, DIM])
+
+    await hass.services.async_call(
+        "light",
+        "set_color",
+        {"entity_id": "light.kitchen", "rgb_color": _CORAL},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(COLOUR).attributes["rgb_color"] == tuple(_CORAL)
+    assert not _light(hass, WHITES).calls, "it went at a light with no colour"
+
+
+async def test_colour_leaves_a_light_that_is_off_alone(hass: HomeAssistant) -> None:
+    """The same promise as the rest of these: adjust, do not switch."""
+    await _setup(hass)
+    await async_set_up_group(hass, [COLOUR, OFF])
+
+    await hass.services.async_call(
+        "light",
+        "set_color",
+        {"entity_id": "light.kitchen", "color_name": "coral"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(OFF).state == "off"
+
+
+async def test_a_colour_is_required(hass: HomeAssistant) -> None:
+    """One of the two ways of naming one, at least."""
+    await _setup(hass)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            "light", "set_color", {"entity_id": COLOUR}, blocking=True
+        )
+
+
+async def test_colour_temperature_is_held_to_what_a_light_can_reach(
+    hass: HomeAssistant,
+) -> None:
+    """Warm white on one lamp is a number another one cannot reach.
+
+    A group is rarely all the same model, so asking for daylight would
+    otherwise be an error on half of them or a silent nothing.
+    """
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "set_color_temperature",
+        {"entity_id": WHITES, "kelvin": _TOO_COOL},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(WHITES).attributes["color_temp_kelvin"] == _COOLEST_IT_GOES
+
+
+async def test_colour_temperature_skips_lights_that_cannot_do_it(
+    hass: HomeAssistant,
+) -> None:
+    """A colour-only light has no white range to sit in."""
+    await _setup(hass)
+    await async_set_up_group(hass, [WHITES, COLOUR])
+
+    await hass.services.async_call(
+        "light",
+        "set_color_temperature",
+        {"entity_id": "light.kitchen", "kelvin": _WARM},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert not _light(hass, COLOUR).calls, "it went at a light with no white range"
+
+
+async def test_an_effect_only_goes_to_lights_that_have_it(
+    hass: HomeAssistant,
+) -> None:
+    """Effect names are per manufacturer and rarely agree.
+
+    Sending one to a light that has never heard of it is an error from the
+    integration, or a light that quietly does nothing.
+    """
+    await _setup(hass)
+    await async_set_up_group(hass, [COLOUR, WHITES])
+
+    await hass.services.async_call(
+        "light",
+        "set_effect",
+        {"entity_id": "light.kitchen", "effect": "Colorloop"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(COLOUR).attributes["effect"] == "Colorloop"
+    assert not _light(hass, WHITES).calls, "it sent an effect to a light without any"
+
+
+async def test_an_effect_nothing_knows_changes_nothing(hass: HomeAssistant) -> None:
+    """Rather than being passed on for the integration to refuse."""
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "set_effect",
+        {"entity_id": COLOUR, "effect": "Disco Inferno"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert not _light(hass, COLOUR).calls

--- a/tests/ectoplasms/light/services/test_set_brightness.py
+++ b/tests/ectoplasms/light/services/test_set_brightness.py
@@ -1,0 +1,77 @@
+"""Tests for the light set brightness action."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.setup import async_setup_component
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.light.services.set_brightness import (
+    SpookService,
+)
+
+from .conftest import BRIGHT, DIM, GROUP, OFF, async_set_up_group, async_set_up_lights
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_HALF = 128
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    """Set up the lights and the action."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await async_set_up_lights(hass)
+    SpookService(hass).async_register()
+    await hass.async_block_till_done()
+
+
+async def test_it_sets_the_lights_that_are_on(hass: HomeAssistant) -> None:
+    """`light.turn_on` sets the level and switches the light on, both at once.
+
+    Adjusting a room usually means the first without the second, and there is
+    no way to ask Home Assistant for that.
+    """
+    await _setup(hass)
+    await async_set_up_group(hass, [DIM, BRIGHT, OFF])
+
+    await hass.services.async_call(
+        "light",
+        "set_brightness",
+        {"entity_id": GROUP, "brightness_pct": 50},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(DIM).attributes["brightness"] == _HALF
+    assert hass.states.get(BRIGHT).attributes["brightness"] == _HALF
+    assert hass.states.get(OFF).state == "off", "it switched on a light that was off"
+
+
+async def test_a_transition_is_passed_along(hass: HomeAssistant) -> None:
+    """Because a jump to half brightness is not what anybody wants to watch."""
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "set_brightness",
+        {"entity_id": DIM, "brightness_pct": 50, "transition": 2},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    light = hass.data["entity_components"]["light"].get_entity(DIM)
+    assert light.transitions == [2.0]
+
+
+async def test_a_brightness_is_required(hass: HomeAssistant) -> None:
+    """Without one there is nothing to set."""
+    await _setup(hass)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            "light", "set_brightness", {"entity_id": DIM}, blocking=True
+        )

--- a/tests/ectoplasms/light/services/test_step_brightness.py
+++ b/tests/ectoplasms/light/services/test_step_brightness.py
@@ -1,0 +1,184 @@
+"""Tests for the light brightness stepping actions."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.setup import async_setup_component
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.light.services.decrease_brightness import (
+    SpookService as DecreaseService,
+)
+from custom_components.spook.ectoplasms.light.services.increase_brightness import (
+    SpookService as IncreaseService,
+)
+
+from .conftest import (
+    BRIGHT,
+    DIM,
+    GROUP,
+    OFF,
+    PLAIN,
+    async_set_up_group,
+    async_set_up_lights,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+# What the lights in the fixtures start at, and where the scale ends.
+_DIM = 26
+_FULL = 255
+_ONE_STEP = 26
+_DIMMEST = 1
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    """Set up the lights and both stepping actions."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await async_set_up_lights(hass)
+    IncreaseService(hass).async_register()
+    DecreaseService(hass).async_register()
+    await hass.async_block_till_done()
+
+
+def _brightness(hass: HomeAssistant, entity_id: str) -> int | None:
+    """Return what a light is set to right now."""
+    return hass.states.get(entity_id).attributes.get("brightness")
+
+
+async def test_each_light_steps_from_its_own_level(hass: HomeAssistant) -> None:
+    """A group keeps its shape rather than levelling out.
+
+    Measured against Home Assistant first: stepping the group entity averages
+    its members and sets every one of them to that average, so a room with a
+    lamp at 10% and one at 100% ends up with both at 65%.
+    """
+    await _setup(hass)
+    await async_set_up_group(hass, [DIM, BRIGHT])
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": GROUP, "step_pct": 10},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert _brightness(hass, DIM) == _DIM + _ONE_STEP
+    assert _brightness(hass, BRIGHT) == _FULL, "it was already as bright as it goes"
+
+
+async def test_a_light_that_is_off_is_left_alone(hass: HomeAssistant) -> None:
+    """Home Assistant reads an off light as zero and turns it on from there.
+
+    So asking a room for more light switches on everything somebody had
+    deliberately turned off. These actions do not switch lights at all.
+    """
+    await _setup(hass)
+    await async_set_up_group(hass, [DIM, OFF])
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": GROUP, "step_pct": 10},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(OFF).state == "off"
+    assert _brightness(hass, DIM) == _DIM + _ONE_STEP
+
+
+async def test_decreasing_stops_at_the_dimmest_a_light_goes(
+    hass: HomeAssistant,
+) -> None:
+    """Rather than switching it off, so holding a button leaves the room lit."""
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "decrease_brightness",
+        {"entity_id": DIM, "step_pct": 100},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(DIM).state == "on"
+    assert _brightness(hass, DIM) == _DIMMEST
+
+
+async def test_increasing_stops_at_full(hass: HomeAssistant) -> None:
+    """There is nothing above full brightness to ask for."""
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": DIM, "step_pct": 100},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert _brightness(hass, DIM) == _FULL
+
+
+async def test_a_step_is_required(hass: HomeAssistant) -> None:
+    """Without one there is nothing to do."""
+    await _setup(hass)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            "light", "increase_brightness", {"entity_id": DIM}, blocking=True
+        )
+
+
+async def test_a_light_with_no_dimmer_is_left_alone(hass: HomeAssistant) -> None:
+    """An on-or-off light has no brightness to step.
+
+    It is still a light, so it lands in a group and in an area target like any
+    other, and asking it for ten percent more is asking for nothing.
+    """
+    await _setup(hass)
+    await async_set_up_group(hass, [DIM, PLAIN])
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": GROUP, "step_pct": 10},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(PLAIN).state == "on"
+    assert "brightness" not in hass.states.get(PLAIN).attributes
+    assert _brightness(hass, DIM) == _DIM + _ONE_STEP
+
+
+async def test_a_light_that_is_off_but_still_reports_a_level_is_left_alone(
+    hass: HomeAssistant,
+) -> None:
+    """Being off is what settles it, not whether a level is on record.
+
+    Home Assistant drops the brightness attribute when a light goes off, but
+    not everything that writes a state does: a restored state or a template
+    can carry both. Reading the level and ignoring the state would turn such a
+    light on.
+    """
+    await _setup(hass)
+    hass.states.async_set(OFF, "off", {"brightness": 128, "color_mode": "brightness"})
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": OFF, "step_pct": 10},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(OFF).state == "off", "it turned on a light that was off"

--- a/tests/ectoplasms/light/services/test_step_brightness.py
+++ b/tests/ectoplasms/light/services/test_step_brightness.py
@@ -3,6 +3,9 @@
 # pylint: disable=wrong-import-order
 from __future__ import annotations
 
+import asyncio
+from functools import partial
+
 from typing import TYPE_CHECKING
 
 from homeassistant.setup import async_setup_component
@@ -19,8 +22,10 @@ from custom_components.spook.ectoplasms.light.services.increase_brightness impor
 from .conftest import (
     BRIGHT,
     DIM,
+    EMPTY_GROUP,
     GROUP,
     OFF,
+    OWNED_GROUP,
     PLAIN,
     async_set_up_group,
     async_set_up_lights,
@@ -182,3 +187,111 @@ async def test_a_light_that_is_off_but_still_reports_a_level_is_left_alone(
     await hass.async_block_till_done()
 
     assert hass.states.get(OFF).state == "off", "it turned on a light that was off"
+
+
+async def test_a_transition_is_passed_along(hass: HomeAssistant) -> None:
+    """Because a jump to a new level is not what anybody wants to watch."""
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": DIM, "step_pct": 10, "transition": 2},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    light = hass.data["entity_components"]["light"].get_entity(DIM)
+    assert light.transitions == [2.0]
+
+
+async def test_lights_are_stepped_together_rather_than_one_after_another(
+    hass: HomeAssistant,
+) -> None:
+    """A room full of lights should not take as long as all of them added up.
+
+    Every light lands on its own level, so this cannot be a single call, but
+    it does not have to wait for each one either. Slow lights are exactly the
+    ones somebody notices while dimming.
+    """
+    await _setup(hass)
+    await async_set_up_group(hass, [DIM, BRIGHT])
+
+    started = asyncio.Event()
+    both_in_flight = asyncio.Event()
+    in_flight = 0
+
+    lights = hass.data["entity_components"]["light"]
+    originals = {
+        entity_id: lights.get_entity(entity_id).async_turn_on
+        for entity_id in (DIM, BRIGHT)
+    }
+
+    async def _slow(entity_id: str, **kwargs: object) -> None:
+        nonlocal in_flight
+        in_flight += 1
+        started.set()
+
+        if in_flight == 2:  # noqa: PLR2004
+            both_in_flight.set()
+
+        await both_in_flight.wait()
+        await originals[entity_id](**kwargs)
+
+    for entity_id in (DIM, BRIGHT):
+        entity = lights.get_entity(entity_id)
+        entity.async_turn_on = partial(_slow, entity_id)  # type: ignore[method-assign]
+
+    async with asyncio.timeout(5):
+        await hass.services.async_call(
+            "light",
+            "increase_brightness",
+            {"entity_id": GROUP, "step_pct": 10},
+            blocking=True,
+        )
+
+    assert both_in_flight.is_set(), "the second light waited for the first to finish"
+
+
+async def test_a_group_an_integration_owns_is_worked_through_too(
+    hass: HomeAssistant,
+) -> None:
+    """Not every light group keeps its members under the same attribute.
+
+    A helper group lists entity IDs under `entity_id`. A group belonging to
+    one integration, like the ones MQTT builds, gets `group_entities` from
+    Home Assistant itself. Reading only the first sort means stepping the
+    second sort's group entity, which is the averaging this exists to avoid.
+    """
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": OWNED_GROUP, "step_pct": 10},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert _brightness(hass, DIM) == _DIM + _ONE_STEP
+    assert _brightness(hass, BRIGHT) == _FULL
+
+
+async def test_a_group_with_no_members_is_not_a_light(hass: HomeAssistant) -> None:
+    """An empty group is still a group, and has no level worth setting.
+
+    Reading its members as "does it hold anything" rather than "does it say
+    what it holds" would drop it through to the plain-light case, and step the
+    group entity itself.
+    """
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": EMPTY_GROUP, "step_pct": 10},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert _brightness(hass, EMPTY_GROUP) == _DIM, "it stepped the group itself"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Three light actions that adjust rather than switch: `light.set_brightness`, `light.increase_brightness` and `light.decrease_brightness`.

`light.turn_on` does two things at once. It sets a level and it turns the light on. Adjusting a room usually means the first without the second, and there is no way to ask Home Assistant for that.

Both halves of the problem were measured rather than assumed:

- `brightness_step_pct: 10` on a light that is **off** turns it on at 26. So dimming the living room lights up whatever somebody had deliberately switched off.
- A light group holding one lamp at 26 and one at 255 reports 140, its average. One step of ten percent leaves **both members at 166**: the dim one jumps up, the bright one drops. Not brighter, just flatter.

These actions work through to the members of a group and step each light from its own level. Lights that are off are skipped, and so are lights with no dimmer at all, since there is nothing there to adjust. Decreasing stops at the dimmest a light goes rather than switching it off, so holding a dim-down button leaves the room lit rather than dark.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is the adjust-if-on half of [architecture#537](https://github.com/home-assistant/architecture/discussions/537), open since 2021, along with core#118009 on group stepping and a long tail of forum threads asking for Hue-style group dimming. No HACS integration occupies this niche.

The other thing people ask for in that discussion, setting a level on a light that is off so it comes back at that level, is deliberately not here. That is hardware-dependent, only some lights support it, and the light platform has no capability flag to check, so Spook cannot promise it generically.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Full suite green at 1330, both against the pinned release and against Home Assistant 2026.10.0.dev0 from git. The documentation builds clean.

The tests set up real lights behind a real light group helper rather than faking the shape, since the group behaviour is exactly what needed proving. Nine tests covering: each member stepping from its own level, an off light staying off, an off light that still reports a level staying off, a light with no dimmer being skipped, clamping at both ends, and a transition being passed along.

Every guard was mutation tested. Two of them turned out to cover for each other: dropping either the on-check or the brightness-check alone changed nothing observable, because Home Assistant removes the brightness attribute when a light goes off. Both have their own test now, the on-check via a state that carries a level while being off, which is what a restored state or a template can produce.

One thing worth noting: the check added in #1500, that every entity component service names its domain in the manifest, caught `light` being missing straight away. That was what it was for.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
