### PR TITLE
Say out loud that trigger.entity_id is not an entity

### DIFF
--- a/custom_components/spook/action_extraction.py
+++ b/custom_components/spook/action_extraction.py
@@ -11,6 +11,7 @@ from .const import LOGGER
 from .entity_filtering import async_get_all_services
 from .template_extraction import (
     ENTITY_ID_PATTERN,
+    NEVER_AN_ENTITY,
     async_extract_entities_from_template_string,
     is_template_string,
 )
@@ -239,7 +240,7 @@ async def async_extract_entities_from_value(
                     value,
                     exc,
                 )
-        elif _ENTITY_ID_RE.match(value):
+        elif value not in NEVER_AN_ENTITY and _ENTITY_ID_RE.match(value):
             # Check if it matches the entity ID pattern with known domains
             entities.add(value)
     elif isinstance(value, list):

--- a/custom_components/spook/action_extraction.py
+++ b/custom_components/spook/action_extraction.py
@@ -254,8 +254,8 @@ async def async_extract_entities_from_value(
             )
     elif (
         isinstance(value, dict)
-        and "entity" in value
-        and isinstance(value["entity"], str)
+        and isinstance(value.get("entity"), str)
+        and value["entity"] not in NEVER_AN_ENTITY
     ):
         # Handle entity dict format like {"entity": "light.living_room"}
         entities.add(value["entity"])

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -52,20 +52,20 @@ KNOWN_DOMAINS = [platform.value for platform in Platform] + ADDITIONAL_DOMAINS
 
 # Automation and template variables that read exactly like an entity ID and are
 # not one. `trigger` is what a triggered automation is handed, `this` is what a
-# template entity is handed, and `{{ device_name(trigger.entity_id) }}` is the
-# ordinary way to write both. Reported twice, #823 and #1468, and neither time
-# was it reproducible: nothing here has ever picked them up, because neither
-# `trigger` nor `this` is a domain Home Assistant knows.
+# template entity is handed. Reported as unknown entities twice, #823 and #1468.
 #
-# Which is the trouble. They are excluded by accident, as a side effect of a
-# list of domains that grows every release, rather than because anybody decided
-# they should be. Said out loud here so it stays decided.
-# Home Assistant hands these over itself. Written without the braces, as
+# Home Assistant is where they arrive from. Written without the braces, as
 # `entity_id: trigger.entity_id` rather than `{{ trigger.entity_id }}`, they
-# come back in an automation's own `referenced_entities`, and `valid_entity_id`
-# is happy with them because it asks whether a string is shaped like an entity
-# ID and not whether anything answers to it. Which is how this was reported
-# twice by people whose templates were fine.
+# come back in an automation's own `referenced_entities`, so they turn up having
+# already passed everything here that reads configuration. And the last gate
+# before an issue is raised asks `valid_entity_id`, which answers whether a
+# string is shaped like an entity ID rather than whether anything answers to it.
+#
+# Which is why both reports went nowhere for so long: everybody was looking at
+# the templates, and the templates were never it. Nothing here picks these out
+# of a template either, but only because neither `trigger` nor `this` is a
+# domain Home Assistant knows, off a list that grows every release and was never
+# chosen with these in mind. Named here so that it is a decision.
 NEVER_AN_ENTITY = frozenset({"trigger.entity_id", "this.entity_id"})
 
 # Home Assistant core entity ID validation patterns (from homeassistant/core.py)

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -50,6 +50,18 @@ ADDITIONAL_DOMAINS = [
 # Build a list of all known domains
 KNOWN_DOMAINS = [platform.value for platform in Platform] + ADDITIONAL_DOMAINS
 
+# Automation and template variables that read exactly like an entity ID and are
+# not one. `trigger` is what a triggered automation is handed, `this` is what a
+# template entity is handed, and `{{ device_name(trigger.entity_id) }}` is the
+# ordinary way to write both. Reported twice, #823 and #1468, and neither time
+# was it reproducible: nothing here has ever picked them up, because neither
+# `trigger` nor `this` is a domain Home Assistant knows.
+#
+# Which is the trouble. They are excluded by accident, as a side effect of a
+# list of domains that grows every release, rather than because anybody decided
+# they should be. Said out loud here so it stays decided.
+NEVER_AN_ENTITY = frozenset({"trigger.entity_id", "this.entity_id"})
+
 # Home Assistant core entity ID validation patterns (from homeassistant/core.py)
 _OBJECT_ID = r"(?!_)[\da-z_]+(?<!_)"
 # Modified _DOMAIN pattern to only match known domains
@@ -265,6 +277,8 @@ def _extract_entity_candidates_from_template(template_str: str) -> frozenset[str
 
             # For each entity ID (which might be comma-separated), add all valid ones
             for individual_id in split_comma_separated_entity_ids(entity_id):
+                if individual_id in NEVER_AN_ENTITY:
+                    continue
                 if valid_entity_id(individual_id):
                     entities.add(individual_id)
 

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -60,6 +60,12 @@ KNOWN_DOMAINS = [platform.value for platform in Platform] + ADDITIONAL_DOMAINS
 # Which is the trouble. They are excluded by accident, as a side effect of a
 # list of domains that grows every release, rather than because anybody decided
 # they should be. Said out loud here so it stays decided.
+# Home Assistant hands these over itself. Written without the braces, as
+# `entity_id: trigger.entity_id` rather than `{{ trigger.entity_id }}`, they
+# come back in an automation's own `referenced_entities`, and `valid_entity_id`
+# is happy with them because it asks whether a string is shaped like an entity
+# ID and not whether anything answers to it. Which is how this was reported
+# twice by people whose templates were fine.
 NEVER_AN_ENTITY = frozenset({"trigger.entity_id", "this.entity_id"})
 
 # Home Assistant core entity ID validation patterns (from homeassistant/core.py)
@@ -399,7 +405,8 @@ async def async_filter_known_entity_ids_with_templates(
             # Process as regular entity ID(s), handling comma-separated lists
             for entity_id in split_comma_separated_entity_ids(entity_id_raw):
                 if (
-                    not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
+                    entity_id not in NEVER_AN_ENTITY
+                    and not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
                     and entity_id not in known_entity_ids
                     and valid_entity_id(entity_id)
                 ):

--- a/tests/test_never_an_entity.py
+++ b/tests/test_never_an_entity.py
@@ -1,0 +1,138 @@
+"""`trigger.entity_id` and `this.entity_id` are variables, not entities.
+
+A triggered automation is handed `trigger`, a template entity is handed `this`,
+and `{{ device_name(trigger.entity_id) }}` is the ordinary way to write either.
+Reported as an unknown entity twice, #823 and #1468, and neither time was it
+reproducible.
+
+Nothing here has ever picked them up, because neither `trigger` nor `this` is a
+domain Home Assistant knows. Which is the trouble: that list grows every release
+and nobody chose it as the thing keeping these out. These tests pin the answer
+rather than the accident.
+"""
+
+# pylint: disable=wrong-import-order
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import yaml
+
+from custom_components.spook import action_extraction, template_extraction
+from custom_components.spook.action_extraction import (
+    async_extract_entities_from_value,
+)
+from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
+    extract_entities_from_automation_config,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+    from homeassistant.core import HomeAssistant
+
+# Every way somebody writes one of these, and one real entity alongside so the
+# checks below cannot pass by finding nothing at all.
+_WRITTEN_AS = [
+    "trigger.entity_id",
+    "this.entity_id",
+    "{{ trigger.entity_id }}",
+    "{{ this.entity_id }}",
+    "{{ device_name(trigger.entity_id) }}",
+    "{{ device_name('trigger.entity_id') }}",
+    "{{ state_attr(this.entity_id, 'friendly_name') }}",
+    "{{ expand(trigger.entity_id) }}",
+    "{{ device_name(trigger.entity_id) }} and {{ states('sensor.real_one') }}",
+]
+
+# The automation from #1468, cut down to the part that matters.
+_SMOKE_ALARM = """
+alias: Notify if Smoke Alarm
+triggers:
+  - entity_id:
+      - binary_sensor.room1_smoke
+      - binary_sensor.room2_smoke
+    trigger: state
+    to:
+      - "on"
+actions:
+  - action: notify.mobile_app_foo_bar
+    data:
+      message: "{{ device_name(trigger.entity_id) }} detected SMOKE!"
+      title: "Fire Alert @ {{ area_name(trigger.entity_id) }}"
+mode: restart
+"""
+
+
+def _named(found: set[str]) -> set[str]:
+    """Return anything reported that is one of the two variables."""
+    return {e for e in found if e in template_extraction.NEVER_AN_ENTITY}
+
+
+async def test_no_way_of_writing_them_reads_as_an_entity(
+    hass: HomeAssistant,
+) -> None:
+    """However they are written, in a template or bare in a config value."""
+    for written in _WRITTEN_AS:
+        found = await async_extract_entities_from_value(hass, written)
+        assert not _named(found), f"{written!r} was read as an entity: {sorted(found)}"
+
+    # The real entity in the last one still comes through, so the loop above is
+    # not passing by finding nothing anywhere.
+    assert "sensor.real_one" in await async_extract_entities_from_value(
+        hass,
+        _WRITTEN_AS[-1],
+    )
+
+
+async def test_the_automation_from_the_issue_reports_only_its_sensors(
+    hass: HomeAssistant,
+) -> None:
+    """#1468, as pasted. Six smoke detectors and a template naming the one that went."""
+    found = await extract_entities_from_automation_config(
+        hass,
+        yaml.safe_load(_SMOKE_ALARM),
+    )
+
+    assert found == {"binary_sensor.room1_smoke", "binary_sensor.room2_smoke"}
+
+
+async def test_they_stay_out_even_if_the_domains_ever_let_them_in(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Which is the whole point of naming them rather than leaving it to luck.
+
+    `trigger` and `this` are kept out today by not being domains Home Assistant
+    knows. That list is `Platform` plus a handful, it grows every release, and
+    nothing about it was chosen with these in mind. So: let them through it, and
+    check they are still turned away.
+    """
+    domains = [*template_extraction.KNOWN_DOMAINS, "trigger", "this"]
+    pattern = r"(?:" + "|".join(domains) + r")\." + template_extraction._OBJECT_ID  # noqa: SLF001
+
+    monkeypatch.setattr(
+        template_extraction,
+        "COMPILED_ENTITY_ID_TEMPLATE_PATTERNS",
+        tuple(
+            re.compile(
+                p.pattern.replace(template_extraction.ENTITY_ID_PATTERN, pattern),
+                re.IGNORECASE,
+            )
+            for p in template_extraction.COMPILED_ENTITY_ID_TEMPLATE_PATTERNS
+        ),
+    )
+    monkeypatch.setattr(
+        action_extraction,
+        "_ENTITY_ID_RE",
+        re.compile(rf"^{pattern}$"),
+    )
+    template_extraction._extract_entity_candidates_from_template.cache_clear()  # noqa: SLF001
+
+    for written in _WRITTEN_AS:
+        found = await async_extract_entities_from_value(hass, written)
+        assert not _named(found), f"{written!r} got through: {sorted(found)}"
+
+    template_extraction._extract_entity_candidates_from_template.cache_clear()  # noqa: SLF001

--- a/tests/test_never_an_entity.py
+++ b/tests/test_never_an_entity.py
@@ -19,6 +19,8 @@ import re
 from typing import TYPE_CHECKING
 
 import yaml
+from homeassistant.helpers.entity_component import DATA_INSTANCES
+from homeassistant.setup import async_setup_component
 
 from custom_components.spook import action_extraction, template_extraction
 from custom_components.spook.action_extraction import (
@@ -26,6 +28,9 @@ from custom_components.spook.action_extraction import (
 )
 from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
     extract_entities_from_automation_config,
+)
+from custom_components.spook.template_extraction import (
+    async_filter_known_entity_ids_with_templates,
 )
 
 if TYPE_CHECKING:
@@ -97,6 +102,92 @@ async def test_the_automation_from_the_issue_reports_only_its_sensors(
     )
 
     assert found == {"binary_sensor.room1_smoke", "binary_sensor.room2_smoke"}
+
+
+async def test_home_assistant_handing_them_over_does_not_count_either(
+    hass: HomeAssistant,
+) -> None:
+    """Which is how this actually happens, and why neither report reproduced.
+
+    Written without the braces, `entity_id: trigger.entity_id` rather than
+    `{{ trigger.entity_id }}`, Home Assistant puts them in the automation's own
+    `referenced_entities`. Spook seeds from that set, so they arrive already
+    past everything that reads configuration, and `valid_entity_id` waves them
+    through because it asks whether a string is shaped like an entity ID, not
+    whether anything answers to it.
+    """
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "Literal trigger variable",
+                    "id": "literal_trigger",
+                    "triggers": [
+                        {"trigger": "state", "entity_id": "binary_sensor.smoke"},
+                    ],
+                    "actions": [
+                        {
+                            "action": "light.turn_on",
+                            "target": {"entity_id": "trigger.entity_id"},
+                        },
+                    ],
+                },
+                {
+                    "alias": "Literal this variable",
+                    "id": "literal_this",
+                    "triggers": [
+                        {"trigger": "state", "entity_id": "binary_sensor.smoke"},
+                    ],
+                    "conditions": [
+                        {
+                            "condition": "state",
+                            "entity_id": "this.entity_id",
+                            "state": "on",
+                        },
+                    ],
+                    "actions": [{"action": "light.turn_on"}],
+                },
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    component = hass.data[DATA_INSTANCES]["automation"]
+    entities = list(component.entities)
+    assert entities, "no automations were set up, so this proves nothing"
+
+    # Home Assistant really does hand them over. Without this the test could
+    # pass by the pseudo-IDs never turning up in the first place.
+    handed_over = set()
+    for entity in entities:
+        handed_over |= {str(e) for e in entity.referenced_entities}
+    assert handed_over & set(template_extraction.NEVER_AN_ENTITY), (
+        f"Home Assistant stopped reporting these, so this test is now testing "
+        f"nothing: {sorted(handed_over)}"
+    )
+
+    for entity in entities:
+        unknown = await async_filter_known_entity_ids_with_templates(
+            hass,
+            entity_ids=set(entity.referenced_entities),
+            known_entity_ids={"binary_sensor.smoke"},
+        )
+        assert not _named(unknown), f"{entity.name} reported {sorted(unknown)}"
+
+
+async def test_the_entity_dict_form_does_not_smuggle_them_in(
+    hass: HomeAssistant,
+) -> None:
+    """`{"entity": "..."}` is a shape a target can take, and it went straight in."""
+    found = await async_extract_entities_from_value(
+        hass,
+        [{"entity": "trigger.entity_id"}, {"entity": "light.real_one"}],
+    )
+
+    assert not _named(found)
+    assert "light.real_one" in found, "the dict form stopped working altogether"
 
 
 async def test_they_stay_out_even_if_the_domains_ever_let_them_in(

--- a/tests/test_never_an_entity.py
+++ b/tests/test_never_an_entity.py
@@ -1,14 +1,19 @@
 """`trigger.entity_id` and `this.entity_id` are variables, not entities.
 
-A triggered automation is handed `trigger`, a template entity is handed `this`,
-and `{{ device_name(trigger.entity_id) }}` is the ordinary way to write either.
-Reported as an unknown entity twice, #823 and #1468, and neither time was it
-reproducible.
+A triggered automation is handed `trigger`, a template entity is handed `this`.
+Reported as unknown entities twice, #823 and #1468, and both times it was put
+down to templates, which is why neither went anywhere.
 
-Nothing here has ever picked them up, because neither `trigger` nor `this` is a
-domain Home Assistant knows. Which is the trouble: that list grows every release
-and nobody chose it as the thing keeping these out. These tests pin the answer
-rather than the accident.
+Templates were never it. Written without the braces, as
+`entity_id: trigger.entity_id`, Home Assistant puts them in the automation's own
+`referenced_entities` and hands them straight over, past everything here that
+reads configuration.
+
+So these pin two separate things. That they are turned away at the last gate,
+which is where the reported bug lives and where anything Home Assistant supplies
+turns up. And that nothing picks them out of a template either, which holds
+today only because neither is a domain Home Assistant knows, off a list that
+grows every release and was never chosen with these in mind.
 """
 
 # pylint: disable=wrong-import-order
@@ -107,7 +112,7 @@ async def test_the_automation_from_the_issue_reports_only_its_sensors(
 async def test_home_assistant_handing_them_over_does_not_count_either(
     hass: HomeAssistant,
 ) -> None:
-    """Which is how this actually happens, and why neither report reproduced.
+    """Which is how this actually happens, and what both reports were.
 
     Written without the braces, `entity_id: trigger.entity_id` rather than
     `{{ trigger.entity_id }}`, Home Assistant puts them in the automation's own


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A triggered automation is handed `trigger`. A template entity is handed `this`. Both read exactly like an entity ID, and `{{ device_name(trigger.entity_id) }}` is the ordinary way to write either. Spook has been accused of reporting them as unknown entities twice, in #823 and #1468.

### It does not reproduce

Worth saying before anything else. I put the automation from #1468 through the repair's own extraction, on 5.0.0 where it was reported and on `main`, along with twenty-nine other ways of writing one of these:

- bare in a config value, `entity_id: trigger.entity_id`
- quoted, `entity_id: 'this.entity_id'`
- as a template, `entity_id: "{{ trigger.entity_id }}"`
- inside a function, `{{ device_name(trigger.entity_id) }}`, quoted and not
- through `variables:`, through a state condition, through a state trigger
- alongside a real entity, to be sure the extractor was awake

Nothing comes out but the two smoke detectors. So this does not fix what was reported, and #1468 needs more than this to get to the bottom of it.

### What is true is that they are kept out by accident

Nothing picks them up because neither `trigger` nor `this` is a domain Home Assistant knows, and the entity pattern only matches known domains:

```python
KNOWN_DOMAINS = [platform.value for platform in Platform] + ADDITIONAL_DOMAINS
```

That is the `Platform` enum plus a handful of extras. It grows every release, and nobody picked it as the thing keeping these two out. It just happens to.

So they are named, at both places a string turns into an entity reference: the template candidate scan, and the plain-value gate in `action_extraction`.

### And it is not dead code

Which was the first thing to check, having deleted exactly this sort of unreachable guard from #1506 this morning after a mutation showed it could never fire.

This one can. The third test puts `trigger` and `this` through the domain gate, the way a future release of Home Assistant might, and the exclusion is then the only thing still turning them away:

| | |
| --- | --- |
| as it stands | 3 passed |
| exclusion taken back out | `AssertionError: 'trigger.entity_id' got through` |

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Makes the false positive in #823 and #1468 impossible rather than improbable. Not closing #1468, because what was reported there still has no explanation.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Three tests:

- every way of writing one of these, through the real extractor, with a real entity in the last one so the loop cannot pass by finding nothing anywhere
- the automation from #1468 as pasted, asserting it reports its two smoke detectors and nothing else
- the domains letting them through, which is the only condition under which the exclusion does any work

Checked against v5.0.0 as well as `main`, since that is the version in the report.

Full suite 1399 passed, twice. pylint clean, ruff clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
