### PR TITLE
Tell you when a blueprint's author has changed it

### DIFF
--- a/custom_components/spook/const.py
+++ b/custom_components/spook/const.py
@@ -17,4 +17,5 @@ PLATFORMS: Final = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.TIME,
+    Platform.UPDATE,
 ]

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -120,11 +120,15 @@ _WOULD_NOT_RUN = (
     "</ha-alert>"
 )
 
+# Deliberately says nothing about why. There are three reasons a thing can end
+# up on that list and the line next to each one gives its own; a heading that
+# names only the commonest of them sends people off fixing the wrong thing.
 _WOULD_BE_REFUSED = (
     "<ha-alert alert-type='error'>"
-    "This one asks for inputs that nothing has set, so Spook will not install "
-    "it. Set them first, or import it yourself from the blueprint page if you "
-    "are happy to go round the automations below afterwards."
+    "Spook will not install this one. What is listed below would stop loading "
+    "the moment it is written, and the version it does work with is gone by "
+    "then. Put those right first, or import it yourself from the blueprint "
+    "page if you would rather sort them out afterwards."
     "</ha-alert>"
 )
 
@@ -533,11 +537,9 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         if short := await self._async_consumers_left_short(fetched):
             msg = (
                 f"Updating {self._said.name} would stop {_listed(short)} from "
-                f"loading, because the new version asks for something they do "
-                f"not set. Nothing has been written. Set those inputs first, "
-                f"or import {self._said.source_url} yourself from the "
-                f"blueprint page if you are happy to reconfigure them "
-                f"afterwards."
+                f"loading. Nothing has been written. Put that right first, or "
+                f"import {self._said.source_url} yourself from the blueprint "
+                f"page if you would rather sort them out afterwards."
             )
             raise HomeAssistantError(msg)
 

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -561,6 +561,10 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             msg = f"Could not write {self.blueprint_path}"
             raise HomeAssistantError(msg) from err
 
+        # A fetch that worked, so whatever the last one could not do is no
+        # longer the news. Left standing, the dialog would go on saying the
+        # source was unreachable until tomorrow's round.
+        self._set_aside = None
         self._fetched = fetched
         self._attr_installed_version = _fingerprint(fetched)
         self._attr_latest_version = self._attr_installed_version

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -1,0 +1,496 @@
+"""Spook - Your homie. Updates for blueprints that came from somewhere."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import timedelta
+import hashlib
+import os
+import random
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+import voluptuous as vol
+
+from homeassistant.components import blueprint
+from homeassistant.components.automation import automations_with_blueprint
+from homeassistant.components.blueprint import BLUEPRINT_SCHEMA
+from homeassistant.components.blueprint.const import (
+    CONF_INPUT,
+    CONF_SOURCE_URL,
+    CONF_USE_BLUEPRINT,
+)
+from homeassistant.components.blueprint.importer import fetch_blueprint_from_url
+from homeassistant.components.script import scripts_with_blueprint
+from homeassistant.components.update import (
+    UpdateEntity,
+    UpdateEntityDescription,
+    UpdateEntityFeature,
+)
+from homeassistant.const import CONF_DEFAULT, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_component import DATA_INSTANCES
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
+from homeassistant.util import yaml as yaml_util
+
+from ...const import DOMAIN, LOGGER
+from ...entity import SpookEntity, SpookEntityDescription
+from ...listeners import async_listen_once_tracked
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+    from pathlib import Path
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import Event, HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+# Only the domains whose blueprint users can be listed. Without that list
+# there is no telling whether an update would leave an automation short of an
+# input, and an install button that cannot promise that is worse than no
+# button at all. Template blueprints are the ones missing out for now.
+_CONSUMERS: dict[str, Callable[[HomeAssistant, str], list[str]]] = {
+    "automation": automations_with_blueprint,
+    "script": scripts_with_blueprint,
+}
+
+# The folder Home Assistant fills with its own example blueprints. All three
+# of them carry a source URL pointing at core's dev branch, so following them
+# would put an update on every installation there is, for something nobody
+# imported, out of a branch that is not the one they are running.
+_HOME_ASSISTANTS_OWN = f"homeassistant{os.sep}"
+
+_CHECK_INTERVAL = timedelta(hours=24)
+
+# Every one of these is a request to somebody else's server, and the community
+# forum and GitHub between them host nearly all of it. Restarts cluster after
+# a release, so the first round waits a random while rather than joining the
+# stampede.
+_FIRST_CHECK_WINDOW = (timedelta(minutes=5), timedelta(minutes=30))
+
+_FETCH_TIMEOUT = 30
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up an update entity for every blueprint that came from a URL."""
+    await _BlueprintUpdates(hass, async_add_entities).async_start(entry)
+
+
+def _fingerprint(raw: str) -> str | None:
+    """Return a short hash of what a blueprint says, or None if unreadable.
+
+    Blueprints carry no version and cannot be given one: the schema for the
+    `blueprint:` block turns away keys it does not know, so an author has
+    nowhere to put one. That leaves the content itself as the version.
+
+    Both sides go through the same parse and re-dump, and deliberately not
+    through the domain's own schema. That one rewrites the older spellings,
+    `trigger` into `triggers` and the rest of it, and only the copy Home
+    Assistant has loaded ever goes through it. Measuring that against a
+    freshly fetched one would call every blueprint written before those names
+    changed out of date, for ever.
+    """
+    try:
+        parsed = yaml_util.parse_yaml(raw)
+        normalized = blueprint.Blueprint(parsed, schema=BLUEPRINT_SCHEMA).yaml()
+    except HomeAssistantError:
+        return None
+
+    return hashlib.sha256(normalized.encode()).hexdigest()[:8]
+
+
+def _fingerprint_files(files: list[Path]) -> list[str | None]:
+    """Return the fingerprint of each blueprint file, in the order given."""
+    fingerprints: list[str | None] = []
+    for file in files:
+        try:
+            raw = file.read_text(encoding="utf-8")
+        except OSError:
+            fingerprints.append(None)
+            continue
+
+        fingerprints.append(_fingerprint(raw))
+
+    return fingerprints
+
+
+@dataclass(frozen=True, kw_only=True)
+class BlueprintSpookUpdateEntityDescription(
+    SpookEntityDescription,
+    UpdateEntityDescription,
+):
+    """Class describing Spook blueprint update entities."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class _OnDisk:
+    """A blueprint that is here, and where it came from."""
+
+    item: blueprint.Blueprint
+    file: Path
+
+
+class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
+    """Keeps the update entities in step with the blueprints on disk.
+
+    Blueprints fire no events at all. Nothing announces one arriving or being
+    deleted, so the only way to notice is to look, which happens on the same
+    round as the checks.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Initialize the manager."""
+        self.hass = hass
+        self._async_add_entities = async_add_entities
+        self._entities: dict[tuple[str, str], BlueprintUpdateEntity] = {}
+        self._stopped = False
+
+    async def async_start(self, entry: ConfigEntry) -> None:
+        """Take stock now or once Home Assistant is up, then keep checking."""
+
+        @callback
+        def _stop() -> None:
+            self._stopped = True
+
+        entry.async_on_unload(_stop)
+
+        if self.hass.state is CoreState.running:
+            await self._async_take_stock()
+        else:
+            entry.async_on_unload(
+                async_listen_once_tracked(
+                    self.hass,
+                    EVENT_HOMEASSISTANT_STARTED,
+                    self._async_started,
+                ),
+            )
+
+        entry.async_on_unload(
+            async_call_later(
+                self.hass,
+                random.uniform(  # noqa: S311
+                    _FIRST_CHECK_WINDOW[0].total_seconds(),
+                    _FIRST_CHECK_WINDOW[1].total_seconds(),
+                ),
+                self._async_check_all,
+            ),
+        )
+        entry.async_on_unload(
+            async_track_time_interval(
+                self.hass,
+                self._async_check_all,
+                _CHECK_INTERVAL,
+            ),
+        )
+
+    async def _async_started(self, _event: Event[Any]) -> None:
+        """Take stock once the blueprint domains have registered themselves."""
+        await self._async_take_stock()
+
+    async def _async_take_stock(self) -> None:
+        """Match the entities to the blueprints that are on disk."""
+        found = await self._async_look()
+
+        fingerprints = await self.hass.async_add_executor_job(
+            _fingerprint_files,
+            [on_disk.file for on_disk in found.values()],
+        )
+
+        await self._async_forget(set(self._entities) - set(found))
+
+        added: list[BlueprintUpdateEntity] = []
+        for (key, on_disk), fingerprint in zip(
+            found.items(),
+            fingerprints,
+            strict=True,
+        ):
+            if fingerprint is None:
+                # Gone or unreadable between the listing and the reading.
+                # Nothing to compare against, so nothing to say.
+                continue
+
+            if (entity := self._entities.get(key)) is not None:
+                entity.async_seen(on_disk.item, fingerprint)
+                continue
+
+            entity = BlueprintUpdateEntity(*key, on_disk.item, fingerprint)
+            self._entities[key] = entity
+            added.append(entity)
+
+        if added:
+            self._async_add_entities(added)
+
+    async def _async_look(self) -> dict[tuple[str, str], _OnDisk]:
+        """Return every blueprint that came from a URL."""
+        found: dict[tuple[str, str], _OnDisk] = {}
+        domain_blueprints: dict[str, blueprint.DomainBlueprints] = self.hass.data.get(
+            blueprint.DOMAIN,
+            {},
+        )
+
+        for domain, domain_blueprint in sorted(domain_blueprints.items()):
+            if domain not in _CONSUMERS:
+                continue
+
+            for path, item in (await domain_blueprint.async_get_blueprints()).items():
+                # Failed to load, or written by hand rather than imported.
+                # Without a source there is nothing to check against, which
+                # is also how somebody opts out: take the URL back out.
+                if not isinstance(item, blueprint.Blueprint):
+                    continue
+                if not item.metadata.get(CONF_SOURCE_URL):
+                    continue
+                if path.startswith(_HOME_ASSISTANTS_OWN):
+                    continue
+
+                found[(domain, path)] = _OnDisk(
+                    item=item,
+                    file=domain_blueprint.blueprint_folder / path,
+                )
+
+        return found
+
+    async def _async_forget(self, keys: set[tuple[str, str]]) -> None:
+        """Drop the entities of blueprints that are no longer there."""
+        if not keys:
+            return
+
+        registry = er.async_get(self.hass)
+        for key in keys:
+            entity = self._entities.pop(key)
+            await entity.async_remove(force_remove=True)
+
+            # The blueprint is gone for good, so the registration goes with
+            # it rather than lingering as something restorable.
+            if registry.async_get(entity.entity_id):
+                registry.async_remove(entity.entity_id)
+
+    async def _async_check_all(self, _now: datetime | None = None) -> None:
+        """Ask every source whether it has moved on since."""
+        if self._stopped:
+            return
+
+        await self._async_take_stock()
+
+        # One at a time on purpose. These nearly all go to two hosts, and
+        # nothing here is in a hurry.
+        for entity in list(self._entities.values()):
+            if self._stopped:
+                return
+
+            await entity.async_check()
+
+
+class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
+    SpookEntity,
+    UpdateEntity,
+):
+    """Spook update entity for a single imported blueprint."""
+
+    _attr_should_poll = False
+    _attr_supported_features = UpdateEntityFeature.INSTALL
+
+    def __init__(
+        self,
+        blueprint_domain: str,
+        blueprint_path: str,
+        item: blueprint.Blueprint,
+        fingerprint: str,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(
+            description=BlueprintSpookUpdateEntityDescription(
+                key=f"{blueprint_domain}_{blueprint_path}",
+                name=item.name,
+            ),
+        )
+        self.blueprint_domain = blueprint_domain
+        self.blueprint_path = blueprint_path
+
+        self._attr_unique_id = f"blueprint_{blueprint_domain}_{blueprint_path}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, blueprint.DOMAIN)},
+            manufacturer="Home Assistant",
+            name="Blueprints",
+        )
+
+        self._source_url: str = item.metadata[CONF_SOURCE_URL]
+        self._attr_title = item.name
+        self._attr_release_url = self._source_url
+        self._attr_installed_version = fingerprint
+        self._attr_latest_version = fingerprint
+
+    @callback
+    def async_seen(self, item: blueprint.Blueprint, fingerprint: str) -> None:
+        """Take in a blueprint that has been read from disk again.
+
+        Somebody can re-import through Home Assistant's own button, or rename
+        the thing, without Spook having any part in it.
+        """
+        self._source_url = item.metadata[CONF_SOURCE_URL]
+        self._attr_title = item.name
+        self._attr_release_url = self._source_url
+
+        if fingerprint == self._attr_installed_version:
+            return
+
+        self._attr_installed_version = fingerprint
+        self.async_write_ha_state()
+
+    def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
+        """Return whether the source says something other than what is here.
+
+        Different is the most that can be known. These are fingerprints of the
+        content, so there is no older and newer, only the same and not the
+        same.
+        """
+        return latest_version != installed_version
+
+    async def async_check(self) -> None:
+        """See whether the source still says what this blueprint says."""
+        try:
+            fetched = await self._async_fetch()
+        except HomeAssistantError as err:
+            # Leave the last answer standing. A source that is down for an
+            # afternoon should not take the update it was offering with it.
+            LOGGER.debug(
+                "Spook could not check blueprint %s: %s",
+                self.blueprint_path,
+                err,
+            )
+            return
+
+        if (fingerprint := _fingerprint(fetched.yaml())) is None:
+            return
+
+        self._attr_latest_version = fingerprint
+        self.async_write_ha_state()
+
+    async def async_install(
+        self,
+        version: str | None,  # noqa: ARG002
+        backup: bool,  # noqa: ARG002, FBT001
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        """Fetch the blueprint again and write it over the one that is here."""
+        fetched = await self._async_fetch()
+
+        if short := self._async_consumers_left_short(fetched):
+            listed = ", ".join(
+                f"{entity_id} ({', '.join(sorted(inputs))})"
+                for entity_id, inputs in sorted(short.items())
+            )
+            msg = (
+                f"Updating {self._attr_title} would stop {listed} from loading, "
+                f"because the new version asks for something they do not set. "
+                f"Nothing has been written. Set those inputs first, or import "
+                f"{self._source_url} yourself from the blueprint page if you are "
+                f"happy to reconfigure them afterwards."
+            )
+            raise HomeAssistantError(msg)
+
+        domain_blueprints: dict[str, blueprint.DomainBlueprints] = self.hass.data.get(
+            blueprint.DOMAIN,
+            {},
+        )
+        if (domain_blueprint := domain_blueprints.get(self.blueprint_domain)) is None:
+            msg = f"{self.blueprint_domain} blueprints are not loaded right now"
+            raise HomeAssistantError(msg)
+
+        try:
+            await domain_blueprint.async_add_blueprint(
+                fetched,
+                self.blueprint_path,
+                allow_override=True,
+            )
+        except OSError as err:
+            msg = f"Could not write {self.blueprint_path}"
+            raise HomeAssistantError(msg) from err
+
+        self._attr_installed_version = _fingerprint(fetched.yaml())
+        self._attr_latest_version = self._attr_installed_version
+        self.async_write_ha_state()
+
+    async def _async_fetch(self) -> blueprint.Blueprint:
+        """Fetch whatever the source URL points at now."""
+        try:
+            async with asyncio.timeout(_FETCH_TIMEOUT):
+                imported = await fetch_blueprint_from_url(self.hass, self._source_url)
+        except (TimeoutError, aiohttp.ClientError) as err:
+            msg = f"Could not reach {self._source_url}"
+            raise HomeAssistantError(msg) from err
+        except vol.Invalid as err:
+            msg = f"{self._source_url} no longer holds a valid blueprint"
+            raise HomeAssistantError(msg) from err
+
+        if imported.blueprint.domain != self.blueprint_domain:
+            # A community topic can hold more than one blueprint, and the
+            # importer takes the first it comes across. Both of them were
+            # given the same source URL on the way in, so following it can
+            # land on the other one entirely.
+            msg = (
+                f"{self._source_url} leads to a {imported.blueprint.domain} "
+                f"blueprint rather than {self.blueprint_domain}, so it is not "
+                f"this one"
+            )
+            raise HomeAssistantError(msg)
+
+        return imported.blueprint
+
+    @callback
+    def _async_consumers_left_short(
+        self,
+        fetched: blueprint.Blueprint,
+    ) -> dict[str, set[str]]:
+        """Return which users of this blueprint the new version would strand.
+
+        An input without a default has to be supplied by whoever uses the
+        blueprint. If a new version asks for one that an automation never set,
+        that automation stops loading the moment this is written, and there is
+        no going back to the version it did work with.
+        """
+        required = {
+            name
+            for name, spec in fetched.inputs.items()
+            if not isinstance(spec, dict) or CONF_DEFAULT not in spec
+        }
+        if not required:
+            return {}
+
+        component = self.hass.data.get(DATA_INSTANCES, {}).get(self.blueprint_domain)
+        if component is None:
+            return {}
+
+        short: dict[str, set[str]] = {}
+        for entity_id in _CONSUMERS[self.blueprint_domain](
+            self.hass,
+            self.blueprint_path,
+        ):
+            if (entity := component.get_entity(entity_id)) is None:
+                continue
+
+            # Not `raw_config`, which is the automation after the blueprint
+            # has been substituted into it and no longer says which inputs
+            # went in. Reached for by name rather than as an attribute so
+            # that a rename upstream reads as "supplies nothing", which
+            # blocks the install rather than going ahead on a guess.
+            inputs = getattr(entity, "_blueprint_inputs", None) or {}
+            used = inputs.get(CONF_USE_BLUEPRINT) or {}
+
+            if missing := required - set(used.get(CONF_INPUT) or ()):
+                short[entity_id] = missing
+
+        return short

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -16,11 +16,7 @@ import voluptuous as vol
 from homeassistant.components import blueprint
 from homeassistant.components.automation import automations_with_blueprint
 from homeassistant.components.blueprint import BLUEPRINT_SCHEMA
-from homeassistant.components.blueprint.const import (
-    CONF_INPUT,
-    CONF_SOURCE_URL,
-    CONF_USE_BLUEPRINT,
-)
+from homeassistant.components.blueprint.const import CONF_SOURCE_URL
 from homeassistant.components.blueprint.importer import fetch_blueprint_from_url
 from homeassistant.components.script import scripts_with_blueprint
 from homeassistant.components.update import (
@@ -28,7 +24,7 @@ from homeassistant.components.update import (
     UpdateEntityDescription,
     UpdateEntityFeature,
 )
-from homeassistant.const import CONF_DEFAULT, EVENT_HOMEASSISTANT_STARTED, STATE_ON
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_ON
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -36,6 +32,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.util import yaml as yaml_util
+from homeassistant.util.yaml import UndefinedSubstitution
 
 from ...const import DOMAIN, LOGGER
 from ...entity import SpookEntity, SpookEntityDescription
@@ -50,40 +47,47 @@ if TYPE_CHECKING:
     from homeassistant.core import Event, HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-# Only the domains whose blueprint users can be listed. Without that list
-# there is no telling whether an update would leave an automation short of an
-# input, and an install button that cannot promise that is worse than no
-# button at all. Template blueprints are the ones missing out for now.
+# Only the domains whose blueprint users can be listed. Without that list there
+# is no telling whether an update would leave an automation short of an input,
+# and an install button that cannot promise that is worse than no button at
+# all. Template blueprints are the ones missing out for now.
 _CONSUMERS: dict[str, Callable[[HomeAssistant, str], list[str]]] = {
     "automation": automations_with_blueprint,
     "script": scripts_with_blueprint,
 }
 
-# The folder Home Assistant fills with its own example blueprints. All three
-# of them carry a source URL pointing at core's dev branch, so following them
-# would put an update on every installation there is, for something nobody
-# imported, out of a branch that is not the one they are running.
+# The folder Home Assistant fills with its own example blueprints. All three of
+# them carry a source URL pointing at core's dev branch, so following them would
+# put an update on every installation there is, for something nobody imported,
+# out of a branch that is not the one they are running.
 _HOME_ASSISTANTS_OWN = f"homeassistant{os.sep}"
 
 _CHECK_INTERVAL = timedelta(hours=24)
 
 # Every one of these is a request to somebody else's server, and the community
-# forum and GitHub between them host nearly all of it. Restarts cluster after
-# a release, so the first round waits a random while rather than joining the
+# forum and GitHub between them host nearly all of it. Restarts cluster after a
+# release, so the first round waits a random while rather than joining the
 # stampede.
 _FIRST_CHECK_WINDOW = (timedelta(minutes=5), timedelta(minutes=30))
 
 _FETCH_TIMEOUT = 30
 
 # What goes in the dialog before somebody presses install. Home Assistant
-# renders `ha-alert` in release notes, which Matter and ZHA both lean on to
-# put a warning in front of a firmware update. Same idea here.
+# renders `ha-alert` in release notes, which Matter and ZHA both lean on to put
+# a warning in front of a firmware update. Same idea here.
 _NO_PROMISES = (
     "<ha-alert alert-type='warning'>"
     "Blueprints carry no changelog, so there is nothing here that says what "
     "changed. An update is whatever the author decided to do, and nothing "
     "promises it still fits the automations you built on it: inputs get "
     "renamed, behaviour gets rethought. Read the source before you install it."
+    "</ha-alert>"
+)
+
+_WOULD_NOT_RUN = (
+    "<ha-alert alert-type='error'>"
+    "This version says it needs a newer Home Assistant than the one you are "
+    "running, so Spook will not install it."
     "</ha-alert>"
 )
 
@@ -105,42 +109,77 @@ async def async_setup_entry(
     await _BlueprintUpdates(hass, async_add_entities).async_start(entry)
 
 
-def _fingerprint(raw: str) -> str | None:
-    """Return a short hash of what a blueprint says, or None if unreadable.
+@dataclass(frozen=True, kw_only=True)
+class _OnDisk:
+    """What a blueprint file says, as of just now.
+
+    No source URL means it was read perfectly well and is not being followed,
+    which is a different answer from not having been able to read it at all.
+    """
+
+    name: str
+    source_url: str | None
+    fingerprint: str
+
+
+def _normalize(raw: str) -> blueprint.Blueprint | None:
+    """Return a blueprint parsed the same way on both sides of a comparison.
+
+    Deliberately not through the domain's own schema. That one rewrites the
+    older spellings, `trigger` into `triggers` and the rest of it, and only the
+    copy Home Assistant has loaded ever goes through it. Measuring that against
+    a freshly fetched one would call every blueprint written before those names
+    changed out of date, for ever.
+    """
+    try:
+        return blueprint.Blueprint(yaml_util.parse_yaml(raw), schema=BLUEPRINT_SCHEMA)
+    except HomeAssistantError:
+        return None
+
+
+def _fingerprint(item: blueprint.Blueprint) -> str:
+    """Return a short hash of what a blueprint says.
 
     Blueprints carry no version and cannot be given one: the schema for the
     `blueprint:` block turns away keys it does not know, so an author has
     nowhere to put one. That leaves the content itself as the version.
-
-    Both sides go through the same parse and re-dump, and deliberately not
-    through the domain's own schema. That one rewrites the older spellings,
-    `trigger` into `triggers` and the rest of it, and only the copy Home
-    Assistant has loaded ever goes through it. Measuring that against a
-    freshly fetched one would call every blueprint written before those names
-    changed out of date, for ever.
     """
-    try:
-        parsed = yaml_util.parse_yaml(raw)
-        normalized = blueprint.Blueprint(parsed, schema=BLUEPRINT_SCHEMA).yaml()
-    except HomeAssistantError:
-        return None
-
-    return hashlib.sha256(normalized.encode()).hexdigest()[:8]
+    return hashlib.sha256(item.yaml().encode()).hexdigest()[:8]
 
 
-def _fingerprint_files(files: list[Path]) -> list[str | None]:
-    """Return the fingerprint of each blueprint file, in the order given."""
-    fingerprints: list[str | None] = []
+def _read_files(files: list[Path]) -> list[_OnDisk | None]:
+    """Return what each blueprint file says, in the order given.
+
+    Read off the file rather than taken from the copy Home Assistant has in
+    memory, because that one is loaded once and then kept. Editing a file does
+    not disturb it, so the name and the source URL it holds can be months out
+    of date, and taking that URL back out of a file is the way somebody says
+    they would rather be left alone.
+
+    `None` for a file that could not be read or made sense of at all, which is
+    not the same as one that was read and names no source.
+    """
+    on_disk: list[_OnDisk | None] = []
     for file in files:
         try:
             raw = file.read_text(encoding="utf-8")
         except OSError:
-            fingerprints.append(None)
+            on_disk.append(None)
             continue
 
-        fingerprints.append(_fingerprint(raw))
+        if (item := _normalize(raw)) is None:
+            on_disk.append(None)
+            continue
 
-    return fingerprints
+        on_disk.append(
+            _OnDisk(
+                name=item.name,
+                source_url=item.metadata.get(CONF_SOURCE_URL) or None,
+                fingerprint=_fingerprint(item),
+            ),
+        )
+
+    return on_disk
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -149,14 +188,6 @@ class BlueprintSpookUpdateEntityDescription(
     UpdateEntityDescription,
 ):
     """Class describing Spook blueprint update entities."""
-
-
-@dataclass(frozen=True, kw_only=True)
-class _OnDisk:
-    """A blueprint that is here, and where it came from."""
-
-    item: blueprint.Blueprint
-    file: Path
 
 
 class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
@@ -222,40 +253,42 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
 
     async def _async_take_stock(self) -> None:
         """Match the entities to the blueprints that are on disk."""
-        found = await self._async_look()
-
-        fingerprints = await self.hass.async_add_executor_job(
-            _fingerprint_files,
-            [on_disk.file for on_disk in found.values()],
+        files = await self._async_look()
+        on_disk = await self.hass.async_add_executor_job(
+            _read_files,
+            list(files.values()),
         )
 
-        await self._async_forget(set(self._entities) - set(found))
+        followed: dict[tuple[str, str], _OnDisk] = {}
+        unreadable: set[tuple[str, str]] = set()
+        for key, said in zip(files, on_disk, strict=True):
+            if said is None:
+                unreadable.add(key)
+            elif said.source_url is not None:
+                followed[key] = said
+
+        # A file that could not be read this time round says nothing either
+        # way, so whatever is already here stays. A file that was read and no
+        # longer names a source is somebody asking to be left alone, and that
+        # one goes.
+        await self._async_forget(set(self._entities) - set(followed) - unreadable)
 
         added: list[BlueprintUpdateEntity] = []
-        for (key, on_disk), fingerprint in zip(
-            found.items(),
-            fingerprints,
-            strict=True,
-        ):
-            if fingerprint is None:
-                # Gone or unreadable between the listing and the reading.
-                # Nothing to compare against, so nothing to say.
-                continue
-
+        for key in sorted(followed):
             if (entity := self._entities.get(key)) is not None:
-                entity.async_seen(on_disk.item, fingerprint)
+                entity.async_seen(followed[key])
                 continue
 
-            entity = BlueprintUpdateEntity(*key, on_disk.item, fingerprint)
+            entity = BlueprintUpdateEntity(*key, followed[key])
             self._entities[key] = entity
             added.append(entity)
 
         if added:
             self._async_add_entities(added)
 
-    async def _async_look(self) -> dict[tuple[str, str], _OnDisk]:
-        """Return every blueprint that came from a URL."""
-        found: dict[tuple[str, str], _OnDisk] = {}
+    async def _async_look(self) -> dict[tuple[str, str], Path]:
+        """Return the file behind every blueprint Home Assistant can load."""
+        files: dict[tuple[str, str], Path] = {}
         domain_blueprints: dict[str, blueprint.DomainBlueprints] = self.hass.data.get(
             blueprint.DOMAIN,
             {},
@@ -266,25 +299,18 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
                 continue
 
             for path, item in (await domain_blueprint.async_get_blueprints()).items():
-                # Failed to load, or written by hand rather than imported.
-                # Without a source there is nothing to check against, which
-                # is also how somebody opts out: take the URL back out.
+                # Failed to load, or Home Assistant's own examples.
                 if not isinstance(item, blueprint.Blueprint):
-                    continue
-                if not item.metadata.get(CONF_SOURCE_URL):
                     continue
                 if path.startswith(_HOME_ASSISTANTS_OWN):
                     continue
 
-                found[(domain, path)] = _OnDisk(
-                    item=item,
-                    file=domain_blueprint.blueprint_folder / path,
-                )
+                files[(domain, path)] = domain_blueprint.blueprint_folder / path
 
-        return found
+        return files
 
     async def _async_forget(self, keys: set[tuple[str, str]]) -> None:
-        """Drop the entities of blueprints that are no longer there."""
+        """Drop the entities of blueprints that are no longer being followed."""
         if not keys:
             return
 
@@ -293,8 +319,8 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
             entity = self._entities.pop(key)
             await entity.async_remove(force_remove=True)
 
-            # The blueprint is gone for good, so the registration goes with
-            # it rather than lingering as something restorable.
+            # Gone for good, so the registration goes with it rather than
+            # lingering as something restorable.
             if registry.async_get(entity.entity_id):
                 registry.async_remove(entity.entity_id)
 
@@ -329,14 +355,13 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         self,
         blueprint_domain: str,
         blueprint_path: str,
-        item: blueprint.Blueprint,
-        fingerprint: str,
+        said: _OnDisk,
     ) -> None:
         """Initialize the entity."""
         super().__init__(
             description=BlueprintSpookUpdateEntityDescription(
                 key=f"{blueprint_domain}_{blueprint_path}",
-                name=item.name,
+                name=said.name,
             ),
         )
         self.blueprint_domain = blueprint_domain
@@ -349,28 +374,31 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             name="Blueprints",
         )
 
-        self._source_url: str = item.metadata[CONF_SOURCE_URL]
+        self._said = said
         self._fetched: blueprint.Blueprint | None = None
-        self._attr_title = item.name
-        self._attr_release_url = self._source_url
-        self._attr_installed_version = fingerprint
-        self._attr_latest_version = fingerprint
+        self._set_aside: str | None = None
+
+        self._attr_name = said.name
+        self._attr_title = said.name
+        self._attr_release_url = said.source_url
+        self._attr_installed_version = said.fingerprint
+        self._attr_latest_version = said.fingerprint
 
     @callback
-    def async_seen(self, item: blueprint.Blueprint, fingerprint: str) -> None:
-        """Take in a blueprint that has been read from disk again.
+    def async_seen(self, said: _OnDisk) -> None:
+        """Take in a blueprint file that has been read again.
 
-        Somebody can re-import through Home Assistant's own button, or rename
-        the thing, without Spook having any part in it.
+        Somebody can re-import through Home Assistant's own button, rename the
+        thing, or edit it by hand, without Spook having any part in it.
         """
-        self._source_url = item.metadata[CONF_SOURCE_URL]
-        self._attr_title = item.name
-        self._attr_release_url = self._source_url
-
-        if fingerprint == self._attr_installed_version:
+        if said == self._said:
             return
 
-        self._attr_installed_version = fingerprint
+        self._said = said
+        self._attr_name = said.name
+        self._attr_title = said.name
+        self._attr_release_url = said.source_url
+        self._attr_installed_version = said.fingerprint
         self.async_write_ha_state()
 
     def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
@@ -389,6 +417,9 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         except HomeAssistantError as err:
             # Leave the last answer standing. A source that is down for an
             # afternoon should not take the update it was offering with it.
+            # The reason is kept so the dialog can say why nothing happens
+            # here, rather than looking simply idle.
+            self._set_aside = str(err)
             LOGGER.debug(
                 "Spook could not check blueprint %s: %s",
                 self.blueprint_path,
@@ -396,11 +427,9 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             )
             return
 
-        if (fingerprint := _fingerprint(fetched.yaml())) is None:
-            return
-
+        self._set_aside = None
         self._fetched = fetched
-        self._attr_latest_version = fingerprint
+        self._attr_latest_version = _fingerprint(fetched)
         self.async_write_ha_state()
 
     async def async_install(
@@ -412,17 +441,24 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         """Fetch the blueprint again and write it over the one that is here."""
         fetched = await self._async_fetch()
 
-        if short := self._async_consumers_left_short(fetched):
-            listed = ", ".join(
-                f"{entity_id} ({', '.join(sorted(inputs))})"
-                for entity_id, inputs in sorted(short.items())
-            )
+        # The blueprint saying for itself that it needs a newer Home Assistant.
+        # Writing it anyway would break every consumer on a version that is
+        # never going to work.
+        if errors := fetched.validate():
             msg = (
-                f"Updating {self._attr_title} would stop {listed} from loading, "
-                f"because the new version asks for something they do not set. "
-                f"Nothing has been written. Set those inputs first, or import "
-                f"{self._source_url} yourself from the blueprint page if you are "
-                f"happy to reconfigure them afterwards."
+                f"{self._said.name} cannot run here: {'; '.join(errors)}. "
+                f"Nothing has been written."
+            )
+            raise HomeAssistantError(msg)
+
+        if short := self._async_consumers_left_short(fetched):
+            msg = (
+                f"Updating {self._said.name} would stop {_listed(short)} from "
+                f"loading, because the new version asks for something they do "
+                f"not set. Nothing has been written. Set those inputs first, "
+                f"or import {self._said.source_url} yourself from the "
+                f"blueprint page if you are happy to reconfigure them "
+                f"afterwards."
             )
             raise HomeAssistantError(msg)
 
@@ -445,7 +481,7 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             raise HomeAssistantError(msg) from err
 
         self._fetched = fetched
-        self._attr_installed_version = _fingerprint(fetched.yaml())
+        self._attr_installed_version = _fingerprint(fetched)
         self._attr_latest_version = self._attr_installed_version
         self.async_write_ha_state()
 
@@ -458,18 +494,34 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         read it, and a plain warning that an author improving their blueprint
         and it still suiting what you built on it are two different things.
         """
-        came_from = f"Imported from [{self._source_url}]({self._source_url})."
+        came_from = f"Imported from [{self._said.source_url}]({self._said.source_url})."
 
         if self.state != STATE_ON or self._fetched is None:
-            return came_from
+            if self._set_aside is None:
+                return came_from
+
+            # Nothing on offer, and a reason for it. Better said here than
+            # left to look like a source that simply never changes.
+            return "\n\n".join(
+                [
+                    f"<ha-alert alert-type='info'>{self._set_aside}</ha-alert>",
+                    came_from,
+                ],
+            )
 
         notes = [_NO_PROMISES, came_from]
+
+        if errors := self._fetched.validate():
+            notes.append(_WOULD_NOT_RUN)
+            notes.extend(f"- {error}" for error in errors)
 
         if short := self._async_consumers_left_short(self._fetched):
             notes.append(_WOULD_BE_REFUSED)
             notes.extend(
                 f"- `{entity_id}` never sets "
                 + ", ".join(f"`{name}`" for name in sorted(inputs))
+                if inputs
+                else f"- `{entity_id}` cannot be checked"
                 for entity_id, inputs in sorted(short.items())
             )
 
@@ -477,29 +529,36 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
 
     async def _async_fetch(self) -> blueprint.Blueprint:
         """Fetch whatever the source URL points at now."""
+        source_url = self._said.source_url
+
         try:
             async with asyncio.timeout(_FETCH_TIMEOUT):
-                imported = await fetch_blueprint_from_url(self.hass, self._source_url)
+                imported = await fetch_blueprint_from_url(self.hass, source_url)
         except (TimeoutError, aiohttp.ClientError) as err:
-            msg = f"Could not reach {self._source_url}"
+            msg = f"Could not reach {source_url}"
             raise HomeAssistantError(msg) from err
         except vol.Invalid as err:
-            msg = f"{self._source_url} no longer holds a valid blueprint"
+            msg = f"{source_url} no longer holds a valid blueprint"
             raise HomeAssistantError(msg) from err
 
-        if imported.blueprint.domain != self.blueprint_domain:
-            # A community topic can hold more than one blueprint, and the
-            # importer takes the first it comes across. Both of them were
-            # given the same source URL on the way in, so following it can
-            # land on the other one entirely.
+        fetched = imported.blueprint
+
+        # A community topic can hold more than one blueprint, and the importer
+        # takes the first it comes across. Every blueprint in a topic was given
+        # the same source URL on the way in, so following one can land on
+        # another. The domain and the name together are the most that can be
+        # asked of a format that carries no identity of its own: an author
+        # renaming their blueprint costs an update, writing somebody else's
+        # blueprint into this file costs a lot more.
+        if fetched.domain != self.blueprint_domain or fetched.name != self._said.name:
             msg = (
-                f"{self._source_url} leads to a {imported.blueprint.domain} "
-                f"blueprint rather than {self.blueprint_domain}, so it is not "
-                f"this one"
+                f"{source_url} leads to '{fetched.name}', a {fetched.domain} "
+                f"blueprint, and not to '{self._said.name}'. Spook will not "
+                f"put one over the other."
             )
             raise HomeAssistantError(msg)
 
-        return imported.blueprint
+        return fetched
 
     @callback
     def _async_consumers_left_short(
@@ -512,15 +571,10 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         blueprint. If a new version asks for one that an automation never set,
         that automation stops loading the moment this is written, and there is
         no going back to the version it did work with.
-        """
-        required = {
-            name
-            for name, spec in fetched.inputs.items()
-            if not isinstance(spec, dict) or CONF_DEFAULT not in spec
-        }
-        if not required:
-            return {}
 
+        Put to Home Assistant's own reckoning of what an input needs rather
+        than worked out again here, so the two cannot drift apart.
+        """
         component = self.hass.data.get(DATA_INSTANCES, {}).get(self.blueprint_domain)
         if component is None:
             return {}
@@ -533,15 +587,35 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             if (entity := component.get_entity(entity_id)) is None:
                 continue
 
-            # Not `raw_config`, which is the automation after the blueprint
-            # has been substituted into it and no longer says which inputs
-            # went in. Reached for by name rather than as an attribute so
-            # that a rename upstream reads as "supplies nothing", which
-            # blocks the install rather than going ahead on a guess.
-            inputs = getattr(entity, "_blueprint_inputs", None) or {}
-            used = inputs.get(CONF_USE_BLUEPRINT) or {}
+            # Not `raw_config`, which is the automation after the blueprint has
+            # been substituted into it and no longer says which inputs went in.
+            # Reached for by name rather than as an attribute so that a rename
+            # upstream reads as "cannot tell", which blocks the install rather
+            # than going ahead on a guess.
+            supplied = getattr(entity, "_blueprint_inputs", None)
+            if supplied is None:
+                short[entity_id] = set()
+                continue
 
-            if missing := required - set(used.get(CONF_INPUT) or ()):
+            candidate = blueprint.BlueprintInputs(fetched, supplied)
+
+            if missing := set(fetched.inputs) - set(candidate.inputs_with_default):
                 short[entity_id] = missing
+                continue
+
+            # And that the thing actually renders, which is the other half of
+            # what a reload would do with it.
+            try:
+                candidate.async_substitute()
+            except UndefinedSubstitution, HomeAssistantError:
+                short[entity_id] = set()
 
         return short
+
+
+def _listed(short: dict[str, set[str]]) -> str:
+    """Return the stranded consumers as something to put in a sentence."""
+    return ", ".join(
+        f"{entity_id} ({', '.join(sorted(inputs))})" if inputs else entity_id
+        for entity_id, inputs in sorted(short.items())
+    )

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -14,11 +14,17 @@ import aiohttp
 import voluptuous as vol
 
 from homeassistant.components import blueprint
-from homeassistant.components.automation import automations_with_blueprint
+from homeassistant.components.automation import (
+    automations_with_blueprint,
+    config as automation_config,
+)
 from homeassistant.components.blueprint import BLUEPRINT_SCHEMA
 from homeassistant.components.blueprint.const import CONF_SOURCE_URL
 from homeassistant.components.blueprint.importer import fetch_blueprint_from_url
-from homeassistant.components.script import scripts_with_blueprint
+from homeassistant.components.script import (
+    config as script_config,
+    scripts_with_blueprint,
+)
 from homeassistant.components.update import (
     UpdateEntity,
     UpdateEntityDescription,
@@ -38,7 +44,7 @@ from ...entity import SpookEntity, SpookEntityDescription
 from ...listeners import async_listen_once_tracked
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
     from datetime import datetime
     from pathlib import Path
 
@@ -46,13 +52,36 @@ if TYPE_CHECKING:
     from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-# Only the domains whose blueprint users can be listed. Without that list there
-# is no telling whether an update would leave an automation short of an input,
-# and an install button that cannot promise that is worse than no button at
-# all. Template blueprints are the ones missing out for now.
-_CONSUMERS: dict[str, Callable[[HomeAssistant, str], list[str]]] = {
-    "automation": automations_with_blueprint,
-    "script": scripts_with_blueprint,
+
+@dataclass(frozen=True, kw_only=True)
+class _UsesBlueprints:
+    """What has to be to hand before Spook will follow a domain's blueprints.
+
+    Its users, so they can be asked what they supply, and the same validation
+    a reload puts them through, so an update can be tried on them before
+    anything is written.
+    """
+
+    users: Callable[[HomeAssistant, str], list[str]]
+    validate: Callable[
+        [HomeAssistant, str, dict[str, Any]],
+        Awaitable[Any],
+    ]
+
+
+# Which is why it is these two and not template blueprints as well. Without
+# both halves there is no telling whether an update would leave something
+# unable to load, and an install button that cannot promise that is worse than
+# no button at all.
+_USES_BLUEPRINTS: dict[str, _UsesBlueprints] = {
+    "automation": _UsesBlueprints(
+        users=automations_with_blueprint,
+        validate=automation_config.async_validate_config_item,
+    ),
+    "script": _UsesBlueprints(
+        users=scripts_with_blueprint,
+        validate=script_config.async_validate_config_item,
+    ),
 }
 
 # The folder Home Assistant fills with its own example blueprints. All three of
@@ -308,7 +337,7 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         )
 
         for domain, domain_blueprint in sorted(domain_blueprints.items()):
-            if domain not in _CONSUMERS:
+            if domain not in _USES_BLUEPRINTS:
                 continue
 
             for path, item in (await domain_blueprint.async_get_blueprints()).items():
@@ -501,7 +530,7 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             )
             raise HomeAssistantError(msg)
 
-        if short := self._async_consumers_left_short(fetched):
+        if short := await self._async_consumers_left_short(fetched):
             msg = (
                 f"Updating {self._said.name} would stop {_listed(short)} from "
                 f"loading, because the new version asks for something they do "
@@ -573,14 +602,11 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             notes.append(_WOULD_NOT_RUN)
             notes.extend(f"- {error}" for error in errors)
 
-        if short := self._async_consumers_left_short(self._fetched):
+        if short := await self._async_consumers_left_short(self._fetched):
             notes.append(_WOULD_BE_REFUSED)
             notes.extend(
-                f"- `{entity_id}` never sets "
-                + ", ".join(f"`{name}`" for name in sorted(inputs))
-                if inputs
-                else f"- `{entity_id}` cannot be checked"
-                for entity_id, inputs in sorted(short.items())
+                f"- `{entity_id}` {reason}"
+                for entity_id, reason in sorted(short.items())
             )
 
         return "\n\n".join(notes)
@@ -625,30 +651,33 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
 
         return fetched
 
-    @callback
-    def _async_consumers_left_short(
+    async def _async_consumers_left_short(
         self,
         fetched: blueprint.Blueprint,
-    ) -> dict[str, set[str]]:
+    ) -> dict[str, str]:
         """Return which users of this blueprint the new version would strand.
 
-        An input without a default has to be supplied by whoever uses the
-        blueprint. If a new version asks for one that an automation never set,
-        that automation stops loading the moment this is written, and there is
-        no going back to the version it did work with.
+        Two ways it can. An input without a default has to be supplied by
+        whoever uses the blueprint, so a new one that nobody sets leaves them
+        with nothing to put there. And a blueprint can be perfectly good as a
+        blueprint while what comes out of it is not something Home Assistant
+        will run: the blueprint schema has nothing whatever to say about
+        triggers, actions or a script's sequence.
 
-        Put to Home Assistant's own reckoning of what an input needs rather
-        than worked out again here, so the two cannot drift apart.
+        Either way they stop loading the moment this is written, and the
+        version they did work with has been written over by then.
+
+        Both questions are put to Home Assistant rather than answered again
+        here, so the two cannot drift apart.
         """
         component = self.hass.data.get(DATA_INSTANCES, {}).get(self.blueprint_domain)
         if component is None:
             return {}
 
-        short: dict[str, set[str]] = {}
-        for entity_id in _CONSUMERS[self.blueprint_domain](
-            self.hass,
-            self.blueprint_path,
-        ):
+        uses = _USES_BLUEPRINTS[self.blueprint_domain]
+        short: dict[str, str] = {}
+
+        for entity_id in uses.users(self.hass, self.blueprint_path):
             if (entity := component.get_entity(entity_id)) is None:
                 continue
 
@@ -659,24 +688,32 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             # than going ahead on a guess.
             supplied = getattr(entity, "_blueprint_inputs", None)
             if supplied is None:
-                short[entity_id] = set()
+                short[entity_id] = "cannot be checked"
                 continue
 
             candidate = blueprint.BlueprintInputs(fetched, supplied)
 
-            # Enough on its own. A blueprint whose body reaches for an input
-            # it never declares is turned away when it is built, so once every
-            # declared input has a value there is nothing left for the
-            # substitution to trip over.
             if missing := set(fetched.inputs) - set(candidate.inputs_with_default):
-                short[entity_id] = missing
+                short[entity_id] = f"never sets {', '.join(sorted(missing))}"
+                continue
+
+            # Substituting cannot fail here: a blueprint whose body reaches for
+            # an input it never declares is turned away when it is built, so by
+            # now every one of them has a value.
+            try:
+                await uses.validate(
+                    self.hass,
+                    entity_id.partition(".")[2],
+                    candidate.async_substitute(),
+                )
+            except (vol.Invalid, HomeAssistantError) as err:
+                short[entity_id] = f"would not load: {err}"
 
         return short
 
 
-def _listed(short: dict[str, set[str]]) -> str:
+def _listed(short: dict[str, str]) -> str:
     """Return the stranded consumers as something to put in a sentence."""
     return ", ".join(
-        f"{entity_id} ({', '.join(sorted(inputs))})" if inputs else entity_id
-        for entity_id, inputs in sorted(short.items())
+        f"{entity_id} ({reason})" for entity_id, reason in sorted(short.items())
     )

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -32,7 +32,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import yaml as yaml_util
-from homeassistant.util.yaml import UndefinedSubstitution
 
 from ...const import DOMAIN, LOGGER
 from ...entity import SpookEntity, SpookEntityDescription
@@ -665,16 +664,12 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
 
             candidate = blueprint.BlueprintInputs(fetched, supplied)
 
+            # Enough on its own. A blueprint whose body reaches for an input
+            # it never declares is turned away when it is built, so once every
+            # declared input has a value there is nothing left for the
+            # substitution to trip over.
             if missing := set(fetched.inputs) - set(candidate.inputs_with_default):
                 short[entity_id] = missing
-                continue
-
-            # And that the thing actually renders, which is the other half of
-            # what a reload would do with it.
-            try:
-                candidate.async_substitute()
-            except UndefinedSubstitution, HomeAssistantError:
-                short[entity_id] = set()
 
         return short
 

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -30,7 +30,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_component import DATA_INSTANCES
-from homeassistant.helpers.event import async_call_later, async_track_time_interval
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util import yaml as yaml_util
 from homeassistant.util.yaml import UndefinedSubstitution
 
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from homeassistant.config_entries import ConfigEntry
-    from homeassistant.core import Event, HomeAssistant
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 # Only the domains whose blueprint users can be listed. Without that list there
@@ -62,13 +62,14 @@ _CONSUMERS: dict[str, Callable[[HomeAssistant, str], list[str]]] = {
 # out of a branch that is not the one they are running.
 _HOME_ASSISTANTS_OWN = f"homeassistant{os.sep}"
 
-_CHECK_INTERVAL = timedelta(hours=24)
-
 # Every one of these is a request to somebody else's server, and the community
 # forum and GitHub between them host nearly all of it. Restarts cluster after a
 # release, so the first round waits a random while rather than joining the
-# stampede.
+# stampede, and every round after it picks its own moment a day or so on rather
+# than keeping to the hour the first one happened to land on.
 _FIRST_CHECK_WINDOW = (timedelta(minutes=5), timedelta(minutes=30))
+_CHECK_INTERVAL = timedelta(hours=24)
+_SPREAD = timedelta(hours=4)
 
 _FETCH_TIMEOUT = 30
 
@@ -208,48 +209,61 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         self._async_add_entities = async_add_entities
         self._entities: dict[tuple[str, str], BlueprintUpdateEntity] = {}
         self._stopped = False
+        self._cancel: CALLBACK_TYPE | None = None
 
     async def async_start(self, entry: ConfigEntry) -> None:
-        """Take stock now or once Home Assistant is up, then keep checking."""
+        """Begin now, or once Home Assistant is up.
 
-        @callback
-        def _stop() -> None:
-            self._stopped = True
-
-        entry.async_on_unload(_stop)
+        Nothing is scheduled before then either. Starting up can take longer
+        than the wait before the first round, and a round that lands in the
+        middle of it looks at blueprint domains that have not finished
+        arriving, and goes out to the internet while the house is still
+        getting dressed.
+        """
+        entry.async_on_unload(self._stop)
 
         if self.hass.state is CoreState.running:
-            await self._async_take_stock()
-        else:
-            entry.async_on_unload(
-                async_listen_once_tracked(
-                    self.hass,
-                    EVENT_HOMEASSISTANT_STARTED,
-                    self._async_started,
-                ),
-            )
+            await self._async_begin()
+            return
 
         entry.async_on_unload(
-            async_call_later(
+            async_listen_once_tracked(
                 self.hass,
-                random.uniform(  # noqa: S311
-                    _FIRST_CHECK_WINDOW[0].total_seconds(),
-                    _FIRST_CHECK_WINDOW[1].total_seconds(),
-                ),
-                self._async_check_all,
+                EVENT_HOMEASSISTANT_STARTED,
+                self._async_started,
             ),
         )
-        entry.async_on_unload(
-            async_track_time_interval(
-                self.hass,
-                self._async_check_all,
-                _CHECK_INTERVAL,
-            ),
-        )
+
+    @callback
+    def _stop(self) -> None:
+        """Stop looking, and take the round that was coming with it."""
+        self._stopped = True
+
+        if self._cancel is not None:
+            self._cancel()
+            self._cancel = None
 
     async def _async_started(self, _event: Event[Any]) -> None:
-        """Take stock once the blueprint domains have registered themselves."""
+        """Begin once the blueprint domains have registered themselves."""
+        await self._async_begin()
+
+    async def _async_begin(self) -> None:
+        """Take stock, then arrange to keep looking."""
         await self._async_take_stock()
+        self._async_schedule(
+            random.uniform(  # noqa: S311
+                _FIRST_CHECK_WINDOW[0].total_seconds(),
+                _FIRST_CHECK_WINDOW[1].total_seconds(),
+            ),
+        )
+
+    @callback
+    def _async_schedule(self, delay: float) -> None:
+        """Arrange the next round, unless there are to be no more."""
+        if self._stopped:
+            return
+
+        self._cancel = async_call_later(self.hass, delay, self._async_check_all)
 
     async def _async_take_stock(self) -> None:
         """Match the entities to the blueprints that are on disk."""
@@ -326,18 +340,38 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
 
     async def _async_check_all(self, _now: datetime | None = None) -> None:
         """Ask every source whether it has moved on since."""
+        self._cancel = None
+
         if self._stopped:
             return
 
-        await self._async_take_stock()
+        try:
+            await self._async_take_stock()
 
-        # One at a time on purpose. These nearly all go to two hosts, and
-        # nothing here is in a hurry.
-        for entity in list(self._entities.values()):
-            if self._stopped:
-                return
+            # One at a time on purpose. These nearly all go to two hosts, and
+            # nothing here is in a hurry.
+            for entity in list(self._entities.values()):
+                if self._stopped:
+                    return
 
-            await entity.async_check()
+                try:
+                    await entity.async_check()
+                # One blueprint pointing somewhere strange must not take the
+                # rest of the round with it. Everything expected is already
+                # dealt with inside; this is for whatever is not.
+                # pylint: disable-next=broad-exception-caught
+                except Exception:  # noqa: BLE001
+                    LOGGER.exception(
+                        "Spook fell over checking blueprint %s; "
+                        "please report this at "
+                        "https://github.com/frenck/spook/issues",
+                        entity.blueprint_path,
+                    )
+        finally:
+            self._async_schedule(
+                _CHECK_INTERVAL.total_seconds()
+                + random.uniform(0, _SPREAD.total_seconds()),  # noqa: S311
+            )
 
 
 class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
@@ -378,6 +412,13 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         self._fetched: blueprint.Blueprint | None = None
         self._set_aside: str | None = None
 
+        # A round of checks and somebody pressing install can land on the same
+        # blueprint at the same moment, and both of them fetch before they
+        # write. Whichever finished last used to win, which could leave this
+        # saying an update is waiting for a version that had just been
+        # installed.
+        self._one_at_a_time = asyncio.Lock()
+
         self._attr_name = said.name
         self._attr_title = said.name
         self._attr_release_url = said.source_url
@@ -412,6 +453,11 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
 
     async def async_check(self) -> None:
         """See whether the source still says what this blueprint says."""
+        async with self._one_at_a_time:
+            await self._async_check()
+
+    async def _async_check(self) -> None:
+        """Fetch and compare, with the blueprint to ourselves."""
         try:
             fetched = await self._async_fetch()
         except HomeAssistantError as err:
@@ -439,6 +485,11 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         """Fetch the blueprint again and write it over the one that is here."""
+        async with self._one_at_a_time:
+            await self._async_install()
+
+    async def _async_install(self) -> None:
+        """Write the source over what is here, with the blueprint to ourselves."""
         fetched = await self._async_fetch()
 
         # The blueprint saying for itself that it needs a newer Home Assistant.
@@ -496,20 +547,28 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         """
         came_from = f"Imported from [{self._said.source_url}]({self._said.source_url})."
 
-        if self.state != STATE_ON or self._fetched is None:
-            if self._set_aside is None:
-                return came_from
+        nothing_on_offer = self.state != STATE_ON or self._fetched is None
 
-            # Nothing on offer, and a reason for it. Better said here than
-            # left to look like a source that simply never changes.
-            return "\n\n".join(
-                [
-                    f"<ha-alert alert-type='info'>{self._set_aside}</ha-alert>",
-                    came_from,
-                ],
+        # Whatever went wrong last time round goes first either way. Left out
+        # of the branch below, it would sit behind news from an older look
+        # while the source itself had stopped answering.
+        aside: list[str] = []
+        if self._set_aside is not None:
+            aside.append(
+                "<ha-alert alert-type='info'>"
+                + self._set_aside
+                + (
+                    ""
+                    if nothing_on_offer
+                    else " What follows is from the last look that worked."
+                )
+                + "</ha-alert>",
             )
 
-        notes = [_NO_PROMISES, came_from]
+        if nothing_on_offer:
+            return "\n\n".join([*aside, came_from])
+
+        notes = [*aside, _NO_PROMISES, came_from]
 
         if errors := self._fetched.validate():
             notes.append(_WOULD_NOT_RUN)
@@ -535,10 +594,17 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             async with asyncio.timeout(_FETCH_TIMEOUT):
                 imported = await fetch_blueprint_from_url(self.hass, source_url)
         except (TimeoutError, aiohttp.ClientError) as err:
-            msg = f"Could not reach {source_url}"
+            msg = f"Could not reach {source_url}."
             raise HomeAssistantError(msg) from err
         except vol.Invalid as err:
-            msg = f"{source_url} no longer holds a valid blueprint"
+            msg = f"{source_url} no longer holds a valid blueprint."
+            raise HomeAssistantError(msg) from err
+        except AssertionError as err:
+            # Home Assistant's own fetchers assert that the YAML they parsed
+            # is a mapping. A source answering with a list, or a bare string,
+            # arrives as an AssertionError, which is nothing this would catch
+            # by type and would take the whole round down with it.
+            msg = f"{source_url} did not answer with a blueprint."
             raise HomeAssistantError(msg) from err
 
         fetched = imported.blueprint

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -453,9 +453,15 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
 
         self._attr_name = said.name
         self._attr_title = said.name
-        self._attr_release_url = said.source_url
         self._attr_installed_version = said.fingerprint
         self._attr_latest_version = said.fingerprint
+
+        # Deliberately no `release_url`. Home Assistant would put it in the
+        # state attributes, which every signed-in person can read, and it lets
+        # a blueprint be imported from an address carrying a token or a
+        # username and password. Every one of its own blueprint commands is
+        # admin only, so the address belongs with the release notes, which are
+        # admin only too, and not in the states.
 
     @callback
     def async_seen(self, said: _OnDisk) -> None:
@@ -470,7 +476,6 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         self._said = said
         self._attr_name = said.name
         self._attr_title = said.name
-        self._attr_release_url = said.source_url
         self._attr_installed_version = said.fingerprint
         self.async_write_ha_state()
 

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -28,7 +28,7 @@ from homeassistant.components.update import (
     UpdateEntityDescription,
     UpdateEntityFeature,
 )
-from homeassistant.const import CONF_DEFAULT, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import CONF_DEFAULT, EVENT_HOMEASSISTANT_STARTED, STATE_ON
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -74,6 +74,26 @@ _CHECK_INTERVAL = timedelta(hours=24)
 _FIRST_CHECK_WINDOW = (timedelta(minutes=5), timedelta(minutes=30))
 
 _FETCH_TIMEOUT = 30
+
+# What goes in the dialog before somebody presses install. Home Assistant
+# renders `ha-alert` in release notes, which Matter and ZHA both lean on to
+# put a warning in front of a firmware update. Same idea here.
+_NO_PROMISES = (
+    "<ha-alert alert-type='warning'>"
+    "Blueprints carry no changelog, so there is nothing here that says what "
+    "changed. An update is whatever the author decided to do, and nothing "
+    "promises it still fits the automations you built on it: inputs get "
+    "renamed, behaviour gets rethought. Read the source before you install it."
+    "</ha-alert>"
+)
+
+_WOULD_BE_REFUSED = (
+    "<ha-alert alert-type='error'>"
+    "This one asks for inputs that nothing has set, so Spook will not install "
+    "it. Set them first, or import it yourself from the blueprint page if you "
+    "are happy to go round the automations below afterwards."
+    "</ha-alert>"
+)
 
 
 async def async_setup_entry(
@@ -301,7 +321,9 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
     """Spook update entity for a single imported blueprint."""
 
     _attr_should_poll = False
-    _attr_supported_features = UpdateEntityFeature.INSTALL
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
+    )
 
     def __init__(
         self,
@@ -328,6 +350,7 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         )
 
         self._source_url: str = item.metadata[CONF_SOURCE_URL]
+        self._fetched: blueprint.Blueprint | None = None
         self._attr_title = item.name
         self._attr_release_url = self._source_url
         self._attr_installed_version = fingerprint
@@ -376,6 +399,7 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         if (fingerprint := _fingerprint(fetched.yaml())) is None:
             return
 
+        self._fetched = fetched
         self._attr_latest_version = fingerprint
         self.async_write_ha_state()
 
@@ -420,9 +444,36 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
             msg = f"Could not write {self.blueprint_path}"
             raise HomeAssistantError(msg) from err
 
+        self._fetched = fetched
         self._attr_installed_version = _fingerprint(fetched.yaml())
         self._attr_latest_version = self._attr_installed_version
         self.async_write_ha_state()
+
+    async def async_release_notes(self) -> str | None:
+        """Return what can honestly be said before somebody presses install.
+
+        Which is not much, and that is the whole of it. A blueprint has no
+        changelog and no version, so there is nothing to show you that says
+        what changed. What is left is where it came from, so you can go and
+        read it, and a plain warning that an author improving their blueprint
+        and it still suiting what you built on it are two different things.
+        """
+        came_from = f"Imported from [{self._source_url}]({self._source_url})."
+
+        if self.state != STATE_ON or self._fetched is None:
+            return came_from
+
+        notes = [_NO_PROMISES, came_from]
+
+        if short := self._async_consumers_left_short(self._fetched):
+            notes.append(_WOULD_BE_REFUSED)
+            notes.extend(
+                f"- `{entity_id}` never sets "
+                + ", ".join(f"`{name}`" for name in sorted(inputs))
+                for entity_id, inputs in sorted(short.items())
+            )
+
+        return "\n\n".join(notes)
 
     async def _async_fetch(self) -> blueprint.Blueprint:
         """Fetch whatever the source URL points at now."""

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -10,6 +10,7 @@
     "group",
     "light",
     "proximity",
+    "script",
     "timer"
   ],
   "codeowners": ["@frenck"],

--- a/custom_components/spook/update.py
+++ b/custom_components/spook/update.py
@@ -1,0 +1,28 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.const import Platform
+
+from .setup_helpers import async_forward_platform_entry_setups_to_ectoplasm
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Spook updates."""
+    await async_forward_platform_entry_setups_to_ectoplasm(
+        hass,
+        entry,
+        async_add_entities,
+        Platform.UPDATE,
+    )

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -29,7 +29,7 @@ Spook adds an action to import Blueprints directly from an URL.
 
 ## Devices & entities
 
-Spook adds a Blueprints {term}`device <device>`, holding one update {term}`entity <entity>` for every blueprint you imported from a URL.
+Spook adds a Blueprints {term}`device <device>`, holding one update {term}`entity <entity>` for every {term}`automation <automation>` or {term}`script <script>` blueprint you imported from a URL.
 
 ### Updates
 
@@ -41,13 +41,17 @@ Spook gives every one of those blueprints an update entity. It follows the addre
 
 Only blueprints that came from a URL get one. A blueprint you wrote yourself has no source to check against, and the three example blueprints Home Assistant lays down for you are left alone as well: they point at Home Assistant's development branch, which is not the version you are running.
 
+Only automation and script blueprints, too. Those are the only two kinds whose users Home Assistant can list, and without that list there is no way to tell whether an update would leave one of them unable to load. An install button that cannot promise that is worse than no button at all, so template blueprints are left out until there is a way to check them.
+
 #### What the update dialog tells you
 
 Every other update dialog in Home Assistant shows you release notes. This one cannot, because there are none: a blueprint has no changelog, and the author is under no obligation to say anything anywhere.
 
 So the dialog carries the next best thing. The address the blueprint came from, as a link, always, so you can go and read what actually changed before deciding. And a warning, because an update dialog looks the same whatever is behind it, and this one deserves a second thought: an author improving their blueprint and it still suiting the {term}`automations <automation>` you built on it are two different things. Inputs get renamed. Behaviour gets rethought.
 
-If Spook already knows the update would leave your automations short, it says so there too, and names them, so you find out before pressing install rather than after.
+If Spook already knows something is wrong, it says so there too. Automations the update would leave short, named. A blueprint that says it needs a newer Home Assistant than the one you are running. Or a source that has stopped leading to this blueprint at all, which is the answer to "why does this one never have an update".
+
+Whatever it finds, the install button will not go through with anything the dialog warned you about.
 
 Matter and ZHA put much the same warning in front of a firmware update, for much the same reason.
 
@@ -63,7 +67,9 @@ Comments and indentation are not part of it. Somebody tidying up their YAML does
 
 An input without a default has to be filled in by whoever uses the blueprint. If a new version asks for one your automations do not set, every automation on that blueprint stops loading the moment the file is written, and the version they did work with is gone.
 
-Spook checks before it writes anything. If an update would leave your automations short, it refuses, names the ones affected and the inputs they are missing, and leaves the blueprint alone. You can then either set those inputs first, or import the blueprint yourself from the blueprint page if you are happy to reconfigure things afterwards.
+Spook checks before it writes anything, using Home Assistant's own reckoning of what an input needs rather than a second opinion that could drift from it. If an update would leave your automations short, it refuses, names the ones affected and the inputs they are missing, and leaves the blueprint alone. You can then either set those inputs first, or import the blueprint yourself from the blueprint page if you are happy to reconfigure things afterwards.
+
+A blueprint that says it needs a newer Home Assistant than the one you are running is refused for the same reason: writing it would break every automation on it, on a version that was never going to work.
 
 :::{warning}
 If you edited an imported blueprint by hand, Spook has no way of telling your changes apart from the author's. It will report an update, because what you have really is no longer what is at the address, and installing it will write over your work.
@@ -72,9 +78,11 @@ If you have made a blueprint your own, take the `source_url:` line out of the fi
 :::
 
 :::{note}
-Community forum topics sometimes hold more than one blueprint, and both of them are imported carrying the address of the topic rather than of the blueprint itself. Following that address can land on the wrong one.
+Community forum topics sometimes hold more than one blueprint, and every one of them is imported carrying the address of the topic rather than of the blueprint itself. Home Assistant takes the first it finds at that address, so following it can land on a different blueprint entirely.
 
-Spook checks that what it finds is at least the same kind of blueprint, an automation for an automation, before offering anything. If it is not, the entity stays quiet rather than offering to replace your blueprint with somebody else's.
+Blueprints carry no identity of their own, so the most that can be asked is that what comes back is the same kind of blueprint and still goes by the same name. If it does not, Spook leaves it alone and says why in the dialog, rather than offering to write somebody else's blueprint over yours.
+
+The cost of that is an author who renames their blueprint: Spook stops following it, and the dialog will tell you what the address leads to now. Re-import it from the blueprint page and it picks up again.
 :::
 
 ## Actions

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -71,6 +71,8 @@ Spook checks before it writes anything, using Home Assistant's own reckoning of 
 
 A blueprint that says it needs a newer Home Assistant than the one you are running is refused for the same reason: writing it would break every automation on it, on a version that was never going to work.
 
+And so is one that would simply not run. A blueprint can be perfectly valid as a blueprint while what comes out of it is not something Home Assistant will take, because the blueprint format has nothing whatever to say about triggers, actions or a script's sequence. Spook builds each of your automations against the new version first and puts it through the same validation a reload would, so a blueprint that would take them all out never reaches the disk.
+
 :::{warning}
 If you edited an imported blueprint by hand, Spook has no way of telling your changes apart from the author's. It will report an update, because what you have really is no longer what is at the address, and installing it will write over your work.
 

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -51,7 +51,7 @@ So the dialog carries the next best thing. The address the blueprint came from, 
 
 If Spook already knows something is wrong, it says so there too. Automations the update would leave short, named. A blueprint that says it needs a newer Home Assistant than the one you are running. Or a source that has stopped leading to this blueprint at all, which is the answer to "why does this one never have an update".
 
-The warning is advice, and an update that is otherwise fine still installs. The other two are refusals: Spook will not write a blueprint that would leave an automation short, or one that says it needs a Home Assistant you are not running.
+The warning is advice, and an update that is otherwise fine still installs. The rest are refusals: Spook will not write a blueprint that would leave an automation or script short of an input, one that would not load once it has been built, or one that says it needs a Home Assistant you are not running.
 
 Matter and ZHA put much the same warning in front of a firmware update, for much the same reason.
 
@@ -71,7 +71,7 @@ Spook checks before it writes anything, using Home Assistant's own reckoning of 
 
 A blueprint that says it needs a newer Home Assistant than the one you are running is refused for the same reason: writing it would break every automation on it, on a version that was never going to work.
 
-And so is one that would simply not run. A blueprint can be perfectly valid as a blueprint while what comes out of it is not something Home Assistant will take, because the blueprint format has nothing whatever to say about triggers, actions or a script's sequence. Spook builds each of your automations against the new version first and puts it through the same validation a reload would, so a blueprint that would take them all out never reaches the disk.
+And so is one that would simply not run. A blueprint can be perfectly valid as a blueprint while what comes out of it is not something Home Assistant will take, because the blueprint format has nothing whatever to say about triggers, actions or a script's sequence. Spook builds every automation and script that uses the blueprint against the new version first and puts each one through the same validation a reload would, so a blueprint that would take them all out never reaches the disk.
 
 :::{warning}
 If you edited an imported blueprint by hand, Spook has no way of telling your changes apart from the author's. It will report an update, because what you have really is no longer what is at the address, and installing it will write over your work.

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -29,7 +29,43 @@ Spook adds an action to import Blueprints directly from an URL.
 
 ## Devices & entities
 
-Spook does not provide any new devices or entities for this integration.
+Spook adds a Blueprints {term}`device <device>`, holding one update {term}`entity <entity>` for every blueprint you imported from a URL.
+
+### Updates
+
+_Default {term}`entity ID <Entity ID>`: `update.blueprints_<blueprint name>`_
+
+When you import a {term}`blueprint <blueprint>`, Home Assistant writes down where it came from. Nothing ever looks at that address again. The blueprint's author can fix a bug in it a week later and you would have no way of knowing, short of opening the forum topic and reading the YAML yourself.
+
+Spook gives every one of those blueprints an update entity. It follows the address the blueprint came in with, once a day, and tells you when what is there no longer matches what you have. Pressing install fetches it again and writes it over the copy you have, exactly as Home Assistant's own re-import button does, and reloads every {term}`automation <automation>` and {term}`script <script>` using it.
+
+Only blueprints that came from a URL get one. A blueprint you wrote yourself has no source to check against, and the three example blueprints Home Assistant lays down for you are left alone as well: they point at Home Assistant's development branch, which is not the version you are running.
+
+#### About those version numbers
+
+They look like `a1b2c3d`, and that is not Spook being clever. Blueprints have no version. There is nowhere in a blueprint to put one, because the format turns away anything it does not recognise, so no author can add one even if they wanted to.
+
+So Spook uses a fingerprint of the contents instead. Same fingerprint, same blueprint. A different one means something in it changed. It cannot tell you whether that change is newer or better, only that it is not what you have.
+
+Comments and indentation are not part of it. Somebody tidying up their YAML does not count as an update.
+
+#### When an update would break your automations
+
+An input without a default has to be filled in by whoever uses the blueprint. If a new version asks for one your automations do not set, every automation on that blueprint stops loading the moment the file is written, and the version they did work with is gone.
+
+Spook checks before it writes anything. If an update would leave your automations short, it refuses, names the ones affected and the inputs they are missing, and leaves the blueprint alone. You can then either set those inputs first, or import the blueprint yourself from the blueprint page if you are happy to reconfigure things afterwards.
+
+:::{warning}
+If you edited an imported blueprint by hand, Spook has no way of telling your changes apart from the author's. It will report an update, because what you have really is no longer what is at the address, and installing it will write over your work.
+
+If you have made a blueprint your own, take the `source_url:` line out of the file. There is then nothing to follow, the update entity goes away on its own, and the blueprint is yours. That is also the way to stop following a blueprint whose author you would rather not track any more.
+:::
+
+:::{note}
+Community forum topics sometimes hold more than one blueprint, and both of them are imported carrying the address of the topic rather than of the blueprint itself. Following that address can land on the wrong one.
+
+Spook checks that what it finds is at least the same kind of blueprint, an automation for an automation, before offering anything. If it is not, the entity stays quiet rather than offering to replace your blueprint with somebody else's.
+:::
 
 ## Actions
 
@@ -97,6 +133,8 @@ Spook has no repair detections for this integration.
 Some use cases for the enhancements Spook provides for this integration:
 
 - Automatically download and import Blueprints. For example, write a script that automatically downloads the top 10 Blueprints from the Home Assistant community forums.
+- Get told when the author of a blueprint you use has changed it, instead of finding out months later that the bug you worked around was fixed all along.
+- Put the blueprint update entities in an automation of your own, so a notification goes out when one of them has something new to say.
 
 ## Blueprints & tutorials
 

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -37,7 +37,7 @@ _Default {term}`entity ID <Entity ID>`: `update.blueprints_<blueprint name>`_
 
 When you import a {term}`blueprint <blueprint>`, Home Assistant writes down where it came from. Nothing ever looks at that address again. The blueprint's author can fix a bug in it a week later and you would have no way of knowing, short of opening the forum topic and reading the YAML yourself.
 
-Spook gives every one of those blueprints an update entity. It follows the address the blueprint came in with, once a day, and tells you when what is there no longer matches what you have. Pressing install fetches it again and writes it over the copy you have, exactly as Home Assistant's own re-import button does, and reloads every {term}`automation <automation>` and {term}`script <script>` using it.
+Spook gives every one of those blueprints an update entity. It follows the address the blueprint came in with, roughly once a day, and tells you when what is there no longer matches what you have. Roughly, because each round picks its own moment for the next one somewhere in the following few hours: a fixed hour would have every installation that restarted after the same release knocking on the community forum together, every day, for ever. Pressing install fetches it again and writes it over the copy you have, exactly as Home Assistant's own re-import button does, and reloads every {term}`automation <automation>` and {term}`script <script>` using it.
 
 Only blueprints that came from a URL get one. A blueprint you wrote yourself has no source to check against, and the three example blueprints Home Assistant lays down for you are left alone as well: they point at Home Assistant's development branch, which is not the version you are running.
 
@@ -51,13 +51,13 @@ So the dialog carries the next best thing. The address the blueprint came from, 
 
 If Spook already knows something is wrong, it says so there too. Automations the update would leave short, named. A blueprint that says it needs a newer Home Assistant than the one you are running. Or a source that has stopped leading to this blueprint at all, which is the answer to "why does this one never have an update".
 
-Whatever it finds, the install button will not go through with anything the dialog warned you about.
+The warning is advice, and an update that is otherwise fine still installs. The other two are refusals: Spook will not write a blueprint that would leave an automation short, or one that says it needs a Home Assistant you are not running.
 
 Matter and ZHA put much the same warning in front of a firmware update, for much the same reason.
 
 #### About those version numbers
 
-They look like `a1b2c3d`, and that is not Spook being clever. Blueprints have no version. There is nowhere in a blueprint to put one, because the format turns away anything it does not recognise, so no author can add one even if they wanted to.
+They look like `a1b2c3d4`, and that is not Spook being clever. Blueprints have no version. There is nowhere in a blueprint to put one, because the format turns away anything it does not recognise, so no author can add one even if they wanted to.
 
 So Spook uses a fingerprint of the contents instead. Same fingerprint, same blueprint. A different one means something in it changed. It cannot tell you whether that change is newer or better, only that it is not what you have.
 

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -41,6 +41,16 @@ Spook gives every one of those blueprints an update entity. It follows the addre
 
 Only blueprints that came from a URL get one. A blueprint you wrote yourself has no source to check against, and the three example blueprints Home Assistant lays down for you are left alone as well: they point at Home Assistant's development branch, which is not the version you are running.
 
+#### What the update dialog tells you
+
+Every other update dialog in Home Assistant shows you release notes. This one cannot, because there are none: a blueprint has no changelog, and the author is under no obligation to say anything anywhere.
+
+So the dialog carries the next best thing. The address the blueprint came from, as a link, always, so you can go and read what actually changed before deciding. And a warning, because an update dialog looks the same whatever is behind it, and this one deserves a second thought: an author improving their blueprint and it still suiting the {term}`automations <automation>` you built on it are two different things. Inputs get renamed. Behaviour gets rethought.
+
+If Spook already knows the update would leave your automations short, it says so there too, and names them, so you find out before pressing install rather than after.
+
+Matter and ZHA put much the same warning in front of a firmware update, for much the same reason.
+
 #### About those version numbers
 
 They look like `a1b2c3d`, and that is not Spook being clever. Blueprints have no version. There is nowhere in a blueprint to put one, because the format turns away anything it does not recognise, so no author can add one even if they wanted to.

--- a/tests/ectoplasms/blueprint/__init__.py
+++ b/tests/ectoplasms/blueprint/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spook blueprint ectoplasm."""

--- a/tests/ectoplasms/blueprint/conftest.py
+++ b/tests/ectoplasms/blueprint/conftest.py
@@ -62,6 +62,14 @@ mode: restart
 MOTION_LIGHT_CHANGED = MOTION_LIGHT.replace('to: "on"', 'to: "off"')
 MOTION_LIGHT_CHANGED_AGAIN = MOTION_LIGHT.replace("mode: restart", "mode: queued")
 
+# Perfectly good as a blueprint. The blueprint schema has nothing to say about
+# triggers, so this only falls over once something tries to run it.
+MOTION_LIGHT_WITH_A_BAD_TRIGGER = MOTION_LIGHT.replace(
+    "  - platform: state",
+    "  - platform: no_such_trigger_platform",
+)
+
+
 # And the same again, asking for something nobody has set yet.
 MOTION_LIGHT_WITH_NEW_INPUT = MOTION_LIGHT.replace(
     "    light_target:\n      name: Light\n",
@@ -99,6 +107,11 @@ sequence:
 """
 
 A_SCRIPT_BLUEPRINT_CHANGED = A_SCRIPT_BLUEPRINT.replace("Boo", "Boo!")
+
+A_SCRIPT_BLUEPRINT_WITH_A_BAD_STEP = A_SCRIPT_BLUEPRINT.replace(
+    "  - service: notify.notify",
+    "  - not_a_step_anybody_knows: true\n  - service: notify.notify",
+)
 
 A_SCRIPT_BLUEPRINT_WITH_NEW_INPUT = A_SCRIPT_BLUEPRINT.replace(
     "    notify_target:\n      name: Where to send it\n",

--- a/tests/ectoplasms/blueprint/conftest.py
+++ b/tests/ectoplasms/blueprint/conftest.py
@@ -88,13 +88,34 @@ blueprint:
   domain: script
   source_url: {source}
   input:
-    notify_device:
-      name: Device
+    notify_target:
+      name: Where to send it
 sequence:
-  - action: notify.notify
+  - service: notify.notify
     data:
       message: Boo
+      target: !input notify_target
 """
+
+A_SCRIPT_BLUEPRINT_CHANGED = A_SCRIPT_BLUEPRINT.replace("Boo", "Boo!")
+
+A_SCRIPT_BLUEPRINT_WITH_NEW_INPUT = A_SCRIPT_BLUEPRINT.replace(
+    "    notify_target:\n      name: Where to send it\n",
+    "    notify_target:\n      name: Where to send it\n    title:\n      name: Title\n",
+)
+
+# Says it needs a Home Assistant nobody is running yet.
+MOTION_LIGHT_FROM_THE_FUTURE = MOTION_LIGHT.replace(
+    "  source_url: {source}\n",
+    "  source_url: {source}\n  homeassistant:\n    min_version: 9999.1.0\n",
+)
+
+# Same domain, different blueprint. What a forum topic holding two of them
+# hands back, since both were imported carrying the address of the topic.
+ANOTHER_AUTOMATION_BLUEPRINT = MOTION_LIGHT.replace(
+    "Spooky motion light",
+    "Spooky doorbell chime",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -217,6 +238,32 @@ async def async_set_up(hass: HomeAssistant) -> ConfigEntry:
         await hass.async_block_till_done()
 
     return entry
+
+
+def async_write_script_config(
+    hass: HomeAssistant,
+    scripts: dict[str, Any] | None = None,
+) -> None:
+    """Write the configuration.yaml a script reload will read back."""
+    Path(hass.config.path("configuration.yaml")).write_text(
+        yaml_util.dump({"automation": [], "script": scripts or {}}),
+        encoding="utf-8",
+    )
+
+
+async def async_add_script(
+    hass: HomeAssistant,
+    key: str,
+    path: str,
+    inputs: dict[str, Any],
+) -> None:
+    """Add a script that runs on a blueprint, through a real reload."""
+    async_write_script_config(
+        hass,
+        {key: {"use_blueprint": {"path": path, "input": inputs}}},
+    )
+    await hass.services.async_call("script", "reload", blocking=True)
+    await hass.async_block_till_done()
 
 
 async def async_add_automation(

--- a/tests/ectoplasms/blueprint/conftest.py
+++ b/tests/ectoplasms/blueprint/conftest.py
@@ -1,0 +1,240 @@
+"""A config directory with blueprints in it, and Spook's update platform."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.blueprint import BLUEPRINT_SCHEMA
+from homeassistant.components.blueprint.importer import ImportedBlueprint
+from homeassistant.components.blueprint.models import Blueprint
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.const import Platform
+from homeassistant.setup import async_setup_component
+from homeassistant.util import yaml as yaml_util
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+
+from custom_components.spook.ectoplasms.blueprint.update import (
+    async_setup_entry as async_set_up_updates,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+SOURCE = "https://community.home-assistant.io/t/spooky-motion-light/1"
+
+# Written the way blueprints out in the wild are: `trigger` and `action`
+# rather than `triggers` and `actions`. The domain's own schema rewrites those
+# on load, which is precisely what the fingerprint has to see past.
+MOTION_LIGHT = """
+blueprint:
+  name: Spooky motion light
+  domain: automation
+  source_url: {source}
+  input:
+    motion_entity:
+      name: Motion sensor
+    light_target:
+      name: Light
+trigger:
+  - platform: state
+    entity_id: !input motion_entity
+    to: "on"
+action:
+  - service: light.turn_on
+    entity_id: !input light_target
+mode: restart
+"""
+
+# The same blueprint, with something changed that matters.
+MOTION_LIGHT_CHANGED = MOTION_LIGHT.replace('to: "on"', 'to: "off"')
+
+# And the same again, asking for something nobody has set yet.
+MOTION_LIGHT_WITH_NEW_INPUT = MOTION_LIGHT.replace(
+    "    light_target:\n      name: Light\n",
+    "    light_target:\n      name: Light\n    wait_time:\n      name: Wait time\n",
+)
+
+# No inputs at all, and no `input:` key to say so. The schema puts an empty
+# one in on the way through, which is why both sides have to go through it.
+NO_INPUTS = """
+blueprint:
+  name: Spooky fixed automation
+  domain: automation
+  source_url: {source}
+trigger:
+  - platform: state
+    entity_id: binary_sensor.landing
+action:
+  - service: light.turn_on
+    entity_id: light.landing
+"""
+
+A_SCRIPT_BLUEPRINT = """
+blueprint:
+  name: Spooky confirmable notification
+  domain: script
+  source_url: {source}
+  input:
+    notify_device:
+      name: Device
+sequence:
+  - action: notify.notify
+    data:
+      message: Boo
+"""
+
+
+@pytest.fixture(autouse=True)
+async def _a_config_dir_of_our_own(
+    hass: HomeAssistant,
+    tmp_path: Path,
+) -> AsyncGenerator[None]:
+    """Give every test its own blueprint folder, and clear up after it.
+
+    The platform is unloaded on the way out so its check timer, which is set
+    for somewhere between five and thirty minutes ahead, does not outlive the
+    test that started it.
+    """
+    hass.config.config_dir = str(tmp_path)
+    async_write_config(hass)
+
+    yield
+
+    for entry in hass.config_entries.async_entries("fake"):
+        await hass.config_entries.async_unload(entry.entry_id)
+
+
+def async_write_config(
+    hass: HomeAssistant,
+    automations: list[dict[str, Any]] | None = None,
+) -> None:
+    """Write the configuration.yaml a reload will read back."""
+    Path(hass.config.path("configuration.yaml")).write_text(
+        yaml_util.dump({"automation": automations or []}),
+        encoding="utf-8",
+    )
+
+
+def async_write_blueprint(
+    hass: HomeAssistant,
+    domain: str,
+    path: str,
+    raw: str,
+    *,
+    source: str = SOURCE,
+) -> Path:
+    """Put a blueprint on disk the way an import would have."""
+    parsed = yaml_util.parse_yaml(raw.format(source=source))
+    item = Blueprint(parsed, schema=BLUEPRINT_SCHEMA)
+
+    file = Path(hass.config.path("blueprints", domain, path))
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text(item.yaml(), encoding="utf-8")
+    return file
+
+
+def write_by_hand(hass: HomeAssistant, domain: str, path: str, raw: str) -> Path:
+    """Put a blueprint on disk exactly as written, without an import.
+
+    Which is what a file looks like after somebody has edited it themselves,
+    rather than one Home Assistant dumped back out.
+    """
+    file = Path(hass.config.path("blueprints", domain, path))
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text(raw.format(source=SOURCE), encoding="utf-8")
+    return file
+
+
+def examples_are_on_disk(hass: HomeAssistant) -> bool:
+    """Return whether Home Assistant laid its own example blueprints down."""
+    return Path(
+        hass.config.path("blueprints", "automation", "homeassistant"),
+    ).is_dir()
+
+
+def imported_from(raw: str, *, source: str = SOURCE) -> ImportedBlueprint:
+    """Return what the importer would hand back for this blueprint."""
+    body = raw.format(source=source)
+    item = Blueprint(yaml_util.parse_yaml(body), schema=BLUEPRINT_SCHEMA)
+    item.update_metadata(source_url=source)
+    return ImportedBlueprint("spook/blueprint", body, item)
+
+
+async def async_set_up(hass: HomeAssistant) -> ConfigEntry:
+    """Set up automations, scripts and Spook's update platform."""
+    assert await async_setup_component(hass, "automation", {"automation": []})
+    assert await async_setup_component(hass, "script", {"script": {}})
+    await hass.async_block_till_done()
+
+    async def _setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+        await hass.config_entries.async_forward_entry_setups(entry, [Platform.UPDATE])
+        return True
+
+    async def _unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+        return await hass.config_entries.async_unload_platforms(
+            entry,
+            [Platform.UPDATE],
+        )
+
+    async def _setup_platform(
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        add: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        await async_set_up_updates(hass, entry, add)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "fake",
+            async_setup_entry=_setup_entry,
+            async_unload_entry=_unload_entry,
+        ),
+    )
+    mock_platform(hass, "fake.config_flow")
+    mock_platform(hass, "fake.update", MockPlatform(async_setup_entry=_setup_platform))
+
+    class _Flow(ConfigFlow, domain="fake"):
+        """A config flow that does nothing."""
+
+    with mock_config_flow("fake", _Flow):
+        entry = MockConfigEntry(domain="fake")
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry
+
+
+async def async_add_automation(
+    hass: HomeAssistant,
+    alias: str,
+    path: str,
+    inputs: dict[str, Any],
+) -> None:
+    """Add an automation that runs on a blueprint, through a real reload."""
+    async_write_config(
+        hass,
+        [
+            {
+                "id": alias.lower().replace(" ", "_"),
+                "alias": alias,
+                "use_blueprint": {"path": path, "input": inputs},
+            },
+        ],
+    )
+    await hass.services.async_call("automation", "reload", blocking=True)
+    await hass.async_block_till_done()

--- a/tests/ectoplasms/blueprint/conftest.py
+++ b/tests/ectoplasms/blueprint/conftest.py
@@ -60,6 +60,7 @@ mode: restart
 
 # The same blueprint, with something changed that matters.
 MOTION_LIGHT_CHANGED = MOTION_LIGHT.replace('to: "on"', 'to: "off"')
+MOTION_LIGHT_CHANGED_AGAIN = MOTION_LIGHT.replace("mode: restart", "mode: queued")
 
 # And the same again, asking for something nobody has set yet.
 MOTION_LIGHT_WITH_NEW_INPUT = MOTION_LIGHT.replace(

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -98,7 +98,7 @@ async def test_a_blueprint_that_came_from_a_url_gets_an_entity(
 
     state = hass.states.get(_ENTITY)
     assert state is not None
-    assert state.attributes["release_url"] == SOURCE
+    assert state.attributes["title"] == "Spooky motion light"
 
 
 async def test_a_blueprint_written_by_hand_is_left_out(
@@ -1205,3 +1205,28 @@ async def test_installing_clears_what_the_last_look_could_not_do(
 
     assert hass.states.get(_ENTITY).state == "off"
     assert "Could not reach" not in await _entity(hass).async_release_notes()
+
+
+async def test_where_a_blueprint_came_from_is_not_told_to_everybody(
+    hass: HomeAssistant,
+) -> None:
+    """Home Assistant keeps blueprints to admins.
+
+    Every one of its blueprint commands is admin only, and so is asking an
+    update entity for its notes. State attributes are not: anything put there
+    is readable by everybody signed in, and a blueprint can be imported from
+    an address carrying a token or a username and password.
+    """
+    async_write_blueprint(
+        hass,
+        "automation",
+        "motion.yaml",
+        MOTION_LIGHT,
+        source="https://someone:hunter2@example.com/blueprints/motion.yaml",
+    )
+    await async_set_up(hass)
+
+    assert "hunter2" not in str(hass.states.get(_ENTITY).attributes)
+
+    # Still in front of the people allowed to see it, though.
+    assert "hunter2" in await _entity(hass).async_release_notes()

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -3,6 +3,7 @@
 # pylint: disable=wrong-import-order
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
@@ -18,7 +19,12 @@ import pytest
 import voluptuous as vol
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
-from custom_components.spook.ectoplasms.blueprint.update import _CHECK_INTERVAL
+from custom_components.spook.ectoplasms.blueprint import update as update_module
+from custom_components.spook.ectoplasms.blueprint.update import (
+    _CHECK_INTERVAL,
+    _SPREAD,
+    BlueprintUpdateEntity,
+)
 
 from .conftest import (
     A_SCRIPT_BLUEPRINT,
@@ -27,6 +33,7 @@ from .conftest import (
     ANOTHER_AUTOMATION_BLUEPRINT,
     MOTION_LIGHT,
     MOTION_LIGHT_CHANGED,
+    MOTION_LIGHT_CHANGED_AGAIN,
     MOTION_LIGHT_FROM_THE_FUTURE,
     MOTION_LIGHT_WITH_NEW_INPUT,
     NO_INPUTS,
@@ -41,6 +48,8 @@ from .conftest import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from freezegun.api import FrozenDateTimeFactory
     from pytest_homeassistant_custom_component.typing import (
         MockHAClientWebSocket,
@@ -53,6 +62,8 @@ if TYPE_CHECKING:
 _ENTITY = "update.blueprints_spooky_motion_light"
 _FETCH = "custom_components.spook.ectoplasms.blueprint.update.fetch_blueprint_from_url"
 _BOTH_OF_THEM = 2
+_NOBODY_SAW_IT_COMING = "something nobody saw coming"
+_ENOUGH_ROUNDS_TO_JUDGE = 8
 
 
 def _source_says(raw: str, *, source: str = SOURCE):  # noqa: ANN202
@@ -66,12 +77,13 @@ async def _check(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
     Nothing else brings one on. Blueprints raise no events, so the timer is
     the only thing that ever looks.
     """
-    freezer.tick(_CHECK_INTERVAL + timedelta(minutes=1))
+    # Past the far end of the window a round picks its next moment from, so
+    # this fires whichever moment it happened to choose.
+    freezer.tick(_CHECK_INTERVAL + _SPREAD + timedelta(minutes=1))
     async_fire_time_changed(hass)
 
-    # `async_track_time_interval` runs its job as a background task, which a
-    # plain `async_block_till_done` walks straight past. Without this the
-    # round is still going when the test moves on.
+    # Waiting on background tasks too, so nothing of the round is still going
+    # when the test moves on.
     await hass.async_block_till_done(wait_background_tasks=True)
 
 
@@ -450,6 +462,11 @@ async def test_a_blueprint_that_cannot_be_read_says_nothing_new(
     assert hass.states.get(_ENTITY).state == "on"
 
 
+def _entity(hass: HomeAssistant) -> BlueprintUpdateEntity:
+    """Return the update entity itself, for what the dialog cannot reach."""
+    return hass.data[DATA_INSTANCES]["update"].get_entity(_ENTITY)
+
+
 async def _release_notes(client: MockHAClientWebSocket) -> str:
     """Ask for the release notes the way the dialog does."""
     await client.send_json_auto_id(
@@ -810,3 +827,222 @@ async def test_a_consumer_that_cannot_be_read_stops_the_install(
             )
 
     assert file.read_text(encoding="utf-8") == before
+
+
+async def test_nothing_is_looked_at_while_home_assistant_is_still_starting(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Starting up can take longer than the wait before the first round.
+
+    A round landing in the middle of it reads blueprint domains that have not
+    finished arriving, and goes out to the internet while the house is still
+    getting dressed.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    hass.set_state(CoreState.not_running)
+    await async_set_up(hass)
+
+    with patch(_FETCH) as fetch:
+        await _check(hass, freezer)
+        assert not fetch.called, "it went looking before Home Assistant was up"
+
+    hass.set_state(CoreState.running)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).state == "on"
+
+
+async def test_each_round_picks_its_own_moment_for_the_next(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Otherwise every instance that restarted together lines up.
+
+    On the same hour, every day after, which is the stampede the wait before
+    the first round exists to avoid, put back a day later.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    seen: list[float] = []
+    schedule = update_module.async_call_later
+
+    def _note_the_delay(
+        hass: HomeAssistant,
+        delay: float,
+        action: object,
+    ) -> Callable[[], None]:
+        """Write down what the scheduler was asked for, then let it get on."""
+        seen.append(delay)
+        return schedule(hass, delay, action)
+
+    with (
+        patch.object(update_module, "async_call_later", _note_the_delay),
+        _source_says(MOTION_LIGHT),
+    ):
+        # Enough rounds that them all landing on the same moment would not be
+        # chance.
+        for _ in range(_ENOUGH_ROUNDS_TO_JUDGE):
+            await _check(hass, freezer)
+
+    assert seen, "no next round was arranged"
+    assert all(
+        _CHECK_INTERVAL.total_seconds()
+        <= delay
+        <= (_CHECK_INTERVAL + _SPREAD).total_seconds()
+        for delay in seen
+    ), seen
+    assert len(set(seen)) > 1, f"every round asked for the same moment: {seen}"
+
+
+async def test_a_source_answering_with_something_else_entirely(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Home Assistant asserts the YAML it parsed is a mapping.
+
+    A source answering with a list, or a bare string, arrives as an
+    `AssertionError`, which is not a `HomeAssistantError` and would otherwise
+    take the whole round down with it.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+    assert hass.states.get(_ENTITY).state == "on"
+
+    with patch(_FETCH, side_effect=AssertionError):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).state == "on"
+
+    # Named as such, rather than swept up by the round's catch-all, so the
+    # dialog can say what happened.
+    assert (
+        "did not answer with a blueprint"
+        in await _entity(
+            hass,
+        ).async_release_notes()
+    )
+
+
+async def test_one_bad_blueprint_does_not_end_the_round(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The round works through them one at a time.
+
+    So the first to fall over would take everything after it with it.
+    Everything expected is dealt with inside the entity; this is for whatever
+    is not.
+    """
+    async_write_blueprint(hass, "automation", "one.yaml", MOTION_LIGHT)
+    async_write_blueprint(
+        hass,
+        "automation",
+        "two.yaml",
+        MOTION_LIGHT.replace("Spooky motion light", "Spooky hallway light"),
+    )
+    await async_set_up(hass)
+
+    reached: list[str] = []
+
+    async def _first_one_explodes(_hass: HomeAssistant, url: str):  # noqa: ANN202
+        reached.append(url)
+        if len(reached) == 1:
+            raise RuntimeError(_NOBODY_SAW_IT_COMING)
+        return imported_from(MOTION_LIGHT)
+
+    with patch(_FETCH, side_effect=_first_one_explodes):
+        await _check(hass, freezer)
+
+    assert len(reached) == _BOTH_OF_THEM, "the round stopped at the first one"
+
+
+async def test_the_notes_say_when_the_news_has_gone_stale(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An update found last week and a source that has stopped answering since.
+
+    Showing the one without the other reads as though the news is current.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+    assert hass.states.get(_ENTITY).state == "on"
+
+    with patch(_FETCH, side_effect=TimeoutError):
+        await _check(hass, freezer)
+
+    # Read off the entity rather than through the dialog: two rounds is two
+    # days of clock, and a websocket does not survive being left that long.
+    notes = await _entity(hass).async_release_notes()
+    assert "alert-type='info'" in notes
+    assert "Could not reach" in notes
+    assert "alert-type='warning'" in notes, "it dropped the update it had found"
+
+
+async def test_a_check_and_an_install_do_not_tread_on_each_other(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Both fetch before they write, so whichever finished last used to win.
+
+    A check that started first and landed last would put its own answer back
+    over the version that had just been installed, leaving this saying an
+    update is waiting for something already here.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+    assert hass.states.get(_ENTITY).state == "on"
+
+    started = asyncio.Event()
+    let_go = asyncio.Event()
+    calls: list[str] = []
+
+    async def _the_first_one_dawdles(_hass: HomeAssistant, _url: str):  # noqa: ANN202
+        calls.append(_url)
+        if len(calls) == 1:
+            started.set()
+            await let_go.wait()
+            return imported_from(MOTION_LIGHT_CHANGED)
+
+        # By the time anybody asks again, the source has moved on once more.
+        return imported_from(MOTION_LIGHT_CHANGED_AGAIN)
+
+    with patch(_FETCH, side_effect=_the_first_one_dawdles):
+        checking = hass.async_create_task(_entity(hass).async_check())
+        await started.wait()
+
+        # The check is mid-fetch. Install now, and let the check land after.
+        installing = hass.async_create_task(
+            hass.services.async_call(
+                "update",
+                "install",
+                {"entity_id": _ENTITY},
+                blocking=True,
+            ),
+        )
+        await asyncio.sleep(0)
+
+        let_go.set()
+        await checking
+        await installing
+
+    await hass.async_block_till_done()
+
+    # What was written is what this now has. A check that landed afterwards
+    # with an older answer would leave this offering an update backwards.
+    assert hass.states.get(_ENTITY).state == "off", "the check undid the install"

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -392,6 +392,13 @@ async def test_unloading_stops_a_round_that_is_under_way(
 
     assert len(reached) == 1, "it carried on after being unloaded"
 
+    # And the one that was mid-fetch when the rug went does not put a live
+    # state back over the unavailable one that unloading left.
+    assert all(
+        hass.states.get(entity_id).state == "unavailable"
+        for entity_id in hass.states.async_entity_ids("update")
+    ), "something wrote a state back after being taken away"
+
 
 async def test_a_blueprint_nobody_dumped_back_out_still_matches(
     hass: HomeAssistant,
@@ -1152,3 +1159,11 @@ async def test_the_notes_say_an_update_would_not_load(
     assert "alert-type='error'" in notes
     assert "automation.landing_light" in notes
     assert "would not load" in notes
+
+    # And the heading over that list says nothing about inputs. There are
+    # three ways onto it, and blaming the commonest of them sends somebody off
+    # setting inputs that were never the trouble.
+    heading = notes.partition("<ha-alert alert-type='error'>")[2].partition(
+        "</ha-alert>",
+    )[0]
+    assert "input" not in heading, heading

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import patch
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.core import CoreState
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 import aiohttp
 import pytest
 import voluptuous as vol
@@ -21,12 +22,17 @@ from custom_components.spook.ectoplasms.blueprint.update import _CHECK_INTERVAL
 
 from .conftest import (
     A_SCRIPT_BLUEPRINT,
+    A_SCRIPT_BLUEPRINT_CHANGED,
+    A_SCRIPT_BLUEPRINT_WITH_NEW_INPUT,
+    ANOTHER_AUTOMATION_BLUEPRINT,
     MOTION_LIGHT,
     MOTION_LIGHT_CHANGED,
+    MOTION_LIGHT_FROM_THE_FUTURE,
     MOTION_LIGHT_WITH_NEW_INPUT,
     NO_INPUTS,
     SOURCE,
     async_add_automation,
+    async_add_script,
     async_set_up,
     async_write_blueprint,
     examples_are_on_disk,
@@ -541,3 +547,266 @@ async def test_the_notes_do_not_warn_when_there_is_nothing_to_install(
         await _check(hass, freezer)
 
     assert "ha-alert" not in await _release_notes(client)
+
+
+async def test_taking_the_source_url_out_of_a_file_is_enough(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """The documented way to be left alone, so it had better work.
+
+    Home Assistant loads a blueprint once and then keeps it, so the copy in
+    memory still names a source long after the file stopped doing so. Reading
+    the metadata off that copy would leave this entity sitting there checking
+    an address the file no longer mentions, until something reloaded.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    assert entity_registry.async_get(_ENTITY) is not None
+
+    write_by_hand(
+        hass,
+        "automation",
+        "motion.yaml",
+        MOTION_LIGHT.replace("  source_url: {source}\n", ""),
+    )
+
+    with _source_says(MOTION_LIGHT):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY) is None
+    assert entity_registry.async_get(_ENTITY) is None
+
+
+async def test_a_renamed_blueprint_follows_its_new_name(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Same reason: the name comes off the file, not off the loaded copy."""
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    write_by_hand(
+        hass,
+        "automation",
+        "motion.yaml",
+        MOTION_LIGHT.replace("Spooky motion light", "Spooky landing light"),
+    )
+
+    with _source_says(MOTION_LIGHT):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).attributes["title"] == "Spooky landing light"
+
+
+async def test_another_blueprint_at_the_same_address_is_not_this_one(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A forum topic can hold two automation blueprints.
+
+    Both were imported carrying the address of the topic, and the importer
+    hands back the first it finds. Matching on the domain alone lets the other
+    one through, and installing would write somebody else's blueprint into
+    this file.
+    """
+    file = async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    before = file.read_text(encoding="utf-8")
+    await async_set_up(hass)
+
+    # Nothing on offer, because what came back is not this blueprint.
+    with _source_says(ANOTHER_AUTOMATION_BLUEPRINT):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).state == "off"
+
+    # And again for the gap in between: an update found honestly, and the
+    # topic having moved on by the time somebody presses the button.
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+    assert hass.states.get(_ENTITY).state == "on"
+
+    with (
+        _source_says(ANOTHER_AUTOMATION_BLUEPRINT),
+        pytest.raises(HomeAssistantError, match="Spooky doorbell chime"),
+    ):
+        await hass.services.async_call(
+            "update",
+            "install",
+            {"entity_id": _ENTITY},
+            blocking=True,
+        )
+
+    assert file.read_text(encoding="utf-8") == before
+
+
+async def test_a_blueprint_needing_a_newer_home_assistant_is_refused(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """A blueprint can say for itself what it needs.
+
+    Writing one that says it needs more than is running breaks every
+    automation on it, on a version that was never going to work.
+    """
+    file = async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    before = file.read_text(encoding="utf-8")
+    await async_set_up(hass)
+    client = await hass_ws_client(hass)
+
+    with _source_says(MOTION_LIGHT_FROM_THE_FUTURE):
+        await _check(hass, freezer)
+
+        assert hass.states.get(_ENTITY).state == "on"
+        assert "9999.1.0" in await _release_notes(client)
+
+        with pytest.raises(HomeAssistantError, match=r"9999\.1\.0"):
+            await hass.services.async_call(
+                "update",
+                "install",
+                {"entity_id": _ENTITY},
+                blocking=True,
+            )
+
+    assert file.read_text(encoding="utf-8") == before
+
+
+async def test_the_notes_say_why_there_is_never_anything_to_install(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """An entity that never has news looks the same as one with nothing to say.
+
+    So when Spook set the answer aside, for a source it could not reach or one
+    that leads somewhere else entirely, the dialog says so.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    client = await hass_ws_client(hass)
+
+    with _source_says(ANOTHER_AUTOMATION_BLUEPRINT):
+        await _check(hass, freezer)
+
+    notes = await _release_notes(client)
+    assert "alert-type='info'" in notes
+    assert "Spooky doorbell chime" in notes
+
+
+async def test_a_script_blueprint_gets_one_too(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Scripts keep their blueprint users in a different place from automations.
+
+    Same shape, different integration, and nothing had been through it.
+    """
+    file = async_write_blueprint(hass, "script", "notify.yaml", A_SCRIPT_BLUEPRINT)
+    await async_set_up(hass)
+
+    entity_id = "update.blueprints_spooky_confirmable_notification"
+    assert hass.states.get(entity_id) is not None
+
+    with _source_says(A_SCRIPT_BLUEPRINT_CHANGED):
+        await _check(hass, freezer)
+        assert hass.states.get(entity_id).state == "on"
+
+        await hass.services.async_call(
+            "update",
+            "install",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    assert "Boo!" in file.read_text(encoding="utf-8")
+    assert hass.states.get(entity_id).state == "off"
+
+
+async def test_a_script_that_would_be_left_short_stops_the_install(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Scripts hold their supplied inputs in their own entities.
+
+    Reading them wrong would let an update through that leaves every script on
+    the blueprint unable to load.
+    """
+    file = async_write_blueprint(hass, "script", "notify.yaml", A_SCRIPT_BLUEPRINT)
+    await async_set_up(hass)
+    await async_add_script(
+        hass,
+        "shout",
+        "notify.yaml",
+        {"notify_target": "mobile_app_phone"},
+    )
+    before = file.read_text(encoding="utf-8")
+
+    entity_id = "update.blueprints_spooky_confirmable_notification"
+    with _source_says(A_SCRIPT_BLUEPRINT_WITH_NEW_INPUT):
+        await _check(hass, freezer)
+
+        with pytest.raises(HomeAssistantError, match="title"):
+            await hass.services.async_call(
+                "update",
+                "install",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+
+    assert file.read_text(encoding="utf-8") == before
+
+
+async def test_a_consumer_that_cannot_be_read_stops_the_install(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The inputs an automation supplies are reached for by name.
+
+    Home Assistant offers no public way to them: `raw_config` is the automation
+    after the blueprint has already been substituted into it. So if that name
+    ever changes, or there is simply nothing behind it, Spook stops being able
+    to tell whether an update is safe. Not knowing is not a reason to write.
+    """
+    file = async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    await async_add_automation(
+        hass,
+        "Landing light",
+        "motion.yaml",
+        {"motion_entity": "binary_sensor.landing", "light_target": {}},
+    )
+    before = file.read_text(encoding="utf-8")
+
+    class _AfterARename:  # pylint: disable=too-few-public-methods
+        """The automation as it would look had that name changed upstream.
+
+        Still listed as a user of the blueprint, because the public property
+        that answers for that would have been renamed along with it, and still
+        carrying `raw_config`, which never says which inputs went in.
+        """
+
+        entity_id = "automation.landing_light"
+        raw_config: ClassVar[dict[str, object]] = {}
+
+    monkeypatch.setattr(
+        hass.data[DATA_INSTANCES]["automation"],
+        "get_entity",
+        lambda _entity_id: _AfterARename(),
+    )
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+
+        with pytest.raises(HomeAssistantError, match="landing_light"):
+            await hass.services.async_call(
+                "update",
+                "install",
+                {"entity_id": _ENTITY},
+                blocking=True,
+            )
+
+    assert file.read_text(encoding="utf-8") == before

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.core import CoreState
 from homeassistant.exceptions import HomeAssistantError
 import aiohttp
@@ -35,6 +36,10 @@ from .conftest import (
 
 if TYPE_CHECKING:
     from freezegun.api import FrozenDateTimeFactory
+    from pytest_homeassistant_custom_component.typing import (
+        MockHAClientWebSocket,
+        WebSocketGenerator,
+    )
 
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import entity_registry as er
@@ -437,3 +442,102 @@ async def test_a_blueprint_that_cannot_be_read_says_nothing_new(
         await _check(hass, freezer)
 
     assert hass.states.get(_ENTITY).state == "on"
+
+
+async def _release_notes(client: MockHAClientWebSocket) -> str:
+    """Ask for the release notes the way the dialog does."""
+    await client.send_json_auto_id(
+        {"type": "update/release_notes", "entity_id": _ENTITY},
+    )
+
+    result = await client.receive_json()
+    assert result["success"], result
+
+    return result["result"]
+
+
+async def test_the_notes_always_say_where_the_blueprint_came_from(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Even with nothing to install.
+
+    The source is the only thing that can tell somebody what a blueprint
+    actually does, so it belongs in front of them rather than a click away.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    client = await hass_ws_client(hass)
+
+    assert SOURCE in await _release_notes(client)
+    assert (
+        UpdateEntityFeature.RELEASE_NOTES
+        in hass.states.get(_ENTITY).attributes["supported_features"]
+    )
+
+
+async def test_the_notes_warn_that_an_update_need_not_still_fit(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """There is no changelog, so this is the only warning anybody gets.
+
+    Matter and ZHA put the same sort of thing in front of a firmware update,
+    for the same reason: the dialog looks like every other update dialog, and
+    this one is not that.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    # Before the clock moves. An access token is good for half an hour, and
+    # a round of checks is a day further on than that.
+    client = await hass_ws_client(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+
+    notes = await _release_notes(client)
+    assert "alert-type='warning'" in notes
+    assert SOURCE in notes
+
+
+async def test_the_notes_name_the_automations_that_would_be_left_short(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Better than finding out by pressing install and being turned down."""
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    await async_add_automation(
+        hass,
+        "Landing light",
+        "motion.yaml",
+        {"motion_entity": "binary_sensor.landing", "light_target": {}},
+    )
+    client = await hass_ws_client(hass)
+
+    with _source_says(MOTION_LIGHT_WITH_NEW_INPUT):
+        await _check(hass, freezer)
+
+    notes = await _release_notes(client)
+    assert "alert-type='error'" in notes
+    assert "automation.landing_light" in notes
+    assert "wait_time" in notes
+
+
+async def test_the_notes_do_not_warn_when_there_is_nothing_to_install(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A warning nobody needs is a warning nobody reads."""
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    client = await hass_ws_client(hass)
+
+    with _source_says(MOTION_LIGHT):
+        await _check(hass, freezer)
+
+    assert "ha-alert" not in await _release_notes(client)

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -1,0 +1,439 @@
+"""Tests for the update entities Spook puts on imported blueprints."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState
+from homeassistant.exceptions import HomeAssistantError
+import aiohttp
+import pytest
+import voluptuous as vol
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.spook.ectoplasms.blueprint.update import _CHECK_INTERVAL
+
+from .conftest import (
+    A_SCRIPT_BLUEPRINT,
+    MOTION_LIGHT,
+    MOTION_LIGHT_CHANGED,
+    MOTION_LIGHT_WITH_NEW_INPUT,
+    NO_INPUTS,
+    SOURCE,
+    async_add_automation,
+    async_set_up,
+    async_write_blueprint,
+    examples_are_on_disk,
+    imported_from,
+    write_by_hand,
+)
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import entity_registry as er
+
+_ENTITY = "update.blueprints_spooky_motion_light"
+_FETCH = "custom_components.spook.ectoplasms.blueprint.update.fetch_blueprint_from_url"
+_BOTH_OF_THEM = 2
+
+
+def _source_says(raw: str, *, source: str = SOURCE):  # noqa: ANN202
+    """Make the importer hand back this blueprint."""
+    return patch(_FETCH, return_value=imported_from(raw, source=source))
+
+
+async def _check(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
+    """Let a round of checks come round, the way it does on its own.
+
+    Nothing else brings one on. Blueprints raise no events, so the timer is
+    the only thing that ever looks.
+    """
+    freezer.tick(_CHECK_INTERVAL + timedelta(minutes=1))
+    async_fire_time_changed(hass)
+
+    # `async_track_time_interval` runs its job as a background task, which a
+    # plain `async_block_till_done` walks straight past. Without this the
+    # round is still going when the test moves on.
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+
+async def test_a_blueprint_that_came_from_a_url_gets_an_entity(
+    hass: HomeAssistant,
+) -> None:
+    """Which is the whole premise: a source to compare against."""
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    state = hass.states.get(_ENTITY)
+    assert state is not None
+    assert state.attributes["release_url"] == SOURCE
+
+
+async def test_a_blueprint_written_by_hand_is_left_out(
+    hass: HomeAssistant,
+) -> None:
+    """No source means nothing to check against, and no button to offer.
+
+    It is also how somebody opts out of one they no longer want followed:
+    take the URL back out of the file. The imported one alongside it is there
+    to prove the platform came up at all, rather than falling over on the
+    blueprint with no URL and leaving nothing behind either way.
+    """
+    async_write_blueprint(
+        hass,
+        "automation",
+        "mine.yaml",
+        MOTION_LIGHT.replace("  source_url: {source}\n", "").replace(
+            "Spooky motion light",
+            "Spooky handmade thing",
+        ),
+    )
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    assert hass.states.async_entity_ids("update") == [_ENTITY]
+
+
+async def test_a_source_that_still_says_the_same_is_not_an_update(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The old spellings have to survive the round trip.
+
+    The file on disk says `trigger`, the copy Home Assistant loaded says
+    `triggers`, because the automation schema rewrites it. Fingerprinting the
+    loaded copy would call every blueprint written before that rename out of
+    date, for ever.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT):
+        await _check(hass, freezer)
+
+    state = hass.states.get(_ENTITY)
+    assert state.state == "off"
+    assert state.attributes["latest_version"] == state.attributes["installed_version"]
+
+
+async def test_a_source_that_has_moved_on_is_an_update(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The point of the exercise."""
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).state == "on"
+
+
+async def test_installing_writes_the_new_blueprint(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """And settles back down afterwards."""
+    file = async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+        await hass.services.async_call(
+            "update",
+            "install",
+            {"entity_id": _ENTITY},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    assert "to: 'off'" in file.read_text(encoding="utf-8")
+    assert hass.states.get(_ENTITY).state == "off"
+
+
+async def test_an_update_that_would_strand_an_automation_is_refused(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An input with no default has to come from whoever uses the blueprint.
+
+    A new one that nobody sets stops every automation on it from loading the
+    moment the file is written, and the old version is gone by then.
+    """
+    file = async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    await async_add_automation(
+        hass,
+        "Landing light",
+        "motion.yaml",
+        {"motion_entity": "binary_sensor.landing", "light_target": {}},
+    )
+    before = file.read_text(encoding="utf-8")
+
+    with _source_says(MOTION_LIGHT_WITH_NEW_INPUT):
+        await _check(hass, freezer)
+
+        with pytest.raises(HomeAssistantError, match="wait_time"):
+            await hass.services.async_call(
+                "update",
+                "install",
+                {"entity_id": _ENTITY},
+                blocking=True,
+            )
+
+    assert file.read_text(encoding="utf-8") == before
+
+
+async def test_a_new_input_nobody_needs_to_set_goes_through(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A default is what makes the difference, so it has to be read."""
+    file = async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    await async_add_automation(
+        hass,
+        "Landing light",
+        "motion.yaml",
+        {"motion_entity": "binary_sensor.landing", "light_target": {}},
+    )
+
+    with _source_says(
+        MOTION_LIGHT_WITH_NEW_INPUT.replace(
+            "    wait_time:\n      name: Wait time\n",
+            "    wait_time:\n      name: Wait time\n      default: 120\n",
+        ),
+    ):
+        await _check(hass, freezer)
+        await hass.services.async_call(
+            "update",
+            "install",
+            {"entity_id": _ENTITY},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    assert "wait_time" in file.read_text(encoding="utf-8")
+
+
+async def test_a_source_leading_to_another_blueprint_is_not_an_update(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A community topic can hold more than one blueprint.
+
+    The importer takes the first valid block it comes across, and both got the
+    same source URL on the way in. Following it can land on the other one
+    entirely, and writing that over this would be the wrong blueprint in the
+    wrong file.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(A_SCRIPT_BLUEPRINT):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).state == "off"
+
+
+@pytest.mark.parametrize(
+    "went_wrong",
+    [
+        TimeoutError(),
+        aiohttp.ClientError(),
+        vol.Invalid("that is not a blueprint any more"),
+        HomeAssistantError("unsupported URL"),
+    ],
+)
+async def test_a_source_that_cannot_be_read_leaves_the_last_answer_alone(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    went_wrong: Exception,
+) -> None:
+    """A forum down for an afternoon should not take the news with it."""
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+    assert hass.states.get(_ENTITY).state == "on"
+
+    with patch(_FETCH, side_effect=went_wrong):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).state == "on"
+
+
+async def test_a_blueprint_that_is_gone_takes_its_entity_with_it(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Nothing announces a blueprint being deleted, so the round has to look."""
+    file = async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    assert entity_registry.async_get(_ENTITY) is not None
+
+    file.unlink()
+
+    with _source_says(MOTION_LIGHT):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY) is None
+    assert entity_registry.async_get(_ENTITY) is None
+
+
+async def test_home_assistants_own_examples_are_left_out(
+    hass: HomeAssistant,
+) -> None:
+    """Home Assistant fills a folder of its own with three example blueprints.
+
+    All three carry a source URL pointing at core's dev branch. Following them
+    would put an update on every installation there is, for something nobody
+    imported, out of a branch nobody is running.
+    """
+    await async_set_up(hass)
+
+    assert examples_are_on_disk(
+        hass,
+    ), "Home Assistant laid down no examples, so this proves nothing"
+    assert not hass.states.async_entity_ids("update")
+
+
+async def test_a_reimport_somewhere_else_is_noticed(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Home Assistant has a re-import button of its own, on the blueprint page.
+
+    Somebody using that settles the update without Spook having any part in
+    it, and reading the fingerprint once at startup would leave this saying
+    there is an update for ever.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+    assert hass.states.get(_ENTITY).state == "on"
+
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT_CHANGED)
+    await hass.services.async_call("automation", "reload", blocking=True)
+    await hass.async_block_till_done()
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).state == "off"
+
+
+async def test_unloading_stops_a_round_that_is_under_way(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A round is a string of network calls, one blueprint after another.
+
+    Cancelling the timer only stops the next round starting. The one already
+    running has to notice for itself, or it goes on talking to the internet
+    and writing to entities that are no longer there.
+    """
+    async_write_blueprint(hass, "automation", "one.yaml", MOTION_LIGHT)
+    async_write_blueprint(
+        hass,
+        "automation",
+        "two.yaml",
+        MOTION_LIGHT.replace("Spooky motion light", "Spooky hallway light"),
+    )
+    entry = await async_set_up(hass)
+    assert len(hass.states.async_entity_ids("update")) == _BOTH_OF_THEM
+
+    reached: list[str] = []
+
+    async def _fetch_then_pull_the_rug(_hass: HomeAssistant, url: str):  # noqa: ANN202
+        reached.append(url)
+        await hass.config_entries.async_unload(entry.entry_id)
+        return imported_from(MOTION_LIGHT)
+
+    with patch(_FETCH, side_effect=_fetch_then_pull_the_rug):
+        await _check(hass, freezer)
+
+    assert len(reached) == 1, "it carried on after being unloaded"
+
+
+async def test_a_blueprint_nobody_dumped_back_out_still_matches(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Both sides have to go through the same schema, not just the same dump.
+
+    This one has no inputs and no `input:` key to say so, and it was written
+    by hand rather than laid down by an import. The schema puts an empty one
+    in on the way through. Only doing that to the copy that came off the
+    internet would call it different for ever.
+    """
+    write_by_hand(hass, "automation", "fixed.yaml", NO_INPUTS)
+    await async_set_up(hass)
+
+    entity_id = "update.blueprints_spooky_fixed_automation"
+    assert hass.states.get(entity_id) is not None
+
+    with _source_says(NO_INPUTS):
+        await _check(hass, freezer)
+
+    assert hass.states.get(entity_id).state == "off"
+
+
+async def test_the_entities_arrive_once_home_assistant_is_up(
+    hass: HomeAssistant,
+) -> None:
+    """Which is how it happens on a real start.
+
+    Spook is set up while Home Assistant is still coming up, and the domains
+    that hold the blueprints register themselves along the way. Looking right
+    then finds nothing at all.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    hass.set_state(CoreState.not_running)
+
+    await async_set_up(hass)
+    assert hass.states.get(_ENTITY) is None
+
+    hass.set_state(CoreState.running)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_ENTITY) is not None
+
+
+async def test_a_blueprint_that_cannot_be_read_says_nothing_new(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Listing a blueprint and reading it are two separate goes at the disk.
+
+    It can be deleted or made unreadable in between. Reading nothing as a
+    fingerprint of nothing would leave the entity with no version at all and
+    no state to show.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+    assert hass.states.get(_ENTITY).state == "on"
+
+    with (
+        patch.object(Path, "read_text", side_effect=OSError),
+        _source_says(MOTION_LIGHT_CHANGED),
+    ):
+        await _check(hass, freezer)
+
+    assert hass.states.get(_ENTITY).state == "on"

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -29,12 +29,14 @@ from custom_components.spook.ectoplasms.blueprint.update import (
 from .conftest import (
     A_SCRIPT_BLUEPRINT,
     A_SCRIPT_BLUEPRINT_CHANGED,
+    A_SCRIPT_BLUEPRINT_WITH_A_BAD_STEP,
     A_SCRIPT_BLUEPRINT_WITH_NEW_INPUT,
     ANOTHER_AUTOMATION_BLUEPRINT,
     MOTION_LIGHT,
     MOTION_LIGHT_CHANGED,
     MOTION_LIGHT_CHANGED_AGAIN,
     MOTION_LIGHT_FROM_THE_FUTURE,
+    MOTION_LIGHT_WITH_A_BAD_TRIGGER,
     MOTION_LIGHT_WITH_NEW_INPUT,
     NO_INPUTS,
     SOURCE,
@@ -723,6 +725,16 @@ async def test_a_script_blueprint_gets_one_too(
     file = async_write_blueprint(hass, "script", "notify.yaml", A_SCRIPT_BLUEPRINT)
     await async_set_up(hass)
 
+    # With a script actually on it, so the update is tried on that script the
+    # way a reload would try it, through the script validator rather than the
+    # automation one.
+    await async_add_script(
+        hass,
+        "shout",
+        "notify.yaml",
+        {"notify_target": "mobile_app_phone"},
+    )
+
     entity_id = "update.blueprints_spooky_confirmable_notification"
     assert hass.states.get(entity_id) is not None
 
@@ -740,6 +752,7 @@ async def test_a_script_blueprint_gets_one_too(
 
     assert "Boo!" in file.read_text(encoding="utf-8")
     assert hass.states.get(entity_id).state == "off"
+    assert hass.states.get("script.shout") is not None
 
 
 async def test_a_script_that_would_be_left_short_stops_the_install(
@@ -1046,3 +1059,96 @@ async def test_a_check_and_an_install_do_not_tread_on_each_other(
     # What was written is what this now has. A check that landed afterwards
     # with an older answer would leave this offering an update backwards.
     assert hass.states.get(_ENTITY).state == "off", "the check undid the install"
+
+
+async def test_an_update_that_would_not_load_is_refused(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A blueprint can be perfectly good and still produce a broken automation.
+
+    The blueprint schema has nothing whatever to say about triggers, actions
+    or a script's sequence, and Home Assistant writes the file before it
+    reloads anybody. So a blueprint that passes on the way in takes out every
+    automation on it, and the working version it replaced is gone.
+    """
+    file = async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    await async_add_automation(
+        hass,
+        "Landing light",
+        "motion.yaml",
+        {"motion_entity": "binary_sensor.landing", "light_target": {}},
+    )
+    before = file.read_text(encoding="utf-8")
+
+    with _source_says(MOTION_LIGHT_WITH_A_BAD_TRIGGER):
+        await _check(hass, freezer)
+
+        with pytest.raises(HomeAssistantError, match="would not load"):
+            await hass.services.async_call(
+                "update",
+                "install",
+                {"entity_id": _ENTITY},
+                blocking=True,
+            )
+
+    assert file.read_text(encoding="utf-8") == before
+    assert hass.states.get("automation.landing_light") is not None
+
+
+async def test_a_script_update_that_would_not_load_is_refused(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Scripts go through a validator of their own, so it needs its own go."""
+    file = async_write_blueprint(hass, "script", "notify.yaml", A_SCRIPT_BLUEPRINT)
+    await async_set_up(hass)
+    await async_add_script(
+        hass,
+        "shout",
+        "notify.yaml",
+        {"notify_target": "mobile_app_phone"},
+    )
+    before = file.read_text(encoding="utf-8")
+
+    entity_id = "update.blueprints_spooky_confirmable_notification"
+    with _source_says(A_SCRIPT_BLUEPRINT_WITH_A_BAD_STEP):
+        await _check(hass, freezer)
+
+        with pytest.raises(HomeAssistantError, match="would not load"):
+            await hass.services.async_call(
+                "update",
+                "install",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+
+    assert file.read_text(encoding="utf-8") == before
+    assert hass.states.get("script.shout") is not None
+
+
+async def test_the_notes_say_an_update_would_not_load(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Before the button, not after it."""
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+    await async_add_automation(
+        hass,
+        "Landing light",
+        "motion.yaml",
+        {"motion_entity": "binary_sensor.landing", "light_target": {}},
+    )
+    client = await hass_ws_client(hass)
+
+    with _source_says(MOTION_LIGHT_WITH_A_BAD_TRIGGER):
+        await _check(hass, freezer)
+
+        notes = await _release_notes(client)
+
+    assert "alert-type='error'" in notes
+    assert "automation.landing_light" in notes
+    assert "would not load" in notes

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -1167,3 +1167,36 @@ async def test_the_notes_say_an_update_would_not_load(
         "</ha-alert>",
     )[0]
     assert "input" not in heading, heading
+
+
+async def test_installing_clears_what_the_last_look_could_not_do(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An install is a fetch that worked, so the old complaint is stale news.
+
+    A source that went quiet for a round and was back by the time somebody
+    pressed the button would otherwise leave the dialog saying it could not be
+    reached, until tomorrow.
+    """
+    async_write_blueprint(hass, "automation", "motion.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await _check(hass, freezer)
+
+    with patch(_FETCH, side_effect=TimeoutError):
+        await _check(hass, freezer)
+    assert "Could not reach" in await _entity(hass).async_release_notes()
+
+    with _source_says(MOTION_LIGHT_CHANGED):
+        await hass.services.async_call(
+            "update",
+            "install",
+            {"entity_id": _ENTITY},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_ENTITY).state == "off"
+    assert "Could not reach" not in await _entity(hass).async_release_notes()

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -378,7 +378,8 @@ async def test_unloading_stops_a_round_that_is_under_way(
         MOTION_LIGHT.replace("Spooky motion light", "Spooky hallway light"),
     )
     entry = await async_set_up(hass)
-    assert len(hass.states.async_entity_ids("update")) == _BOTH_OF_THEM
+    both = hass.states.async_entity_ids("update")
+    assert len(both) == _BOTH_OF_THEM
 
     reached: list[str] = []
 
@@ -393,11 +394,15 @@ async def test_unloading_stops_a_round_that_is_under_way(
     assert len(reached) == 1, "it carried on after being unloaded"
 
     # And the one that was mid-fetch when the rug went does not put a live
-    # state back over the unavailable one that unloading left.
-    assert all(
-        hass.states.get(entity_id).state == "unavailable"
-        for entity_id in hass.states.async_entity_ids("update")
-    ), "something wrote a state back after being taken away"
+    # state back over the unavailable one that unloading left. Gone through by
+    # the names taken before the unload, so an empty list cannot pass this by
+    # having nothing to disagree with.
+    for entity_id in both:
+        left_behind = hass.states.get(entity_id)
+        assert left_behind is not None, f"{entity_id} went altogether"
+        assert left_behind.state == "unavailable", (
+            f"{entity_id} had a state written back after being taken away"
+        )
 
 
 async def test_a_blueprint_nobody_dumped_back_out_still_matches(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Importing a blueprint writes down where it came from. Nothing ever looks at that address again. The author can fix a bug in it a week later and you have no way of knowing, short of opening the forum topic and reading the YAML yourself.

Every blueprint that came from a URL now gets an update entity. Spook follows that address once a day, spread out and jittered, and tells you when what is there is no longer what you have. Installing fetches it again and writes it over, which is what Home Assistant's own re-import button does, reload of every consuming automation and script included.

Four things had to be right or this would have been worse than useless.

### Versions, which blueprints do not have

And cannot be given. The schema for the `blueprint:` block is `PREVENT_EXTRA`, so there is nowhere for an author to put a version even if they wanted one. That leaves the content as the version, as a short hash. They read `a1b2c3d`, which is ugly and honest. HACS does the same for anything non-semver.

`version_is_newer` is overridden to mean "different", because a fingerprint has no order.

### The one that would have sunk it

Both sides are put through the same parse and re-dump, and deliberately not through the domain's own schema.

That schema rewrites the older spellings. Measured rather than assumed:

```diff
--- generic schema
+++ automation schema
-trigger:
+mode: restart
+triggers:
 - platform: state
-action:
+actions:
 - service: light.turn_on
-mode: restart
```

Only the copy Home Assistant has loaded goes through that. Fingerprinting it against a freshly fetched one would have called **every blueprint written before those names changed out of date, for ever**, which is a fair share of what is out there.

So the fingerprint is read off the file on disk, through `BLUEPRINT_SCHEMA` on both sides.

### Installing can break automations

An input without a default has to be supplied by whoever uses the blueprint. A new one that nobody sets stops every automation on it from loading the moment the file is written, and the version they did work with is gone by then.

So the consumers are checked first, and the install refuses, naming the automations and the inputs they would be missing, rather than doing it and leaving you to find out. That check is the whole reason for doing this in Spook rather than leaving it to the re-import button.

The inputs come off `_blueprint_inputs` rather than `raw_config`. `raw_config` is the automation after the blueprint has been substituted into it, and no longer says which inputs went in. It is reached for by name, so a rename upstream reads as "supplies nothing", which blocks an install rather than going ahead on a guess.

### Home Assistant's own example blueprints

All three of them carry a source URL pointing at core's **dev branch**:

```
source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/motion_light.yaml
```

Without a filter that puts an update entity on every installation there is, for something nobody imported, out of a branch nobody is running. The folder Home Assistant fills itself is skipped.

### The update dialog

Every other update dialog in Home Assistant shows release notes. This one cannot, so it carries the next best thing: the address the blueprint came from as a link, always, and a warning that an author improving their blueprint and it still suiting what you built on it are two different things. Where Spook already knows the update would leave automations short, that goes in as well, naming them, so it turns up before somebody presses install.

Matter and ZHA put much the same in front of a firmware update, through the same `ha-alert` in the notes markdown.

### Scope

Only automation and script blueprints, being the only domains whose users can be listed. Without that list there is no telling whether an update would strand something, and an install button that cannot promise that is worse than no button at all. The `unused_blueprints` repair skips the other domains for the same reason.

A blueprint you have edited yourself will report an update, because what you have really is no longer what is at the address, and there is no telling your changes from the author's. Documented, along with the way out: take the `source_url:` line back out and the entity goes with it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Blueprints are how most people get started automating, and they are the one thing in Home Assistant that never tells you it has moved on. Every other piece of the system has an update entity. This was the gap.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Everything about core's behaviour here was read out of the installed source or measured, not remembered: the blueprint schema rejecting unknown keys, `async_add_blueprint` reloading consumers, blueprints firing no events at all, Hue-style containers, the schema rewriting old spellings, and the example blueprints pointing at `dev`.

23 tests, and every guard in the module was checked by breaking it:

| Mutation | Result |
| --- | --- |
| control | 23 passed |
| fingerprint the copy Home Assistant loaded, domain schema and all | 3 failed |
| drop the schema, plain parse and dump | 1 failed |
| an unreadable file fingerprints as nothing | 1 failed |
| keep Home Assistant's own example folder | 3 failed |
| no source URL is fine | 1 failed |
| any domain will do, never mind which | 1 failed |
| let a fetch failure blank the answer | 5 failed |
| install without checking the consumers | 1 failed |
| a default does not make an input optional | 1 failed |
| never mind whether a round is still in flight | 1 failed |
| seen once at startup is enough | 1 failed |
| leave the registration behind | 1 failed |
| take stock at setup, never mind that nothing is up yet | 1 failed |
| no need to look again on the round | 2 failed |
| no release notes feature at all | 4 failed |
| leave the source out of the notes | 2 failed |
| warn even when there is nothing to install | 2 failed |
| never warn at all | 1 failed |
| do not name the automations that would be left short | 1 failed |
| forget what was fetched | 2 failed |

Two flaws in the test harness itself turned up on the way and are fixed:

- `async_track_time_interval` runs its job as a **background** task, which a plain `async_block_till_done` walks straight past. The helper was racing the round it was testing, and it showed up as a real network call escaping its `patch` block, but only in the full suite and only sometimes.
- An access token is good for half an hour, and a check round is a day further on. The websocket clients are opened before the clock moves.

Full suite green at 1383 passed, run twice for the flakiness. pylint clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
