### PR TITLE
Stop naming an action that does not exist

### DIFF
--- a/custom_components/spook/ectoplasms/recorder/repairs/orphaned_statistics.py
+++ b/custom_components/spook/ectoplasms/recorder/repairs/orphaned_statistics.py
@@ -22,8 +22,10 @@ class SpookRepair(AbstractSpookRepair):
 
     Removing a sensor leaves its recorded statistics behind; Home
     Assistant keeps them but never points them out. This surfaces them so
-    they can be cleaned up (Developer Tools > Statistics, or the
-    ``recorder.clear_statistics`` action).
+    they can be cleaned up on the Developer Tools > Statistics page, which
+    is the only place Home Assistant offers to do it: `clear_statistics` is
+    a websocket command that page calls, and not an action anybody can
+    reach from Developer Tools > Actions.
     """
 
     domain = "recorder"

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -622,7 +622,7 @@
       "title": "Unknown members in notify group: {group}"
     },
     "orphaned_statistics": {
-      "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Developer Tools > Statistics and fix them there, or remove them using the `recorder.clear_statistics` action.\n\nSpook 👻 Your homie.",
+      "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Developer Tools > Statistics and fix them there.\n\nSpook 👻 Your homie.",
       "title": "Orphaned long-term statistics found"
     },
     "person_unknown_device_trackers": {

--- a/documentation/integrations/recorder.md
+++ b/documentation/integrations/recorder.md
@@ -158,7 +158,7 @@ The recorder keeps long-term statistics separately from the states it records, a
 
 These are not harmful, but they are not free either: they take up database space, and they keep showing up in pickers and graphs long after the sensor they belonged to is gone.
 
-To resolve the raised issue, open {term}`Developer tools` > Statistics and fix them there, or remove them with the `recorder.clear_statistics` action. Spook will automatically remove the repair issue once the issue is fixed.
+To resolve the raised issue, open {term}`Developer tools` > Statistics and fix them there. Spook will automatically remove the repair issue once the issue is fixed.
 
 ## Use cases
 

--- a/tests/test_action_references.py
+++ b/tests/test_action_references.py
@@ -1,0 +1,87 @@
+"""Every action Spook names in its own words has to be one that exists.
+
+Spook told people to clear orphaned statistics with `recorder.clear_statistics`
+for as long as that repair existed. There is no such action: it is a websocket
+command the Developer Tools statistics page calls, and nothing anybody can find
+under Developer Tools > Actions. Reported as #1510 by somebody who went looking
+for it and could not find it.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import homeassistant
+import yaml
+
+SPOOK = pathlib.Path(__file__).parents[1] / "custom_components" / "spook"
+DOCUMENTATION = pathlib.Path(__file__).parents[1] / "documentation"
+CORE = pathlib.Path(homeassistant.__file__).parent / "components"
+
+# Something in backticks, called an action in the very next word. That is a
+# claim about what somebody will find in Home Assistant, and it either holds
+# or it does not.
+_CLAIMED_AS_AN_ACTION = re.compile(r"`([a-z_]+\.[a-z_]+)`\s+action\b")
+
+# Notify services are named after whoever set them up, so these stand for
+# "your phone" rather than naming anything that exists anywhere.
+_STANDS_FOR_YOUR_OWN = {"notify.my_phone", "notify.phone"}
+
+# If the wording drifts and the pattern stops matching, this test would pass by
+# having nothing left to check. It has to keep finding at least what it found
+# the day it was written.
+_AT_LEAST_THIS_MANY = 10
+
+
+def _referenced() -> set[tuple[str, str]]:
+    """Return every action Spook calls an action, and where it says so."""
+    found = {
+        (ref, "translations/en.json")
+        for ref in _CLAIMED_AS_AN_ACTION.findall(
+            json.dumps(json.loads((SPOOK / "translations" / "en.json").read_text())),
+        )
+    }
+    for markdown in DOCUMENTATION.rglob("*.md"):
+        found |= {
+            (ref, str(markdown.relative_to(DOCUMENTATION.parent)))
+            for ref in _CLAIMED_AS_AN_ACTION.findall(markdown.read_text())
+        }
+
+    return found
+
+
+def _exists(action: str) -> bool:
+    """Return whether Home Assistant or Spook actually offers this action."""
+    domain, _, service = action.partition(".")
+
+    spook_services = yaml.safe_load((SPOOK / "services.yaml").read_text()) or {}
+    if f"{domain}_{service}" in spook_services:
+        return True
+
+    descriptor = CORE / domain / "services.yaml"
+    if not descriptor.is_file():
+        return False
+
+    try:
+        return service in (yaml.safe_load(descriptor.read_text()) or {})
+    except yaml.YAMLError:
+        return False
+
+
+def test_every_action_spook_names_is_one_that_exists() -> None:
+    """Telling somebody to use an action that is not there wastes their evening."""
+    referenced = _referenced()
+
+    assert len(referenced) >= _AT_LEAST_THIS_MANY, (
+        f"only found {len(referenced)} action references, so the wording has "
+        f"moved and this test has stopped looking at anything: {referenced}"
+    )
+
+    missing = sorted(
+        f"{action} ({where})"
+        for action, where in referenced
+        if action not in _STANDS_FOR_YOUR_OWN and not _exists(action)
+    )
+    assert not missing, "Spook names actions that do not exist: " + ", ".join(missing)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The orphaned statistics repair told people to clear them with the `recorder.clear_statistics` action. There is no such action, which is how the issue was found: somebody went looking for it under Developer Tools > Actions and it was not there.

`clear_statistics` exists, but as a websocket command that the Developer Tools statistics page calls behind its fix button. The recorder integration offers exactly five actions, and that is not one of them:

```
disable, enable, get_statistics, purge, purge_entities
```

**Not swapped for `recorder.purge_entities`**, as suggested on the issue. That one works through `StatesMeta`, purging states and events for entities that still have them. An orphaned statistic is orphaned precisely because there is no state left to match it, so it would not be found, let alone removed. Following that advice would have been wrong in a new way.

The rest of the sentence was already right, and is what is left: the statistics page is the only place Home Assistant offers to do this.

Fixed in the three places it was said: the string people read, the repair's own docstring, and the documentation.

### And a test, because nothing was checking

Anything Spook calls an action, in its strings or its documentation, now has to be one that Home Assistant or Spook actually offers. Thirteen references across both.

The pattern is deliberately narrow: something in backticks with the word "action" immediately after it. That is a claim about what somebody will find in their instance, and it either holds or it does not. `trigger.entity_id` and friends are template variables rather than claims, and are left alone.

Two references stay allowed by name. `notify.my_phone` and `notify.phone` are named after whoever set them up and stand for "your phone" rather than naming anything that exists.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1510. Thanks to @TheFes for going looking and saying so.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Read out of the installed core: the recorder's own `services.yaml` for what it offers, `websocket_api.py` for where `clear_statistics` really lives, and `purge.py` for what `purge_entity_data` touches, before ruling the suggested replacement out.

The new test was checked in both directions, because a scanning test is only worth having if it can fail:

| | |
| --- | --- |
| as it stands | passes, 13 references checked |
| the phantom action put back | fails, naming both places it appears |
| the pattern broken so it matches nothing | fails, saying it has stopped looking at anything |

That last one is the failure mode a test like this usually dies of. It goes quietly green and nobody notices for a year.

Full suite at 1394 passed, pylint clean, ruff clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
