### PR TITLE
A template condition is a condition, not the name of one

### DIFF
--- a/custom_components/spook/reference_extraction.py
+++ b/custom_components/spook/reference_extraction.py
@@ -173,7 +173,13 @@ def _walk_platform_keys(config: Any, found: ExtractedPlatformKeys) -> None:
         return
 
     if isinstance(condition := config.get("condition"), str):
-        found.condition_keys.add(condition)
+        # `condition: "{{ ... }}"` is Home Assistant's own shorthand for a
+        # template condition, and `cv.CONDITION_SCHEMA` takes it. The string
+        # is the condition itself, not the name of something that provides
+        # one, so reading it as a platform key reports the whole template
+        # back at somebody as an integration they do not have. #1520.
+        if not is_template_string(condition):
+            found.condition_keys.add(condition)
     else:
         # Only collect trigger keys outside condition configurations: the
         # trigger condition carries trigger IDs (not platform keys) in its

--- a/custom_components/spook/template_extraction.py
+++ b/custom_components/spook/template_extraction.py
@@ -116,10 +116,25 @@ _DEVICE_ENTITIES_PATTERN = re.compile(
 
 
 def is_template_string(value: str) -> bool:
-    """Check if a string looks like a Jinja2 template."""
+    """Check if a string looks like a Jinja2 template.
+
+    All three of Jinja's delimiters, comments included. A comment on its own
+    is a template as far as Home Assistant is concerned, and it will take one
+    as a shorthand condition, so anything that does not know that reads it as
+    the name of an integration instead. #1520.
+
+    Stricter than `homeassistant.helpers.template.is_template_string`, which
+    is happy with an opening delimiter and no closing one. That is deliberate
+    and tested: a half-written template is not something to go extracting
+    references out of.
+    """
     if not isinstance(value, str):
         return False
-    return ("{{" in value and "}}" in value) or ("{%" in value and "%}" in value)
+    return (
+        ("{{" in value and "}}" in value)
+        or ("{%" in value and "%}" in value)
+        or ("{#" in value and "#}" in value)
+    )
 
 
 async def async_extract_entities_from_template_string(

--- a/tests/test_shorthand_conditions.py
+++ b/tests/test_shorthand_conditions.py
@@ -1,0 +1,87 @@
+"""`condition: "{{ ... }}"` is a condition, not the name of one.
+
+Home Assistant takes a template straight in the `condition` field as shorthand
+for a template condition, and `cv.CONDITION_SCHEMA` accepts it. Spook read that
+field as the name of whatever provides the condition, so it reported the entire
+template back as an integration nobody has.
+
+Reported as #1520 against Cover Control Automation, which writes conditions that
+way about forty times over. Every automation built on it was flagged.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import config_validation as cv
+from homeassistant.setup import async_setup_component
+import yaml
+
+from custom_components.spook.platform_validation import (
+    async_filter_unknown_condition_keys,
+)
+from custom_components.spook.reference_extraction import (
+    extract_platform_keys_from_config,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+# Written the way the blueprint writes them, folded and inline.
+_SHORTHAND = """
+actions:
+  - condition: >-
+      {{
+        is_sun_elevation_enabled and
+        sun_elevation_mode == 'dynamic'
+      }}
+  - condition: "{{ state_attr(blind, 'current_position') is none }}"
+  - condition: state
+    entity_id: binary_sensor.real
+    state: "on"
+  - action: light.turn_on
+"""
+
+
+def test_home_assistant_really_does_take_this() -> None:
+    """The premise. If core stops accepting it, the rest of this is moot."""
+    assert cv.CONDITION_SCHEMA({"condition": "{{ 1 > 0 }}"})
+
+
+def test_a_template_condition_is_not_read_as_a_platform() -> None:
+    """The name of the thing providing a condition, or the condition itself."""
+    keys = extract_platform_keys_from_config(yaml.safe_load(_SHORTHAND))
+
+    assert keys.condition_keys == {"state"}
+
+
+async def test_the_shorthand_is_not_reported(hass: HomeAssistant) -> None:
+    """End to end, which is where the repair reads it."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    keys = extract_platform_keys_from_config(yaml.safe_load(_SHORTHAND))
+
+    assert await async_filter_unknown_condition_keys(hass, keys.condition_keys) == set()
+
+
+async def test_a_condition_that_really_is_gone_is_still_reported(
+    hass: HomeAssistant,
+) -> None:
+    """So none of the above can pass by the repair having stopped looking."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    await hass.async_block_till_done()
+
+    config = yaml.safe_load(
+        """
+        conditions:
+          - condition: "{{ 1 > 0 }}"
+          - condition: no_such_integration_provides_this
+        """,
+    )
+    keys = extract_platform_keys_from_config(config)
+
+    assert await async_filter_unknown_condition_keys(hass, keys.condition_keys) == {
+        "no_such_integration_provides_this",
+    }

--- a/tests/test_shorthand_conditions.py
+++ b/tests/test_shorthand_conditions.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.helpers import config_validation as cv
 from homeassistant.setup import async_setup_component
+import pytest
 import yaml
 
 from custom_components.spook.platform_validation import (
@@ -44,9 +45,33 @@ actions:
 """
 
 
-def test_home_assistant_really_does_take_this() -> None:
-    """The premise. If core stops accepting it, the rest of this is moot."""
-    assert cv.CONDITION_SCHEMA({"condition": "{{ 1 > 0 }}"})
+@pytest.mark.parametrize(
+    "shorthand",
+    [
+        "{{ 1 > 0 }}",
+        "{% if true %}yes{% endif %}",
+        # A comment on its own is a template too, and core takes it.
+        "{# nothing to see here #}",
+    ],
+)
+def test_home_assistant_really_does_take_these(shorthand: str) -> None:
+    """The premise. If core stops accepting them, the rest of this is moot."""
+    assert cv.CONDITION_SCHEMA({"condition": shorthand})
+
+
+@pytest.mark.parametrize(
+    "shorthand",
+    [
+        "{{ 1 > 0 }}",
+        "{% if true %}yes{% endif %}",
+        "{# nothing to see here #}",
+    ],
+)
+def test_no_flavour_of_template_is_read_as_a_platform(shorthand: str) -> None:
+    """All three of Jinja's delimiters, comments included."""
+    keys = extract_platform_keys_from_config({"conditions": [{"condition": shorthand}]})
+
+    assert keys.condition_keys == set()
 
 
 def test_a_template_condition_is_not_read_as_a_platform() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
         "{% if true %}on{% endif %}",
         "prefix {{ x }} suffix",
         "{% set x = 1 %}{{ x }}",
+        # A comment on its own is still a template, and Home Assistant will
+        # take one as a shorthand condition. #1520.
+        "{# just a comment #}",
+        "{# leading comment #}{{ x }}",
     ],
 )
 def test_is_template_string_recognizes_jinja(value: str) -> None:
@@ -49,6 +53,7 @@ def test_is_template_string_recognizes_jinja(value: str) -> None:
         "light.kitchen",
         "{{ unmatched",
         "{% unmatched",
+        "{# unmatched",
         "{ not jinja }",
     ],
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Home Assistant takes a template straight in the `condition` field, as shorthand for a template condition:

```yaml
- condition: "{{ state_attr(blind, 'current_position') is none }}"
```

`cv.CONDITION_SCHEMA` accepts it, and there is a test in here asserting that, because the whole change rests on it.

Spook read that field as the name of whatever provides the condition. So it handed the entire Jinja template back to people as an integration they do not have installed.

### Not what the report said, which is worth saying

@Xr1H0 put the blame on optional condition inputs defaulting to `[]`, which is a reasonable thing to land on: that blueprint is full of them. It is not that. A list is not a string, so an empty one was never collected in the first place, and fifteen shapes of empty and configured condition inputs come back clean on 5.1.0 and on `main` alike.

So I fetched the blueprint they named, Cover Control Automation, and put it through the repair with every input left at its default:

```
before   REPORTED unknown conditions: [ 43 entire Jinja templates ]
after    condition keys: ['template']      REPORTED: []
```

CCA writes conditions that way forty-three times. That is why all thirteen of their automations were flagged, and why anybody else using it would see the same.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1520. Thanks to @Xr1H0, whose report named the blueprint and the version, which is what made it findable even though the diagnosis pointed elsewhere.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Against the real blueprint, fetched and rendered with defaults, before and after.

Four tests. That Home Assistant really does accept the shorthand, since everything else here follows from it. That a template is not collected as a platform key, folded and inline both, alongside a `state` condition that still is. The same end to end through the filter the repair uses. And a condition that genuinely no integration provides, which is still reported, so none of the others can pass by the repair having quietly stopped looking.

| | |
| --- | --- |
| control | 4 passed |
| read the template as a platform name again, which is `main` today | 3 failed |

Full suite 1416 passed, twice. pylint clean, ruff clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
