### PR TITLE
Fill the holes in the documentation index

### DIFF
--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -51,6 +51,7 @@ parts:
       - file: integrations/scene
       - file: integrations/script
       - file: integrations/select
+      - file: integrations/sensor
       - file: integrations/switch_as_x
       - file: integrations/template
       - file: integrations/timer

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -390,7 +390,7 @@ Adds a device tracker to a person. _#bigbrother_
 
 Removes a device tracker from a person. _#privacy_
 
-`person.add_device_tracker`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=person.remove_device_tracker), [documentation](integrations/person#remove-a-device-tracker) 📚
+`person.remove_device_tracker`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=person.remove_device_tracker), [documentation](integrations/person#remove-a-device-tracker) 📚
 
 ## Random fail
 
@@ -439,6 +439,12 @@ Extends the existing restart action with a "force" option. Because forcing is al
 This action selects a random option from the list of options of a select entity. Optionally this can be limited to a set of given options. _#random_
 
 `select.random`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=select.random), [documentation](integrations/select#select-random-option) 📚
+
+## Sensor: Set display precision
+
+Sets how many decimals a sensor shows, on as many sensors as you like at once. _#decimated_
+
+`sensor.set_display_precision`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=sensor.set_display_precision), [documentation](integrations/sensor#set-display-precision) 📚
 
 ## Timer: Set duration
 

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -148,7 +148,7 @@ This action can be used to disable a device on the fly. _#whatever_
 
 Guess what... this action does the reverse of [](#device-disable). _#noway_
 
-`homeassistant.disable_device`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.disable_device), [documentation](devices#disable-a-device) 📚
+`homeassistant.enable_device`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_device), [documentation](devices#enable-a-device) 📚
 
 (entity-disable)=
 
@@ -183,6 +183,20 @@ Do the math... this action does the reverse of [](#entity-hide). _#reveal_
 This action can be used to rename an entity on the fly. _#LookMaNewName_
 
 `homeassistant.rename_entity`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.rename_entity), [documentation](entities#rename-an-entity) 📚
+
+(entity-expose-to-assistants)=
+
+## Entity: Expose to assistants
+
+Lets your voice assistants see an entity that was hidden from them. _#saymyname_
+
+`homeassistant.expose_entity`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.expose_entity), [documentation](entities#expose-an-entity-to-assistants) 📚
+
+## Entity: Stop exposing to assistants
+
+Takes an entity back out of a voice assistant's reach. This action does the reverse of [](#entity-expose-to-assistants). _#neverheardofher_
+
+`homeassistant.unexpose_entity`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.unexpose_entity), [documentation](entities#stop-exposing-an-entity-to-assistants) 📚
 
 ## Entity: Update ID
 
@@ -232,11 +246,29 @@ Dynamically remove an area from a floor. _#poef_
 
 `homeassistant.remove_area_from_floor`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.remove_area_from_floor), [documentation](floors#remove-an-area-from-a-floor) 📚
 
+## List all orphaned database entities
+
+Hands back every entity your recorder still has rows for but which no longer exists, so you can look before you delete. _#showmethebodies_
+
+`homeassistant.list_orphaned_database_entities`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.list_orphaned_database_entities), [documentation](entities#list-all-orphaned-database-entities) 📚
+
 ## Ignore all discovered devices & services
 
 Click ignore on all discovered items on the integration dashboard; optionally only for specific integration (like, `bluetooth`). _#talktothehand_
 
 `homeassistant.ignore_all_discovered`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.ignore_all_discovered), [documentation](integrations#ignore-all-discovered-devices-services) 📚
+
+## Input number: Create
+
+Creates an input number helper without going anywhere near the helpers page. _#outofthinair_
+
+`input_number.create`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.create), [documentation](integrations/input_number#create-an-input-number) 📚
+
+## Input number: Delete
+
+Removes an input number helper you created earlier. _#nevermind_
+
+`input_number.delete`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=input_number.delete), [documentation](integrations/input_number#delete-an-input-number) 📚
 
 ## Input number: Decrease value
 
@@ -465,3 +497,23 @@ This action can be used to disable a user account on the fly, preventing them fr
 Guess what... this action does the reverse of [](#user-disable). _#welcome_
 
 `homeassistant.enable_user`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.enable_user), [documentation](users#enable-a-user) 📚
+
+(zone-create)=
+
+## Zone: Create
+
+Creates a zone on the fly, wherever you like. _#roomforonemore_
+
+`zone.create`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.create), [documentation](integrations/zone#create-a-zone) 📚
+
+## Zone: Update
+
+Moves a zone, or resizes it, without touching the map yourself. This action changes a zone made by [](#zone-create), or any other zone you created in the UI. _#movingday_
+
+`zone.update`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.update), [documentation](integrations/zone#update-a-zone) 📚
+
+## Zone: Delete
+
+Makes a zone disappear. _#offthemap_
+
+`zone.delete`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=zone.delete), [documentation](integrations/zone#delete-a-zone) 📚

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -202,7 +202,7 @@ Takes an entity back out of a voice assistant's reach. This action does the reve
 
 This action can be used to update the ID of an entity on the fly. _#secret_
 
-`homeassistant.update_entity_id`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.update_entity_id), [documentation](entities#update-an-entitys_id) 📚
+`homeassistant.update_entity_id`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.update_entity_id), [documentation](entities#update-an-entitys-id) 📚
 
 ## Floors: Create a floor
 

--- a/documentation/enhanced_integrations.md
+++ b/documentation/enhanced_integrations.md
@@ -95,6 +95,11 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 [![](https://brands.home-assistant.io/select/icon.png)](integrations/select)
 :::
 
+:::{card} Sensor
+:footer: 📚 [Learn more](integrations/sensor)
+[![](https://brands.home-assistant.io/sensor/icon.png)](integrations/sensor)
+:::
+
 :::{card} Switch as X
 :footer: 📚 [Learn more](integrations/switch_as_x)
 [![](https://brands.home-assistant.io/switch_as_x/icon.png)](integrations/switch_as_x)

--- a/documentation/enhanced_integrations.md
+++ b/documentation/enhanced_integrations.md
@@ -11,6 +11,11 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 
 ::::{grid} 1 2 2 3
 
+:::{card} Alert
+:footer: 📚 [Learn more](integrations/alert)
+[![](https://brands.home-assistant.io/alert/icon.png)](integrations/alert)
+:::
+
 :::{card} Automations
 :footer: 📚 [Learn more](integrations/automation)
 
@@ -28,6 +33,11 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 [![](https://brands.home-assistant.io/lovelace/icon.png)](integrations/lovelace)
 :::
 
+:::{card} Energy
+:footer: 📚 [Learn more](integrations/energy)
+[![](https://brands.home-assistant.io/energy/icon.png)](integrations/energy)
+:::
+
 :::{card} Groups
 :footer: 📚 [Learn more](integrations/group)
 
@@ -40,6 +50,11 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 [![](https://brands.home-assistant.io/cloud/icon.png)](integrations/cloud)
 :::
 
+:::{card} Home Assistant Core
+:footer: 📚 [Learn more](integrations/homeassistant)
+[![](https://brands.home-assistant.io/homeassistant/icon.png)](integrations/homeassistant)
+:::
+
 :::{card} Input number
 :footer: 📚 [Learn more](integrations/input_number)
 [![](https://brands.home-assistant.io/input_number/icon.png)](integrations/input_number)
@@ -48,6 +63,16 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 :::{card} Input select
 :footer: 📚 [Learn more](integrations/input_select)
 [![](https://brands.home-assistant.io/input_select/icon.png)](integrations/input_select)
+:::
+
+:::{card} Light
+:footer: 📚 [Learn more](integrations/light)
+[![](https://brands.home-assistant.io/light/icon.png)](integrations/light)
+:::
+
+:::{card} Notify
+:footer: 📚 [Learn more](integrations/notify)
+[![](https://brands.home-assistant.io/notify/icon.png)](integrations/notify)
 :::
 
 :::{card} Number
@@ -103,6 +128,11 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 :::{card} Switch as X
 :footer: 📚 [Learn more](integrations/switch_as_x)
 [![](https://brands.home-assistant.io/switch_as_x/icon.png)](integrations/switch_as_x)
+:::
+
+:::{card} Template
+:footer: 📚 [Learn more](integrations/template)
+[![](https://brands.home-assistant.io/template/icon.png)](integrations/template)
 :::
 
 :::{card} Timer

--- a/documentation/entities.md
+++ b/documentation/entities.md
@@ -216,7 +216,7 @@ This action allows you to unhide an entity on the fly.
 :header-rows: 1
 * - Action properties
 * - {term}`Action`
-  - Unide an entity 👻
+  - Unhide an entity 👻
 * - {term}`Action name`
   - `homeassistant.unhide_entity`
 * - {term}`Action targets`
@@ -262,6 +262,158 @@ data:
   entity_id:
     - light.living_room
     - light.kitchen_ceiling
+```
+
+:::
+
+### Expose an entity to assistants
+
+This action allows you to expose an entity to your voice assistants on the fly.
+
+Home Assistant keeps a separate list per assistant of what it is allowed to see. This is the same setting you find under **Settings** > **Voice assistants** > **Expose**, applied to as many entities as you like at once.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Expose an entity to assistants 👻
+* - {term}`Action name`
+  - `homeassistant.expose_entity`
+* - {term}`Action targets`
+  - No
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action.
+* - {term}`Tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.expose_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.expose_entity)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `entity_id`
+  - {term}`string <string>` | {term}`list of strings <list>`
+  - Yes
+  - `"light.living_room"`
+* - `assistants`
+  - {term}`string <string>` | {term}`list of strings <list>`
+  - Yes
+  - `cloud.alexa`, `cloud.google_assistant`, `conversation`
+```
+
+:::{note}
+The assistants are named the way Home Assistant names them internally:
+`cloud.alexa` for Alexa, `cloud.google_assistant` for Google Assistant, and
+`conversation` for Assist. Anything else is refused.
+
+Every entity is checked before any of them change, so naming one that does not
+exist fails the whole call instead of leaving the ones before it done.
+:::
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: homeassistant.expose_entity
+data:
+  entity_id: light.living_room
+  assistants: conversation
+```
+
+Or several entities and several assistants at once:
+
+```{code-block} yaml
+:linenos:
+action: homeassistant.expose_entity
+data:
+  entity_id:
+    - light.living_room
+    - light.kitchen_ceiling
+  assistants:
+    - cloud.alexa
+    - conversation
+```
+
+:::
+
+### Stop exposing an entity to assistants
+
+This action does the reverse of [](#expose-an-entity-to-assistants), taking an entity back out of a voice assistant's reach.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Stop exposing an entity to assistants 👻
+* - {term}`Action name`
+  - `homeassistant.unexpose_entity`
+* - {term}`Action targets`
+  - No
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action.
+* - {term}`Tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.unexpose_entity)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.unexpose_entity)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `entity_id`
+  - {term}`string <string>` | {term}`list of strings <list>`
+  - Yes
+  - `"light.living_room"`
+* - `assistants`
+  - {term}`string <string>` | {term}`list of strings <list>`
+  - Yes
+  - `cloud.alexa`, `cloud.google_assistant`, `conversation`
+```
+
+:::{note}
+The assistants are named the way Home Assistant names them internally:
+`cloud.alexa` for Alexa, `cloud.google_assistant` for Google Assistant, and
+`conversation` for Assist. Anything else is refused.
+
+Every entity is checked before any of them change, so naming one that does not
+exist fails the whole call instead of leaving the ones before it done.
+:::
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: homeassistant.unexpose_entity
+data:
+  entity_id: light.living_room
+  assistants: conversation
+```
+
+Or several entities and several assistants at once:
+
+```{code-block} yaml
+:linenos:
+action: homeassistant.unexpose_entity
+data:
+  entity_id:
+    - light.living_room
+    - light.kitchen_ceiling
+  assistants:
+    - cloud.alexa
+    - conversation
 ```
 
 :::

--- a/documentation/integrations/sensor.md
+++ b/documentation/integrations/sensor.md
@@ -1,0 +1,113 @@
+---
+subject: Enhanced integrations
+title: Sensor
+subtitle: How many decimals is too many decimals?
+description: Spook adds a new action to the sensor integration, which allows you to set the number of decimals shown for one or more sensors at once.
+date: 2026-08-30T12:00:00+02:00
+---
+
+```{image} https://brands.home-assistant.io/sensor/logo.png
+:alt: The Home Assistant sensor icon
+:width: 250px
+:align: center
+```
+
+<br><br>
+
+The sensor {term}`integration <integration>` is the one that reports things: temperatures, power usage, how full the bins are. Most {term}`integrations <integration>` you install bring some along.
+
+Home Assistant lets you set how many decimals a sensor shows, but only one sensor at a time, by opening its settings in the UI. That is fine for one. It is less fine when an integration hands you forty power sensors that all report six decimals.
+
+Spook adds an action that sets the display precision on as many sensors as you like in a single call.
+
+## Devices & entities
+
+Spook does not provide any new devices or entities for this integration.
+
+## Actions
+
+Spook adds the following new actions to your Home Assistant instance:
+
+### Set display precision
+
+Sets the number of decimals shown for one or more sensors.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Set display precision 👻
+* - {term}`Action name`
+  - `sensor.set_display_precision`
+* - {term}`Action targets`
+  - No
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action
+* - {term}`Tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=sensor.set_display_precision)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=sensor.set_display_precision)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `entity_id`
+  - {term}`string <string>` or {term}`list <list>`
+  - Yes
+  - `"sensor.living_room_temperature"`
+* - `display_precision`
+  - {term}`integer <integer>`
+  - Yes
+  - `1`
+```
+
+:::{note}
+This is the same setting you find under a sensor's own settings in the UI, so
+it survives restarts and applies everywhere the sensor is shown.
+
+Every entity you name is looked up before any of them are changed. If one of
+them does not exist, the whole call fails and nothing is touched, rather than
+leaving you with half your sensors updated and nothing saying which half.
+:::
+
+:::{seealso} Example {term}`action <performing actions>` in {term}`YAML`
+:class: dropdown
+
+```{code-block} yaml
+:linenos:
+action: sensor.set_display_precision
+data:
+  entity_id:
+    - sensor.living_room_temperature
+    - sensor.bedroom_temperature
+  display_precision: 1
+```
+
+:::
+
+## Repairs
+
+Spook has no repair detections for this integration.
+
+## Use cases
+
+Some use cases for the enhancements Spook provides for this integration:
+
+- Trim every sensor an integration added down to a sensible number of decimals in one action, instead of opening each one in the UI.
+- Show more decimals on a sensor temporarily, for example while working out why a reading looks wrong, and set it back afterwards.
+
+## Blueprints & tutorials
+
+There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+## Feature requests, ideas, and support
+
+If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+Are you stuck using these new features? Or maybe you've run into a bug? Please check the [](../support) page on where to go for help.

--- a/tests/test_documentation_index.py
+++ b/tests/test_documentation_index.py
@@ -1,0 +1,182 @@
+"""Tests that the documentation index covers everything Spook ships.
+
+Both of these gaps are invisible from the inside. An action missing from the
+list is only noticed by somebody who already knows it exists and cannot find
+it, and a page with no card is only noticed by somebody who was not looking
+for it in the first place.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).parents[1]
+SPOOK = ROOT / "custom_components" / "spook"
+DOCS = ROOT / "documentation"
+
+# Spook ships well over eighty actions and twenty-odd integration pages, so
+# anything near this means a regex stopped matching rather than a real drop.
+AT_LEAST_THIS_MANY = 50
+
+ACTIONS = (DOCS / "actions.md").read_text()
+CARDS = (DOCS / "enhanced_integrations.md").read_text()
+TOC = (DOCS / "_toc.yml").read_text()
+
+# Every entry is a name in backticks followed by the deep link that offers it.
+_LISTED = re.compile(
+    r"^`([a-z_]+\.[a-z_]+)`, \[Try this action\]\((?P<link>[^)]+)\)"
+    r"(?:, \[documentation\]\((?P<doc>[^)]+)\))?",
+    re.MULTILINE,
+)
+
+
+def _domains() -> list[str]:
+    """Return the domains Spook adds actions to, longest first.
+
+    `services.yaml` joins the two halves with an underscore, and plenty of
+    domains contain one themselves, so the split has to know the domains
+    rather than guess at the first underscore.
+    """
+    ectoplasms = SPOOK / "ectoplasms"
+    return sorted(
+        (path.name for path in ectoplasms.iterdir() if (path / "services").is_dir()),
+        key=len,
+        reverse=True,
+    )
+
+
+def _shipped_actions() -> set[str]:
+    """Return every action Spook registers, read off services.yaml.
+
+    That file is what Home Assistant serves to the UI, so it is the list a
+    user can actually see, and therefore the list they can fail to find in
+    the documentation. Reading the modules instead would miss the actions
+    that inherit their name from another one.
+    """
+    domains = _domains()
+    services = yaml.safe_load((SPOOK / "services.yaml").read_text())
+
+    actions = set()
+    for key in services:
+        for domain in domains:
+            if key.startswith(f"{domain}_"):
+                actions.add(f"{domain}.{key[len(domain) + 1 :]}")
+                break
+        else:
+            # Spook's own actions are keyed bare, without a domain in front.
+            actions.add(f"spook.{key}")
+    return actions
+
+
+def _slug(heading: str) -> str:
+    """Turn a heading into the anchor the site gives it.
+
+    Punctuation is dropped rather than replaced, so "Update an entity's ID"
+    becomes `update-an-entitys-id` and not `update-an-entity-s-id`. Getting
+    that backwards is how the link to that very section came to be broken.
+    """
+    kept = re.sub(r"[^a-z0-9 -]+", "", heading.lower())
+    return re.sub(r"[ -]+", "-", kept).strip("-")
+
+
+def _page(reference: str) -> Path | None:
+    """Return the file a documentation reference points at.
+
+    The site slugifies underscores into hyphens, and the references in the
+    action list are written both ways, so both have to resolve.
+    """
+    for candidate in (reference, reference.replace("-", "_")):
+        if (path := DOCS / f"{candidate}.md").exists():
+            return path
+    return None
+
+
+def test_the_scan_finds_the_entries() -> None:
+    """Guard the two regexes, which would otherwise pass by matching nothing."""
+    assert len(_LISTED.findall(ACTIONS)) > AT_LEAST_THIS_MANY
+    assert len(_shipped_actions()) > AT_LEAST_THIS_MANY
+
+
+def test_every_action_is_in_the_list() -> None:
+    """An action nobody can find might as well not have shipped."""
+    listed = {match[0] for match in _LISTED.findall(ACTIONS)}
+    missing = _shipped_actions() - listed
+    assert not missing, f"not in documentation/actions.md: {sorted(missing)}"
+
+
+def test_no_action_is_claimed_by_two_entries() -> None:
+    """Entries get copied from the one above and only half corrected.
+
+    Device: Enable carried the disable action, its link and its documentation
+    for a long time, which reads as a working entry right up until somebody
+    uses it.
+    """
+    named = [match[0] for match in _LISTED.findall(ACTIONS)]
+    twice = sorted(action for action, count in Counter(named).items() if count > 1)
+    assert not twice, f"listed under more than one heading: {twice}"
+
+
+def test_no_documentation_link_is_shared_by_two_entries() -> None:
+    """The other half of the same copy: the name fixed, the link left behind."""
+    docs = [m["doc"] for m in _LISTED.finditer(ACTIONS) if m["doc"]]
+    twice = sorted(link for link, count in Counter(docs).items() if count > 1)
+    assert not twice, f"documentation link used by more than one entry: {twice}"
+
+
+def _pages() -> set[str]:
+    """Return the integration pages the table of contents carries."""
+    return set(re.findall(r"- file: integrations/(\w+)", TOC))
+
+
+@pytest.mark.parametrize("direction", ["page-without-card", "card-without-page"])
+def test_pages_and_cards_agree(direction: str) -> None:
+    """Pages and cards have to line up in both directions.
+
+    The card grid is how these pages get found, so one without a card is only
+    reachable by guessing its URL.
+    """
+    pages = _pages()
+    cards = set(re.findall(r"\]\(integrations/(\w+)\)", CARDS))
+    assert pages, "no integration pages found in the table of contents"
+
+    if direction == "page-without-card":
+        assert not pages - cards, (
+            f"no card on the integrations page: {sorted(pages - cards)}"
+        )
+    else:
+        assert not cards - pages, f"card points at no page: {sorted(cards - pages)}"
+
+
+def test_every_documentation_link_points_at_a_page_that_exists() -> None:
+    """A link into a page that was renamed reads fine and goes nowhere."""
+    broken = []
+    for match in _LISTED.finditer(ACTIONS):
+        if not (doc := match["doc"]):
+            continue
+        if _page(doc.split("#", 1)[0]) is None:
+            broken.append(f"{match[0]} -> {doc}")
+    assert not broken, f"documentation links with no page: {broken}"
+
+
+def test_every_documentation_anchor_points_at_a_real_heading() -> None:
+    """Anchors rot quietly when a heading is reworded."""
+    broken = []
+    for match in _LISTED.finditer(ACTIONS):
+        if not (doc := match["doc"]) or "#" not in doc:
+            continue
+        page, _, anchor = doc.partition("#")
+        if (path := _page(page)) is None:
+            continue
+        text = path.read_text()
+        headings = {
+            _slug(heading) for heading in re.findall(r"^#+ (.+)$", text, re.MULTILINE)
+        }
+        headings |= set(re.findall(r"^\(([a-z0-9-]+)\)=$", text, re.MULTILINE))
+        if anchor not in headings:
+            broken.append(f"{match[0]} -> {doc}")
+    assert not broken, f"documentation anchors with no heading: {broken}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Stacked on #1533, so the base is that branch. The diff shown here is this work only.

Eight shipped actions had no entry in the action list, and six integration pages had no card on the enhanced integrations page. Both are gaps that only get noticed by somebody who already knows the thing exists and then cannot find it.

Two entries that were there named the wrong action:

- **Device: Enable** was copied from **Device: Disable** and kept all three of its links. So the entry for enabling a device handed you the disable action, the disable deep link and the disable documentation.
- **Person: Remove a device tracker** names `person.add_device_tracker`, beside a heading, a description and a link that all say remove.

Exposing an entity to voice assistants turned out to have no documentation anywhere, so that got written rather than linked. Two sections on the entities page, one per direction, covering the bit that is easy to get wrong: the assistants go by their internal names (`cloud.alexa`, `cloud.google_assistant`, `conversation`) and every entity is checked before any of them change.

Then a test so none of it drifts again, which turned up one more broken link on its own.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Found while writing the sensor page in #1533. Once the missing entries were written out by hand it was obvious they would go missing again, since nothing anywhere connected what Spook serves to what the documentation lists.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

New `tests/test_documentation_index.py`, which pins six things:

- Every action in `services.yaml` has an entry in the action list.
- No two entries claim the same action.
- No two entries share a documentation link.
- Every documentation link lands on a page that exists.
- Every anchor lands on a heading that exists.
- Pages and cards agree, in both directions.

The action list comes from `services.yaml` rather than the modules, because that is what Home Assistant hands the UI, and because `input_select.random` inherits its name from `select.random` and is invisible to anything reading the source.

Writing the anchor check found one more broken link on its own: the entry for updating an entity ID pointed at `update-an-entitys_id`, while the heading slugifies to `update-an-entitys-id`. Confirmed against the live site, which serves `id="update-an-entitys-id"`. Getting punctuation wrong is exactly how that link broke, so the helper drops it rather than replacing it, as the site does.

Each check was mutation tested by breaking the thing it watches:

| Mutation | Result |
| --- | --- |
| Drop the `zone.create` entry | 1 failed |
| Put the disable action back on Device: Enable | 3 failed |
| Bend one documentation anchor | 1 failed |
| Point a link at a page that is gone | 1 failed |
| Delete the Alert card | 1 failed |

Full suite is 1418 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None. The two new sections on the entities page have no screenshots, unlike their neighbours.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
