### PR TITLE
A wildcard is a pattern, not the name of anything

### DIFF
--- a/custom_components/spook/dashboard_extraction.py
+++ b/custom_components/spook/dashboard_extraction.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from .entity_filtering import split_comma_separated_entity_ids
+from .reference_extraction import is_pattern_reference
 
 # Keys whose value holds one or more entity references, anywhere in a
 # dashboard configuration. Values may be a single entity ID, a
@@ -84,11 +85,19 @@ _AREA_REFERENCE_KEYS = frozenset({"area", "area_id"})
 
 
 def _collect_plain(value: Any, out: set[str]) -> None:
-    """Collect plain string IDs from a key's string or list value."""
+    """Collect plain string IDs from a key's string or list value.
+
+    A pattern is not a name, so `area: KG/*` is left where it is.
+    """
     if isinstance(value, str):
-        out.add(value)
+        if not is_pattern_reference(value):
+            out.add(value)
     elif isinstance(value, list):
-        out.update(item for item in value if isinstance(item, str))
+        out.update(
+            item
+            for item in value
+            if isinstance(item, str) and not is_pattern_reference(item)
+        )
 
 
 def _walk_areas(node: Any, areas: set[str]) -> None:

--- a/custom_components/spook/reference_extraction.py
+++ b/custom_components/spook/reference_extraction.py
@@ -58,11 +58,26 @@ class ExtractedTargets:
     label_ids: set[str] = field(default_factory=set)
 
 
+def is_pattern_reference(value: str) -> bool:
+    """Return whether a reference is a pattern rather than a name.
+
+    Cards and helpers that take a filter read ``KG/*`` as every area under
+    ``KG``. Home Assistant has no area, floor or label called ``KG/*`` and
+    never will, so looking one up and finding nothing says nothing about
+    whether the dashboard works. Reported as #1514.
+
+    Only for areas, floors and labels. An entity ID has a shape, and
+    ``light.*`` is already turned away for not having it.
+    """
+    return "*" in value
+
+
 def _collect_ids(value: Any) -> set[str]:
     """Return the plain string IDs in a config value.
 
-    Templated values cannot be resolved statically and the ``all``/``none``
-    match constants are not references; both are skipped.
+    Templated values cannot be resolved statically, the ``all``/``none``
+    match constants are not references, and a pattern is not a name; all
+    three are skipped.
     """
     if isinstance(value, str):
         values = [value]
@@ -77,6 +92,7 @@ def _collect_ids(value: Any) -> set[str]:
         if item
         and item not in (ENTITY_MATCH_ALL, ENTITY_MATCH_NONE)
         and not is_template_string(item)
+        and not is_pattern_reference(item)
     }
 
 

--- a/tests/test_pattern_references.py
+++ b/tests/test_pattern_references.py
@@ -1,0 +1,88 @@
+"""A wildcard is a pattern, not the name of anything.
+
+Cards that take a filter read `area: KG/*` as every area under `KG`. Home
+Assistant has no area called `KG/*`, so Spook looking one up and finding
+nothing says nothing at all about whether the dashboard works. Reported as
+#1514, against a `custom:auto-entities` card.
+
+Areas, floors and labels only. An entity ID has a shape and `light.*` does not
+have it, so that one is already turned away for a better reason.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+import yaml
+
+from custom_components.spook.dashboard_extraction import (
+    extract_areas_from_dashboard_node,
+)
+from custom_components.spook.reference_extraction import extract_targets_from_config
+
+# The card from the issue, as pasted.
+_AUTO_ENTITIES = """
+type: custom:auto-entities
+card:
+  type: entities
+  title: KG
+  state_color: true
+  show_header_toggle: true
+filter:
+  include:
+    - domain: light
+      area: KG/*
+      options: {}
+  exclude: []
+show_empty: true
+sort:
+  method: friendly_name
+"""
+
+
+def test_the_card_from_the_issue_reports_no_areas() -> None:
+    """`KG/*` is every area under KG, not an area that has gone missing."""
+    assert extract_areas_from_dashboard_node(yaml.safe_load(_AUTO_ENTITIES)) == set()
+
+
+def test_a_dashboard_still_finds_the_areas_it_really_names() -> None:
+    """So the check above cannot pass by having stopped looking."""
+    config = {
+        "views": [
+            {
+                "cards": [
+                    {"type": "area", "area": "kitchen"},
+                    {
+                        "type": "custom:auto-entities",
+                        "filter": {
+                            "include": [{"domain": "light", "area": "KG/*"}],
+                        },
+                    },
+                    {"type": "button", "tap_action": {"area_id": ["hallway", "DG/*"]}},
+                ],
+            },
+        ],
+    }
+
+    assert extract_areas_from_dashboard_node(config) == {"kitchen", "hallway"}
+
+
+def test_an_automation_ignores_patterns_for_all_three() -> None:
+    """Areas, floors and labels: whatever takes a filter can take a wildcard."""
+    config = {
+        "actions": [
+            {
+                "action": "light.turn_on",
+                "target": {
+                    "area_id": ["kitchen", "KG/*"],
+                    "floor_id": ["ground_floor", "DG/*"],
+                    "label_id": ["holiday", "seasonal_*"],
+                },
+            },
+        ],
+    }
+
+    targets = extract_targets_from_config(config)
+
+    assert targets.area_ids == {"kitchen"}
+    assert targets.floor_ids == {"ground_floor"}
+    assert targets.label_ids == {"holiday"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A `custom:auto-entities` card filtering on `area: KG/*` means every area under `KG`. Spook went looking for an area called `KG/*`, did not find one, and raised a repair about a dashboard that works perfectly well.

Patterns are now skipped wherever an area, floor or label reference is collected: in dashboards, and in automations and scripts alike. Anything that takes a filter can take a wildcard, and none of them are names.

### Why those three and not entities

Not an oversight. An entity ID has a shape and a wildcard does not fit it:

```python
valid_entity_id("light.*")  # False
valid_entity_id("KG/*")     # False
```

So `light.*` was already being turned away, for a better reason than this one. Areas, floors and labels have no shape to fail, which is exactly why they are the three that got reported.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1514.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Three tests. The card from the issue, pasted as it was written, reporting no areas at all. All three reference types in one automation target, keeping the real names and dropping the patterns. And a dashboard mixing `kitchen`, `KG/*`, `hallway` and `DG/*`, which still comes back with `{kitchen, hallway}` so the other two cannot be passing by having stopped looking.

Each of the three places this is applied was checked by taking it back out:

| | |
| --- | --- |
| control | 3 passed |
| dashboards take a pattern as a name again | 2 failed |
| dashboard lists take a pattern as a name again | 1 failed |
| automations take a pattern as a name again | 1 failed |

Full suite 1404 passed, twice. pylint clean, ruff clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
