### PR TITLE
Say which integration left entities behind, and offer to clear them

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from datetime import datetime
 
-    from homeassistant.core import Event, HomeAssistant, State
+    from homeassistant.core import Event, State
 
 
 # How long an integration gets to produce its first entity before Spook takes
@@ -53,15 +53,10 @@ class SpookRepair(AbstractSpookRepair):
     inspect_config_entry_changed = True
     automatically_clean_up_issues = True
 
-    #: When each config entry was first seen loaded with nothing to show for
-    #: it. In memory on purpose: a restart is exactly when a push-fed
-    #: integration has not been pushed to yet, so the wait starts over.
-    _loaded_since: dict[str, datetime]
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the repair."""
-        super().__init__(hass)
-        self._loaded_since = {}
+    # Nothing happens when the wait below runs out: that is the whole point of
+    # it, an integration that has gone quiet. So the passage of time has to be
+    # what brings this back round.
+    inspect_interval = _LONG_ENOUGH_TO_PUSH
 
     async def async_activate(self) -> None:
         """Handle activating the repair."""
@@ -122,15 +117,23 @@ class SpookRepair(AbstractSpookRepair):
         the wait below, because an integration whose every entity is genuinely
         gone would otherwise never be reported at all.
         """
-        if any(
-            (state := self.hass.states.get(entry.entity_id)) is not None
-            and not state.attributes.get(ATTR_RESTORED)
-            for entry in er.async_entries_for_config_entry(entity_registry, entry_id)
-        ):
-            return True
+        newest: datetime | None = None
 
-        first_seen = self._loaded_since.setdefault(entry_id, dt_util.utcnow())
-        return dt_util.utcnow() - first_seen >= _LONG_ENOUGH_TO_PUSH
+        for entry in er.async_entries_for_config_entry(entity_registry, entry_id):
+            if (state := self.hass.states.get(entry.entity_id)) is None:
+                continue
+
+            if not state.attributes.get(ATTR_RESTORED):
+                return True
+
+            if newest is None or state.last_changed > newest:
+                newest = state.last_changed
+
+        # Read off the placeholders themselves rather than kept in the repair,
+        # because a reload takes them away and writes them again, so this
+        # starts over exactly when the integration does. Which is the point:
+        # after a reload a push-fed integration has not been pushed to yet.
+        return newest is not None and dt_util.utcnow() - newest >= _LONG_ENOUGH_TO_PUSH
 
     async def async_inspect(self) -> None:
         """Trigger an inspection."""

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntryState
@@ -15,14 +16,23 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.loader import Integration, async_get_integrations
+from homeassistant.util import dt as dt_util
 
 from ....const import LOGGER
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from datetime import datetime
 
-    from homeassistant.core import Event, State
+    from homeassistant.core import Event, HomeAssistant, State
+
+
+# How long an integration gets to produce its first entity before Spook takes
+# the silence at face value. Devices that push on their own schedule are the
+# slow ones here: a weather station reporting every fifteen minutes is normal,
+# and being wrong about this is worse than being late.
+_LONG_ENOUGH_TO_PUSH = timedelta(hours=1)
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -42,6 +52,16 @@ class SpookRepair(AbstractSpookRepair):
     }
     inspect_config_entry_changed = True
     automatically_clean_up_issues = True
+
+    #: When each config entry was first seen loaded with nothing to show for
+    #: it. In memory on purpose: a restart is exactly when a push-fed
+    #: integration has not been pushed to yet, so the wait starts over.
+    _loaded_since: dict[str, datetime]
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the repair."""
+        super().__init__(hass)
+        self._loaded_since = {}
 
     async def async_activate(self) -> None:
         """Handle activating the repair."""
@@ -83,12 +103,12 @@ class SpookRepair(AbstractSpookRepair):
         )
 
     @callback
-    def _async_has_living_entities(
+    def _async_had_its_chance(
         self,
         entry_id: str,
         entity_registry: er.EntityRegistry,
     ) -> bool:
-        """Return whether anything of this config entry has actually turned up.
+        """Return whether this config entry has had time to produce anything.
 
         Being loaded is not the same as having data. An integration fed by a
         webhook, Ecowitt among them, sets up in a moment and then waits for
@@ -97,14 +117,20 @@ class SpookRepair(AbstractSpookRepair):
         that would be telling somebody their weather station is gone while it
         is simply between readings.
 
-        One entity that made it is enough to say the data arrived, and that
-        whatever else is still missing is missing for a different reason.
+        One entity that made it settles it at once: the data arrived, and
+        whatever is still missing is missing for another reason. Failing that,
+        the wait below, because an integration whose every entity is genuinely
+        gone would otherwise never be reported at all.
         """
-        return any(
+        if any(
             (state := self.hass.states.get(entry.entity_id)) is not None
             and not state.attributes.get(ATTR_RESTORED)
             for entry in er.async_entries_for_config_entry(entity_registry, entry_id)
-        )
+        ):
+            return True
+
+        first_seen = self._loaded_since.setdefault(entry_id, dt_util.utcnow())
+        return dt_util.utcnow() - first_seen >= _LONG_ENOUGH_TO_PUSH
 
     async def async_inspect(self) -> None:
         """Trigger an inspection."""
@@ -130,7 +156,7 @@ class SpookRepair(AbstractSpookRepair):
             for entry_id in dead_by_entry
             if (entry := self.hass.config_entries.async_get_entry(entry_id)) is not None
             and entry.state is ConfigEntryState.LOADED
-            and self._async_has_living_entities(entry_id, entity_registry)
+            and self._async_had_its_chance(entry_id, entity_registry)
         }
 
         # The name people know an integration by lives in its manifest. A

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
@@ -82,6 +82,30 @@ class SpookRepair(AbstractSpookRepair):
             ),
         )
 
+    @callback
+    def _async_has_living_entities(
+        self,
+        entry_id: str,
+        entity_registry: er.EntityRegistry,
+    ) -> bool:
+        """Return whether anything of this config entry has actually turned up.
+
+        Being loaded is not the same as having data. An integration fed by a
+        webhook, Ecowitt among them, sets up in a moment and then waits for
+        the device to push, which can be minutes. Everything it registered
+        sits there restored and unavailable in the meantime, and reporting
+        that would be telling somebody their weather station is gone while it
+        is simply between readings.
+
+        One entity that made it is enough to say the data arrived, and that
+        whatever else is still missing is missing for a different reason.
+        """
+        return any(
+            (state := self.hass.states.get(entry.entity_id)) is not None
+            and not state.attributes.get(ATTR_RESTORED)
+            for entry in er.async_entries_for_config_entry(entity_registry, entry_id)
+        )
+
     async def async_inspect(self) -> None:
         """Trigger an inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
@@ -106,6 +130,7 @@ class SpookRepair(AbstractSpookRepair):
             for entry_id in dead_by_entry
             if (entry := self.hass.config_entries.async_get_entry(entry_id)) is not None
             and entry.state is ConfigEntryState.LOADED
+            and self._async_has_living_entities(entry_id, entity_registry)
         }
 
         # The name people know an integration by lives in its manifest. A

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/dead_entities.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.loader import Integration, async_get_integrations
 
 from ....const import LOGGER
 from ....repairs import AbstractSpookRepair
@@ -100,24 +101,47 @@ class SpookRepair(AbstractSpookRepair):
                 continue
             dead_by_entry[entry.config_entry_id].append(state.entity_id)
 
-        for entry_id, entity_ids in dead_by_entry.items():
-            config_entry = self.hass.config_entries.async_get_entry(entry_id)
-            if (
-                config_entry is None
-                or config_entry.state is not ConfigEntryState.LOADED
-            ):
-                # The integration is gone or still (re)loading; its entities
-                # may still appear, so this is not a dead-entity signal.
-                continue
+        entries = {
+            entry_id: entry
+            for entry_id in dead_by_entry
+            if (entry := self.hass.config_entries.async_get_entry(entry_id)) is not None
+            and entry.state is ConfigEntryState.LOADED
+        }
+
+        # The name people know an integration by lives in its manifest. A
+        # config entry's title is whatever it was set up as, which for an
+        # account-based integration is the name of the account holder: being
+        # told that "Franck Nijhof" registered dead entities is not helpful.
+        names = await async_get_integrations(
+            self.hass, {entry.domain for entry in entries.values()}
+        )
+
+        for entry_id, config_entry in entries.items():
+            integration = names.get(config_entry.domain)
+            name = (
+                integration.name
+                if isinstance(integration, Integration)
+                else config_entry.domain
+            )
 
             self.possible_issue_ids.add(entry_id)
             self.async_create_issue(
                 issue_id=entry_id,
                 issue_domain=config_entry.domain,
-                translation_placeholders={
-                    "integration": config_entry.title,
+                is_fixable=True,
+                data={
+                    "dead_entities_config_entry_id": entry_id,
+                    "integration": name,
                     "entities": "\n".join(
-                        f"- `{entity_id}`" for entity_id in sorted(entity_ids)
+                        f"- `{entity_id}`"
+                        for entity_id in sorted(dead_by_entry[entry_id])
+                    ),
+                },
+                translation_placeholders={
+                    "integration": name,
+                    "entities": "\n".join(
+                        f"- `{entity_id}`"
+                        for entity_id in sorted(dead_by_entry[entry_id])
                     ),
                 },
             )

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -20,7 +20,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigEntryChange,
 )
-from homeassistant.const import CONF_ENTITIES
+from homeassistant.const import ATTR_RESTORED, CONF_ENTITIES
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
@@ -956,6 +956,47 @@ class HelperUnknownSourcesFixFlow(_RemoveOrIgnoreFixFlow):
         return self.async_create_entry(data={})
 
 
+class DeadEntitiesFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for registry entries whose entities never came back.
+
+    Removes the registry entries themselves, which is the only place these
+    still exist. Telling somebody to go and do that by hand was the old
+    advice, and it asked them to know what an entity registry is.
+    """
+
+    _key = "integration"
+    _id_key = "dead_entities_config_entry_id"
+
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Name the integration and its dead entities in the menu step."""
+        data = self.data or {}
+        return {
+            "integration": str(data.get("integration", "")),
+            "entities": str(data.get("entities", "")),
+        }
+
+    async def async_step_remove(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Remove the registry entries of entities that never came back.
+
+        Read afresh rather than taken from the issue: the issue may have been
+        sitting in front of somebody for a while, and an entity that has since
+        returned is not one to delete.
+        """
+        entry_id = str((self.data or {}).get(self._id_key, ""))
+        entity_registry = er.async_get(self.hass)
+
+        for entry in er.async_entries_for_config_entry(entity_registry, entry_id):
+            state = self.hass.states.get(entry.entity_id)
+
+            if state is not None and state.attributes.get(ATTR_RESTORED):
+                entity_registry.async_remove(entry.entity_id)
+
+        return self.async_create_entry(data={})
+
+
 # Remove-or-ignore fix flows, keyed by the data field that identifies their
 # leftover registry thing.
 _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
@@ -968,6 +1009,7 @@ _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
     "group_entity_id": GroupUnknownMembersFixFlow,
     "min_max_config_entry_id": MinMaxUnknownSourcesFixFlow,
     "helper_config_entry_id": HelperUnknownSourcesFixFlow,
+    "dead_entities_config_entry_id": DeadEntitiesFixFlow,
 }
 
 

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -19,6 +19,7 @@ from homeassistant.config_entries import (
     SIGNAL_CONFIG_ENTRY_CHANGED,
     ConfigEntry,
     ConfigEntryChange,
+    ConfigEntryState,
 )
 from homeassistant.const import ATTR_RESTORED, CONF_ENTITIES
 from homeassistant.core import Event, HomeAssistant, callback
@@ -986,6 +987,15 @@ class DeadEntitiesFixFlow(_RemoveOrIgnoreFixFlow):
         returned is not one to delete.
         """
         entry_id = str((self.data or {}).get(self._id_key, ""))
+
+        config_entry = self.hass.config_entries.async_get_entry(entry_id)
+        if config_entry is None or config_entry.state is not ConfigEntryState.LOADED:
+            # Everything of an integration that is reloading or retrying looks
+            # restored while that lasts, and the issue may have been sitting
+            # here since before it started. Deleting then would take entities
+            # that are on their way back.
+            return self.async_abort(reason="not_loaded")
+
         entity_registry = er.async_get(self.hass)
 
         for entry in er.async_entries_for_config_entry(entity_registry, entry_id):

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -503,7 +503,7 @@
       "fix_flow": {
         "step": {
           "init": {
-            "title": "Entities {integration} never brought back",
+            "title": "Entities that {integration} never brought back",
             "description": "The {integration} integration is running, but these entities of its own never turned up:\n\n{entities}\n\nThey are gone at the source and only their leftover registrations remain, which is why they show as unavailable and why nothing can be done with them.\n\nSpook \ud83d\udc7b Your homie.",
             "menu_options": {
               "remove": "Clear out these entities",
@@ -514,6 +514,7 @@
         },
         "abort": {
           "issue_ignored": "Spook will keep quiet about these entities from now on.",
+          "not_loaded": "That integration is reloading right now, and everything of it looks missing while that lasts. Try again once it has settled.",
           "manage": "You can find them on the [entities page](/config/entities), where filtering by status Unavailable brings them together. Select them and use Remove selected."
         }
       }

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -499,8 +499,24 @@
       "title": "Unknown triggers used in: {automation}"
     },
     "dead_entities": {
-      "description": "Spook has found a ghost in your entities 👻\n\nThe {integration} integration finished setting up, but the following entities it registered never appeared, so they no longer exist:\n\n{entities}\n\n\n\nThis usually happens when a device or its entities were removed at the source but their registry entries stayed behind. To fix this error, remove these entities from the entity registry if you no longer need them.\n\nSpook 👻 Your homie.",
-      "title": "Non-existing entities registered by: {integration}"
+      "title": "Non-existing entities registered by: {integration}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Entities {integration} never brought back",
+            "description": "The {integration} integration is running, but these entities of its own never turned up:\n\n{entities}\n\nThey are gone at the source and only their leftover registrations remain, which is why they show as unavailable and why nothing can be done with them.\n\nSpook \ud83d\udc7b Your homie.",
+            "menu_options": {
+              "remove": "Clear out these entities",
+              "ignore": "Keep them, stop telling me",
+              "manage": "Let me do it myself"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about these entities from now on.",
+          "manage": "You can find them on the [entities page](/config/entities), where filtering by status Unavailable brings them together. Select them and use Remove selected."
+        }
+      }
     },
     "empty_areas": {
       "title": "Empty area: {area}",

--- a/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
@@ -12,7 +12,10 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_RESTORED, STATE_UNAVAILABLE
 from homeassistant.core import State
 
+from homeassistant.data_entry_flow import FlowResultType
+
 from custom_components.spook.const import DOMAIN
+from custom_components.spook.repairs import DeadEntitiesFixFlow
 from custom_components.spook.ectoplasms.homeassistant.repairs.dead_entities import (
     SpookRepair,
 )
@@ -23,8 +26,14 @@ if TYPE_CHECKING:
     from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 
-def _loaded_entry(hass: HomeAssistant, title: str = "Hue") -> MockConfigEntry:
-    """Add a loaded config entry to hass."""
+def _loaded_entry(
+    hass: HomeAssistant, title: str = "Somebody's account"
+) -> MockConfigEntry:
+    """Add a loaded config entry to hass.
+
+    The title is deliberately not the integration's name, because for an
+    account-based integration it never is.
+    """
     entry = MockConfigEntry(domain="derivative", title=title)
     entry.add_to_hass(hass)
     entry.mock_state(hass, ConfigEntryState.LOADED)
@@ -63,7 +72,10 @@ async def test_dead_entity_of_loaded_entry_is_reported(
     assert issue
     assert issue.translation_placeholders
     assert issue.translation_placeholders["entities"] == f"- `{dead}`"
-    assert issue.translation_placeholders["integration"] == "Hue"
+    assert issue.translation_placeholders["integration"] == "Derivative", (
+        "it named the config entry rather than the integration"
+    )
+    assert issue.is_fixable, "there is nothing a person can do with this by hand"
 
 
 async def test_live_entity_is_not_reported(
@@ -246,3 +258,52 @@ async def test_entity_removed_outright_does_not_recheck(hass: HomeAssistant) -> 
     repair to find.
     """
     assert await _count_scheduled_inspections(hass, _live(), None) == 0
+
+
+async def test_the_fix_clears_out_the_leftover_registrations(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Which is the only place these entities still exist.
+
+    The old advice was to go and remove them from the entity registry, which
+    asks somebody to know what an entity registry is and where to find it.
+    """
+    entry = _loaded_entry(hass)
+    dead = _register_restored(hass, entity_registry, entry, "dead")
+    other = _register_restored(hass, entity_registry, None, "not_this_one")
+
+    flow = DeadEntitiesFixFlow()
+    flow.hass = hass
+    flow.data = {"dead_entities_config_entry_id": entry.entry_id}
+
+    result = await flow.async_step_remove()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entity_registry.async_get(dead) is None
+    assert entity_registry.async_get(other) is not None, "it took one that was not its"
+
+
+async def test_the_fix_leaves_an_entity_that_came_back(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """An issue can sit in front of somebody for a while.
+
+    An entity that turned up again in the meantime is a working entity, and
+    deleting its registration would take its history and settings with it.
+    """
+    entry = _loaded_entry(hass)
+    dead = _register_restored(hass, entity_registry, entry, "dead")
+    returned = _register_restored(hass, entity_registry, entry, "returned")
+
+    hass.states.async_set(returned, "21.5")
+
+    flow = DeadEntitiesFixFlow()
+    flow.hass = hass
+    flow.data = {"dead_entities_config_entry_id": entry.entry_id}
+
+    await flow.async_step_remove()
+
+    assert entity_registry.async_get(dead) is None
+    assert entity_registry.async_get(returned) is not None

--- a/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
@@ -449,3 +449,77 @@ async def test_an_integration_with_nothing_left_is_reported_in_the_end(
     await repair.async_inspect()
 
     assert issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+
+
+async def test_a_reload_starts_the_wait_over(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A reloaded integration has not been pushed to yet either.
+
+    The wait is read off the placeholder states, and a reload takes those
+    away and writes them again, so it begins afresh without anything having
+    to remember that it should.
+    """
+    entry = _loaded_entry(hass)
+    dead = _register_restored(hass, entity_registry, entry, "the_only_one")
+    repair = SpookRepair(hass)
+
+    freezer.tick(timedelta(hours=1, minutes=1))
+
+    # What a reload does to a placeholder: gone, and written again.
+    hass.states.async_remove(dead)
+    hass.states.async_set(dead, STATE_UNAVAILABLE, {ATTR_RESTORED: True})
+
+    await repair.async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+        is None
+    ), "it counted the wait from before the reload"
+
+
+def test_the_wait_brings_the_inspection_back_by_itself() -> None:
+    """Nothing happens when the wait runs out, which is the point of it.
+
+    An integration that has gone quiet raises no events, so without the
+    passage of time bringing this round again the wait would only expire on
+    paper.
+    """
+    assert SpookRepair.inspect_interval is not None
+    assert SpookRepair.inspect_interval <= timedelta(hours=1), (
+        "the wait would expire long before anything looked again"
+    )
+
+
+async def test_the_wait_runs_from_the_most_recent_placeholder(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """One placeholder written just now means the integration is doing things.
+
+    Reading the oldest instead would report the lot on the strength of an
+    entity that has been sitting there since before the integration last
+    stirred.
+    """
+    entry = _loaded_entry(hass)
+    old = _register_restored(hass, entity_registry, entry, "sitting_there")
+
+    freezer.tick(timedelta(hours=1, minutes=1))
+    _register_restored(hass, entity_registry, entry, "just_now")
+
+    assert (
+        hass.states.get(old).last_changed
+        < hass.states.get("sensor.hue_just_now").last_changed
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+        is None
+    ), "it went by the oldest placeholder rather than the newest"

--- a/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
@@ -57,6 +57,28 @@ def _register_restored(
     return reg.entity_id
 
 
+def _register_living(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    entry: MockConfigEntry,
+    object_id: str = "living",
+) -> str:
+    """Register an entity of this entry that actually turned up.
+
+    Most tests want one. The repair only speaks up once something of a config
+    entry has real data, since an integration that is loaded but still waiting
+    for its first push has everything restored and nothing wrong with it.
+    """
+    reg = entity_registry.async_get_or_create(
+        "sensor",
+        "hue",
+        object_id,
+        config_entry=entry,
+    )
+    hass.states.async_set(reg.entity_id, "21.5")
+    return reg.entity_id
+
+
 async def test_dead_entity_of_loaded_entry_is_reported(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -64,6 +86,7 @@ async def test_dead_entity_of_loaded_entry_is_reported(
 ) -> None:
     """Test a restored entity of a loaded entry is reported."""
     entry = _loaded_entry(hass)
+    _register_living(hass, entity_registry, entry)
     dead = _register_restored(hass, entity_registry, entry, "dead")
 
     await SpookRepair(hass).async_inspect()
@@ -154,6 +177,7 @@ async def test_entity_dying_mid_session_is_reported(
     the config entry stays loaded, so nothing else marks the moment.
     """
     entry = _loaded_entry(hass)
+    _register_living(hass, entity_registry, entry)
     reg = entity_registry.async_get_or_create(
         "sensor", "hue", "dies", config_entry=entry
     )
@@ -179,6 +203,7 @@ async def test_issue_clears_when_the_entity_finally_appears(
 ) -> None:
     """Test the issue goes away once the entity shows up for real."""
     entry = _loaded_entry(hass)
+    _register_living(hass, entity_registry, entry)
     dead = _register_restored(hass, entity_registry, entry, "late")
     repair = SpookRepair(hass)
 
@@ -270,6 +295,7 @@ async def test_the_fix_clears_out_the_leftover_registrations(
     asks somebody to know what an entity registry is and where to find it.
     """
     entry = _loaded_entry(hass)
+    _register_living(hass, entity_registry, entry)
     dead = _register_restored(hass, entity_registry, entry, "dead")
     other = _register_restored(hass, entity_registry, None, "not_this_one")
 
@@ -294,6 +320,7 @@ async def test_the_fix_leaves_an_entity_that_came_back(
     deleting its registration would take its history and settings with it.
     """
     entry = _loaded_entry(hass)
+    _register_living(hass, entity_registry, entry)
     dead = _register_restored(hass, entity_registry, entry, "dead")
     returned = _register_restored(hass, entity_registry, entry, "returned")
 
@@ -307,3 +334,53 @@ async def test_the_fix_leaves_an_entity_that_came_back(
 
     assert entity_registry.async_get(dead) is None
     assert entity_registry.async_get(returned) is not None
+
+
+async def test_an_integration_still_waiting_for_its_first_data_is_not_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Loaded is not the same as having data.
+
+    An integration fed by a webhook, Ecowitt among them, sets up in a moment
+    and then waits for the device to push, which can be minutes. Everything it
+    registered sits restored and unavailable in the meantime. Reporting that
+    tells somebody their weather station is gone while it is between
+    readings, and with a fix button attached they can throw the lot away.
+    """
+    entry = _loaded_entry(hass)
+    for name in ("temperature", "humidity", "wind"):
+        _register_restored(hass, entity_registry, entry, name)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+        is None
+    ), "it reported an integration that had simply not been pushed to yet"
+
+
+async def test_once_the_data_arrives_what_is_still_missing_is_reported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """One entity through the door says the rest are not coming.
+
+    A sensor removed at the station is a real leftover, and by then there is
+    something to tell it apart from an integration that has not started
+    talking yet.
+    """
+    entry = _loaded_entry(hass)
+    for name in ("temperature", "humidity"):
+        _register_restored(hass, entity_registry, entry, name)
+    _register_living(hass, entity_registry, entry, "wind")
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+    assert issue
+    assert issue.translation_placeholders
+    assert "temperature" in issue.translation_placeholders["entities"]
+    assert "wind" not in issue.translation_placeholders["entities"]

--- a/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_dead_entities.py
@@ -4,6 +4,7 @@
 # pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -15,13 +16,15 @@ from homeassistant.core import State
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.spook.const import DOMAIN
-from custom_components.spook.repairs import DeadEntitiesFixFlow
+from custom_components.spook.repairs import DeadEntitiesFixFlow, async_create_fix_flow
 from custom_components.spook.ectoplasms.homeassistant.repairs.dead_entities import (
     SpookRepair,
 )
 from tests.repair_helpers import async_count_scheduled_inspections
 
 if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
@@ -299,7 +302,14 @@ async def test_the_fix_clears_out_the_leftover_registrations(
     dead = _register_restored(hass, entity_registry, entry, "dead")
     other = _register_restored(hass, entity_registry, None, "not_this_one")
 
-    flow = DeadEntitiesFixFlow()
+    flow = await async_create_fix_flow(
+        hass,
+        f"dead_entities_{entry.entry_id}",
+        {"dead_entities_config_entry_id": entry.entry_id},
+    )
+    assert isinstance(flow, DeadEntitiesFixFlow), (
+        "the issue would fall back to a plain confirm dialog"
+    )
     flow.hass = hass
     flow.data = {"dead_entities_config_entry_id": entry.entry_id}
 
@@ -384,3 +394,58 @@ async def test_once_the_data_arrives_what_is_still_missing_is_reported(
     assert issue.translation_placeholders
     assert "temperature" in issue.translation_placeholders["entities"]
     assert "wind" not in issue.translation_placeholders["entities"]
+
+
+async def test_the_fix_stands_down_while_the_integration_is_reloading(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Everything of a reloading integration looks missing while that lasts.
+
+    The issue may have been sitting there since before the reload started, so
+    acting on it then would delete entities that are on their way back. The
+    inspection already refuses to look at entries that are not loaded; the fix
+    has to as well.
+    """
+    entry = _loaded_entry(hass)
+    dead = _register_restored(hass, entity_registry, entry, "dead")
+    entry.mock_state(hass, ConfigEntryState.SETUP_RETRY)
+
+    flow = DeadEntitiesFixFlow()
+    flow.hass = hass
+    flow.data = {"dead_entities_config_entry_id": entry.entry_id}
+
+    result = await flow.async_step_remove()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_loaded"
+    assert entity_registry.async_get(dead) is not None
+
+
+async def test_an_integration_with_nothing_left_is_reported_in_the_end(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Waiting for a living sibling alone would never report some of these.
+
+    An integration with one entity, or an account whose every device was
+    removed, has nothing living to point at and never would. It gets an hour
+    to produce something, which is longer than any device that pushes on its
+    own schedule takes, and then the silence is taken at face value.
+    """
+    entry = _loaded_entry(hass)
+    _register_restored(hass, entity_registry, entry, "the_only_one")
+    repair = SpookRepair(hass)
+
+    await repair.async_inspect()
+    assert (
+        issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")
+        is None
+    ), "it gave up on the integration before it had a chance"
+
+    freezer.tick(timedelta(hours=1, minutes=1))
+    await repair.async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, f"dead_entities_{entry.entry_id}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Two things wrong with the dead entities repair, both found by living with it rather than by reading it.

**It named the config entry rather than the integration.** For anything set up with an account, the entry title is the name of the account holder, so the repair announced *"Non-existing entities registered by: Franck Nijhof"* about a Tibber Pulse. The name people know an integration by lives in its manifest, and that is what it reads now.

The test covering this pinned the wrong behaviour: it built a config entry on the `derivative` domain, titled it "Hue", and asserted the repair said "Hue". It now expects "Derivative", which is the integration that entry actually belongs to.

**And there was nothing anybody could do about it.** The issue offered Ignore, and a description saying to remove the entities from the entity registry. That asks somebody to know what an entity registry is, where to find it, and that filtering by status Unavailable is what brings these together.

Spook can just do it. Those leftover registrations are the only place these entities still exist, which is exactly the kind of tidying the other leftover repairs already offer. So the issue is fixable now, using the same remove-or-ignore flow as empty areas, unused labels and the rest:

- **Clear out these entities** removes the registry entries
- **Keep them, stop telling me** ignores the issue
- **Let me do it myself** points at the entities page and names the filter

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A repair that names the wrong thing and offers no way out is worse than no repair: it is a warning about something you cannot act on, attributed to a name that means nothing to you.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Full suite green at 1313.

Three mutations, each caught by exactly one test: reading the entry title again, dropping `is_fixable`, and letting the removal take entities that have since come back.

That last one is worth its own note. The removal re-reads the registry rather than trusting the list stored on the issue. One of these can sit in front of somebody for days, and an entity that turned up again in the meantime is a working entity whose history and settings should not go anywhere.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
