### PR TITLE
Document the sensor integration

### DIFF
--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -51,6 +51,7 @@ parts:
       - file: integrations/scene
       - file: integrations/script
       - file: integrations/select
+      - file: integrations/sensor
       - file: integrations/switch_as_x
       - file: integrations/template
       - file: integrations/timer

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -390,7 +390,7 @@ Adds a device tracker to a person. _#bigbrother_
 
 Removes a device tracker from a person. _#privacy_
 
-`person.add_device_tracker`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=person.remove_device_tracker), [documentation](integrations/person#remove-a-device-tracker) 📚
+`person.remove_device_tracker`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=person.remove_device_tracker), [documentation](integrations/person#remove-a-device-tracker) 📚
 
 ## Random fail
 
@@ -439,6 +439,12 @@ Extends the existing restart action with a "force" option. Because forcing is al
 This action selects a random option from the list of options of a select entity. Optionally this can be limited to a set of given options. _#random_
 
 `select.random`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=select.random), [documentation](integrations/select#select-random-option) 📚
+
+## Sensor: Set display precision
+
+Sets how many decimals a sensor shows, on as many sensors as you like at once. _#decimated_
+
+`sensor.set_display_precision`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=sensor.set_display_precision), [documentation](integrations/sensor#set-display-precision) 📚
 
 ## Timer: Set duration
 

--- a/documentation/enhanced_integrations.md
+++ b/documentation/enhanced_integrations.md
@@ -95,6 +95,11 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 [![](https://brands.home-assistant.io/select/icon.png)](integrations/select)
 :::
 
+:::{card} Sensor
+:footer: 📚 [Learn more](integrations/sensor)
+[![](https://brands.home-assistant.io/sensor/icon.png)](integrations/sensor)
+:::
+
 :::{card} Switch as X
 :footer: 📚 [Learn more](integrations/switch_as_x)
 [![](https://brands.home-assistant.io/switch_as_x/icon.png)](integrations/switch_as_x)

--- a/documentation/integrations/sensor.md
+++ b/documentation/integrations/sensor.md
@@ -1,0 +1,113 @@
+---
+subject: Enhanced integrations
+title: Sensor
+subtitle: How many decimals is too many decimals?
+description: Spook adds a new action to the sensor integration, which allows you to set the number of decimals shown for one or more sensors at once.
+date: 2026-08-30T12:00:00+02:00
+---
+
+```{image} https://brands.home-assistant.io/sensor/logo.png
+:alt: The Home Assistant sensor icon
+:width: 250px
+:align: center
+```
+
+<br><br>
+
+The sensor {term}`integration <integration>` is the one that reports things: temperatures, power usage, how full the bins are. Most {term}`integrations <integration>` you install bring some along.
+
+Home Assistant lets you set how many decimals a sensor shows, but only one sensor at a time, by opening its settings in the UI. That is fine for one. It is less fine when an integration hands you forty power sensors that all report six decimals.
+
+Spook adds an action that sets the display precision on as many sensors as you like in a single call.
+
+## Devices & entities
+
+Spook does not provide any new devices or entities for this integration.
+
+## Actions
+
+Spook adds the following new actions to your Home Assistant instance:
+
+### Set display precision
+
+Sets the number of decimals shown for one or more sensors.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Set display precision 👻
+* - {term}`Action name`
+  - `sensor.set_display_precision`
+* - {term}`Action targets`
+  - No
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action
+* - {term}`Tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=sensor.set_display_precision)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=sensor.set_display_precision)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `entity_id`
+  - {term}`string <string>` or {term}`list <list>`
+  - Yes
+  - `"sensor.living_room_temperature"`
+* - `display_precision`
+  - {term}`integer <integer>`
+  - Yes
+  - `1`
+```
+
+:::{note}
+This is the same setting you find under a sensor's own settings in the UI, so
+it survives restarts and applies everywhere the sensor is shown.
+
+Every entity you name is looked up before any of them are changed. If one of
+them does not exist, the whole call fails and nothing is touched, rather than
+leaving you with half your sensors updated and nothing saying which half.
+:::
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: sensor.set_display_precision
+data:
+  entity_id:
+    - sensor.living_room_temperature
+    - sensor.bedroom_temperature
+  display_precision: 1
+```
+
+:::
+
+## Repairs
+
+Spook has no repair detections for this integration.
+
+## Use cases
+
+Some use cases for the enhancements Spook provides for this integration:
+
+- Trim every sensor an integration added down to a sensible number of decimals in one action, instead of opening each one in the UI.
+- Show more decimals on a sensor temporarily, for example while working out why a reading looks wrong, and set it back afterwards.
+
+## Blueprints & tutorials
+
+There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+## Feature requests, ideas, and support
+
+If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+Are you stuck using these new features? Or maybe you've run into a bug? Please check the [](../support) page on where to go for help.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a documentation page for the sensor integration, and wires it into the three places an integration page has to appear: the table of contents, the action list, and the card grid on the enhanced integrations page.

The page says what the action is actually for, which is the part a reference table never carries. Home Assistant can already set how many decimals a sensor shows, one sensor at a time, through that sensor's own settings. This is the same setting applied to as many as you like at once. It also documents that every entity is resolved before any of them change, so a typo fails the whole call rather than leaving half your sensors done and nothing saying which half.

While adding the action to the action list I found the person entry naming the wrong action. Its heading, its description and its link all say remove a device tracker, while the action beside them reads `person.add_device_tracker`. Copied from the section above it and never corrected. Fixed here.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`sensor.set_display_precision` shipped in 5.1.0 with no documentation at all. No page, no entry in the action list, no card. The only way to find it was to go looking in the Actions tool and hope.

This came up while answering #257, which asked for exactly this action and which I have just closed as done. It seemed worth making that answer true.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Documentation only, so the checks are that the page is reachable and the links resolve.

- The page is registered in `_toc.yml` between select and switch_as_x, matching the existing ordering.
- Every documented parameter was read back off the action's own schema and `services.yaml`, not from memory: `entity_id` is a required multi-entity selector limited to the sensor domain, and `display_precision` is a required integer from 0 to 100.
- The action name, the properties table and the deep link were copied from the shape the neighbouring pages use, and the anchor `integrations/sensor#set-display-precision` matches the heading it points at.
- Prettier is clean on all four files.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None. The page has no screenshots, unlike its neighbours, because there is no `documentation/images/integrations/sensor` directory to put them in. Happy to add them if you would rather it matched.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
