### PR TITLE
Read a Hue room's members, whatever container they arrive in

### DIFF
--- a/custom_components/spook/ectoplasms/light/__init__.py
+++ b/custom_components/spook/ectoplasms/light/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from homeassistant.components.light import DOMAIN
@@ -81,7 +82,11 @@ def _async_members(state: State) -> list[str] | None:
             continue
 
         members = state.attributes[key]
-        if not isinstance(members, (list, tuple)):
+
+        # Whatever container the integration reached for: a list from the
+        # group helper, a set from Hue. A string is iterable as well and would
+        # come apart into single characters, so it is turned away by name.
+        if isinstance(members, str) or not isinstance(members, Iterable):
             continue
 
         return [

--- a/tests/ectoplasms/light/services/conftest.py
+++ b/tests/ectoplasms/light/services/conftest.py
@@ -31,6 +31,7 @@ PLAIN = "light.plain"
 GROUP = "light.kitchen"
 OWNED_GROUP = "light.theset"
 EMPTY_GROUP = "light.nobody"
+SET_GROUP = "light.hallway"
 COLOUR = "light.colour"
 WHITES = "light.whites"
 
@@ -157,6 +158,24 @@ class IntegrationGroupLight(FakeLight):
         self.group = IntegrationSpecificGroup(self, member_unique_ids)
 
 
+class SetGroupLight(FakeLight):
+    """A group that hands its members out as a set, the way Hue does.
+
+    Under the same `entity_id` attribute the group helper uses, so the only
+    thing telling them apart is the container.
+    """
+
+    def __init__(self, name: str, members: set[str]) -> None:
+        """Initialize the group."""
+        super().__init__(name, 26, on=True)
+        self._members = members
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the members, in the container Hue hands them out in."""
+        return {"entity_id": self._members}
+
+
 async def async_set_up_lights(hass: HomeAssistant) -> None:
     """Set up three lights: one dim, one bright, one off."""
 
@@ -177,6 +196,7 @@ async def async_set_up_lights(hass: HomeAssistant) -> None:
                 OnOffLight("plain", on=True),
                 IntegrationGroupLight("theset", ["dim", "bright"]),
                 IntegrationGroupLight("nobody", []),
+                SetGroupLight("hallway", {DIM, BRIGHT}),
                 ColourLight("colour"),
                 ColourTemperatureLight("whites"),
             ]

--- a/tests/ectoplasms/light/services/test_colour.py
+++ b/tests/ectoplasms/light/services/test_colour.py
@@ -169,3 +169,31 @@ async def test_an_effect_nothing_knows_changes_nothing(hass: HomeAssistant) -> N
     await hass.async_block_till_done()
 
     assert not _light(hass, COLOUR).calls
+
+
+async def test_a_transition_reaches_the_colour_actions_too(
+    hass: HomeAssistant,
+) -> None:
+    """Both of these advertise it, so both of them have to forward it.
+
+    Not `set_effect`: an effect runs on the light's own terms, and there is
+    nothing for a fade to fade between.
+    """
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "set_color",
+        {"entity_id": COLOUR, "rgb_color": _CORAL, "transition": 3},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        "light",
+        "set_color_temperature",
+        {"entity_id": WHITES, "kelvin": _WARM, "transition": 3},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert _light(hass, COLOUR).transitions == [3]
+    assert _light(hass, WHITES).transitions == [3]

--- a/tests/ectoplasms/light/services/test_step_brightness.py
+++ b/tests/ectoplasms/light/services/test_step_brightness.py
@@ -26,6 +26,7 @@ from .conftest import (
     GROUP,
     OFF,
     OWNED_GROUP,
+    SET_GROUP,
     PLAIN,
     async_set_up_group,
     async_set_up_lights,
@@ -295,3 +296,26 @@ async def test_a_group_with_no_members_is_not_a_light(hass: HomeAssistant) -> No
     await hass.async_block_till_done()
 
     assert _brightness(hass, EMPTY_GROUP) == _DIM, "it stepped the group itself"
+
+
+async def test_a_group_that_hands_its_members_out_as_a_set(
+    hass: HomeAssistant,
+) -> None:
+    """Hue keeps its members under `entity_id`, but in a set rather than a list.
+
+    Insisting on a list means a Hue room falls through to the plain-light path
+    and gets stepped from its own averaged level, which is core#118009 all over
+    again.
+    """
+    await _setup(hass)
+
+    await hass.services.async_call(
+        "light",
+        "increase_brightness",
+        {"entity_id": SET_GROUP, "step_pct": 10},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert _brightness(hass, DIM) == _DIM + _ONE_STEP
+    assert _brightness(hass, BRIGHT) == _FULL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The light actions from #1503 walk a group's members rather than the group entity itself. They find those members by reading the group's attributes, and until now they insisted the members arrived in a list or a tuple.

Hue does not hand them out that way. Its grouped light puts its members under `entity_id`, the same key the group helper uses, but in a `set`:

```python
light_names: set[str] = set()
light_entities: set[str] = set()
...
light_entities.add(entity_id)
```

That is `homeassistant/components/hue/v2/group.py`, and those two sets go straight into `extra_state_attributes`. So a Hue room was rejected as a group and fell through to the plain-light path: stepping it started from the room's own averaged brightness and pushed every lamp to the same level. Which is exactly home-assistant/core#118009, in the actions that exist to avoid it.

Any container will do now, except a string, which is iterable as well and would come apart into single characters.

Also covers the `transition` on `set_color` and `set_color_temperature`, which nothing exercised. The only transition test went through `set_brightness`, so both branches could have quietly stopped forwarding it. Not `set_effect`: an effect runs on the light's own terms and there is nothing for a fade to fade between, so it does not advertise one.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up to #1503, which merged just before this went in. Hue rooms are one of the more common ways people target a group of lights, so this is a fair share of the cases these actions were built for.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Read against the installed core rather than from memory: `components/hue/v2/group.py` builds both `lights` and `entity_id` as sets and returns them as state attributes.

Three tests, and each one was checked by breaking the thing it covers:

| Mutation | Result |
| --- | --- |
| control | 23 passed |
| lists and tuples only, back to rejecting a set | 1 failed |
| `set_color` drops the transition | 1 failed |
| `set_color_temperature` drops the transition | 1 failed |

Full suite green at 1358 passed, pylint clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
