### PR TITLE
It is Settings > Tools now, everywhere

### DIFF
--- a/custom_components/spook/ectoplasms/recorder/repairs/orphaned_statistics.py
+++ b/custom_components/spook/ectoplasms/recorder/repairs/orphaned_statistics.py
@@ -22,10 +22,11 @@ class SpookRepair(AbstractSpookRepair):
 
     Removing a sensor leaves its recorded statistics behind; Home
     Assistant keeps them but never points them out. This surfaces them so
-    they can be cleaned up on the Developer Tools > Statistics page, which
+    they can be cleaned up on the Settings > Tools > Statistics page, which
     is the only place Home Assistant offers to do it: `clear_statistics` is
-    a websocket command that page calls, and not an action anybody can
-    reach from Developer Tools > Actions.
+    a websocket command that page calls, and not an action anybody can reach
+    from the Actions tool. That page was called Developer Tools and sat in
+    the sidebar until Home Assistant moved it in 2026.
     """
 
     domain = "recorder"

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -601,7 +601,7 @@
       "title": "Unknown members in notify group: {group}"
     },
     "orphaned_statistics": {
-      "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Developer Tools > Statistics and fix them there.\n\nSpook 👻 Your homie.",
+      "description": "Spook has found a ghost in your recorder 👻\n\nHome Assistant is keeping long-term statistics for the following, but there is no matching entity for them anymore:\n\n{statistics}\n\n\n\nThis usually happens when a sensor was removed while its statistics were kept. To fix this error, open Settings > Tools > Statistics and fix them there.\n\nSpook 👻 Your homie.",
       "title": "Orphaned long-term statistics found"
     },
     "person_unknown_device_trackers": {

--- a/documentation/areas.md
+++ b/documentation/areas.md
@@ -10,7 +10,7 @@ date: 2023-08-09T21:29:00+02:00
 Spook provides {term}`actions <action>` that allows you to manage and {term}`automate <automation>` the areas in Home Assistant programatically. Great for creating "dynamic" areas, or for creating areas on the fly.
 
 ```{figure} ./images/areas/example.png
-:alt: Screenshot of the developer actions tools, listing the new actions to manage areas.
+:alt: Screenshot of the Actions tool, listing the new actions to manage areas.
 :align: center
 ```
 

--- a/documentation/areas.md
+++ b/documentation/areas.md
@@ -249,7 +249,7 @@ Removes one or more aliases from an existing area. This action will leave the ot
 As area aliases are used by voice assistants, you could remove (and also add) aliases to an area using {term}`automations <automation>`, which allows you to make them available/unavailable programatically.
 
 ```{figure} ./images/areas/remove_alias.png
-:alt: Screenshot of the remove an alias to an area action on the Tools page.
+:alt: Screenshot of the remove an alias from an area action on the Tools page.
 :align: center
 ```
 
@@ -334,7 +334,7 @@ Sets the aliases for an area. This action will overwrite/remove all existing ali
 As area aliases are used by voice assistants, you could remove (and also add) aliases to an area using {term}`automations <automation>`, which allows you to make them available/unavailable programatically.
 
 ```{figure} ./images/areas/set_aliases.png
-:alt: Screenshot of the set aliases to for an area action on the Tools page.
+:alt: Screenshot of the set aliases for an area action on the Tools page.
 :align: center
 ```
 
@@ -471,7 +471,7 @@ That template will find the area ID of the area with the name "Living room".
 :::{tip} Finding a device ID
 :class: dropdown
 
-Not sure what the `device_id` of an your device is? There are a few ways to find it:
+Not sure what the `device_id` of your device is? There are a few ways to find it:
 
 Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
@@ -518,7 +518,7 @@ data:
 Removes one or more device(s) from an area. This action will leave the other devices in the area untouched.
 
 ```{figure} ./images/areas/remove_device.png
-:alt: Screenshot of the add a device to an area action on the Tools page.
+:alt: Screenshot of the remove a device from an area action on the Tools page.
 :align: center
 ```
 
@@ -562,9 +562,9 @@ While this action is area related, it does not need to know the area ID. A devic
 :::{tip} Finding a device ID
 :class: dropdown
 
-Not sure what the `device_id` of an your device is? There are a few ways to find it:
+Not sure what the `device_id` of your device is? There are a few ways to find it:
 
-Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to remove from the area and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::
@@ -688,7 +688,7 @@ data:
 Removes one or more device(s) from an area. This action will leave the other devices in the area untouched.
 
 ```{figure} ./images/areas/remove_entity.png
-:alt: Screenshot of the add a device to an area action on the Tools page.
+:alt: Screenshot of the remove an entity from an area action on the Tools page.
 :align: center
 ```
 

--- a/documentation/areas.md
+++ b/documentation/areas.md
@@ -23,7 +23,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Adds a new area to your Home Assistant instance.
 
 ```{figure} ./images/areas/create.png
-:alt: Screenshot of the create area action in the developer tools.
+:alt: Screenshot of the create area action on the Tools page.
 :align: center
 ```
 
@@ -40,9 +40,9 @@ Adds a new area to your Home Assistant instance.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_area)
 ```
 
 ```{list-table}
@@ -89,7 +89,7 @@ data:
 Adds a new area to your Home Assistant instance.
 
 ```{figure} ./images/areas/delete.png
-:alt: Screenshot of the delete area action in the developer tools.
+:alt: Screenshot of the delete area action on the Tools page.
 :align: center
 ```
 
@@ -106,9 +106,9 @@ Adds a new area to your Home Assistant instance.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_area)
 ```
 
 ```{list-table}
@@ -164,7 +164,7 @@ Adds one or more aliases to an existing area. This action does not remove existi
 As area aliases are used by voice assistants, you could add (and also remove) aliases to an area using {term}`automations <automation>`, which allows you to make them available/unavailable programatically.
 
 ```{figure} ./images/areas/add_alias.png
-:alt: Screenshot of the add an alias to an area action in the developer tools.
+:alt: Screenshot of the add an alias to an area action on the Tools page.
 :align: center
 ```
 
@@ -181,9 +181,9 @@ As area aliases are used by voice assistants, you could add (and also remove) al
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_alias_to_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_alias_to_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_alias_to_area)
 ```
 
 ```{list-table}
@@ -249,7 +249,7 @@ Removes one or more aliases from an existing area. This action will leave the ot
 As area aliases are used by voice assistants, you could remove (and also add) aliases to an area using {term}`automations <automation>`, which allows you to make them available/unavailable programatically.
 
 ```{figure} ./images/areas/remove_alias.png
-:alt: Screenshot of the remove an alias to an area action in the developer tools.
+:alt: Screenshot of the remove an alias to an area action on the Tools page.
 :align: center
 ```
 
@@ -266,9 +266,9 @@ As area aliases are used by voice assistants, you could remove (and also add) al
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_alias_from_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_alias_from_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_alias_from_area)
 ```
 
 ```{list-table}
@@ -334,7 +334,7 @@ Sets the aliases for an area. This action will overwrite/remove all existing ali
 As area aliases are used by voice assistants, you could remove (and also add) aliases to an area using {term}`automations <automation>`, which allows you to make them available/unavailable programatically.
 
 ```{figure} ./images/areas/set_aliases.png
-:alt: Screenshot of the set aliases to for an area action in the developer tools.
+:alt: Screenshot of the set aliases to for an area action on the Tools page.
 :align: center
 ```
 
@@ -351,9 +351,9 @@ As area aliases are used by voice assistants, you could remove (and also add) al
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.set_area_aliases)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.set_area_aliases)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.set_area_aliases)
 ```
 
 ```{list-table}
@@ -417,7 +417,7 @@ data:
 Adds one or more device(s) to an area. This action will leave the other devices in the area untouched.
 
 ```{figure} ./images/areas/add_device.png
-:alt: Screenshot of the add a device to an area action in the developer tools.
+:alt: Screenshot of the add a device to an area action on the Tools page.
 :align: center
 ```
 
@@ -434,9 +434,9 @@ Adds one or more device(s) to an area. This action will leave the other devices 
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_device_to_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_device_to_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_device_to_area)
 ```
 
 ```{list-table}
@@ -473,7 +473,7 @@ That template will find the area ID of the area with the name "Living room".
 
 Not sure what the `device_id` of an your device is? There are a few ways to find it:
 
-Use this action in the developer tools, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::
@@ -518,7 +518,7 @@ data:
 Removes one or more device(s) from an area. This action will leave the other devices in the area untouched.
 
 ```{figure} ./images/areas/remove_device.png
-:alt: Screenshot of the add a device to an area action in the developer tools.
+:alt: Screenshot of the add a device to an area action on the Tools page.
 :align: center
 ```
 
@@ -535,9 +535,9 @@ Removes one or more device(s) from an area. This action will leave the other dev
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_device_from_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_device_from_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_device_from_area)
 ```
 
 ```{list-table}
@@ -564,7 +564,7 @@ While this action is area related, it does not need to know the area ID. A devic
 
 Not sure what the `device_id` of an your device is? There are a few ways to find it:
 
-Use this action in the developer tools, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::
@@ -597,7 +597,7 @@ data:
 Adds one or more entities to an area. This action will leave the other entities in the area untouched.
 
 ```{figure} ./images/areas/add_entity.png
-:alt: Screenshot of the add an entity to an area action in the developer tools.
+:alt: Screenshot of the add an entity to an area action on the Tools page.
 :align: center
 ```
 
@@ -614,9 +614,9 @@ Adds one or more entities to an area. This action will leave the other entities 
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_entity_to_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_entity_to_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_entity_to_area)
 ```
 
 ```{list-table}
@@ -688,7 +688,7 @@ data:
 Removes one or more device(s) from an area. This action will leave the other devices in the area untouched.
 
 ```{figure} ./images/areas/remove_entity.png
-:alt: Screenshot of the add a device to an area action in the developer tools.
+:alt: Screenshot of the add a device to an area action on the Tools page.
 :align: center
 ```
 
@@ -705,9 +705,9 @@ Removes one or more device(s) from an area. This action will leave the other dev
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_entity_from_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_entity_from_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_entity_from_area)
 ```
 
 ```{list-table}

--- a/documentation/devices.md
+++ b/documentation/devices.md
@@ -16,7 +16,7 @@ The following device management actions are added to your Home Assistant instanc
 This action allows you to disable a device on the fly.
 
 ```{figure} ./images/devices/disable_device.png
-:alt: Screenshot of the Home Assistant disable device action in the developer tools.
+:alt: Screenshot of the Home Assistant disable device action on the Tools page.
 :align: center
 ```
 
@@ -33,9 +33,9 @@ This action allows you to disable a device on the fly.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_device)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_device)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_device)
 ```
 
 ```{list-table}
@@ -56,7 +56,7 @@ This action allows you to disable a device on the fly.
 
 Not sure what the `device_id` of an your device is? There are a few ways to find it:
 
-Use this action in the developer tools, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::
@@ -89,7 +89,7 @@ data:
 This action allows you to enable a device on the fly.
 
 ```{figure} ./images/devices/enable_device.png
-:alt: Screenshot of the Home Assistant enable device action in the developer tools.
+:alt: Screenshot of the Home Assistant enable device action on the Tools page.
 :align: center
 ```
 
@@ -106,9 +106,9 @@ This action allows you to enable a device on the fly.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_device)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_device)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_device)
 ```
 
 ```{list-table}
@@ -129,7 +129,7 @@ This action allows you to enable a device on the fly.
 
 Not sure what the `device_id` of an your device is? There are a few ways to find it:
 
-Use this action in the developer tools, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::

--- a/documentation/devices.md
+++ b/documentation/devices.md
@@ -54,9 +54,9 @@ This action allows you to disable a device on the fly.
 :::{tip} Finding a device ID
 :class: dropdown
 
-Not sure what the `device_id` of an your device is? There are a few ways to find it:
+Not sure what the `device_id` of your device is? There are a few ways to find it:
 
-Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to disable and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::
@@ -127,9 +127,9 @@ This action allows you to enable a device on the fly.
 :::{tip} Finding a device ID
 :class: dropdown
 
-Not sure what the `device_id` of an your device is? There are a few ways to find it:
+Not sure what the `device_id` of your device is? There are a few ways to find it:
 
-Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to enable and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::

--- a/documentation/entities.md
+++ b/documentation/entities.md
@@ -16,7 +16,7 @@ The following entity management actions are added to your Home Assistant instanc
 This action allows you to disable an entity on the fly.
 
 ```{figure} ./images/entities/disable_entity.png
-:alt: Screenshot of the Home Assistant disable entity action in the developer tools.
+:alt: Screenshot of the Home Assistant disable entity action on the Tools page.
 :align: center
 ```
 
@@ -33,9 +33,9 @@ This action allows you to disable an entity on the fly.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_entity)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_entity)
 ```
 
 ```{list-table}
@@ -79,7 +79,7 @@ data:
 This action allows you to enable an entity on the fly.
 
 ```{figure} ./images/entities/enable_entity.png
-:alt: Screenshot of the Home Assistant enable entity action in the developer tools.
+:alt: Screenshot of the Home Assistant enable entity action on the Tools page.
 :align: center
 ```
 
@@ -96,9 +96,9 @@ This action allows you to enable an entity on the fly.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_entity)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_entity)
 ```
 
 ```{list-table}
@@ -145,7 +145,7 @@ It can be particularly useful when you have a lot of entities, and you want to h
 Hidden entities are not exposed to external voice assistants, like Google Assistant or Alexa, by default. They can still be exposed explicitly in the voice assistant settings.
 
 ```{figure} ./images/entities/hide_entity.png
-:alt: Screenshot of the Home Assistant hide entity action in the developer tools.
+:alt: Screenshot of the Home Assistant hide entity action on the Tools page.
 :align: center
 ```
 
@@ -162,9 +162,9 @@ Hidden entities are not exposed to external voice assistants, like Google Assist
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.hide_entity)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.hide_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.hide_entity)
 ```
 
 ```{list-table}
@@ -208,7 +208,7 @@ data:
 This action allows you to unhide an entity on the fly.
 
 ```{figure} ./images/entities/unhide_entity.png
-:alt: Screenshot of the Home Assistant unhide entity action in the developer tools.
+:alt: Screenshot of the Home Assistant unhide entity action on the Tools page.
 :align: center
 ```
 
@@ -225,9 +225,9 @@ This action allows you to unhide an entity on the fly.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.unhide_entity)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.unhide_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.unhide_entity)
 ```
 
 ```{list-table}
@@ -271,7 +271,7 @@ data:
 This action allows you to update an entity's ID on the fly.
 
 ```{figure} ./images/entities/update_entity_id.png
-:alt: Screenshot of the Home Assistant update entity ID action in the developer tools.
+:alt: Screenshot of the Home Assistant update entity ID action on the Tools page.
 :align: center
 ```
 
@@ -288,9 +288,9 @@ This action allows you to update an entity's ID on the fly.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.update_entity_id)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.update_entity_id)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.update_entity_id)
 ```
 
 ```{list-table}
@@ -334,7 +334,7 @@ Entities might have been marked orphaned because an integration is offline or no
 :::
 
 ```{figure} ./images/entities/delete_all_orphaned_entities.png
-:alt: Screenshot of the Home Assistant unhide entity action in the developer tools.
+:alt: Screenshot of the Home Assistant unhide entity action on the Tools page.
 :align: center
 ```
 
@@ -351,9 +351,9 @@ Entities might have been marked orphaned because an integration is offline or no
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_all_orphaned_entities)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_all_orphaned_entities)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_all_orphaned_entities)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -373,7 +373,7 @@ Mass clean up your database with the help of Spook by listing all orphaned datab
 Orphaned database entities are entities that are no longer claimed by integration but still exist in the database. This can happen when an integration is removed or when an entity is disabled.
 
 ```{figure} ./images/entities/list_orphaned_database_entities.png
-:alt: Screenshot of the Home Assistant list orphaned database entities action in the developer tools.
+:alt: Screenshot of the Home Assistant list orphaned database entities action on the Tools page.
 :align: center
 ```
 
@@ -390,9 +390,9 @@ Orphaned database entities are entities that are no longer claimed by integratio
   - Action response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.list_orphaned_database_entities)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.list_orphaned_database_entities)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.list_orphaned_database_entities)
 ```
 
 ```{list-table}
@@ -441,7 +441,7 @@ That template will find the area ID of the area with the name "Living room".
 This action allows you to update an entity friendly_name on the fly.
 
 ```{figure} ./images/entities/rename_entity.png
-:alt: Screenshot of the Home Assistant rename entity action in the developer tools.
+:alt: Screenshot of the Home Assistant rename entity action on the Tools page.
 :align: center
 ```
 
@@ -458,9 +458,9 @@ This action allows you to update an entity friendly_name on the fly.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.rename_entity)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.rename_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.rename_entity)
 ```
 
 ```{list-table}

--- a/documentation/entities.md
+++ b/documentation/entities.md
@@ -334,7 +334,7 @@ Entities might have been marked orphaned because an integration is offline or no
 :::
 
 ```{figure} ./images/entities/delete_all_orphaned_entities.png
-:alt: Screenshot of the Home Assistant unhide entity action on the Tools page.
+:alt: Screenshot of the Home Assistant delete all orphaned entities action on the Tools page.
 :align: center
 ```
 

--- a/documentation/floors.md
+++ b/documentation/floors.md
@@ -94,7 +94,7 @@ data:
 Delete a floor from your Home Assistant instance.
 
 ```{figure} ./images/floors/delete.png
-:alt: Screenshot of the delete flor action on the Tools page.
+:alt: Screenshot of the delete a floor action on the Tools page.
 :align: center
 ```
 
@@ -525,7 +525,7 @@ data:
 Removes one or more area(s) from a floor. This action will leave the other area on the floor untouched.
 
 ```{figure} ./images/floors/remove_area.png
-:alt: Screenshot of the add a device to an area action on the Tools page.
+:alt: Screenshot of the remove an area from a floor action on the Tools page.
 :align: center
 ```
 

--- a/documentation/floors.md
+++ b/documentation/floors.md
@@ -10,7 +10,7 @@ date: 2024-04-04T08:44:57+02:00
 Spook provides that allows you to manage and {term}`automate <automation>` the floors in Home Assistant programatically. Great for creating "dynamic" floors, or for creating floors on the fly.
 
 ```{figure} ./images/floors/example.png
-:alt: Screenshot of the developer action tools, listing the new actions to manage floors.
+:alt: Screenshot of the Actions tool, listing the new actions to manage floors.
 :align: center
 ```
 

--- a/documentation/floors.md
+++ b/documentation/floors.md
@@ -23,7 +23,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Adds a new floor to your Home Assistant instance.
 
 ```{figure} ./images/floors/create.png
-:alt: Screenshot of the create floor action in the developer tools.
+:alt: Screenshot of the create floor action on the Tools page.
 :align: center
 ```
 
@@ -40,9 +40,9 @@ Adds a new floor to your Home Assistant instance.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_floor)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_floor)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_floor)
 ```
 
 ```{list-table}
@@ -94,7 +94,7 @@ data:
 Delete a floor from your Home Assistant instance.
 
 ```{figure} ./images/floors/delete.png
-:alt: Screenshot of the delete flor action in the developer tools.
+:alt: Screenshot of the delete flor action on the Tools page.
 :align: center
 ```
 
@@ -111,9 +111,9 @@ Delete a floor from your Home Assistant instance.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_floor)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_floor)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_floor)
 ```
 
 ```{list-table}
@@ -169,7 +169,7 @@ Adds one or more aliases to an existing floor. This action does not remove exist
 As floor aliases are used by voice assistants, you could add (and also remove) aliases to a floor using {term}`automations <automation>`, which allows you to make them available/unavailable programatically.
 
 ```{figure} ./images/floors/add_alias.png
-:alt: Screenshot of the add an alias to a floor action in the developer tools.
+:alt: Screenshot of the add an alias to a floor action on the Tools page.
 :align: center
 ```
 
@@ -186,9 +186,9 @@ As floor aliases are used by voice assistants, you could add (and also remove) a
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_alias_to_floor)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_alias_to_floor)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_alias_to_floor)
 ```
 
 ```{list-table}
@@ -254,7 +254,7 @@ Removes one or more aliases from an existing floor. This action will leave the o
 As floor aliases are used by voice assistants, you could remove (and also add) aliases to a floor using {term}`automations <automation>`, which allows you to make them available/unavailable programatically.
 
 ```{figure} ./images/floors/remove_alias.png
-:alt: Screenshot of the remove an alias to a floor action in the developer tools.
+:alt: Screenshot of the remove an alias to a floor action on the Tools page.
 :align: center
 ```
 
@@ -271,9 +271,9 @@ As floor aliases are used by voice assistants, you could remove (and also add) a
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_alias_from_floor)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_alias_from_floor)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_alias_from_floor)
 ```
 
 ```{list-table}
@@ -339,7 +339,7 @@ Sets the aliases for a floor. This action will overwrite/remove all existing ali
 As floor aliases are used by voice assistants, you could remove (and also add) aliases to a floor using {term}`automations <automation>`, which allows you to make them available/unavailable programatically.
 
 ```{figure} ./images/floors/set_aliases.png
-:alt: Screenshot of the set aliases to for a floor action in the developer tools.
+:alt: Screenshot of the set aliases to for a floor action on the Tools page.
 :align: center
 ```
 
@@ -356,9 +356,9 @@ As floor aliases are used by voice assistants, you could remove (and also add) a
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.set_floor_aliases)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.set_floor_aliases)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.set_floor_aliases)
 ```
 
 ```{list-table}
@@ -422,7 +422,7 @@ data:
 Adds one or more area(s) to a floor. This action will leave the other areas on the floor untouched.
 
 ```{figure} ./images/floors/add_area.png
-:alt: Screenshot of the add an area to a floor action in the developer tools.
+:alt: Screenshot of the add an area to a floor action on the Tools page.
 :align: center
 ```
 
@@ -439,9 +439,9 @@ Adds one or more area(s) to a floor. This action will leave the other areas on t
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_area_to_floor)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_area_to_floor)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_area_to_floor)
 ```
 
 ```{list-table}
@@ -525,7 +525,7 @@ data:
 Removes one or more area(s) from a floor. This action will leave the other area on the floor untouched.
 
 ```{figure} ./images/floors/remove_area.png
-:alt: Screenshot of the add a device to an area action in the developer tools.
+:alt: Screenshot of the add a device to an area action on the Tools page.
 :align: center
 ```
 
@@ -542,9 +542,9 @@ Removes one or more area(s) from a floor. This action will leave the other area 
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_area_from_floor)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_area_from_floor)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_area_from_floor)
 ```
 
 ```{list-table}

--- a/documentation/glossary.md
+++ b/documentation/glossary.md
@@ -87,12 +87,6 @@ Dashboard
 :::
 
 :::{glossary}
-Developer tools
-: The developer tools in {term}`Home Assistant` are a set of tools that can be used to inspect, debug and play with your Home Assistant instance. It may sound very technical, but don't let that scare you. The developer tools can be used to, for example, inspect the state of {term}`entities <entity>`, experiment with {term}`performing action <performing actions>`, or test and debug your {term}`templates <template>`.
-: [Learn more in the official Home Assistant documentation](https://www.home-assistant.io/docs/tools/dev-tools/)
-:::
-
-:::{glossary}
 Device
 : A device in {term}`Home Assistant` represents a physical device in your home, but a device can also represent a web service, like one that provides weather information. Devices are a logical grouping for {term}`entities <entity>`. For example, a device that can measure temperature, humidity, and pressure will have three entities: a temperature sensor, a humidity sensor, and a pressure sensor. All three entities belong to the same device.
 : [Learn more in the official Home Assistant documentation](https://www.home-assistant.io/getting-started/concepts-terminology/#devices--entities)
@@ -300,6 +294,13 @@ Template test function
 : Test functions are a special type of {term}`template function <template function>` that can be used to check if a condition is true or false. Inside a template they use the `is` operator. For example `3 is odd` will return `True` and `3 is even` will return `False`.
 : [Learn more in the official Home Assistant documentation](https://www.home-assistant.io/docs/configuration/templating/)
 : [Learn more in the Jinja2 documentation](https://jinja.palletsprojects.com/en/3.0.x/templates/#tests)
+:::
+
+:::{glossary}
+Tools
+: The tools in {term}`Home Assistant` are a set of tools that can be used to inspect, debug and play with your Home Assistant instance. You will find them under **Settings** > **Tools**. It may sound very technical, but don't let that scare you. They can be used to, for example, inspect the state of {term}`entities <entity>`, experiment with {term}`performing action <performing actions>`, or test and debug your {term}`templates <template>`.
+: These were called the "developer tools" and lived in their own place in the sidebar until Home Assistant moved and renamed them in 2026. Plenty of guides out there still call them that.
+: [Learn more in the official Home Assistant documentation](https://www.home-assistant.io/docs/tools/dev-tools/)
 :::
 
 :::{glossary}

--- a/documentation/integrations.md
+++ b/documentation/integrations.md
@@ -16,7 +16,7 @@ The following integration management actions are added to your Home Assistant in
 Disable a single instance of an integration by its {term}`integration entry <integration entry>`.
 
 ```{figure} ./images/integration/disable_config_entry.png
-:alt: Screenshot of the Home Assistant disable config entry action in the developer tools.
+:alt: Screenshot of the Home Assistant disable config entry action on the Tools page.
 :align: center
 ```
 
@@ -33,9 +33,9 @@ Disable a single instance of an integration by its {term}`integration entry <int
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_config_entry)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_config_entry)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_config_entry)
 ```
 
 ```{list-table}
@@ -56,7 +56,7 @@ Disable a single instance of an integration by its {term}`integration entry <int
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the {term}`developer tools <developer tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the {term}`tools <tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -87,7 +87,7 @@ data:
 Enable a single instance of an integration by its {term}`integration entry <integration entry>`.
 
 ```{figure} ./images/integration/enable_config_entry.png
-:alt: Screenshot of the Home Assistant enable config entry action in the developer tools.
+:alt: Screenshot of the Home Assistant enable config entry action on the Tools page.
 :align: center
 ```
 
@@ -104,9 +104,9 @@ Enable a single instance of an integration by its {term}`integration entry <inte
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_config_entry)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_config_entry)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_config_entry)
 ```
 
 ```{list-table}
@@ -127,7 +127,7 @@ Enable a single instance of an integration by its {term}`integration entry <inte
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the {term}`developer tools <developer tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the {term}`tools <tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -160,7 +160,7 @@ Disable integration polling of a single integration instance by its {term}`integ
 Some integrations frequently poll for updates. In some cases, it can be helpful to disable this temporarily. For example, in case you are not at home and want to stop polling on an integration that consumes a paid API.
 
 ```{figure} ./images/integration/disable_polling.png
-:alt: Screenshot of the Home Assistant disable polling action in the developer tools.
+:alt: Screenshot of the Home Assistant disable polling action on the Tools page.
 :align: center
 ```
 
@@ -177,9 +177,9 @@ Some integrations frequently poll for updates. In some cases, it can be helpful 
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_polling)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_polling)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_polling)
 ```
 
 ```{list-table}
@@ -200,7 +200,7 @@ Some integrations frequently poll for updates. In some cases, it can be helpful 
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the {term}`developer tools <developer tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the {term}`tools <tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -222,7 +222,7 @@ Enable integration polling of a single integration instance by its {term}`integr
 Some integrations frequently poll for updates. In some cases, it can be helpful to enable this just temporarily. For example, in case you are not at home and want to stop polling on an integration that consumes a paid API and want to turn it back on again when you are back.
 
 ```{figure} ./images/integration/enable_polling.png
-:alt: Screenshot of the Home Assistant enable polling action in the developer tools.
+:alt: Screenshot of the Home Assistant enable polling action on the Tools page.
 :align: center
 ```
 
@@ -239,9 +239,9 @@ Some integrations frequently poll for updates. In some cases, it can be helpful 
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_polling)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_polling)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_polling)
 ```
 
 ```{list-table}
@@ -262,7 +262,7 @@ Some integrations frequently poll for updates. In some cases, it can be helpful 
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the {term}`developer tools <developer tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the {term}`tools <tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -284,7 +284,7 @@ When Home Assistant discovers new devices or services, it will show up on the in
 It also supports ignoring all discovered devices from a specific {term}`integration <integration>`. For example, if you want to ignore all discovered devices from the `bluetooth` integration, you could do that periodically with an automation.
 
 ```{figure} ./images/integration/ignore_all_discovered.png
-:alt: Screenshot of the Home Assistant enable polling action in the developer tools.
+:alt: Screenshot of the Home Assistant enable polling action on the Tools page.
 :align: center
 ```
 
@@ -301,9 +301,9 @@ It also supports ignoring all discovered devices from a specific {term}`integrat
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.ignore_all_discovered)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.ignore_all_discovered)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.ignore_all_discovered)
 ```
 
 ```{list-table}

--- a/documentation/integrations.md
+++ b/documentation/integrations.md
@@ -56,7 +56,7 @@ Disable a single instance of an integration by its {term}`integration entry <int
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the {term}`tools <tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -127,7 +127,7 @@ Enable a single instance of an integration by its {term}`integration entry <inte
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the {term}`tools <tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -200,7 +200,7 @@ Some integrations frequently poll for updates. In some cases, it can be helpful 
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the {term}`tools <tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -262,7 +262,7 @@ Some integrations frequently poll for updates. In some cases, it can be helpful 
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the {term}`tools <tools>`, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`

--- a/documentation/integrations.md
+++ b/documentation/integrations.md
@@ -56,7 +56,7 @@ Disable a single instance of an integration by its {term}`integration entry <int
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the Actions tool, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the Actions tool, in the UI select the integration you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -127,7 +127,7 @@ Enable a single instance of an integration by its {term}`integration entry <inte
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the Actions tool, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the Actions tool, in the UI select the integration you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -200,7 +200,7 @@ Some integrations frequently poll for updates. In some cases, it can be helpful 
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the Actions tool, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the Actions tool, in the UI select the integration you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -262,7 +262,7 @@ Some integrations frequently poll for updates. In some cases, it can be helpful 
 
 Not sure what the `config_entry_id` of your integration is?
 
-Use this action in the Actions tool, in the UI select the device you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
+Use this action in the Actions tool, in the UI select the integration you want to use and select the **Go to YAML mode** button. This will show you the config entry ID in the YAML code.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -284,7 +284,7 @@ When Home Assistant discovers new devices or services, it will show up on the in
 It also supports ignoring all discovered devices from a specific {term}`integration <integration>`. For example, if you want to ignore all discovered devices from the `bluetooth` integration, you could do that periodically with an automation.
 
 ```{figure} ./images/integration/ignore_all_discovered.png
-:alt: Screenshot of the Home Assistant enable polling action on the Tools page.
+:alt: Screenshot of the Home Assistant ignore all discovered devices and services action on the Tools page.
 :align: center
 ```
 

--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -53,9 +53,9 @@ Turns an automation off for a while, and turns it back on when the time is up.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.snooze)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.snooze)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.snooze)
 ```
 
 ```{list-table}
@@ -131,9 +131,9 @@ Turns an automation on for a while, and turns it back off when the time is up.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.turn_on_for)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.turn_on_for)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=automation.turn_on_for)
 ```
 
 ```{list-table}

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -21,7 +21,7 @@ They are a great way to learn how to automate your home and an inspiration for n
 
 ```{figure} ../images/integrations/blueprint/example.png
 :name: example
-:alt: Screenshot of the Blueprint import action in the developer tools.
+:alt: Screenshot of the Blueprint import action on the Tools page.
 :align: center
 
 Spook adds an action to import Blueprints directly from an URL.
@@ -108,9 +108,9 @@ Downloads and imports an automation/script blueprint, directly from the URL you 
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=blueprint.import)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=blueprint.import)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=blueprint.import)
 ```
 
 ```{list-table}

--- a/documentation/integrations/input_number.md
+++ b/documentation/integrations/input_number.md
@@ -21,7 +21,7 @@ Spook adds some new actions to the input number {term}`integration <integration>
 
 ```{figure} ../images/integrations/input_number/example.png
 :name: example
-:alt: Screenshot of the developer actions tools, listing the new actions for input number.
+:alt: Screenshot of the Actions tool, listing the new actions for input number.
 :align: center
 
 Spook adds many new actions to the input number helper integrations.

--- a/documentation/integrations/input_number.md
+++ b/documentation/integrations/input_number.md
@@ -38,7 +38,7 @@ Spook adds the following new actions to your Home Assistant instance:
 ### Create an input number
 
 ```{figure} ../images/integrations/input_number/create.png
-:alt: Screenshot of the input number create action in the developer tools.
+:alt: Screenshot of the input number create action on the Tools page.
 :align: center
 ```
 
@@ -55,9 +55,9 @@ Spook adds the following new actions to your Home Assistant instance:
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.create)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.create)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.create)
 ```
 
 ```{list-table}
@@ -129,7 +129,7 @@ Input number helpers that are created and managed using manual YAML configuratio
 :::
 
 ```{figure} ../images/integrations/input_number/delete.png
-:alt: Screenshot of the input number delete action in the developer tools.
+:alt: Screenshot of the input number delete action on the Tools page.
 :align: center
 ```
 
@@ -146,9 +146,9 @@ Input number helpers that are created and managed using manual YAML configuratio
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.delete)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.delete)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.delete)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -168,7 +168,7 @@ target:
 Decrease an input number entity value by a certain amount.
 
 ```{figure} ../images/integrations/input_number/decrease.png
-:alt: Screenshot of the input number decrease value action in the developer tools.
+:alt: Screenshot of the input number decrease value action on the Tools page.
 :align: center
 ```
 
@@ -185,9 +185,9 @@ Decrease an input number entity value by a certain amount.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Adds an amount to decrement the value with
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.decrement)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.decrement)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.decrement)
 ```
 
 ```{list-table}
@@ -224,7 +224,7 @@ data:
 Increase an input number entity value by a certain amount.
 
 ```{figure} ../images/integrations/input_number/increase.png
-:alt: Screenshot of the input number increase value action in the developer tools.
+:alt: Screenshot of the input number increase value action on the Tools page.
 :align: center
 ```
 
@@ -241,9 +241,9 @@ Increase an input number entity value by a certain amount.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Adds an amount to increment the value with
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.increment)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.increment)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.increment)
 ```
 
 ```{list-table}
@@ -280,7 +280,7 @@ data:
 Set an input number entity to its maximum value.
 
 ```{figure} ../images/integrations/input_number/maximum.png
-:alt: Screenshot of the input number maximum value action in the developer tools.
+:alt: Screenshot of the input number maximum value action on the Tools page.
 :align: center
 ```
 
@@ -297,9 +297,9 @@ Set an input number entity to its maximum value.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.max)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.max)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.max)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -319,7 +319,7 @@ target:
 Set an input number entity to its minimum value.
 
 ```{figure} ../images/integrations/input_number/minimum.png
-:alt: Screenshot of the input number minimum value action in the developer tools.
+:alt: Screenshot of the input number minimum value action on the Tools page.
 :align: center
 ```
 
@@ -336,9 +336,9 @@ Set an input number entity to its minimum value.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.min)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.min)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.min)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`

--- a/documentation/integrations/input_select.md
+++ b/documentation/integrations/input_select.md
@@ -40,7 +40,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Select a random option from the list of options in the input select.
 
 ```{figure} ../images/integrations/input_select/random.png
-:alt: Screenshot of the input select random action in the developer tools.
+:alt: Screenshot of the input select random action on the Tools page.
 :align: center
 ```
 
@@ -57,9 +57,9 @@ Select a random option from the list of options in the input select.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.random)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.random)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.random)
 ```
 
 ```{list-table}
@@ -107,7 +107,7 @@ Shuffles the list of available options in the input select and keeps the current
 select options selected.
 
 ```{figure} ../images/integrations/input_select/shuffle.png
-:alt: Screenshot of the input select shuffle action in the developer tools.
+:alt: Screenshot of the input select shuffle action on the Tools page.
 :align: center
 ```
 
@@ -124,9 +124,9 @@ select options selected.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.shuffle)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.shuffle)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.shuffle)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -151,7 +151,7 @@ Sorts the list of available options in the input select and keeps the current
 select options selected.
 
 ```{figure} ../images/integrations/input_select/sort.png
-:alt: Screenshot of the input select sort action in the developer tools.
+:alt: Screenshot of the input select sort action on the Tools page.
 :align: center
 ```
 
@@ -168,9 +168,9 @@ select options selected.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.sort)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.sort)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=input_select.sort)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`

--- a/documentation/integrations/input_select.md
+++ b/documentation/integrations/input_select.md
@@ -21,7 +21,7 @@ Spook adds some new actions to the input select {term}`integration <integration>
 
 ```{figure} ../images/integrations/input_select/example.png
 :name: example
-:alt: Screenshot of the developer actions tools, listing the new actions for input select.
+:alt: Screenshot of the Actions tool, listing the new actions for input select.
 :align: center
 
 Spook adds a bunch of new actions to the input select helper integrations.

--- a/documentation/integrations/light.md
+++ b/documentation/integrations/light.md
@@ -45,9 +45,9 @@ Set the brightness of the lights that are already on.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_brightness)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_brightness)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_brightness)
 ```
 
 ```{list-table}
@@ -101,9 +101,9 @@ Turn up the lights that are already on.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.increase_brightness)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.increase_brightness)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.increase_brightness)
 ```
 
 ```{list-table}
@@ -156,9 +156,9 @@ Turn down the lights that are already on, stopping at the dimmest they go.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.decrease_brightness)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.decrease_brightness)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.decrease_brightness)
 ```
 
 ```{list-table}
@@ -209,9 +209,9 @@ Set the color of the lights that are already on. Lights that cannot do color are
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color)
 ```
 
 ```{list-table}
@@ -262,9 +262,9 @@ Set the color temperature of the lights that are already on, each within the ran
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color_temperature)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color_temperature)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_color_temperature)
 ```
 
 ```{list-table}
@@ -316,9 +316,9 @@ Set an effect on the lights that are already on and actually have it. Effect nam
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_effect)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_effect)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=light.set_effect)
 ```
 
 ```{list-table}

--- a/documentation/integrations/number.md
+++ b/documentation/integrations/number.md
@@ -40,7 +40,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Decrease a number entity value by a certain amount.
 
 ```{figure} ../images/integrations/number/decrease.png
-:alt: Screenshot of the number decrease value action in the developer tools.
+:alt: Screenshot of the number decrease value action on the Tools page.
 :align: center
 ```
 
@@ -57,9 +57,9 @@ Decrease a number entity value by a certain amount.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=number.decrement)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=number.decrement)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=number.decrement)
 ```
 
 ```{list-table}
@@ -96,7 +96,7 @@ data:
 Increase a number entity value by a certain amount.
 
 ```{figure} ../images/integrations/number/increase.png
-:alt: Screenshot of the number increase value action in the developer tools.
+:alt: Screenshot of the number increase value action on the Tools page.
 :align: center
 ```
 
@@ -113,9 +113,9 @@ Increase a number entity value by a certain amount.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=number.increment)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=number.increment)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=number.increment)
 ```
 
 ```{list-table}
@@ -152,7 +152,7 @@ data:
 Set an number entity to its maximum value.
 
 ```{figure} ../images/integrations/number/maximum.png
-:alt: Screenshot of the number maximum value action in the developer tools.
+:alt: Screenshot of the number maximum value action on the Tools page.
 :align: center
 ```
 
@@ -169,9 +169,9 @@ Set an number entity to its maximum value.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=number.max)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=number.max)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=number.max)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -191,7 +191,7 @@ target:
 Set an number entity to its minimum value.
 
 ```{figure} ../images/integrations/number/minimum.png
-:alt: Screenshot of the number minimum value action in the developer tools.
+:alt: Screenshot of the number minimum value action on the Tools page.
 :align: center
 ```
 
@@ -208,9 +208,9 @@ Set an number entity to its minimum value.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=number.min)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=number.min)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=number.min)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`

--- a/documentation/integrations/number.md
+++ b/documentation/integrations/number.md
@@ -21,7 +21,7 @@ Spook adds some new actions to the number {term}`integration <integration>`, whi
 
 ```{figure} ../images/integrations/number/example.png
 :name: example
-:alt: Screenshot of the developer actions tools, listing the new actions for number.
+:alt: Screenshot of the Actions tool, listing the new actions for number.
 :align: center
 
 Spook adds a bunch of new actions to the number helper integrations.

--- a/documentation/integrations/person.md
+++ b/documentation/integrations/person.md
@@ -21,7 +21,7 @@ Spook adds some new actions to the person {term}`integration <integration>`, tha
 
 ```{figure} ../images/integrations/person/example.png
 :name: example
-:alt: Screenshot of the developer actions tools, listing the new actions for persons.
+:alt: Screenshot of the Actions tool, listing the new actions for persons.
 :align: center
 
 Spook adds some new actions to the person integration.

--- a/documentation/integrations/person.md
+++ b/documentation/integrations/person.md
@@ -40,7 +40,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Adds a device tracker to a person.
 
 ```{figure} ../images/integrations/person/add_device_tracker.png
-:alt: Screenshot of the person add device tracker action in the developer tools.
+:alt: Screenshot of the person add device tracker action on the Tools page.
 :align: center
 ```
 
@@ -57,9 +57,9 @@ Adds a device tracker to a person.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=person.add_device_tracker)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=person.add_device_tracker)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=person.add_device_tracker)
 ```
 
 ```{list-table}
@@ -109,7 +109,7 @@ data:
 Removes a device tracker from a person.
 
 ```{figure} ../images/integrations/person/remove_device_tracker.png
-:alt: Screenshot of the person remove device tracker action in the developer tools.
+:alt: Screenshot of the person remove device tracker action on the Tools page.
 :align: center
 ```
 
@@ -126,9 +126,9 @@ Removes a device tracker from a person.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=person.remove_device_tracker)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=person.remove_device_tracker)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=person.remove_device_tracker)
 ```
 
 ```{list-table}

--- a/documentation/integrations/recorder.md
+++ b/documentation/integrations/recorder.md
@@ -19,7 +19,7 @@ The recorder {term}`integration <integration>` in {term}`Home Assistant` is resp
 
 ```{figure} ../images/integrations/recorder/example.png
 :name: example
-:alt: Screenshot of the recorder import statistics action in the developer tools.
+:alt: Screenshot of the recorder import statistics action on the Tools page.
 :align: center
 
 Spook adds an action that allows importing data into the recorder.
@@ -38,7 +38,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Manually import long-term statistics into the recorder database of Home Assistant.
 
 ```{figure} ../images/integrations/recorder/import.png
-:alt: Screenshot of the recorder import statistics action in the developer tools.
+:alt: Screenshot of the recorder import statistics action on the Tools page.
 :align: center
 ```
 
@@ -55,9 +55,9 @@ Manually import long-term statistics into the recorder database of Home Assistan
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=recorder.import_statistics)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=recorder.import_statistics)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=recorder.import_statistics)
 ```
 
 ```{list-table}
@@ -158,7 +158,7 @@ The recorder keeps long-term statistics separately from the states it records, a
 
 These are not harmful, but they are not free either: they take up database space, and they keep showing up in pickers and graphs long after the sensor they belonged to is gone.
 
-To resolve the raised issue, open {term}`Developer tools` > Statistics and fix them there. Spook will automatically remove the repair issue once the issue is fixed.
+To resolve the raised issue, open {term}`Tools` > Statistics and fix them there. Spook will automatically remove the repair issue once the issue is fixed.
 
 ## Use cases
 

--- a/documentation/integrations/recorder.md
+++ b/documentation/integrations/recorder.md
@@ -158,7 +158,7 @@ The recorder keeps long-term statistics separately from the states it records, a
 
 These are not harmful, but they are not free either: they take up database space, and they keep showing up in pickers and graphs long after the sensor they belonged to is gone.
 
-To resolve the raised issue, open {term}`Tools` > Statistics and fix them there. Spook will automatically remove the repair issue once the issue is fixed.
+To resolve the raised issue, open **Settings** > {term}`Tools` > **Statistics** and fix them there. Spook will automatically remove the repair issue once the issue is fixed.
 
 ## Use cases
 

--- a/documentation/integrations/repairs.md
+++ b/documentation/integrations/repairs.md
@@ -23,7 +23,7 @@ Spook enhances the integration by providing actions that allow you to raise and 
 
 ```{figure} ../images/integrations/repairs/example.png
 :name: example
-:alt: Screenshot of the repairs actions Spook adds to Home Assistant, taken from the developer tools.
+:alt: Screenshot of the repairs actions Spook adds to Home Assistant, taken from the Tools page.
 :align: center
 
 Spook adds many new actions to the repairs integration so that you can create your own.
@@ -97,7 +97,7 @@ to raise low battery reports for your devices or to raise an issue when
 a device becomes unreachable.
 
 ```{figure} ../images/integrations/repairs/create.png
-:alt: Screenshot of the repairs create issue action in the developer tools.
+:alt: Screenshot of the repairs create issue action on the Tools page.
 :align: center
 ```
 
@@ -119,9 +119,9 @@ a device becomes unreachable.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.create)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.create)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.create)
 ```
 
 ```{list-table}
@@ -183,7 +183,7 @@ data:
 Adds a single action to ignore all issues currently raised in the repairs dashboard.
 
 ```{figure} ../images/integrations/repairs/ignore_all.png
-:alt: Screenshot of the repairs ignore all issues action in the developer tools.
+:alt: Screenshot of the repairs ignore all issues action on the Tools page.
 :align: center
 ```
 
@@ -200,9 +200,9 @@ Adds a single action to ignore all issues currently raised in the repairs dashbo
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.ignore_all)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.ignore_all)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.ignore_all)
 ```
 
 :::{tip}
@@ -226,7 +226,7 @@ action: repairs.ignore_all
 Remove an issue from the repairs integration.
 
 ```{figure} ../images/integrations/repairs/remove.png
-:alt: Screenshot of the repairs remove issue action in the developer tools.
+:alt: Screenshot of the repairs remove issue action on the Tools page.
 :align: center
 ```
 
@@ -243,9 +243,9 @@ Remove an issue from the repairs integration.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.remove)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.remove)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.remove)
 ```
 
 ```{list-table}
@@ -283,7 +283,7 @@ data:
 Adds a single action to unignore all repair issues currently still active (but previously ignored).
 
 ```{figure} ../images/integrations/repairs/unignore_all.png
-:alt: Screenshot of the repairs unignore all issues action in the developer tools.
+:alt: Screenshot of the repairs unignore all issues action on the Tools page.
 :align: center
 ```
 
@@ -300,9 +300,9 @@ Adds a single action to unignore all repair issues currently still active (but p
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.unignore_all)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.unignore_all)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=repairs.unignore_all)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`

--- a/documentation/integrations/select.md
+++ b/documentation/integrations/select.md
@@ -40,7 +40,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Select a random option from the list of options in the input select.
 
 ```{figure} ../images/integrations/select/example.png
-:alt: Screenshot of the select random action in the developer tools.
+:alt: Screenshot of the select random action on the Tools page.
 :align: center
 ```
 
@@ -57,9 +57,9 @@ Select a random option from the list of options in the input select.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=select.random)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=select.random)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=select.random)
 ```
 
 ```{list-table}

--- a/documentation/integrations/select.md
+++ b/documentation/integrations/select.md
@@ -21,7 +21,7 @@ Spook extends the select integration with an option to select a random option fr
 
 ```{figure} ../images/integrations/select/example.png
 :name: example
-:alt: Screenshot of the developer actions tools, showing the new random actions for select.
+:alt: Screenshot of the Actions tool, showing the new random actions for select.
 :align: center
 
 Spook adds a new random select action to the select integration.

--- a/documentation/integrations/timer.md
+++ b/documentation/integrations/timer.md
@@ -43,9 +43,9 @@ Set the duration for a timer entity.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=timer.set_duration)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=timer.set_duration)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=timer.set_duration)
 ```
 
 ```{list-table}

--- a/documentation/integrations/zone.md
+++ b/documentation/integrations/zone.md
@@ -21,7 +21,7 @@ Spook adds new actions to the zone integrations that allow you to manage and mod
 
 ```{figure} ../images/integrations/zone/example.png
 :name: example
-:alt: Screenshot of the recorder import statistics action in the developer tools.
+:alt: Screenshot of the recorder import statistics action on the Tools page.
 :align: center
 
 Spook adds an action that allows importing data into the recorder.
@@ -40,7 +40,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Adds a new zone to your Home Assistant instance.
 
 ```{figure} ../images/integrations/zone/create.png
-:alt: Screenshot of the zone create action in the developer tools.
+:alt: Screenshot of the zone create action on the Tools page.
 :align: center
 ```
 
@@ -57,9 +57,9 @@ Adds a new zone to your Home Assistant instance.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.create)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.create)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.create)
 ```
 
 ```{list-table}
@@ -118,7 +118,7 @@ Zones that are created and managed using manual YAML configuration cannot be upd
 :::
 
 ```{figure} ../images/integrations/zone/update.png
-:alt: Screenshot of the zone update action in the developer tools.
+:alt: Screenshot of the zone update action on the Tools page.
 :align: center
 ```
 
@@ -135,9 +135,9 @@ Zones that are created and managed using manual YAML configuration cannot be upd
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.update)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.update)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.update)
 ```
 
 ```{list-table}
@@ -198,7 +198,7 @@ Zones that are created and managed using manual YAML configuration cannot be del
 :::
 
 ```{figure} ../images/integrations/zone/delete.png
-:alt: Screenshot of the zone delete action in the developer tools.
+:alt: Screenshot of the zone delete action on the Tools page.
 :align: center
 ```
 
@@ -215,9 +215,9 @@ Zones that are created and managed using manual YAML configuration cannot be del
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.delete)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.delete)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.delete)
 ```
 
 ```{list-table}

--- a/documentation/labels.md
+++ b/documentation/labels.md
@@ -23,7 +23,7 @@ Spook adds the following new actions to your Home Assistant instance:
 Adds a new label to your Home Assistant instance.
 
 ```{figure} ./images/labels/create.png
-:alt: Screenshot of the create label action in the developer tools.
+:alt: Screenshot of the create label action on the Tools page.
 :align: center
 ```
 
@@ -40,9 +40,9 @@ Adds a new label to your Home Assistant instance.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_label)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_label)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_label)
 ```
 
 ```{list-table}
@@ -90,7 +90,7 @@ data:
 Delete a new label to your Home Assistant instance.
 
 ```{figure} ./images/labels/delete.png
-:alt: Screenshot of the delete label action in the developer tools.
+:alt: Screenshot of the delete label action on the Tools page.
 :align: center
 ```
 
@@ -107,9 +107,9 @@ Delete a new label to your Home Assistant instance.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_label)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_label)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.delete_label)
 ```
 
 ```{list-table}
@@ -163,7 +163,7 @@ data:
 Adds one or more labels(s) to an area.
 
 ```{figure} ./images/labels/add_to_area.png
-:alt: Screenshot of the add a label to an area action in the developer tools.
+:alt: Screenshot of the add a label to an area action on the Tools page.
 :align: center
 ```
 
@@ -180,9 +180,9 @@ Adds one or more labels(s) to an area.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_area)
 ```
 
 ```{list-table}
@@ -269,7 +269,7 @@ data:
 Removes one or more label(s) from an area.
 
 ```{figure} ./images/labels/remove_from_area.png
-:alt: Screenshot of the remove a label from an area action in the developer tools.
+:alt: Screenshot of the remove a label from an area action on the Tools page.
 :align: center
 ```
 
@@ -286,9 +286,9 @@ Removes one or more label(s) from an area.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_area)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_area)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_area)
 ```
 
 ```{list-table}
@@ -375,7 +375,7 @@ data:
 Adds one or more labels(s) to a device.
 
 ```{figure} ./images/labels/add_to_device.png
-:alt: Screenshot of the add a label to a device action in the developer tools.
+:alt: Screenshot of the add a label to a device action on the Tools page.
 :align: center
 ```
 
@@ -392,9 +392,9 @@ Adds one or more labels(s) to a device.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_device)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_device)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_device)
 ```
 
 ```{list-table}
@@ -431,7 +431,7 @@ That template will find the label ID of the label with the name "Battery powered
 
 Not sure what the `device_id` of an your device is? There are a few ways to find it:
 
-Use this action in the developer tools, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::
@@ -479,7 +479,7 @@ data:
 Removes one or more label(s) from a device.
 
 ```{figure} ./images/labels/remove_from_device.png
-:alt: Screenshot of the remove a label from a device action in the developer tools.
+:alt: Screenshot of the remove a label from a device action on the Tools page.
 :align: center
 ```
 
@@ -496,9 +496,9 @@ Removes one or more label(s) from a device.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_device)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_device)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_device)
 ```
 
 ```{list-table}
@@ -535,7 +535,7 @@ That template will find the label ID of the label with the name "Battery powered
 
 Not sure what the `device_id` of an your device is? There are a few ways to find it:
 
-Use this action in the developer tools, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::
@@ -583,7 +583,7 @@ data:
 Adds one or more labels(s) to an entity.
 
 ```{figure} ./images/labels/add_to_entity.png
-:alt: Screenshot of the add a label to an entity action in the developer tools.
+:alt: Screenshot of the add a label to an entity action on the Tools page.
 :align: center
 ```
 
@@ -600,9 +600,9 @@ Adds one or more labels(s) to an entity.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_entity)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.add_label_to_entity)
 ```
 
 ```{list-table}
@@ -677,7 +677,7 @@ data:
 Removes one or more label(s) from an entity.
 
 ```{figure} ./images/labels/remove_from_entity.png
-:alt: Screenshot of the remove a label from an entity action in the developer tools.
+:alt: Screenshot of the remove a label from an entity action on the Tools page.
 :align: center
 ```
 
@@ -694,9 +694,9 @@ Removes one or more label(s) from an entity.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_entity)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_label_from_entity)
 ```
 
 ```{list-table}

--- a/documentation/labels.md
+++ b/documentation/labels.md
@@ -10,7 +10,7 @@ date: 2024-04-04T08:50:07+02:00
 Spook provides that allows you to manage and {term}`automate <automation>` the areas in Home Assistant programatically. Great for creating "dynamic" labels, or for creating labels on the fly.
 
 ```{figure} ./images/labels/example.png
-:alt: Screenshot of the developer actions tools, listing the new actions to manage labels.
+:alt: Screenshot of the Actions tool, listing the new actions to manage labels.
 :align: center
 ```
 

--- a/documentation/labels.md
+++ b/documentation/labels.md
@@ -429,7 +429,7 @@ That template will find the label ID of the label with the name "Battery powered
 :::{tip} Finding a device ID
 :class: dropdown
 
-Not sure what the `device_id` of an your device is? There are a few ways to find it:
+Not sure what the `device_id` of your device is? There are a few ways to find it:
 
 Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
@@ -533,9 +533,9 @@ That template will find the label ID of the label with the name "Battery powered
 :::{tip} Finding a device ID
 :class: dropdown
 
-Not sure what the `device_id` of an your device is? There are a few ways to find it:
+Not sure what the `device_id` of your device is? There are a few ways to find it:
 
-Use this action in the Actions tool, in the UI select the device you want to add and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
+Use this action in the Actions tool, in the UI select the device you want to remove the label from and select the **Go to YAML mode** button. This will show you the device ID in the YAML code.
 
 Alternatively, you can visit the device page in the UI and look at the URL. The device ID is the last part of the URL, and will look something like this: `dc23e666e6100f184e642a0ac345d3eb`.
 :::

--- a/documentation/misc.md
+++ b/documentation/misc.md
@@ -23,7 +23,7 @@ integrations. It is recommended to use this action only when necessary.
 :::
 
 ```{figure} ./images/misc/restart.png
-:alt: Screenshot of the Home Assistant restart action in the developer tools.
+:alt: Screenshot of the Home Assistant restart action on the Tools page.
 :align: center
 ```
 
@@ -40,9 +40,9 @@ integrations. It is recommended to use this action only when necessary.
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Extends the existing restart action with a "force" option.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.restart)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.restart)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.restart)
 ```
 
 ```{list-table}

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -19,7 +19,7 @@ Spook offers the following useless actions:
 This acti will just always scare Home Assistant, causing this action call to fail. Calling this action in any of your automations will thus cause your automation to stop and error.
 
 ```{figure} ./images/spook/boo.png
-:alt: Screenshot of the Spook Boo! action in the developer tools.
+:alt: Screenshot of the Spook Boo! action on the Tools page.
 :align: center
 ```
 
@@ -36,9 +36,9 @@ This acti will just always scare Home Assistant, causing this action call to fai
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.boo)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.boo)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.boo)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -58,7 +58,7 @@ action: homeassistant.boo
 This action call will randomly fail (and thus randomly stop your automation or script).
 
 ```{figure} ./images/spook/random_fail.png
-:alt: Screenshot of the Spook random fail action in the developer tools.
+:alt: Screenshot of the Spook random fail action on the Tools page.
 :align: center
 ```
 
@@ -75,9 +75,9 @@ This action call will randomly fail (and thus randomly stop your automation or s
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.random_fail)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.random_fail)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.random_fail)
 ```
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
@@ -109,9 +109,9 @@ Waits until a condition is true, and carries on straight away if it already is.
   - Optional response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.wait_for_condition)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.wait_for_condition)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=spook.wait_for_condition)
 ```
 
 ```{list-table}
@@ -178,7 +178,7 @@ Give up after five minutes, and do something else about it:
 :::{attention} Known limitations
 :class: dropdown
 
-- A template has to still be a template, which rules out the placement you would normally use. A script or automation renders every template in the action data before calling the action, so `{{ is_state(...) }}` arrives as the `true` or `false` it happened to be at that moment, and a constant can never turn; that is refused rather than quietly waited on forever. What can be seen from here is whether any Jinja is left, not where the value came from, so a literal `value_template: true` in a direct call is refused too: by the time it arrives the two are the same thing. A template that still has its Jinja, from the API or the developer tools, is watched like any other condition. Inside a script, wait on a template with `wait_template`, which is what that is for.
+- A template has to still be a template, which rules out the placement you would normally use. A script or automation renders every template in the action data before calling the action, so `{{ is_state(...) }}` arrives as the `true` or `false` it happened to be at that moment, and a constant can never turn; that is refused rather than quietly waited on forever. What can be seen from here is whether any Jinja is left, not where the value came from, so a literal `value_template: true` in a direct call is refused too: by the time it arrives the two are the same thing. A template that still has its Jinja, from the API or the Actions tool, is watched like any other condition. Inside a script, wait on a template with `wait_template`, which is what that is for.
 - A condition that asks about the run it is in cannot be watched either, and is refused for the same reason: `trigger`, and Spook's own `cooldown`, `quota`, `triggered_by_user`, `not_triggered_by_user` and `triggered_by_automation`. An action call is not a trigger, so their answer would not mean anything.
 - The condition is checked again every 30 seconds regardless of anything happening, so the wait can end up to half a minute late. That polling pass is what covers the turns that arrive without a state change: a plain time or sun condition, a `state` condition whose `for:` runs out, a `time` condition whose moment passes. A condition that turns true and false again inside those 30 seconds is missed entirely.
 - Without a `timeout` it waits for as long as the script runs. Stopping the automation or script stops the wait with it. A `timeout` of zero means look now and do not wait, so it answers `completed: false` unless the condition is already true.

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -44,9 +44,9 @@ Spook reveals himself on each of the action he added or enriched, so you can eas
 On each action Spook added or enriched, he reveals himself 👻.
 ```
 
-If you like to explore all available actions Spook provides and play with them from the comfort of your Home Assistant instance, you can use the {term}`My Home Assistant` button below to open your Home Assistant instance and show your actions {term}`developer tools <developer tools>`. Scroll through the list of actions available and you will notice Spook being there.
+If you like to explore all available actions Spook provides and play with them from the comfort of your Home Assistant instance, you can use the {term}`My Home Assistant` button below to open your Home Assistant instance and show your actions {term}`tools <tools>`. Scroll through the list of actions available and you will notice Spook being there.
 
-[![Open your Home Assistant instance and show your actions developer tools.](https://my.home-assistant.io/badges/developer_services.svg)](https://my.home-assistant.io/redirect/developer_services/)
+[![Open your Home Assistant instance and show the Actions tool.](https://my.home-assistant.io/badges/developer_services.svg)](https://my.home-assistant.io/redirect/developer_services/)
 
 Alternatively, take a look at our [actions reference page](actions) to get an instant overview of all actions provided by Spook.
 

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -44,7 +44,7 @@ Spook reveals himself on each of the action he added or enriched, so you can eas
 On each action Spook added or enriched, he reveals himself 👻.
 ```
 
-If you like to explore all available actions Spook provides and play with them from the comfort of your Home Assistant instance, you can use the {term}`My Home Assistant` button below to open your Home Assistant instance and show your actions {term}`tools <tools>`. Scroll through the list of actions available and you will notice Spook being there.
+If you like to explore all available actions Spook provides and play with them from the comfort of your Home Assistant instance, you can use the {term}`My Home Assistant` button below to open your Home Assistant instance and show the actions on the {term}`Tools <tools>` page. Scroll through the list of actions available and you will notice Spook being there.
 
 [![Open your Home Assistant instance and show the Actions tool.](https://my.home-assistant.io/badges/developer_services.svg)](https://my.home-assistant.io/redirect/developer_services/)
 

--- a/documentation/users.md
+++ b/documentation/users.md
@@ -28,9 +28,9 @@ This action allows you to disable a user account on the fly, preventing them fro
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_user)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_user)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_user)
 ```
 
 ```{list-table}
@@ -51,7 +51,7 @@ This action allows you to disable a user account on the fly, preventing them fro
 
 Not sure what the `user_id` of a user is? You can find it in the Home Assistant UI by going to **Settings** → **People** → selecting the person → clicking on the **User** tab. The user ID is displayed on that page.
 
-Alternatively, you can use the **Developer Tools** → **Template** tab and use the following template to list all user IDs:
+Alternatively, you can use **Settings** > **Tools** > **Template** and use the following template to list all user IDs:
 
 ```{code-block} yaml
 {% for state in states.person %}
@@ -103,9 +103,9 @@ This action allows you to enable a user account on the fly, allowing them to log
   - No response
 * - {term}`Spook's influence <influence of spook>`
   - Newly added action.
-* - {term}`Developer tools`
+* - {term}`Tools`
   - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_user)
-    [![Open your Home Assistant instance and show your actions developer tools with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_user)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_user)
 ```
 
 ```{list-table}

--- a/tests/test_retired_names.py
+++ b/tests/test_retired_names.py
@@ -21,7 +21,9 @@ ROOT = pathlib.Path(__file__).parents[1]
 SPOOK = ROOT / "custom_components" / "spook"
 DOCUMENTATION = ROOT / "documentation"
 
-_RETIRED = re.compile(r"developer[ _-]?tools", re.IGNORECASE)
+# Deliberately loose about what sits between the two words. Eight captions
+# said "developer actions tools", which a tighter matcher walked past.
+_RETIRED = re.compile(r"developer(?:[ _-]\w+)?[ _-]?tools", re.IGNORECASE)
 
 # What people will still find in older guides, said once in each place so that
 # the rename is explained rather than silently applied.
@@ -33,9 +35,9 @@ _DELIBERATE = (
     "That page was called Developer Tools and sat in",
 )
 
-# My Home Assistant redirect names. These are identifiers in somebody else's
-# API, not prose, and they have not been renamed.
-_NOT_OURS = re.compile(r"my\.home-assistant\.io/redirect/[a-z_]+")
+# My Home Assistant redirect and badge names. These are identifiers in
+# somebody else's API, not prose, and they have not been renamed.
+_NOT_OURS = re.compile(r"my\.home-assistant\.io/(?:redirect|badges)/[a-z_]+")
 
 
 def _lines_naming_it() -> list[str]:
@@ -45,6 +47,9 @@ def _lines_naming_it() -> list[str]:
         *DOCUMENTATION.rglob("*.md"),
         *SPOOK.rglob("*.py"),
         *SPOOK.rglob("*.json"),
+        # The action, trigger and condition descriptors are read by people in
+        # the UI as much as anything else here is.
+        *SPOOK.rglob("*.yaml"),
     ]:
         if "_build" in str(path):
             continue

--- a/tests/test_retired_names.py
+++ b/tests/test_retired_names.py
@@ -54,12 +54,15 @@ def _lines_naming_it() -> list[str]:
         if "_build" in str(path):
             continue
         for number, line in enumerate(path.read_text().splitlines(), start=1):
+            # Cut the allowed phrases out rather than passing over the whole
+            # line that carries one. A line is allowed to explain the rename
+            # once, not to become somewhere the old name can be hidden.
             stripped = _NOT_OURS.sub("", line)
-            if not _RETIRED.search(stripped):
-                continue
-            if any(allowed in line for allowed in _DELIBERATE):
-                continue
-            found.append(f"{path.relative_to(ROOT)}:{number}")
+            for allowed in _DELIBERATE:
+                stripped = stripped.replace(allowed, "")
+
+            if _RETIRED.search(stripped):
+                found.append(f"{path.relative_to(ROOT)}:{number}")
     return found
 
 

--- a/tests/test_retired_names.py
+++ b/tests/test_retired_names.py
@@ -1,0 +1,79 @@
+"""Home Assistant renamed Developer Tools, so Spook stops calling it that.
+
+It is `Settings` > `Tools` now, and the frontend has no "Developer tools"
+string left at all. Spook said the old name in a repair, in a glossary term,
+and in eighty-five places across the documentation that linked to that term.
+Reported as #1526, against the one place the reporter happened to look.
+
+Two mentions survive on purpose, both saying what the thing used to be called
+so that somebody following an older guide can tell they are in the right place.
+They are spelled out here rather than matched loosely, so editing one is a
+decision somebody makes rather than a hole that widens on its own.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).parents[1]
+SPOOK = ROOT / "custom_components" / "spook"
+DOCUMENTATION = ROOT / "documentation"
+
+_RETIRED = re.compile(r"developer[ _-]?tools", re.IGNORECASE)
+
+# What people will still find in older guides, said once in each place so that
+# the rename is explained rather than silently applied.
+_DELIBERATE = (
+    (
+        'These were called the "developer tools" and lived in their own place in '
+        "the sidebar until Home Assistant moved and renamed them in 2026."
+    ),
+    "That page was called Developer Tools and sat in",
+)
+
+# My Home Assistant redirect names. These are identifiers in somebody else's
+# API, not prose, and they have not been renamed.
+_NOT_OURS = re.compile(r"my\.home-assistant\.io/redirect/[a-z_]+")
+
+
+def _lines_naming_it() -> list[str]:
+    """Return every line still calling it that, minus the ones allowed above."""
+    found = []
+    for path in [
+        *DOCUMENTATION.rglob("*.md"),
+        *SPOOK.rglob("*.py"),
+        *SPOOK.rglob("*.json"),
+    ]:
+        if "_build" in str(path):
+            continue
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            stripped = _NOT_OURS.sub("", line)
+            if not _RETIRED.search(stripped):
+                continue
+            if any(allowed in line for allowed in _DELIBERATE):
+                continue
+            found.append(f"{path.relative_to(ROOT)}:{number}")
+    return found
+
+
+def test_the_deliberate_mentions_are_still_there() -> None:
+    """Otherwise the check below passes by having nothing to allow."""
+    everything = "\n".join(
+        p.read_text()
+        for p in [*DOCUMENTATION.rglob("*.md"), *SPOOK.rglob("*.py")]
+        if "_build" not in str(p)
+    )
+
+    for allowed in _DELIBERATE:
+        assert allowed in everything, (
+            f"the note explaining the rename is gone: {allowed!r}"
+        )
+
+
+def test_nothing_calls_it_developer_tools_any_more() -> None:
+    """It is Settings > Tools, and has been since Home Assistant moved it."""
+    naming_it = _lines_naming_it()
+
+    assert not naming_it, "these still call it Developer Tools: " + ", ".join(naming_it)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Home Assistant moved Developer Tools in 2026. It is a card on the Settings dashboard called Tools now, and the frontend has no "Developer tools" string left in it at all:

```
ui.panel.config.dashboard.tools.main        = "Tools"
ui.panel.config.tools.tabs.statistics.title = "Statistics"
```

The orphaned statistics repair was still sending people to the old place. @ferreto1978 spotted it there, which is a sentence I touched only this morning for a different reason (#1510, an action that does not exist), so it is fair enough that the rest of it did not get a second look.

### Not just the sentence that was reported

The old name was in the glossary, in eighty-five documentation references pointing at that glossary term, in sixty-nine screenshot captions and in eighty My Home Assistant badge labels. Fixing only the one place somebody happened to look means this gets reported again next week about a different page.

So the glossary term is renamed and moved into the T section where it now sorts, every reference follows it, the captions say the Tools page, and the badge labels name the Actions tool.

The redirect URLs behind those badges are left exactly as they are. `my.home-assistant.io/redirect/developer_call_service` and the other 230 of them are identifiers in somebody else's API, not prose.

Two mentions of the old name stay on purpose, one in the glossary and one in the repair's docstring, both saying what the thing used to be called. Anybody following a guide written last year needs to know they are in the right place.

### The other languages need nothing

#1513 already dropped this description from all thirteen of them, so they fall back to the English string and pick this up along with it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1526.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

The rename was checked against the frontend's own translations before touching anything, rather than taken from the report.

There is a test, because eighty-five references drifting back one page at a time is exactly how this returns. It fails on a new mention anywhere in the documentation or the component, and it fails just as loudly if the two notes explaining the rename are deleted, since an allowance nobody is watching is how a check like that turns into a hole.

| | |
| --- | --- |
| control | 2 passed |
| one documentation page drifts back to the old name | 1 failed |
| the note explaining the rename is deleted | 1 failed |

Full suite 1403 passed, twice. All 66 translation files parse and still agree with `en.json` on placeholders. pylint clean, ruff clean, pre-commit clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
