### PR TITLE
Add an action to update a label

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/labels.py
+++ b/custom_components/spook/ectoplasms/homeassistant/labels.py
@@ -28,3 +28,37 @@ def async_check_labels_exist(hass: HomeAssistant, label_ids: Iterable[str]) -> N
         if not label_registry.async_get_label(label_id):
             msg = f"Label {label_id} not found"
             raise HomeAssistantError(msg)
+
+
+# Kept in step with `homeassistant.components.config.label_registry`, which is
+# what the label registry itself accepts. Copied rather than imported: reaching
+# into a core component from here would break the day core moves it, and a
+# copy that drifts is caught by the test that compares the two.
+SUPPORTED_LABEL_THEME_COLORS = {
+    "accent",
+    "amber",
+    "black",
+    "blue",
+    "blue-grey",
+    "brown",
+    "cyan",
+    "dark-grey",
+    "deep-orange",
+    "deep-purple",
+    "disabled",
+    "green",
+    "grey",
+    "indigo",
+    "light-blue",
+    "light-green",
+    "light-grey",
+    "lime",
+    "orange",
+    "pink",
+    "primary",
+    "purple",
+    "red",
+    "teal",
+    "white",
+    "yellow",
+}

--- a/custom_components/spook/ectoplasms/homeassistant/services/create_label.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/create_label.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, label_registry as lr
 
 from ....services import AbstractSpookAdminService
@@ -33,9 +34,14 @@ class SpookService(AbstractSpookAdminService):
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
         label_registry = lr.async_get(self.hass)
-        label_registry.async_create(
-            name=call.data["name"],
-            color=call.data.get("color"),
-            description=call.data.get("description"),
-            icon=call.data.get("icon"),
-        )
+        try:
+            label_registry.async_create(
+                name=call.data["name"],
+                color=call.data.get("color"),
+                description=call.data.get("description"),
+                icon=call.data.get("icon"),
+            )
+        except ValueError as err:
+            # A name another label already has. Left alone this comes back as
+            # an unknown error with the registry's own wording.
+            raise HomeAssistantError(str(err)) from err

--- a/custom_components/spook/ectoplasms/homeassistant/services/create_label.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/create_label.py
@@ -10,38 +10,10 @@ from homeassistant.components.homeassistant import DOMAIN
 from homeassistant.helpers import config_validation as cv, label_registry as lr
 
 from ....services import AbstractSpookAdminService
+from ..labels import SUPPORTED_LABEL_THEME_COLORS
 
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
-
-SUPPORTED_LABEL_THEME_COLORS = {
-    "primary",
-    "accent",
-    "disabled",
-    "amber",
-    "black",
-    "blue-grey",
-    "blue",
-    "brown",
-    "cyan",
-    "dark-grey",
-    "deep-orange",
-    "deep-purple",
-    "green",
-    "grey",
-    "indigo",
-    "light-blue",
-    "light-green",
-    "light-grey",
-    "lime",
-    "orange",
-    "pink",
-    "purple",
-    "red",
-    "teal",
-    "white",
-    "yellow",
-}
 
 
 class SpookService(AbstractSpookAdminService):

--- a/custom_components/spook/ectoplasms/homeassistant/services/update_label.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/update_label.py
@@ -23,10 +23,11 @@ _UPDATABLE = ("name", "description", "icon", "color")
 class SpookService(AbstractSpookAdminService):
     """Home Assistant service to update a label on the fly.
 
-    Creating a label with a name that already exists makes a second label
-    rather than changing the first, so the only way to edit one used to be
-    deleting it and starting over. That takes the label off everything it was
-    on, which is rarely what somebody wanting a new description had in mind.
+    Home Assistant can edit a label in the UI, but nothing could do it from an
+    automation. Creating one with a name that is already taken is refused, so
+    the only way through was to delete the label and make it again. Deleting
+    takes it off everything it was on, which is a lot to lose over a
+    description.
     """
 
     domain = DOMAIN
@@ -34,11 +35,12 @@ class SpookService(AbstractSpookAdminService):
     schema = {
         vol.Required("label_id"): cv.string,
         vol.Optional("name"): cv.string,
+        # `None` clears these, which is why they are not plain validators.
         vol.Optional("color"): vol.Any(
-            cv.color_hex, vol.In(SUPPORTED_LABEL_THEME_COLORS)
+            None, cv.color_hex, vol.In(SUPPORTED_LABEL_THEME_COLORS)
         ),
-        vol.Optional("description"): cv.string,
-        vol.Optional("icon"): cv.icon,
+        vol.Optional("description"): vol.Any(None, cv.string),
+        vol.Optional("icon"): vol.Any(None, cv.icon),
     }
 
     async def async_handle_service(self, call: ServiceCall) -> None:
@@ -46,8 +48,8 @@ class SpookService(AbstractSpookAdminService):
         label_id = call.data["label_id"]
         async_check_labels_exist(self.hass, [label_id])
 
-        # Everything left out keeps the value it has. Without this an
-        # unmentioned icon would be read as "remove the icon".
+        # Left out means keep, `None` means clear. Passing everything through
+        # would turn an unmentioned icon into "remove the icon".
         changes = {
             field: call.data[field] for field in _UPDATABLE if field in call.data
         }
@@ -59,7 +61,12 @@ class SpookService(AbstractSpookAdminService):
             )
             raise HomeAssistantError(msg)
 
-        lr.async_get(self.hass).async_update(
-            label_id,
-            **{field: changes.get(field, UNDEFINED) for field in _UPDATABLE},
-        )
+        try:
+            lr.async_get(self.hass).async_update(
+                label_id,
+                **{field: changes.get(field, UNDEFINED) for field in _UPDATABLE},
+            )
+        except ValueError as err:
+            # Renaming onto a name another label already has. Left alone this
+            # comes back as an unknown error with the registry's own wording.
+            raise HomeAssistantError(str(err)) from err

--- a/custom_components/spook/ectoplasms/homeassistant/services/update_label.py
+++ b/custom_components/spook/ectoplasms/homeassistant/services/update_label.py
@@ -1,0 +1,65 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import DOMAIN
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, label_registry as lr
+from homeassistant.helpers.typing import UNDEFINED
+
+from ....services import AbstractSpookAdminService
+from ..labels import SUPPORTED_LABEL_THEME_COLORS, async_check_labels_exist
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+_UPDATABLE = ("name", "description", "icon", "color")
+
+
+class SpookService(AbstractSpookAdminService):
+    """Home Assistant service to update a label on the fly.
+
+    Creating a label with a name that already exists makes a second label
+    rather than changing the first, so the only way to edit one used to be
+    deleting it and starting over. That takes the label off everything it was
+    on, which is rarely what somebody wanting a new description had in mind.
+    """
+
+    domain = DOMAIN
+    service = "update_label"
+    schema = {
+        vol.Required("label_id"): cv.string,
+        vol.Optional("name"): cv.string,
+        vol.Optional("color"): vol.Any(
+            cv.color_hex, vol.In(SUPPORTED_LABEL_THEME_COLORS)
+        ),
+        vol.Optional("description"): cv.string,
+        vol.Optional("icon"): cv.icon,
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        label_id = call.data["label_id"]
+        async_check_labels_exist(self.hass, [label_id])
+
+        # Everything left out keeps the value it has. Without this an
+        # unmentioned icon would be read as "remove the icon".
+        changes = {
+            field: call.data[field] for field in _UPDATABLE if field in call.data
+        }
+
+        if not changes:
+            msg = (
+                f"Nothing to update on label {label_id}: "
+                f"give at least one of {', '.join(_UPDATABLE)}"
+            )
+            raise HomeAssistantError(msg)
+
+        lr.async_get(self.hass).async_update(
+            label_id,
+            **{field: changes.get(field, UNDEFINED) for field in _UPDATABLE},
+        )

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -776,13 +776,13 @@ homeassistant_create_label:
             - label: Purple
               value: purple
             - label: Deep purple
-              value: deep_purple
+              value: deep-purple
             - label: Indigo
               value: indigo
             - label: Blue
               value: blue
             - label: Light blue
-              value: light_blue
+              value: light-blue
             - label: Cyan
               value: cyan
             - label: Teal
@@ -790,21 +790,119 @@ homeassistant_create_label:
             - label: Green
               value: green
             - label: Light green
-              value: light_green
+              value: light-green
             - label: Lime
               value: lime
             - label: Yellow
               value: yellow
+            - label: Amber
+              value: amber
             - label: Orange
               value: orange
             - label: Deep orange
-              value: deep_orange
+              value: deep-orange
             - label: Brown
               value: brown
+            - label: Light grey
+              value: light-grey
             - label: Grey
               value: grey
+            - label: Dark grey
+              value: dark-grey
             - label: Blue grey
-              value: blue_grey
+              value: blue-grey
+            - label: Black
+              value: black
+            - label: White
+              value: white
+
+homeassistant_update_label:
+  name: Update a label 👻
+  description: >-
+    Updates an existing label on the fly. Anything left empty keeps the value
+    it already has.
+  fields:
+    label_id:
+      name: Label ID
+      description: The ID of the label to update.
+      required: true
+      selector:
+        label:
+    name:
+      name: Name
+      description: New name for the label.
+      required: false
+      selector:
+        text:
+    description:
+      name: Description
+      description: New description for the label.
+      required: false
+      selector:
+        text:
+    icon:
+      name: Icon
+      description: New icon to use for the label.
+      required: false
+      selector:
+        icon:
+          placeholder: mdi:tag
+    color:
+      name: Color
+      description: >-
+        Color to use for the label. Can be a color name from the list, or a
+        hex color code (like #FF0000).
+      selector:
+        select:
+          options:
+            - label: Primary theme color
+              value: primary
+            - label: Accent theme color
+              value: accent
+            - label: Disabled theme color
+              value: disabled
+            - label: Red
+              value: red
+            - label: Pink
+              value: pink
+            - label: Purple
+              value: purple
+            - label: Deep purple
+              value: deep-purple
+            - label: Indigo
+              value: indigo
+            - label: Blue
+              value: blue
+            - label: Light blue
+              value: light-blue
+            - label: Cyan
+              value: cyan
+            - label: Teal
+              value: teal
+            - label: Green
+              value: green
+            - label: Light green
+              value: light-green
+            - label: Lime
+              value: lime
+            - label: Yellow
+              value: yellow
+            - label: Amber
+              value: amber
+            - label: Orange
+              value: orange
+            - label: Deep orange
+              value: deep-orange
+            - label: Brown
+              value: brown
+            - label: Light grey
+              value: light-grey
+            - label: Grey
+              value: grey
+            - label: Dark grey
+              value: dark-grey
+            - label: Blue grey
+              value: blue-grey
             - label: Black
               value: black
             - label: White

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -820,7 +820,8 @@ homeassistant_update_label:
   name: Update a label 👻
   description: >-
     Updates an existing label on the fly. Anything you leave out keeps the
-    value it already has, while setting one to null clears it.
+    value it already has. The description, icon and color can be cleared by
+    setting them to null.
   fields:
     label_id:
       name: Label ID

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -819,8 +819,8 @@ homeassistant_create_label:
 homeassistant_update_label:
   name: Update a label 👻
   description: >-
-    Updates an existing label on the fly. Anything left empty keeps the value
-    it already has.
+    Updates an existing label on the fly. Anything you leave out keeps the
+    value it already has, while setting one to null clears it.
   fields:
     label_id:
       name: Label ID

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1297,7 +1297,7 @@
     },
     "homeassistant_update_label": {
       "name": "Update a label",
-      "description": "Updates an existing label on the fly. Anything you leave out keeps the value it already has, while setting one to null clears it.",
+      "description": "Updates an existing label on the fly. Anything you leave out keeps the value it already has. The description, icon and color can be cleared by setting them to null.",
       "fields": {
         "label_id": {
           "name": "Label ID",

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1295,6 +1295,32 @@
         }
       }
     },
+    "homeassistant_update_label": {
+      "name": "Update a label",
+      "description": "Updates an existing label on the fly. Anything left empty keeps the value it already has.",
+      "fields": {
+        "label_id": {
+          "name": "Label ID",
+          "description": "The ID of the label to update."
+        },
+        "name": {
+          "name": "Name",
+          "description": "New name for the label."
+        },
+        "description": {
+          "name": "Description",
+          "description": "New description for the label."
+        },
+        "icon": {
+          "name": "Icon",
+          "description": "New icon to use for the label."
+        },
+        "color": {
+          "name": "Color",
+          "description": "Color to use for the label. Can be a color name from the list, or a hex color code (like #FF0000)."
+        }
+      }
+    },
     "homeassistant_add_label_to_area": {
       "name": "Add a label to an area",
       "description": "Adds a label to an area. If multiple labels or multiple areas are provided, all combinations will be added.",

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1297,7 +1297,7 @@
     },
     "homeassistant_update_label": {
       "name": "Update a label",
-      "description": "Updates an existing label on the fly. Anything left empty keeps the value it already has.",
+      "description": "Updates an existing label on the fly. Anything you leave out keeps the value it already has, while setting one to null clears it.",
       "fields": {
         "label_id": {
           "name": "Label ID",

--- a/documentation/labels.md
+++ b/documentation/labels.md
@@ -88,7 +88,12 @@ data:
 ### Update a label
 
 Updates an existing label in your Home Assistant instance. Anything you leave
-out keeps the value it already has.
+out keeps the value it already has. Setting `description`, `icon` or `color` to
+`null` clears it.
+
+Note that leaving a field out is not the same as giving it an empty string: a
+`description: ""` sets the description to nothing at all, which is a change
+like any other.
 
 ```{list-table}
 :header-rows: 1
@@ -141,6 +146,9 @@ out keeps the value it already has.
 You need to give at least one thing to change. A call with only a `label_id`
 is refused, so a misspelled parameter cannot pass for a successful update that
 quietly did nothing.
+
+Renaming a label to a name another label already carries is refused too, since
+Home Assistant keeps label names unique.
 :::
 
 :::{seealso} Example {term}`action <performing actions>` in {term}`YAML`

--- a/documentation/labels.md
+++ b/documentation/labels.md
@@ -129,15 +129,15 @@ like any other.
   - No
   - `Battery powered`
 * - `description`
-  - {term}`string <string>`
+  - {term}`string <string>` or `null`
   - No
   - `Label to tag all battery powered devices`
 * - `icon`
-  - {term}`string <string>`
+  - {term}`string <string>` or `null`
   - No
   - `mdi:battery`
 * - `color`
-  - {term}`string <string>`
+  - {term}`string <string>` or `null`
   - No
   - `indigo`
 ```

--- a/documentation/labels.md
+++ b/documentation/labels.md
@@ -31,7 +31,7 @@ Adds a new label to your Home Assistant instance.
 :header-rows: 1
 * - Action properties
 * - {term}`Action`
-  - Create an label 👻
+  - Create a label 👻
 * - {term}`Action name`
   - `homeassistant.create_label`
 * - {term}`Action targets`
@@ -85,9 +85,80 @@ data:
 
 :::
 
+### Update a label
+
+Updates an existing label in your Home Assistant instance. Anything you leave
+out keeps the value it already has.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Update a label 👻
+* - {term}`Action name`
+  - `homeassistant.update_label`
+* - {term}`Action targets`
+  - No
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action
+* - {term}`Tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.update_label)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.update_label)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `label_id`
+  - {term}`string <string>`
+  - Yes
+  - `battery_powered`
+* - `name`
+  - {term}`string <string>`
+  - No
+  - `Battery powered`
+* - `description`
+  - {term}`string <string>`
+  - No
+  - `Label to tag all battery powered devices`
+* - `icon`
+  - {term}`string <string>`
+  - No
+  - `mdi:battery`
+* - `color`
+  - {term}`string <string>`
+  - No
+  - `indigo`
+```
+
+:::{note}
+You need to give at least one thing to change. A call with only a `label_id`
+is refused, so a misspelled parameter cannot pass for a successful update that
+quietly did nothing.
+:::
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: homeassistant.update_label
+data:
+  label_id: "battery_powered"
+  description: "Label to tag all battery powered devices"
+```
+
+:::
+
 ### Delete a label
 
-Delete a new label to your Home Assistant instance.
+Deletes a label from your Home Assistant instance.
 
 ```{figure} ./images/labels/delete.png
 :alt: Screenshot of the delete label action on the Tools page.

--- a/tests/ectoplasms/homeassistant/services/test_label_colors.py
+++ b/tests/ectoplasms/homeassistant/services/test_label_colors.py
@@ -1,0 +1,70 @@
+"""Tests for the label colours Spook accepts and offers."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from pathlib import Path
+
+import voluptuous as vol
+import yaml
+
+from homeassistant.components.config.label_registry import (
+    SUPPORTED_LABEL_THEME_COLORS as CORE_COLORS,
+)
+import pytest
+
+from custom_components.spook.ectoplasms.homeassistant.labels import (
+    SUPPORTED_LABEL_THEME_COLORS,
+)
+
+# Both label actions offer one today; the check is worthless if it finds none.
+EXPECTED_PICKERS = 2
+
+SPOOK_ROOT = Path(__file__).parents[4] / "custom_components" / "spook"
+SERVICES = yaml.safe_load((SPOOK_ROOT / "services.yaml").read_text())
+
+# Whatever offers a colour picker gets checked, so an action added later is
+# covered without anybody remembering to come back here.
+WITH_A_COLOUR_PICKER = sorted(
+    name
+    for name, action in SERVICES.items()
+    if "color" in (action.get("fields") or {})
+    and "select" in (action["fields"]["color"].get("selector") or {})
+)
+
+
+def test_the_colours_we_accept_are_the_ones_core_accepts() -> None:
+    """Spook keeps its own copy rather than importing from a core component.
+
+    A copy that drifts is the whole risk of doing it that way, so this is the
+    thing that notices.
+    """
+    assert set(CORE_COLORS) == SUPPORTED_LABEL_THEME_COLORS
+
+
+def test_there_is_something_to_check() -> None:
+    """Guard the discovery above, which would otherwise pass by finding none."""
+    assert len(WITH_A_COLOUR_PICKER) >= EXPECTED_PICKERS
+
+
+@pytest.mark.parametrize("action", WITH_A_COLOUR_PICKER)
+def test_every_colour_the_picker_offers_is_one_the_action_takes(action: str) -> None:
+    """The picker used to offer five colours the schema then rejected.
+
+    `deep_purple` and friends were written with underscores in the selector
+    while the registry only ever took `deep-purple`, so picking one of those
+    in the UI failed the call.
+    """
+    offered = [
+        option["value"]
+        for option in SERVICES[action]["fields"]["color"]["selector"]["select"][
+            "options"
+        ]
+    ]
+    assert offered
+
+    validate = vol.Schema(vol.In(SUPPORTED_LABEL_THEME_COLORS))
+    for value in offered:
+        validate(value)
+
+    assert set(offered) == SUPPORTED_LABEL_THEME_COLORS

--- a/tests/ectoplasms/homeassistant/services/test_label_services.py
+++ b/tests/ectoplasms/homeassistant/services/test_label_services.py
@@ -13,6 +13,7 @@ from custom_components.spook.ectoplasms.homeassistant.services import (
     add_label_to_area,
     add_label_to_device,
     add_label_to_entity,
+    create_label,
     remove_label_from_area,
     remove_label_from_device,
     remove_label_from_entity,
@@ -104,4 +105,22 @@ async def test_a_label_that_does_not_exist_is_refused_on_removal_too(
             service.service,
             {"label_id": "no_such_label", field: targets[field]},
             blocking=True,
+        )
+
+
+async def test_creating_a_label_whose_name_is_taken_says_so(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Core refuses this with a bare ValueError, not a second label.
+
+    Unconverted it reaches the caller as an unknown error, which is a poor
+    description of a name collision.
+    """
+    label_registry.async_create("Ghosts")
+    await _setup(hass, create_label)
+
+    with pytest.raises(HomeAssistantError, match="already in use"):
+        await hass.services.async_call(
+            "homeassistant", "create_label", {"name": "Ghosts"}, blocking=True
         )

--- a/tests/ectoplasms/homeassistant/services/test_update_label.py
+++ b/tests/ectoplasms/homeassistant/services/test_update_label.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
+import voluptuous as vol
+
 import pytest
 
 from custom_components.spook.ectoplasms.homeassistant.services import update_label
@@ -142,3 +144,25 @@ async def test_renaming_onto_another_label_says_so(
         await _update(hass, label_id=spooks.label_id, name="Ghosts")
 
     assert label_registry.async_get_label(spooks.label_id).name == "Spooks"
+
+
+async def test_a_label_cannot_be_left_without_a_name(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """A label without a name is not a thing the registry has.
+
+    Three of the four fields are nullable and the action description names
+    them, so this pins which side of that line `name` sits on.
+    """
+    label = label_registry.async_create("Ghosts", icon="mdi:ghost")
+    await _setup(hass)
+
+    with pytest.raises(vol.Invalid):
+        await _update(hass, label_id=label.label_id, name=None)
+
+    assert label_registry.async_get_label(label.label_id).name == "Ghosts"
+
+    # The other three take it, which is the distinction being drawn.
+    await _update(hass, label_id=label.label_id, icon=None)
+    assert label_registry.async_get_label(label.label_id).icon is None

--- a/tests/ectoplasms/homeassistant/services/test_update_label.py
+++ b/tests/ectoplasms/homeassistant/services/test_update_label.py
@@ -101,3 +101,44 @@ async def test_a_call_that_changes_nothing_is_refused(
 
     with pytest.raises(HomeAssistantError, match="Nothing to update"):
         await _update(hass, label_id=label.label_id)
+
+
+async def test_null_clears_a_field_where_leaving_it_out_would_keep_it(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """The registry takes `None` to mean "no icon", and so does this.
+
+    Which is the other half of leaving a field out: without it there is no way
+    to take an icon back off a label once it has one.
+    """
+    label = label_registry.async_create(
+        "Ghosts", color="red", description="Old", icon="mdi:ghost"
+    )
+    await _setup(hass)
+
+    await _update(hass, label_id=label.label_id, icon=None)
+
+    updated = label_registry.async_get_label(label.label_id)
+    assert updated.icon is None
+    assert updated.description == "Old"
+    assert updated.color == "red"
+
+
+async def test_renaming_onto_another_label_says_so(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Core raises a bare ValueError here, which surfaces as an unknown error.
+
+    The registry's own wording says which name is taken, so it is worth
+    keeping, just as something an automation can actually catch.
+    """
+    label_registry.async_create("Ghosts")
+    spooks = label_registry.async_create("Spooks")
+    await _setup(hass)
+
+    with pytest.raises(HomeAssistantError, match="already in use"):
+        await _update(hass, label_id=spooks.label_id, name="Ghosts")
+
+    assert label_registry.async_get_label(spooks.label_id).name == "Spooks"

--- a/tests/ectoplasms/homeassistant/services/test_update_label.py
+++ b/tests/ectoplasms/homeassistant/services/test_update_label.py
@@ -1,0 +1,103 @@
+"""Tests for the homeassistant.update_label action."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
+import pytest
+
+from custom_components.spook.ectoplasms.homeassistant.services import update_label
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import (
+        entity_registry as er,
+        label_registry as lr,
+    )
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    """Register the action."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    update_label.SpookService(hass).async_register()
+    await hass.async_block_till_done()
+
+
+async def _update(hass: HomeAssistant, **data: object) -> None:
+    """Call the action."""
+    await hass.services.async_call(
+        "homeassistant", "update_label", dict(data), blocking=True
+    )
+
+
+async def test_it_leaves_alone_what_the_call_did_not_mention(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """The reason this action exists at all.
+
+    Somebody updating a description wants the icon, colour and name they
+    already picked to survive it. Passing every field through would read an
+    unmentioned icon as "remove the icon".
+    """
+    label = label_registry.async_create(
+        "Ghosts", color="red", description="Old", icon="mdi:ghost"
+    )
+    await _setup(hass)
+
+    await _update(hass, label_id=label.label_id, description="New")
+
+    updated = label_registry.async_get_label(label.label_id)
+    assert updated.description == "New"
+    assert updated.name == "Ghosts"
+    assert updated.color == "red"
+    assert updated.icon == "mdi:ghost"
+
+
+async def test_it_keeps_the_label_on_everything_it_was_on(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Editing used to mean deleting and recreating.
+
+    That took the label off every entity and device carrying it, which is why
+    this was asked for in the first place.
+    """
+    label = label_registry.async_create("Ghosts", description="Old")
+    entry = entity_registry.async_get_or_create("light", "test", "1")
+    entity_registry.async_update_entity(entry.entity_id, labels={label.label_id})
+    await _setup(hass)
+
+    await _update(hass, label_id=label.label_id, description="New")
+
+    assert entity_registry.async_get(entry.entity_id).labels == {label.label_id}
+
+
+async def test_a_label_that_does_not_exist_is_refused(
+    hass: HomeAssistant,
+) -> None:
+    """Core raises a bare KeyError on this, which surfaces as an unknown error."""
+    await _setup(hass)
+
+    with pytest.raises(HomeAssistantError, match=r"Label .* not found"):
+        await _update(hass, label_id="no_such_label", name="Ghosts")
+
+
+async def test_a_call_that_changes_nothing_is_refused(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """A misspelled field name would otherwise be a successful no-op.
+
+    The automation that made the call carries on as though it had renamed
+    something, and nothing anywhere says it did not.
+    """
+    label = label_registry.async_create("Ghosts")
+    await _setup(hass)
+
+    with pytest.raises(HomeAssistantError, match="Nothing to update"):
+        await _update(hass, label_id=label.label_id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds `homeassistant.update_label`, which takes a `label_id` and any of `name`, `description`, `icon` and `color`.

Anything left out keeps the value it already has, rather than being read as "clear this". A call carrying nothing but the label ID is refused, so a misspelled parameter cannot pass for an update that quietly did nothing.

While writing its colour picker I found the one on `create_label` was wrong. It offered `deep_purple`, `light_blue`, `light_green`, `deep_orange` and `blue_grey`, none of which its own schema accepts. The label registry only ever took the hyphenated spellings, so picking any of those five in the UI failed the call. It also never offered amber, light grey or dark grey at all. Both pickers now list exactly the 26 colours the registry takes.

The colour set moved to the shared label module so the two actions cannot drift apart. Spook keeps a copy rather than importing from a core component, and a copy that drifts is the whole risk of doing it that way, so a test compares it to Home Assistant's own list.

Also corrected two slips in the label documentation while in there: the create section called the action "Create an label", and the delete section said "Delete a new label to your Home Assistant instance".

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1052.

Creating a label with a name that already exists makes a second label instead of changing the first, so the only way to edit one was to delete it and start over. Deleting takes the label off every entity and device carrying it, which is a heavy price for fixing a description.

That is exactly what happened to the person who asked: they deleted, recreated, and then had to reassign every label with a second script.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Seven new tests, all calling the action through `hass.services.async_call` rather than the handler directly.

- An update that mentions only the description leaves the name, colour and icon alone.
- The label stays on every entity that carried it, which is the thing deleting and recreating destroyed.
- A label that does not exist is refused. Core raises a bare `KeyError` here, which surfaces as an unknown error.
- A call carrying nothing but the label ID is refused.
- The colours Spook accepts are the ones `homeassistant.components.config.label_registry` accepts.
- Every colour either picker offers validates against the schema, for both actions.

Each guard was mutation tested on its own, and every mutant was caught:

| Mutation | Result |
| --- | --- |
| Pass every field through instead of `UNDEFINED` | 2 failed |
| Drop the label-exists check | 1 failed |
| Drop the nothing-to-update guard | 1 failed |
| Put the underscore colours back in `services.yaml` | 2 failed |
| Drift one colour away from core | 3 failed |
| Drop the colour selector from the new action | 1 failed |

Full suite is 1413 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None. The new documentation section has no screenshot yet, unlike its neighbours.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
