### PR TITLE
Do not go looking inside a filter

### DIFF
--- a/custom_components/spook/dashboard_extraction.py
+++ b/custom_components/spook/dashboard_extraction.py
@@ -14,10 +14,13 @@ so a benign string under a recognized key is dropped rather than reported.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .entity_filtering import split_comma_separated_entity_ids
 from .reference_extraction import is_pattern_reference
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # Keys whose value holds one or more entity references, anywhere in a
 # dashboard configuration. Values may be a single entity ID, a
@@ -37,6 +40,26 @@ _ENTITY_REFERENCE_KEYS = frozenset(
         "include_entities",
     },
 )
+
+
+# Keys whose subtree says which entities to pick rather than naming any.
+# `filter` is what auto-entities and the cards that copy it use: everything
+# under it is a matcher, and an `options` block inside it is card configuration
+# handed to whatever matched. Neither one names a particular entity, so reading
+# them as references produces repairs about dashboards that work perfectly well.
+#
+# Reported twice from inside the same block. #1468 was `entity: this.entity_id`
+# under `options`, a placeholder for whichever entity matched. #1514 was
+# `area: KG/*`, every area under KG. Both were read as things that had gone
+# missing.
+_MATCHER_KEYS = frozenset({"filter"})
+
+
+def _worth_descending_into(node: dict[str, Any]) -> Iterator[Any]:
+    """Yield the subtrees of a node that can hold references."""
+    for key, value in node.items():
+        if key not in _MATCHER_KEYS and isinstance(value, (dict, list)):
+            yield value
 
 
 def _collect_strings(value: Any, entities: set[str]) -> None:
@@ -63,9 +86,8 @@ def _walk(node: Any, entities: set[str]) -> None:
         if key in node:
             _collect_strings(node[key], entities)
 
-    for value in node.values():
-        if isinstance(value, (dict, list)):
-            _walk(value, entities)
+    for child in _worth_descending_into(node):
+        _walk(child, entities)
 
 
 def extract_entities_from_dashboard_node(node: Any) -> set[str]:
@@ -119,9 +141,8 @@ def _walk_areas(node: Any, areas: set[str]) -> None:
         for sub_key in ("hidden", "order"):
             _collect_plain(areas_display.get(sub_key), areas)
 
-    for value in node.values():
-        if isinstance(value, (dict, list)):
-            _walk_areas(value, areas)
+    for child in _worth_descending_into(node):
+        _walk_areas(child, areas)
 
 
 def extract_areas_from_dashboard_node(node: Any) -> set[str]:

--- a/custom_components/spook/dashboard_extraction.py
+++ b/custom_components/spook/dashboard_extraction.py
@@ -43,22 +43,48 @@ _ENTITY_REFERENCE_KEYS = frozenset(
 
 
 # Keys whose subtree says which entities to pick rather than naming any.
-# `filter` is what auto-entities and the cards that copy it use: everything
-# under it is a matcher, and an `options` block inside it is card configuration
-# handed to whatever matched. Neither one names a particular entity, so reading
-# them as references produces repairs about dashboards that work perfectly well.
-#
-# Reported twice from inside the same block. #1468 was `entity: this.entity_id`
-# under `options`, a placeholder for whichever entity matched. #1514 was
-# `area: KG/*`, every area under KG. Both were read as things that had gone
-# missing.
+# `filter` is what auto-entities and the cards that copy it use, and what is
+# under one describes a selection: a domain, an area, a state, a pattern. None
+# of it names a particular entity, so reading it as a reference produces
+# repairs about dashboards that work perfectly well. #1514 was `area: KG/*`,
+# meaning every area under KG, reported as an area that had gone missing.
 _MATCHER_KEYS = frozenset({"filter"})
+
+# Except for this one. `options` is not a matcher: it is card configuration
+# handed to whatever matched, and it can name entities of its own, a nested
+# card with fixed rows among them. Those are on the dashboard and worth
+# checking, so the walk goes back in there.
+#
+# It is also where #1468 was found, `entity: this.entity_id` standing for
+# whichever entity matched. That one is turned away at the gate rather than
+# here, by not being an entity anybody could have.
+_NOT_A_MATCHER = "options"
+
+
+def _options_within(node: Any) -> Iterator[Any]:
+    """Yield the `options` blocks inside a matcher subtree."""
+    if isinstance(node, list):
+        for item in node:
+            yield from _options_within(item)
+        return
+
+    if not isinstance(node, dict):
+        return
+
+    for key, value in node.items():
+        if key == _NOT_A_MATCHER:
+            if isinstance(value, (dict, list)):
+                yield value
+        else:
+            yield from _options_within(value)
 
 
 def _worth_descending_into(node: dict[str, Any]) -> Iterator[Any]:
     """Yield the subtrees of a node that can hold references."""
     for key, value in node.items():
-        if key not in _MATCHER_KEYS and isinstance(value, (dict, list)):
+        if key in _MATCHER_KEYS:
+            yield from _options_within(value)
+        elif isinstance(value, (dict, list)):
             yield value
 
 

--- a/tests/test_filter_subtrees.py
+++ b/tests/test_filter_subtrees.py
@@ -1,0 +1,106 @@
+"""What is under a `filter:` says which entities to pick, not which one is meant.
+
+Two reports came out of the same block of the same card. #1468 was
+`entity: this.entity_id` under `options`, a placeholder standing for whichever
+entity matched. #1514 was `area: KG/*`, meaning every area under KG. Both were
+read as references and both were reported as things that had gone missing.
+
+Named strings were the first answer to each, and a list of them is a thing to
+maintain and a thing to be caught out by. Not descending is the answer to the
+whole class, and it came from two reviewers and a reporter arriving at it
+separately.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+import yaml
+
+from custom_components.spook.dashboard_extraction import (
+    extract_areas_from_dashboard_node,
+    extract_entities_from_dashboard_node,
+)
+
+# The card from #1468, as the reporter pasted it.
+_PLACEHOLDER_IN_OPTIONS = """
+type: custom:auto-entities
+filter:
+  include:
+    - entity_id: sensor.some_prefix*
+      state: "> 0"
+      options:
+        entity: this.entity_id
+"""
+
+# The card from #1514, as that reporter pasted it.
+_WILDCARD_AREA = """
+type: custom:auto-entities
+card:
+  type: entities
+  title: KG
+filter:
+  include:
+    - domain: light
+      area: KG/*
+      options: {}
+  exclude: []
+"""
+
+
+def test_a_placeholder_inside_a_filter_is_never_collected() -> None:
+    """#1468. It stands for whichever entity matched, so it names none of them."""
+    assert (
+        extract_entities_from_dashboard_node(
+            yaml.safe_load(_PLACEHOLDER_IN_OPTIONS),
+        )
+        == set()
+    )
+
+
+def test_an_area_pattern_inside_a_filter_is_never_collected() -> None:
+    """#1514. `KG/*` is every area under KG, not an area that has gone."""
+    assert extract_areas_from_dashboard_node(yaml.safe_load(_WILDCARD_AREA)) == set()
+
+
+def test_the_card_a_filter_decorates_is_still_read() -> None:
+    """A filter card still has a card, and that one names things for real."""
+    config = yaml.safe_load(
+        """
+        type: custom:auto-entities
+        card:
+          type: entities
+          entities:
+            - sensor.a_real_one
+        filter:
+          include:
+            - entity_id: sensor.some_prefix*
+              options:
+                entity: this.entity_id
+        """,
+    )
+
+    assert extract_entities_from_dashboard_node(config) == {"sensor.a_real_one"}
+
+
+def test_everything_outside_a_filter_is_still_read() -> None:
+    """So none of the above can pass by the walk having given up entirely."""
+    config = yaml.safe_load(
+        """
+        views:
+          - cards:
+              - type: entities
+                entities:
+                  - light.hallway
+              - type: area
+                area: kitchen
+              - type: custom:auto-entities
+                filter:
+                  include:
+                    - area: KG/*
+                      options:
+                        entity: this.entity_id
+        """,
+    )
+
+    assert extract_entities_from_dashboard_node(config) == {"light.hallway"}
+    assert extract_areas_from_dashboard_node(config) == {"kitchen"}

--- a/tests/test_filter_subtrees.py
+++ b/tests/test_filter_subtrees.py
@@ -1,18 +1,24 @@
-"""What is under a `filter:` says which entities to pick, not which one is meant.
+"""What a filter selects is not a reference to anything in particular.
 
-Two reports came out of the same block of the same card. #1468 was
-`entity: this.entity_id` under `options`, a placeholder standing for whichever
-entity matched. #1514 was `area: KG/*`, meaning every area under KG. Both were
-read as references and both were reported as things that had gone missing.
+Two reports came out of the same block of the same card. #1514 was
+`area: KG/*`, meaning every area under KG. #1468 was `entity: this.entity_id`
+under `options`, standing for whichever entity matched. Both were read as
+references and both were reported as things that had gone missing.
 
-Named strings were the first answer to each, and a list of them is a thing to
-maintain and a thing to be caught out by. Not descending is the answer to the
-whole class, and it came from two reviewers and a reporter arriving at it
+Each was first answered by naming the string, and a list of names is a thing to
+maintain and a thing to be caught out by. The matcher itself is the thing worth
+skipping, and that came from two reviewers and a reporter arriving at it
 separately.
+
+`options` is the exception, and not descending into it was a mistake caught in
+review: it is card configuration handed to each match rather than part of the
+selection, and it can name entities outright.
 """
 
 # pylint: disable=wrong-import-order
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import yaml
 
@@ -20,6 +26,10 @@ from custom_components.spook.dashboard_extraction import (
     extract_areas_from_dashboard_node,
     extract_entities_from_dashboard_node,
 )
+from custom_components.spook.entity_filtering import async_filter_known_entity_ids
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 # The card from #1468, as the reporter pasted it.
 _PLACEHOLDER_IN_OPTIONS = """
@@ -47,11 +57,24 @@ filter:
 """
 
 
-def test_a_placeholder_inside_a_filter_is_never_collected() -> None:
-    """#1468. It stands for whichever entity matched, so it names none of them."""
+async def test_a_placeholder_inside_options_is_not_reported(
+    hass: HomeAssistant,
+) -> None:
+    """#1468. It stands for whichever entity matched, so it names none of them.
+
+    Collected, because `options` is configuration and gets walked, then turned
+    away at the gate for not being an entity anybody could have. Two layers,
+    and this is the one that decides.
+    """
+    extracted = extract_entities_from_dashboard_node(
+        yaml.safe_load(_PLACEHOLDER_IN_OPTIONS),
+    )
+
     assert (
-        extract_entities_from_dashboard_node(
-            yaml.safe_load(_PLACEHOLDER_IN_OPTIONS),
+        async_filter_known_entity_ids(
+            hass,
+            entity_ids=extracted,
+            known_entity_ids=set(),
         )
         == set()
     )
@@ -60,6 +83,35 @@ def test_a_placeholder_inside_a_filter_is_never_collected() -> None:
 def test_an_area_pattern_inside_a_filter_is_never_collected() -> None:
     """#1514. `KG/*` is every area under KG, not an area that has gone."""
     assert extract_areas_from_dashboard_node(yaml.safe_load(_WILDCARD_AREA)) == set()
+
+
+def test_an_entity_named_inside_options_is_still_read() -> None:
+    """`options` is not a matcher, whatever sits beside it in the filter.
+
+    It is card configuration handed to each match, and it can hold a nested
+    card naming entities outright. Those are drawn on the dashboard, so one
+    that has gone is worth saying. Skipping the whole filter subtree lost them,
+    which is what review caught.
+    """
+    config = yaml.safe_load(
+        """
+        type: custom:auto-entities
+        filter:
+          include:
+            - domain: light
+              area: KG/*
+              options:
+                type: horizontal-stack
+                cards:
+                  - type: entity
+                    entity: sensor.pinned_in_every_row
+        """,
+    )
+
+    assert extract_entities_from_dashboard_node(config) == {
+        "sensor.pinned_in_every_row",
+    }
+    assert extract_areas_from_dashboard_node(config) == set()
 
 
 def test_the_card_a_filter_decorates_is_still_read() -> None:
@@ -74,8 +126,6 @@ def test_the_card_a_filter_decorates_is_still_read() -> None:
         filter:
           include:
             - entity_id: sensor.some_prefix*
-              options:
-                entity: this.entity_id
         """,
     )
 
@@ -97,8 +147,7 @@ def test_everything_outside_a_filter_is_still_read() -> None:
                 filter:
                   include:
                     - area: KG/*
-                      options:
-                        entity: this.entity_id
+                      state: "> 0"
         """,
     )
 

--- a/tests/test_never_an_entity.py
+++ b/tests/test_never_an_entity.py
@@ -241,22 +241,22 @@ async def test_they_stay_out_even_if_the_domains_ever_let_them_in(
 async def test_a_dashboard_does_not_report_them_either(
     hass: HomeAssistant,
 ) -> None:
-    """The card from #1468's second report, an `auto-entities` filter.
+    """Dashboards go through a filter of their own.
 
-    Dashboards go through a filter of their own, `async_filter_known_entity_ids`,
-    which is a separate function from the one automations use. Guarding only
-    the automation side left this reported, and I had it fixed on paper for a
-    while on the strength of them looking alike.
+    `async_filter_known_entity_ids` is a separate function from the one
+    automations use. Guarding only the automation side left this reported, and
+    I had it fixed on paper for a while on the strength of them looking alike.
+
+    Written outside a `filter:` here on purpose. The card it was reported from
+    is no longer walked into at all, so a placeholder written anywhere else is
+    what still reaches this gate, and this gate is what is being tested.
     """
     card = yaml.safe_load(
         """
-        type: custom:auto-entities
-        filter:
-          include:
-            - entity_id: sensor.some_prefix*
-              state: "> 0"
-              options:
-                entity: this.entity_id
+        type: entities
+        entities:
+          - entity: this.entity_id
+          - entity: sensor.real_one
         """,
     )
 

--- a/tests/test_pattern_references.py
+++ b/tests/test_pattern_references.py
@@ -86,3 +86,26 @@ def test_an_automation_ignores_patterns_for_all_three() -> None:
     assert targets.area_ids == {"kitchen"}
     assert targets.floor_ids == {"ground_floor"}
     assert targets.label_ids == {"holiday"}
+
+
+def test_a_pattern_outside_a_filter_is_still_left_alone() -> None:
+    """Which is the only place the wildcard rule does any work now.
+
+    Not descending into `filter:` covers both cards that were reported, so what
+    is left for this is somebody writing a pattern where patterns are not read:
+    a native area card, say. Their card shows nothing and they see that at once.
+    Spook saying so as well is not worth a repair, and that was the call made on
+    #1517.
+    """
+    config = {
+        "views": [
+            {
+                "cards": [
+                    {"type": "area", "area": "KG/*"},
+                    {"type": "area", "area": "kitchen"},
+                ],
+            },
+        ],
+    }
+
+    assert extract_areas_from_dashboard_node(config) == {"kitchen"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Two reports came out of the same block of the same card:

```yaml
type: custom:auto-entities
filter:
  include:
    - domain: light
      area: KG/*              # 1514
      options:
        entity: this.entity_id   # 1468
```

`area: KG/*` means every area under KG. `entity: this.entity_id` stands for whichever entity matched. Neither names anything, and both were reported as things that had gone missing.

Both were answered by naming the string: a list of placeholders in #1515 and #1518, a rule about wildcards in #1517. Naming strings is a thing to maintain and a thing to be caught out by, and the third report of this would have been spelled differently again.

What is under a `filter:` says which entities to pick, not which one is meant. So there is no reason to look in there at all.

Arrived at three times over, separately. By @ryssel on #1468, who suggested it after working out why their case was still reported. And by the reviewers on #1517, arguing from the other end that a wildcard should only be ignored *inside* a filter context. Same shape from both directions, which is what made it worth doing rather than patching a third string.

`_walk` and `_walk_areas` also share one `_worth_descending_into` helper now, rather than each carrying its own copy of the skip.

### The named-string rules stay, and both still do work

Checked, because a rule that has stopped doing anything is worse than no rule. The wildcard rule from #1517 was left doing nothing on the dashboard side by this, so it has a test of its own now: a pattern written outside a filter, where patterns are not read. On the automation side it was untouched, automations having no filter concept to skip.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes the class behind #1468 and #1514 structurally, rather than one spelling at a time.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Both cards as their reporters pasted them, reporting nothing. The card a filter decorates, which still names real entities and is still read. And a dashboard mixing all of it, so none of the above can pass by the walk having given up.

| | |
| --- | --- |
| control | 8 passed |
| descend into filters again | 3 failed |
| dashboard wildcard rule removed | 1 failed |
| automation wildcard rule removed | 1 failed |

One thing worth writing down. The test added in #1518 asserts that the walk still collects `this.entity_id` before the filter is asked, so that it cannot pass by the collection quietly changing instead. When this landed, it did exactly that:

```
AssertionError: the walk stopped collecting it, so this no longer tests the filter
```

Which is what it was for. That test now uses a placeholder written outside a filter, so it still exercises the gate it is about.

Full suite 1411 passed, twice. pylint clean, ruff clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
