### PR TITLE
Dashboards have a gate of their own, and it was not guarded

### DIFF
--- a/custom_components/spook/action_extraction.py
+++ b/custom_components/spook/action_extraction.py
@@ -8,10 +8,9 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.const import CONF_ENABLED
 
 from .const import LOGGER
-from .entity_filtering import async_get_all_services
+from .entity_filtering import NEVER_AN_ENTITY, async_get_all_services
 from .template_extraction import (
     ENTITY_ID_PATTERN,
-    NEVER_AN_ENTITY,
     async_extract_entities_from_template_string,
     is_template_string,
 )

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -434,6 +434,25 @@ def async_drop_existing_action_names(
     }
 
 
+# Automation and template variables that read exactly like an entity ID and are
+# not one. `trigger` is what a triggered automation is handed, `this` is what a
+# template entity is handed. Reported as unknown entities twice, #823 and #1468.
+#
+# Home Assistant is where they arrive from. Written without the braces, as
+# `entity_id: trigger.entity_id` rather than `{{ trigger.entity_id }}`, they
+# come back in an automation's own `referenced_entities`, so they turn up having
+# already passed everything here that reads configuration. And the last gate
+# before an issue is raised asks `valid_entity_id`, which answers whether a
+# string is shaped like an entity ID rather than whether anything answers to it.
+#
+# Which is why both reports went nowhere for so long: everybody was looking at
+# the templates, and the templates were never it. Nothing here picks these out
+# of a template either, but only because neither `trigger` nor `this` is a
+# domain Home Assistant knows, off a list that grows every release and was never
+# chosen with these in mind. Named here so that it is a decision.
+NEVER_AN_ENTITY = frozenset({"trigger.entity_id", "this.entity_id"})
+
+
 @callback
 def async_filter_known_entity_ids(
     hass: HomeAssistant,
@@ -456,7 +475,8 @@ def async_filter_known_entity_ids(
         # Process any comma-separated entity lists
         for entity_id in split_comma_separated_entity_ids(entity_id_raw):
             if (
-                not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
+                entity_id not in NEVER_AN_ENTITY
+                and not entity_id.startswith(IGNORED_ENTITY_DOMAINS)
                 and entity_id not in known_entity_ids
                 and valid_entity_id(entity_id)
             ):

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.template import Template
 from .const import LOGGER
 from .entity_filtering import (
     IGNORED_ENTITY_DOMAINS,
+    NEVER_AN_ENTITY,
     async_drop_existing_action_names,
     async_get_all_entity_ids,
     async_get_all_services,
@@ -50,23 +51,6 @@ ADDITIONAL_DOMAINS = [
 # Build a list of all known domains
 KNOWN_DOMAINS = [platform.value for platform in Platform] + ADDITIONAL_DOMAINS
 
-# Automation and template variables that read exactly like an entity ID and are
-# not one. `trigger` is what a triggered automation is handed, `this` is what a
-# template entity is handed. Reported as unknown entities twice, #823 and #1468.
-#
-# Home Assistant is where they arrive from. Written without the braces, as
-# `entity_id: trigger.entity_id` rather than `{{ trigger.entity_id }}`, they
-# come back in an automation's own `referenced_entities`, so they turn up having
-# already passed everything here that reads configuration. And the last gate
-# before an issue is raised asks `valid_entity_id`, which answers whether a
-# string is shaped like an entity ID rather than whether anything answers to it.
-#
-# Which is why both reports went nowhere for so long: everybody was looking at
-# the templates, and the templates were never it. Nothing here picks these out
-# of a template either, but only because neither `trigger` nor `this` is a
-# domain Home Assistant knows, off a list that grows every release and was never
-# chosen with these in mind. Named here so that it is a decision.
-NEVER_AN_ENTITY = frozenset({"trigger.entity_id", "this.entity_id"})
 
 # Home Assistant core entity ID validation patterns (from homeassistant/core.py)
 _OBJECT_ID = r"(?!_)[\da-z_]+(?<!_)"

--- a/tests/test_never_an_entity.py
+++ b/tests/test_never_an_entity.py
@@ -34,6 +34,10 @@ from custom_components.spook.action_extraction import (
 from custom_components.spook.ectoplasms.automation.repairs.unknown_entity_references import (
     extract_entities_from_automation_config,
 )
+from custom_components.spook.dashboard_extraction import (
+    extract_entities_from_dashboard_node,
+)
+from custom_components.spook.entity_filtering import async_filter_known_entity_ids
 from custom_components.spook.template_extraction import (
     async_filter_known_entity_ids_with_templates,
 )
@@ -232,3 +236,52 @@ async def test_they_stay_out_even_if_the_domains_ever_let_them_in(
         assert not _named(found), f"{written!r} got through: {sorted(found)}"
 
     template_extraction._extract_entity_candidates_from_template.cache_clear()  # noqa: SLF001
+
+
+async def test_a_dashboard_does_not_report_them_either(
+    hass: HomeAssistant,
+) -> None:
+    """The card from #1468's second report, an `auto-entities` filter.
+
+    Dashboards go through a filter of their own, `async_filter_known_entity_ids`,
+    which is a separate function from the one automations use. Guarding only
+    the automation side left this reported, and I had it fixed on paper for a
+    while on the strength of them looking alike.
+    """
+    card = yaml.safe_load(
+        """
+        type: custom:auto-entities
+        filter:
+          include:
+            - entity_id: sensor.some_prefix*
+              state: "> 0"
+              options:
+                entity: this.entity_id
+        """,
+    )
+
+    extracted = extract_entities_from_dashboard_node(card)
+    assert "this.entity_id" in extracted, (
+        "the walk stopped collecting it, so this no longer tests the filter"
+    )
+
+    unknown = async_filter_known_entity_ids(
+        hass,
+        entity_ids=extracted,
+        known_entity_ids={"sensor.real_one"},
+    )
+
+    assert not _named(unknown), f"a dashboard reported {sorted(unknown)}"
+
+
+async def test_a_dashboard_still_reports_an_entity_that_really_is_gone(
+    hass: HomeAssistant,
+) -> None:
+    """So the check above cannot pass by the dashboard filter reporting nothing."""
+    unknown = async_filter_known_entity_ids(
+        hass,
+        entity_ids={"this.entity_id", "sensor.long_gone"},
+        known_entity_ids={"sensor.real_one"},
+    )
+
+    assert unknown == {"sensor.long_gone"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

#1515 put `trigger.entity_id` and `this.entity_id` behind a guard and I called the class closed. It was not. There are two near-identical final gates, and only one of them was guarded.

A second reporter on #1468 came back with a `custom:auto-entities` card still reporting `this.entity_id`, and worked out why themselves: dashboards go through `entity_filtering.async_filter_known_entity_ids`, which is a different function from the `async_filter_known_entity_ids_with_templates` automations use. Same `valid_entity_id` check inside, none of the guard.

They believed #1515 covered them. It does not. On `main` today:

```
extracted from the card: ['sensor.some_prefix*', 'this.entity_id']
reported as unknown:      ['this.entity_id']
```

So `NEVER_AN_ENTITY` moves to `entity_filtering`, which both sides import without a cycle, and both gates read it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Finishes #1468, which #1515 only half closed.

Credit to @ryssel, who found the path, read the code, narrowed it to the exact key, and pointed out that the sibling key in the very same block behaves differently: `sensor.some_prefix*` is dropped on shape while `this.entity_id` survives, because one has a shape to fail and the other does not. Their card is the test.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two tests on the dashboard path. Their card, reporting nothing. And a dashboard filter asked about `this.entity_id` alongside `sensor.long_gone`, which still comes back with the one that really is gone.

The first also asserts that the walk still collects the string before the filter is asked:

```python
assert "this.entity_id" in extracted, (
    "the walk stopped collecting it, so this no longer tests the filter"
)
```

Without that it would pass just as happily on the day the collection changes and the filter is never exercised at all, which is the way this sort of test dies.

Both gates checked by taking the guard back out of each in turn:

| | |
| --- | --- |
| control | 7 passed |
| dashboard gate unguarded, which is `main` today | 2 failed |
| automation gate unguarded | 1 failed |

Full suite 1406 passed, twice. pylint clean, ruff clean, pre-commit clean.

### Not in this one

@ryssel also suggests not descending into a `filter:` key at all, since nothing under one is ever a concrete reference. That is the same shape the reviewers on #1517 were arguing from the other side, and it would cover the class without any list of names. Worth doing, worth doing on its own.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
