### PR TITLE
Say it in thirteen more languages, and mean it

### DIFF
--- a/custom_components/spook/translations/de.json
+++ b/custom_components/spook/translations/de.json
@@ -486,7 +486,6 @@
             "title": "Unbekannte Mitglieder in Min/Max-Helfer: {helper}"
         },
         "orphaned_statistics": {
-            "description": "Spook hat einen Geist in deinem Recorder entdeckt 👻\n\nHome Assistant führt Langzeitstatistiken für die folgenden Elemente, doch es gibt keine entsprechenden Entitäten mehr dafür:\n\n{statistics}\n\nDies passiert in der Regel, wenn ein Sensor entfernt wurde, während seine Statistiken weiterhin gespeichert wurden. Um diesen Fehler zu beheben, öffne „Entwickler-Tools“ > „Statistiken“ und korrigiere sie dort oder entferne sie mithilfe der Aktion `recorder.clear_statistics`.\n\nSpook 👻 Dein Kumpel.",
             "title": "Verwaiste Langzeitstatistik gefunden"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/en-GB.json
+++ b/custom_components/spook/translations/en-GB.json
@@ -446,7 +446,6 @@
             "title": "Unknown members used in min/max helper: {helper}"
         },
         "orphaned_statistics": {
-            "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Developer Tools > Statistics and fix them there, or remove them using the `recorder.clear_statistics` action.\n\nSpook 👻 Your homie.",
             "title": "Orphaned long-term statistics found"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/es-419.json
+++ b/custom_components/spook/translations/es-419.json
@@ -446,7 +446,6 @@
             "title": "Miembros desconocidos usados en el asistente mín/máx: {helper}"
         },
         "orphaned_statistics": {
-            "description": "Spook ha encontrado un fantasma en tu recorder 👻\n\nHome Assistant guarda estadísticas a largo plazo de lo siguiente, pero ya no hay ninguna entidad que les corresponda:\n\n{statistics}\n\nEsto suele pasar cuando se ha quitado un sensor y se han conservado sus estadísticas. Para solucionar este error, abre Herramientas para desarrolladores > Estadísticas y arréglalas ahí, o quítalas con la acción `recorder.clear_statistics`.\n\nSpook 👻 Tu colega.",
             "title": "Se han encontrado estadísticas a largo plazo huérfanas"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/es.json
+++ b/custom_components/spook/translations/es.json
@@ -446,7 +446,6 @@
             "title": "Miembros desconocidos usados en el asistente mín/máx: {helper}"
         },
         "orphaned_statistics": {
-            "description": "Spook ha encontrado un fantasma en tu recorder 👻\n\nHome Assistant guarda estadísticas a largo plazo de lo siguiente, pero ya no hay ninguna entidad que les corresponda:\n\n{statistics}\n\nEsto suele pasar cuando se ha quitado un sensor y se han conservado sus estadísticas. Para solucionar este error, abre Herramientas para desarrolladores > Estadísticas y arréglalas ahí, o quítalas con la acción `recorder.clear_statistics`.\n\nSpook 👻 Tu colega.",
             "title": "Se han encontrado estadísticas a largo plazo huérfanas"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/fi.json
+++ b/custom_components/spook/translations/fi.json
@@ -438,7 +438,6 @@
             }
         },
         "orphaned_statistics": {
-            "description": "Spook on löytäny kummituksen tilastoistasi 👻\n\nHome Assistant pitää pitkän ajan tilastoja seuraavista, mutta vastaavaa entiteettiä ei enää ole:\n\n{statistics}\n\n\n\nTämä tapahtuu yleensä kun sensori on poistettu, mutta sen tilastot on säilytetty. Korjataksesi ongelman, avaa Kehittäjän työkalut > Tilastot ja korjaa ne siellä, tai poista ne käyttäen `recorder.clear_statistics` toimintoa.\n\nSpook 👻 Kamusi.",
             "title": "Orpoja pitkän aikavälin tilastoja löydetty"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/fr.json
+++ b/custom_components/spook/translations/fr.json
@@ -503,8 +503,7 @@
             "title": "Dispositifs de suivi inconnus suivis par : {person}"
         },
         "orphaned_statistics": {
-            "title": "Statistiques long terme orpheline trouvée",
-            "description": "Spook a trouvé un fantôme dans votre recorder 👻\n\n\n\nHome Assistant garde ces statistiques longue durée, mais ils ne correspondent à aucune entité qui existe :\n\n\n\n{statistics}\n\n\n\n\n\n\n\nCeci arrive habituellement lorsqu'un capteur est supprimé et que ses statistiques sont conservées. Pour corriger cette erreur, ouvrez Outils de développement > Statistiques et corrigez le problème, ou supprimez les en utilisant l'action `recorder.clear_statistics`.\n\n\n\nSpook 👻 Votre pote."
+            "title": "Statistiques long terme orpheline trouvée"
         },
         "automation_unknown_condition_references": {
             "description": "Spook a trouvé un fantôme dans vos automatisations 👻\n\n\n\nEn flottant dans les parages, Spook est tombé sur l'automatisation suivante :\n\n\n\n[{automation}]({edit}) (`{entity_id}`)\n\n\n\nCette automatisation utilise ces conditions qui ne peuvent être fournies par aucune intégration disponible à Home Assistant :\n\n\n\n{conditions}\n\n\n\n\n\n\n\nIl arrive souvent que l'intégration qui les fournissait ait été supprimée. Pour corriger cette erreur, [modifiez l'automatisation]({edit}) et n'utilisez plus ces conditions ou réinstallez l'intégration qui les fournissait.\n\n\n\nSpook 👻 Votre pote.",

--- a/custom_components/spook/translations/it.json
+++ b/custom_components/spook/translations/it.json
@@ -446,7 +446,6 @@
             "title": "Membri sconosciuti usati nell'helper min/max: {helper}"
         },
         "orphaned_statistics": {
-            "description": "👻 Spook ha trovato un fantasma nel tuo recorder\n\nHome Assistant conserva statistiche a lungo termine per quanto segue, ma non esiste più un'entità corrispondente:\n\n{statistics}\n\nSuccede di solito quando un sensore è stato rimosso mantenendo le sue statistiche. Per risolvere questo errore, apri Strumenti per sviluppatori > Statistiche e sistemale lì, oppure rimuovile con l'azione `recorder.clear_statistics`.\n\nSpook 👻 Il tuo compare.",
             "title": "Trovate statistiche a lungo termine orfane"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/nl.json
+++ b/custom_components/spook/translations/nl.json
@@ -446,7 +446,6 @@
             "title": "Onbekende leden gebruikt in min/max-helper: {helper}"
         },
         "orphaned_statistics": {
-            "description": "Spook heeft een geest gevonden in je recorder 👻\n\nHome Assistant bewaart langetermijnstatistieken voor het volgende, maar er is geen bijbehorende entiteit meer:\n\n{statistics}\n\nDit gebeurt meestal wanneer een sensor is verwijderd terwijl zijn statistieken bewaard bleven. Om deze fout te verhelpen, open je Ontwikkelhulpmiddelen > Statistieken en los je ze daar op, of verwijder je ze met de actie `recorder.clear_statistics`.\n\nSpook 👻 Je homie.",
             "title": "Verweesde langetermijnstatistieken gevonden"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/pt-BR.json
+++ b/custom_components/spook/translations/pt-BR.json
@@ -446,7 +446,6 @@
             "title": "Membros desconhecidos usados no auxiliar mín/máx: {helper}"
         },
         "orphaned_statistics": {
-            "description": "Spook encontrou um fantasma no seu recorder 👻\n\nO Home Assistant guarda estatísticas de longo prazo para o seguinte, mas não existe mais nenhuma entidade correspondente:\n\n{statistics}\n\nIsso costuma acontecer quando um sensor foi removido e as estatísticas dele ficaram. Para corrigir esse erro, abra Ferramentas de Desenvolvedor > Estatísticas e resolva por lá, ou remova com a ação `recorder.clear_statistics`.\n\nSpook 👻 Seu mano.",
             "title": "Foram encontradas estatísticas de longo prazo órfãs"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/pt.json
+++ b/custom_components/spook/translations/pt.json
@@ -535,7 +535,6 @@
             "title": "Notificadores desconhecidos usados pelo alerta: {alert}"
         },
         "orphaned_statistics": {
-            "description": "Spook encontrou um fantasma no teu recorder 👻\n\nO Home Assistant guarda estatísticas de longo prazo para o seguinte, mas já não existe nenhuma entidade correspondente:\n\n{statistics}\n\nIsto acontece normalmente quando um sensor foi removido e as suas estatísticas ficaram. Para corrigir este erro, abre Ferramentas de Desenvolvimento > Estatísticas e resolve-as aí, ou remove-as com a ação `recorder.clear_statistics`.\n\nSpook 👻 O teu amigo.",
             "title": "Encontradas estatísticas de longo prazo órfãs"
         },
         "script_unknown_trigger_references": {

--- a/custom_components/spook/translations/sv.json
+++ b/custom_components/spook/translations/sv.json
@@ -503,8 +503,7 @@
             "description": "Spook har hittat ett spöke bland dina entiteter 👻\n\nIntegrationen {integration} har slutfört sin konfiguration, men följande entiteter som den registrerade har inte dykt upp, så de existerar inte längre:\n\n{entities}\n\n\n\nDetta kan hända när en enhet eller dess entiteter tas bort i källan utan att deras registerposter uppdateras. För att åtgärda felet, ta bort dessa entiteter från entitetsregistret om du inte längre behöver dem.\n\nSpook 👻 Din polare."
         },
         "orphaned_statistics": {
-            "title": "Föräldralös långtidsstatistik hittad",
-            "description": "Spook har hittat ett spöke i din recorder 👻\n\nHome Assistant sparar långtidsstatistik för följande, där det inte längre finns någon matchande entitet:\n\n{statistics}\n\n\n\nDetta kan hända när en senor tas bort medan dess statistik behålls. För att åtgärda felet, öppna Inställningar > Verktyg > Statistik och åtgärda problemet där, eller ta bort dem genom att använda åtgärden `recorder.clear_statistics`.\n\nSpook 👻 Din polare."
+            "title": "Föräldralös långtidsstatistik hittad"
         },
         "lovelace_unknown_area_references": {
             "title": "Okända områden används i kontrollpanel: {dashboard}",

--- a/custom_components/spook/translations/zh-Hans.json
+++ b/custom_components/spook/translations/zh-Hans.json
@@ -438,7 +438,6 @@
             }
         },
         "orphaned_statistics": {
-            "description": "Spook 在你的录制器中发现了一个幽灵 👻\n\nHome Assistant 正在为以下项保留长期统计数据，但已没有与之匹配的实体：\n\n{statistics}\n\n\n\n这通常发生在传感器被移除但统计数据被保留时。要修复此错误，请打开 开发者工具 > 统计数据 在那里进行修复，或者使用 `recorder.clear_statistics` 动作将其移除。\n\nSpook 👻 你的好哥们。",
             "title": "发现孤立的长期统计数据"
         },
         "person_unknown_device_trackers": {

--- a/custom_components/spook/translations/zh-Hant.json
+++ b/custom_components/spook/translations/zh-Hant.json
@@ -438,7 +438,6 @@
             }
         },
         "orphaned_statistics": {
-            "description": "Spook 在您的錄製器中發現了一個幽靈 👻\n\nHome Assistant 正為以下項目保留長期統計數據，但已沒有與其相匹配的實體：\n\n{statistics}\n\n\n\n這通常發生在感測器被移除但統計數據被保留時。要修正此錯誤，請開啟 開發者工具 > 統計數據 進行修復，或使用 `recorder.clear_statistics` 動作將其移除。\n\nSpook 👻 您的好夥伴。",
             "title": "發現孤立的長期統計數據"
         },
         "person_unknown_device_trackers": {

--- a/tests/test_action_references.py
+++ b/tests/test_action_references.py
@@ -57,6 +57,12 @@ def _exists(action: str) -> bool:
     domain, _, service = action.partition(".")
 
     spook_services = yaml.safe_load((SPOOK / "services.yaml").read_text()) or {}
+
+    # Spook writes its descriptors two ways: bare for the actions it puts on
+    # its own domain, and `{domain}_{service}` for the ones it hangs off
+    # somebody else's. Both count.
+    if domain == "spook" and service in spook_services:
+        return True
     if f"{domain}_{service}" in spook_services:
         return True
 
@@ -68,6 +74,50 @@ def _exists(action: str) -> bool:
         return service in (yaml.safe_load(descriptor.read_text()) or {})
     except yaml.YAMLError:
         return False
+
+
+# Names Home Assistant does not answer to, that Spook has said out loud at some
+# point. The translations go round through Weblate, which still holds the
+# sentences these were in, so "we took it out once" is not the same as "it is
+# gone". Nothing shipped, in any language, may say these again.
+_NEVER_AGAIN = {
+    # #1510. A websocket command the statistics page calls, never an action.
+    "recorder.clear_statistics",
+}
+
+
+def test_no_language_still_names_a_retired_action() -> None:
+    """The prose gets translated. The identifier in the backticks does not.
+
+    So a wrong action name outlives the sentence it sat in, in every language
+    at once, long after the English has been put right. Which is exactly what
+    happened here: the English was corrected and thirteen translations carried
+    on telling people to call it.
+    """
+    files = sorted((SPOOK / "translations").glob("*.json"))
+    assert len(files) > 1, "found no translations to check, so this proves nothing"
+    assert _NEVER_AGAIN, "nothing to look for, so this proves nothing"
+
+    saying_it = sorted(
+        f"{f.name} says {dead}"
+        for f in files
+        for dead in _NEVER_AGAIN
+        if dead in f.read_text()
+    )
+    assert not saying_it, "retired actions still named: " + ", ".join(saying_it)
+
+
+def test_the_check_can_find_an_action_of_either_shape() -> None:
+    """Otherwise the scan above quietly passes everything it cannot look up.
+
+    Spook's own actions are keyed bare in `services.yaml`, the ones it adds to
+    other integrations are keyed `{domain}_{service}`, and reading only one of
+    those shapes makes half of them look like they do not exist.
+    """
+    assert _exists("spook.boo"), "cannot find an action Spook puts on its own domain"
+    assert _exists("repairs.create"), "cannot find an action Spook adds to another"
+    assert _exists("light.turn_on"), "cannot find an action from Home Assistant"
+    assert not _exists("recorder.clear_statistics"), "found one that does not exist"
 
 
 def test_every_action_spook_names_is_one_that_exists() -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Two from the review of #1512, which merged before I could push them, plus one thing that review turned up in my own test.

### The English was corrected and nothing else was

Home Assistant loads English and then overlays the chosen language on top of it. A string that exists in both is answered by the translation, so thirteen of them carried on telling people to call `recorder.clear_statistics` after the English had been put right. Which is to say the bug #1512 was about was still live for everybody not reading in English.

Their descriptions are dropped rather than rewritten. A *missing* key does fall back to English, checked in `helpers/translation.py` rather than assumed:

```python
# English is always the fallback language so we load them first
self._build_category_cache(language, components, ...[LOCALE_EN])
if language != LOCALE_EN:
    # Now overlay the requested language on top of the English
```

So everybody gets the corrected sentence now, and Weblate fills them back in from the new source, in French rather better than I would. The titles stay: they never named the action.

### And the check only ever read `en.json`

Which is the file that had already been fixed, so it would have sat and watched this happen.

It goes through every language now. Not by the English wording, which does not survive translation, but by the identifier inside the backticks, which does: `recorder.clear_statistics` reads the same in all thirteen.

A structural rule was the first thing I tried, and it does not work. An action and an entity ID are the same shape, so "anything on a real integration's domain must be a real action" flags `sensor.areas`, `switch.cloud_remote`, `button.ignore_all_issues` and seventy others. Hence a list of names retired for cause instead, which is also the right shape for the actual risk here: the translations go round through Weblate, which still holds the sentences these were in, so taking one out once is not the same as it being gone.

### The lookup could not find half of Spook's own actions

Caught by @coderabbitai. Spook writes its descriptors two ways, bare for the actions on its own domain and `{domain}_{service}` for the ones it hangs off somebody else's, and I only read the second:

| reference | `{domain}_{service}` | bare |
| --- | --- | --- |
| `spook.boo` | no | yes |
| `spook.random_fail` | no | yes |
| `repairs.create` | yes | no |
| `input_number.increment` | yes | no |
| `light.set_brightness` | yes | no |

So `spook.boo` would have been reported as not existing the first time anybody wrote it down as an action. The suggested diff fixes that half and breaks the other one, so it reads both shapes now.

There is a test on the lookup itself as well, because it was wrong in a way the scan above it could never have shown: the scan passed by having nothing it could look up.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up to #1512, finishing #1510 for everybody who does not read Home Assistant in English.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Each of the three checked by breaking the thing it covers:

| | |
| --- | --- |
| control | 3 passed |
| translations left as they were | fails, naming all thirteen files |
| lookup reads only `{domain}_{service}` | fails on `spook.boo` |
| lookup reads only the bare key (the suggested diff) | fails on `repairs.create` |
| the pattern broken so it matches nothing | fails, saying it has stopped looking at anything |

The translations were edited in each file's own formatting rather than re-dumped, so the diff is one line per language. Two of them are two lines, because there the description came after the title and the title loses its trailing comma.

Full suite 1396 passed, pylint clean, ruff clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
