### PR TITLE
Notice a dashboard resource listed twice

### DIFF
--- a/custom_components/spook/dashboard_resources.py
+++ b/custom_components/spook/dashboard_resources.py
@@ -9,8 +9,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from homeassistant.components.lovelace import DOMAIN as LOVELACE_DOMAIN
+
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.collection import ChangeListener
 
 # Resources served out of the configuration directory, where the path is the
 # file. Anything else is somebody else's server, and a query string there can
@@ -89,3 +94,33 @@ def redundant_item_ids(items: Iterable[dict], key: str) -> list[str]:
     """
     matching = [item for item in items if item.get("url") and group_key(item) == key]
     return [item["id"] for item in matching[:-1] if item.get("id")]
+
+
+def async_watch_resources(
+    hass: HomeAssistant,
+    on_change: ChangeListener,
+) -> Callable[[], None] | None:
+    """Call `on_change` whenever a dashboard resource is added or removed.
+
+    `EVENT_LOVELACE_UPDATED` does not cover this. Home Assistant fires that
+    when a dashboard configuration is saved, while the resource collection
+    tells its own listeners and nobody else. Without this a resource added
+    from Settings goes unnoticed until something unrelated loads or the house
+    restarts.
+
+    Returns nothing when there is nothing to watch. Resources listed in YAML
+    are a plain list rather than an observable collection, and they cannot
+    change without a reload anyway.
+    """
+    if (lovelace := hass.data.get(LOVELACE_DOMAIN)) is None:
+        return None
+
+    # Reached by attribute rather than assumed: this is another integration's
+    # data, and Spook is a guest in it.
+    if (resources := getattr(lovelace, "resources", None)) is None:
+        return None
+
+    if not hasattr(resources, "async_add_listener"):
+        return None
+
+    return resources.async_add_listener(on_change)

--- a/custom_components/spook/dashboard_resources.py
+++ b/custom_components/spook/dashboard_resources.py
@@ -1,0 +1,73 @@
+"""Spook - Your homie. Shared rules for dashboard resources.
+
+Both the repair that finds duplicated resources and the fix flow that clears
+them need to agree on what makes two resources the same thing. They live on
+opposite sides of an import cycle, so the rule lives here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# Resources served out of the configuration directory, where the path is the
+# file. Anything else is somebody else's server, and a query string there can
+# genuinely change what comes back.
+_LOCAL_PREFIXES = ("/local/", "/hacsfiles/")
+
+
+def is_local(url: str) -> bool:
+    """Return whether this URL maps to a file Home Assistant serves itself."""
+    return url.startswith(_LOCAL_PREFIXES)
+
+
+def group_key(url: str) -> str:
+    """Return what makes two resources the same thing.
+
+    For a local file the query string is cache busting, so `card.js?v=1` and
+    `card.js?v=2` are one file listed twice, and the browser loading both is
+    what breaks the card. For anything else the query can be the difference
+    between two real files, so only an exact repeat counts.
+    """
+    if is_local(url):
+        return url.split("?", 1)[0]
+    return url
+
+
+def find_duplicates(items: Iterable[dict]) -> dict[str, list[str]]:
+    """Return every resource listed more than once, by what it points at."""
+    seen: dict[str, list[str]] = {}
+    for item in items:
+        if url := item.get("url"):
+            seen.setdefault(group_key(url), []).append(url)
+
+    return {key: urls for key, urls in seen.items() if len(urls) > 1}
+
+
+def describe(key: str, urls: list[str]) -> str:
+    """Return one line naming a duplicated resource."""
+    unique = sorted(set(urls))
+    if len(unique) == 1:
+        # Name it as it appears in the list. For a local resource the key is
+        # the path with the query taken off, so reporting that would send
+        # somebody looking for a URL that is not in there.
+        return f"- `{unique[0]}`, listed {len(urls)} times"
+
+    listed = ", ".join(f"`{url}`" for url in unique)
+    return f"- `{key}`, listed {len(urls)} times: {listed}"
+
+
+def redundant_item_ids(items: Iterable[dict], key: str) -> list[str]:
+    """Return the IDs of the copies to clear, keeping one.
+
+    The one kept is the last, which is the most recently added. For the case
+    this exists to clean up, a card updated by adding a resource for the new
+    version instead of editing the old one, that is the version somebody
+    actually meant to end up with.
+    """
+    matching = [
+        item for item in items if (url := item.get("url")) and group_key(url) == key
+    ]
+    return [item["id"] for item in matching[:-1] if item.get("id")]

--- a/custom_components/spook/dashboard_resources.py
+++ b/custom_components/spook/dashboard_resources.py
@@ -17,31 +17,51 @@ if TYPE_CHECKING:
 # genuinely change what comes back.
 _LOCAL_PREFIXES = ("/local/", "/hacsfiles/")
 
+# Separates the resource type from what it points at, in the key that decides
+# whether two resources are the same one.
+_SEPARATOR = "|"
+
 
 def is_local(url: str) -> bool:
     """Return whether this URL maps to a file Home Assistant serves itself."""
     return url.startswith(_LOCAL_PREFIXES)
 
 
-def group_key(url: str) -> str:
-    """Return what makes two resources the same thing.
+def _target(url: str) -> str:
+    """Return what a URL points at, ignoring cache busting on local files.
 
     For a local file the query string is cache busting, so `card.js?v=1` and
-    `card.js?v=2` are one file listed twice, and the browser loading both is
-    what breaks the card. For anything else the query can be the difference
-    between two real files, so only an exact repeat counts.
+    `card.js?v=2` are one file, and the browser loading both is what breaks
+    the card. For anything else the query can be the difference between two
+    real files, so only an exact repeat counts.
     """
     if is_local(url):
         return url.split("?", 1)[0]
     return url
 
 
+def group_key(item: dict) -> str:
+    """Return what makes two resources the same thing.
+
+    The type is part of it. Home Assistant loads a `module` differently from a
+    `css`, so the same URL under two types is two different instructions, not
+    a repeat. Clearing one of those would take away something that was meant
+    to be there.
+    """
+    return f"{item.get('type', '')}{_SEPARATOR}{_target(item.get('url', ''))}"
+
+
+def target_of(key: str) -> str:
+    """Return the part of a key worth showing somebody."""
+    return key.split(_SEPARATOR, 1)[-1]
+
+
 def find_duplicates(items: Iterable[dict]) -> dict[str, list[str]]:
     """Return every resource listed more than once, by what it points at."""
     seen: dict[str, list[str]] = {}
     for item in items:
-        if url := item.get("url"):
-            seen.setdefault(group_key(url), []).append(url)
+        if item.get("url"):
+            seen.setdefault(group_key(item), []).append(item["url"])
 
     return {key: urls for key, urls in seen.items() if len(urls) > 1}
 
@@ -50,13 +70,13 @@ def describe(key: str, urls: list[str]) -> str:
     """Return one line naming a duplicated resource."""
     unique = sorted(set(urls))
     if len(unique) == 1:
-        # Name it as it appears in the list. For a local resource the key is
-        # the path with the query taken off, so reporting that would send
+        # Name it as it appears in the list. For a local resource the target
+        # is the path with the query taken off, so reporting that would send
         # somebody looking for a URL that is not in there.
         return f"- `{unique[0]}`, listed {len(urls)} times"
 
     listed = ", ".join(f"`{url}`" for url in unique)
-    return f"- `{key}`, listed {len(urls)} times: {listed}"
+    return f"- `{target_of(key)}`, listed {len(urls)} times: {listed}"
 
 
 def redundant_item_ids(items: Iterable[dict], key: str) -> list[str]:
@@ -67,7 +87,5 @@ def redundant_item_ids(items: Iterable[dict], key: str) -> list[str]:
     version instead of editing the old one, that is the version somebody
     actually meant to end up with.
     """
-    matching = [
-        item for item in items if (url := item.get("url")) and group_key(url) == key
-    ]
+    matching = [item for item in items if item.get("url") and group_key(item) == key]
     return [item["id"] for item in matching[:-1] if item.get("id")]

--- a/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
@@ -6,7 +6,12 @@ from homeassistant.components.lovelace import DOMAIN
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
 
 from ....const import LOGGER
-from ....dashboard_resources import describe, find_duplicates, target_of
+from ....dashboard_resources import (
+    async_watch_resources,
+    describe,
+    find_duplicates,
+    target_of,
+)
 from ....repairs import AbstractSpookRepair
 
 
@@ -27,6 +32,29 @@ class SpookRepair(AbstractSpookRepair):
         EVENT_LOVELACE_UPDATED,
     }
     automatically_clean_up_issues = True
+
+    async def async_activate(self) -> None:
+        """Activate, and also watch the resource list itself.
+
+        `inspect_events` covers component loads and dashboard saves. Neither
+        fires when somebody adds or removes a resource, so without this the
+        next look at them is a restart away.
+        """
+        await super().async_activate()
+
+        if (
+            unsub := async_watch_resources(self.hass, self._async_resources_changed)
+        ) is not None:
+            self._event_subs.add(unsub)
+
+    async def _async_resources_changed(  # pylint: disable=unused-argument
+        self,
+        change_type: str,  # noqa: ARG002
+        item_id: str,  # noqa: ARG002
+        config: dict,  # noqa: ARG002
+    ) -> None:
+        """Look again, once the changes stop arriving."""
+        await self.inspect_debouncer.async_call()
 
     async def async_inspect(self) -> None:
         """Trigger an inspection."""

--- a/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
@@ -6,7 +6,7 @@ from homeassistant.components.lovelace import DOMAIN
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
 
 from ....const import LOGGER
-from ....dashboard_resources import describe, find_duplicates
+from ....dashboard_resources import describe, find_duplicates, target_of
 from ....repairs import AbstractSpookRepair
 
 
@@ -53,12 +53,12 @@ class SpookRepair(AbstractSpookRepair):
                 is_fixable=True,
                 data={
                     "duplicate_resource_url": key,
-                    "resource": key,
+                    "resource": target_of(key),
                     "resources": describe(key, urls),
                     "count": str(len(urls)),
                 },
                 translation_placeholders={
-                    "resource": key,
+                    "resource": target_of(key),
                     "resources": describe(key, urls),
                     "count": str(len(urls)),
                 },

--- a/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
@@ -1,0 +1,101 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from homeassistant.components.lovelace import DOMAIN
+from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
+
+from ....const import LOGGER
+from ....repairs import AbstractSpookRepair
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# Resources served from the configuration directory, where the path is the
+# file. Anything else is somebody else's server, and a query string there can
+# genuinely change what comes back.
+_LOCAL_PREFIXES = ("/local/", "/hacsfiles/")
+
+
+def _is_local(url: str) -> bool:
+    """Return whether this URL maps to a file Home Assistant serves itself."""
+    return url.startswith(_LOCAL_PREFIXES)
+
+
+def _group_key(url: str) -> str:
+    """Return what makes two resources the same thing.
+
+    For a local file the query string is cache busting, so `card.js?v=1` and
+    `card.js?v=2` are one file listed twice, and the browser loading both is
+    what breaks the card. For anything else the query can be the difference
+    between two real files, so only an exact repeat counts.
+    """
+    if _is_local(url):
+        return url.split("?", 1)[0]
+    return url
+
+
+def _describe(key: str, urls: list[str]) -> str:
+    """Return one line naming a duplicated resource."""
+    unique = sorted(set(urls))
+    if len(unique) == 1:
+        return f"- `{key}`, listed {len(urls)} times"
+    listed = ", ".join(f"`{url}`" for url in unique)
+    return f"- `{key}`, listed {len(urls)} times: {listed}"
+
+
+class SpookRepair(AbstractSpookRepair):
+    """Spook repair finds the same dashboard resource listed more than once.
+
+    Updating a custom card by adding a resource for the new version, instead
+    of editing the one already there, leaves both behind. The browser fetches
+    both, the card tries to register itself twice, and the second attempt
+    throws. The card is then broken in a way that points at the card rather
+    than at the resource list.
+    """
+
+    domain = DOMAIN
+    repair = "lovelace_duplicate_resources"
+    inspect_events = {
+        EVENT_COMPONENT_LOADED,
+        EVENT_LOVELACE_UPDATED,
+    }
+    automatically_clean_up_issues = True
+
+    async def async_inspect(self) -> None:
+        """Trigger an inspection."""
+        LOGGER.debug("Spook is inspecting: %s", self.repair)
+
+        self.possible_issue_ids.add(self.repair)
+
+        if (resources := self.hass.data[DOMAIN].resources) is None:
+            return
+
+        # Storage-mode resources load the first time somebody asks for them,
+        # which is normally the dashboard, long after Spook looks.
+        await resources.async_get_info()
+
+        if not (duplicated := self._find_duplicates(resources.async_items() or [])):
+            return
+
+        self.async_create_issue(
+            issue_id=self.repair,
+            translation_placeholders={
+                "resources": "\n".join(
+                    _describe(key, duplicated[key]) for key in sorted(duplicated)
+                ),
+            },
+        )
+
+    @staticmethod
+    def _find_duplicates(items: Iterable[dict]) -> dict[str, list[str]]:
+        """Return every resource listed more than once, by what it points at."""
+        seen: dict[str, list[str]] = defaultdict(list)
+        for item in items:
+            if url := item.get("url"):
+                seen[_group_key(url)].append(url)
+
+        return {key: urls for key, urls in seen.items() if len(urls) > 1}

--- a/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
@@ -42,7 +42,10 @@ def _describe(key: str, urls: list[str]) -> str:
     """Return one line naming a duplicated resource."""
     unique = sorted(set(urls))
     if len(unique) == 1:
-        return f"- `{key}`, listed {len(urls)} times"
+        # Name it as it appears in the list. For a local resource the key is
+        # the path with the query taken off, so reporting that would send
+        # somebody looking for a URL that is not in there.
+        return f"- `{unique[0]}`, listed {len(urls)} times"
     listed = ", ".join(f"`{url}`" for url in unique)
     return f"- `{key}`, listed {len(urls)} times: {listed}"
 

--- a/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
@@ -74,7 +74,12 @@ class SpookRepair(AbstractSpookRepair):
 
         self.possible_issue_ids.add(self.repair)
 
-        if (resources := self.hass.data[DOMAIN].resources) is None:
+        # Every component that loads pokes this repair, and Lovelace is not
+        # necessarily one of the ones already up when that happens.
+        if (lovelace := self.hass.data.get(DOMAIN)) is None:
+            return
+
+        if (resources := lovelace.resources) is None:
             return
 
         # Storage-mode resources load the first time somebody asks for them,

--- a/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
@@ -2,52 +2,12 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-from typing import TYPE_CHECKING
-
 from homeassistant.components.lovelace import DOMAIN
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
 
 from ....const import LOGGER
+from ....dashboard_resources import describe, find_duplicates
 from ....repairs import AbstractSpookRepair
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-# Resources served from the configuration directory, where the path is the
-# file. Anything else is somebody else's server, and a query string there can
-# genuinely change what comes back.
-_LOCAL_PREFIXES = ("/local/", "/hacsfiles/")
-
-
-def _is_local(url: str) -> bool:
-    """Return whether this URL maps to a file Home Assistant serves itself."""
-    return url.startswith(_LOCAL_PREFIXES)
-
-
-def _group_key(url: str) -> str:
-    """Return what makes two resources the same thing.
-
-    For a local file the query string is cache busting, so `card.js?v=1` and
-    `card.js?v=2` are one file listed twice, and the browser loading both is
-    what breaks the card. For anything else the query can be the difference
-    between two real files, so only an exact repeat counts.
-    """
-    if _is_local(url):
-        return url.split("?", 1)[0]
-    return url
-
-
-def _describe(key: str, urls: list[str]) -> str:
-    """Return one line naming a duplicated resource."""
-    unique = sorted(set(urls))
-    if len(unique) == 1:
-        # Name it as it appears in the list. For a local resource the key is
-        # the path with the query taken off, so reporting that would send
-        # somebody looking for a URL that is not in there.
-        return f"- `{unique[0]}`, listed {len(urls)} times"
-    listed = ", ".join(f"`{url}`" for url in unique)
-    return f"- `{key}`, listed {len(urls)} times: {listed}"
 
 
 class SpookRepair(AbstractSpookRepair):
@@ -72,8 +32,6 @@ class SpookRepair(AbstractSpookRepair):
         """Trigger an inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
-        self.possible_issue_ids.add(self.repair)
-
         # Every component that loads pokes this repair, and Lovelace is not
         # necessarily one of the ones already up when that happens.
         if (lovelace := self.hass.data.get(DOMAIN)) is None:
@@ -86,24 +44,20 @@ class SpookRepair(AbstractSpookRepair):
         # which is normally the dashboard, long after Spook looks.
         await resources.async_get_info()
 
-        if not (duplicated := self._find_duplicates(resources.async_items() or [])):
-            return
+        # Resources listed in YAML are static, so there is nothing to offer
+        # beyond pointing at them: the fix has to happen in the file.
+        can_remove = hasattr(resources, "async_delete_item")
 
-        self.async_create_issue(
-            issue_id=self.repair,
-            translation_placeholders={
-                "resources": "\n".join(
-                    _describe(key, duplicated[key]) for key in sorted(duplicated)
-                ),
-            },
-        )
-
-    @staticmethod
-    def _find_duplicates(items: Iterable[dict]) -> dict[str, list[str]]:
-        """Return every resource listed more than once, by what it points at."""
-        seen: dict[str, list[str]] = defaultdict(list)
-        for item in items:
-            if url := item.get("url"):
-                seen[_group_key(url)].append(url)
-
-        return {key: urls for key, urls in seen.items() if len(urls) > 1}
+        items = list(resources.async_items() or [])
+        for key, urls in find_duplicates(items).items():
+            self.possible_issue_ids.add(key)
+            self.async_create_issue(
+                issue_id=key,
+                is_fixable=can_remove,
+                data={"duplicate_resource_url": key, "resource": key},
+                translation_placeholders={
+                    "resource": key,
+                    "resources": describe(key, urls),
+                    "count": str(len(urls)),
+                },
+            )

--- a/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
@@ -45,16 +45,12 @@ class SpookRepair(AbstractSpookRepair):
         # which is normally the dashboard, long after Spook looks.
         await resources.async_get_info()
 
-        # Resources listed in YAML are static, so there is nothing to offer
-        # beyond pointing at them: the fix has to happen in the file.
-        can_remove = hasattr(resources, "async_delete_item")
-
         items = list(resources.async_items() or [])
         for key, urls in find_duplicates(items).items():
             self.possible_issue_ids.add(key)
             self.async_create_issue(
                 issue_id=key,
-                is_fixable=can_remove,
+                is_fixable=True,
                 data={
                     "duplicate_resource_url": key,
                     "resource": key,

--- a/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/duplicate_resources.py
@@ -32,12 +32,13 @@ class SpookRepair(AbstractSpookRepair):
         """Trigger an inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
-        # Every component that loads pokes this repair, and Lovelace is not
-        # necessarily one of the ones already up when that happens.
-        if (lovelace := self.hass.data.get(DOMAIN)) is None:
-            return
-
-        if (resources := lovelace.resources) is None:
+        # Reached straight rather than guarded: Lovelace is a hard dependency
+        # in the manifest, so Home Assistant has set it up before Spook. A
+        # guard here would be worse than none, because returning early counts
+        # as a clean inspection and cleanup would then delete every issue this
+        # repair has, ignored ones included. If that invariant ever breaks, a
+        # KeyError is what should happen: it leaves the bookkeeping intact.
+        if (resources := self.hass.data[DOMAIN].resources) is None:
             return
 
         # Storage-mode resources load the first time somebody asks for them,
@@ -54,7 +55,12 @@ class SpookRepair(AbstractSpookRepair):
             self.async_create_issue(
                 issue_id=key,
                 is_fixable=can_remove,
-                data={"duplicate_resource_url": key, "resource": key},
+                data={
+                    "duplicate_resource_url": key,
+                    "resource": key,
+                    "resources": describe(key, urls),
+                    "count": str(len(urls)),
+                },
                 translation_placeholders={
                     "resource": key,
                     "resources": describe(key, urls),

--- a/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
@@ -9,6 +9,7 @@ from homeassistant.components.lovelace import DOMAIN
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
 
 from ....const import LOGGER
+from ....dashboard_resources import async_watch_resources
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -46,6 +47,29 @@ class SpookRepair(AbstractSpookRepair):
         EVENT_LOVELACE_UPDATED,
     }
     automatically_clean_up_issues = True
+
+    async def async_activate(self) -> None:
+        """Activate, and also watch the resource list itself.
+
+        `inspect_events` covers component loads and dashboard saves. Neither
+        fires when somebody adds or removes a resource, so without this the
+        next look at them is a restart away.
+        """
+        await super().async_activate()
+
+        if (
+            unsub := async_watch_resources(self.hass, self._async_resources_changed)
+        ) is not None:
+            self._event_subs.add(unsub)
+
+    async def _async_resources_changed(  # pylint: disable=unused-argument
+        self,
+        change_type: str,  # noqa: ARG002
+        item_id: str,  # noqa: ARG002
+        config: dict,  # noqa: ARG002
+    ) -> None:
+        """Look again, once the changes stop arriving."""
+        await self.inspect_debouncer.async_call()
 
     async def async_inspect(self) -> None:
         """Trigger an inspection."""

--- a/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
@@ -53,7 +53,12 @@ class SpookRepair(AbstractSpookRepair):
 
         self.possible_issue_ids.add(self.repair)
 
-        if (resources := self.hass.data[DOMAIN].resources) is None:
+        # Every component that loads pokes this repair, and Lovelace is not
+        # necessarily one of the ones already up when that happens.
+        if (lovelace := self.hass.data.get(DOMAIN)) is None:
+            return
+
+        if (resources := lovelace.resources) is None:
             return
 
         # Storage-mode resources are loaded the first time somebody asks for

--- a/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
@@ -53,12 +53,13 @@ class SpookRepair(AbstractSpookRepair):
 
         self.possible_issue_ids.add(self.repair)
 
-        # Every component that loads pokes this repair, and Lovelace is not
-        # necessarily one of the ones already up when that happens.
-        if (lovelace := self.hass.data.get(DOMAIN)) is None:
-            return
-
-        if (resources := lovelace.resources) is None:
+        # Reached straight rather than guarded: Lovelace is a hard dependency
+        # in the manifest, so Home Assistant has set it up before Spook. A
+        # guard here would be worse than none, because returning early counts
+        # as a clean inspection and cleanup would then delete every issue this
+        # repair has, ignored ones included. If that invariant ever breaks, a
+        # KeyError is what should happen: it leaves the bookkeeping intact.
+        if (resources := self.hass.data[DOMAIN].resources) is None:
             return
 
         # Storage-mode resources are loaded the first time somebody asks for

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -10,7 +10,7 @@ import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, final
 
-from homeassistant.components import blueprint
+from homeassistant.components import blueprint, lovelace as lovelace_const
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.homeassistant import SERVICE_HOMEASSISTANT_RESTART
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
@@ -38,6 +38,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.async_ import create_eager_task
 
 from .const import DOMAIN, LOGGER
+from .dashboard_resources import redundant_item_ids
 from .entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from .entity_suggestions import async_describe_unknown_entities
 
@@ -723,6 +724,39 @@ class UnusedBlueprintFixFlow(_RemoveOrIgnoreFixFlow):
         return self.async_create_entry(data={})
 
 
+class DuplicateResourceFixFlow(_RemoveOrIgnoreFixFlow):
+    """Handler for a dashboard resource listed more than once.
+
+    Clearing the copies is async and needs the resource collection, so this
+    overrides ``async_step_remove`` rather than the synchronous ``_remove``
+    hook. One copy is kept: the most recently added, which for a card updated
+    by adding a resource instead of editing one is the version wanted.
+    """
+
+    _key = "resource"
+    _id_key = "duplicate_resource_url"
+
+    async def async_step_remove(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Clear the redundant copies, keeping the most recent."""
+        key = str((self.data or {}).get(self._id_key, ""))
+
+        if (lovelace := self.hass.data.get(lovelace_const.DOMAIN)) is None or (
+            resources := lovelace.resources
+        ) is None:
+            return self.async_create_entry(data={})
+
+        for item_id in redundant_item_ids(resources.async_items() or [], key):
+            # Somebody may have cleared it themselves since the issue was
+            # raised, which is a fine way for this to end too.
+            with suppress(KeyError, ValueError):
+                await resources.async_delete_item(item_id)
+
+        return self.async_create_entry(data={})
+
+
 class PersonUnknownDeviceTrackerFixFlow(_RemoveOrIgnoreFixFlow):
     """Handler for a person's unknown device trackers.
 
@@ -938,6 +972,7 @@ _REMOVE_OR_IGNORE_FLOWS: dict[str, type[_RemoveOrIgnoreFixFlow]] = {
     "empty_floor_id": EmptyFloorFixFlow,
     "unused_label_id": UnusedLabelFixFlow,
     "unused_blueprint_path": UnusedBlueprintFixFlow,
+    "duplicate_resource_url": DuplicateResourceFixFlow,
     "person_entity_id": PersonUnknownDeviceTrackerFixFlow,
     "group_entity_id": GroupUnknownMembersFixFlow,
     "min_max_config_entry_id": MinMaxUnknownSourcesFixFlow,

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -750,6 +750,27 @@ class DuplicateResourceFixFlow(_RemoveOrIgnoreFixFlow):
             "count": str(data.get("count", "")),
         }
 
+    async def async_step_init(
+        self,
+        _: dict[str, str] | None = None,
+    ) -> FlowResult:
+        """Offer the usual menu, unless there is nothing here that can fix it.
+
+        Resources listed in YAML are static: nothing in Home Assistant can
+        delete one, so offering to would be a button that quietly does
+        nothing. Those get told where the file is instead.
+        """
+        lovelace = self.hass.data.get(lovelace_const.DOMAIN)
+        resources = lovelace.resources if lovelace is not None else None
+
+        if resources is not None and not hasattr(resources, "async_delete_item"):
+            return self.async_abort(
+                reason="yaml",
+                description_placeholders=self._menu_placeholders(),
+            )
+
+        return await super().async_step_init()
+
     async def async_step_remove(
         self,
         _: dict[str, str] | None = None,

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -736,6 +736,19 @@ class DuplicateResourceFixFlow(_RemoveOrIgnoreFixFlow):
     _key = "resource"
     _id_key = "duplicate_resource_url"
 
+    def _menu_placeholders(self) -> dict[str, str]:
+        """Name the resource, how many copies, and which URLs.
+
+        The inherited version supplies only the name, and this dialog's text
+        interpolates all three.
+        """
+        data = self.data or {}
+        return {
+            "resource": str(data.get("resource", "")),
+            "resources": str(data.get("resources", "")),
+            "count": str(data.get("count", "")),
+        }
+
     async def async_step_remove(
         self,
         _: dict[str, str] | None = None,
@@ -747,6 +760,11 @@ class DuplicateResourceFixFlow(_RemoveOrIgnoreFixFlow):
             resources := lovelace.resources
         ) is None:
             return self.async_create_entry(data={})
+
+        # A storage collection hands out nothing until it has been loaded, and
+        # this flow cannot assume the inspection that raised the issue is what
+        # loaded it. Reading it cold would clear nothing and still say it did.
+        await resources.async_get_info()
 
         for item_id in redundant_item_ids(resources.async_items() or [], key):
             # Somebody may have cleared it themselves since the issue was

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -25,6 +25,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     area_registry as ar,
+    collection,
     device_registry as dr,
     entity_registry as er,
     floor_registry as fr,
@@ -767,9 +768,9 @@ class DuplicateResourceFixFlow(_RemoveOrIgnoreFixFlow):
         await resources.async_get_info()
 
         for item_id in redundant_item_ids(resources.async_items() or [], key):
-            # Somebody may have cleared it themselves since the issue was
-            # raised, which is a fine way for this to end too.
-            with suppress(KeyError, ValueError):
+            # Somebody may have cleared it themselves between the snapshot
+            # above and here, which is a fine way for this to end too.
+            with suppress(collection.ItemNotFound):
                 await resources.async_delete_item(item_id)
 
         return self.async_create_entry(data={})

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -788,9 +788,27 @@ class DuplicateResourceFixFlow(_RemoveOrIgnoreFixFlow):
         # loaded it. Reading it cold would clear nothing and still say it did.
         await resources.async_get_info()
 
-        for item_id in redundant_item_ids(resources.async_items() or [], key):
-            # Somebody may have cleared it themselves between the snapshot
-            # above and here, which is a fine way for this to end too.
+        # Worked out again after every deletion rather than once up front.
+        # Each delete awaits, and somebody editing the same resource in that
+        # window can take away the copy this was going to keep. Against a
+        # stale list that ends with every copy gone, which is not what anybody
+        # asked for.
+        tried: set[str] = set()
+        while True:
+            redundant = [
+                item_id
+                for item_id in redundant_item_ids(resources.async_items() or [], key)
+                if item_id not in tried
+            ]
+            if not redundant:
+                break
+
+            item_id = redundant[0]
+            # Remembered whatever happens, so a copy that cannot be deleted
+            # cannot spin this loop forever either.
+            tried.add(item_id)
+
+            # Somebody clearing it themselves first is a fine ending too.
             with suppress(collection.ItemNotFound):
                 await resources.async_delete_item(item_id)
 

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -568,8 +568,24 @@
       "title": "Dashboard resources point at missing files"
     },
     "lovelace_duplicate_resources": {
-      "description": "Spook has found a ghost in your dashboards \ud83d\udc7b\n\nThe following dashboard resources are listed more than once:\n\n{resources}\n\n\n\nThis usually happens when a custom card was updated by adding a resource for the new version instead of editing the one already there. The browser loads both, the card tries to register itself twice, and the second attempt fails, which looks like a broken card rather than a duplicated resource. To fix this error, open Settings > Dashboards > Resources and remove the copies you no longer need.\n\nSpook \ud83d\udc7b Your homie.",
-      "title": "Dashboard resources listed more than once"
+      "title": "Dashboard resource listed more than once: {resource}",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Dashboard resource listed more than once: {resource}",
+            "description": "Spook has found a ghost in your dashboards \ud83d\udc7b\n\nThis dashboard resource is listed {count} times:\n\n{resources}\n\nThis usually happens when a custom card was updated by adding a resource for the new version instead of editing the one already there. The browser loads both, the card tries to register itself twice, and the second attempt fails, which looks like a broken card rather than a duplicated resource.\n\nSpook can clear the extra copies and keep the most recently added one.\n\nSpook \ud83d\udc7b Your homie.",
+            "menu_options": {
+              "remove": "Clear the extra copies, keep the most recent",
+              "ignore": "Leave them, stop telling me",
+              "manage": "Let me fix it myself"
+            }
+          }
+        },
+        "abort": {
+          "issue_ignored": "Spook will keep quiet about this resource from now on.",
+          "manage": "You can manage your dashboard resources yourself on the [Resources page](/config/lovelace/resources)."
+        }
+      }
     },
     "lovelace_unknown_area_references": {
       "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n{dashboard}\n\nThis dashboard references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nThis often happens when an area was renamed or removed. To fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -568,6 +568,7 @@
       "title": "Dashboard resources point at missing files"
     },
     "lovelace_duplicate_resources": {
+      "description": "Spook has found a ghost in your dashboards \ud83d\udc7b\n\nThis dashboard resource is listed {count} times:\n\n{resources}\n\nThis usually happens when a custom card was updated by adding a resource for the new version instead of editing the one already there. The browser loads both, the card tries to register itself twice, and the second attempt fails, which looks like a broken card rather than a duplicated resource.\n\nThese resources are listed in your YAML configuration, so Spook cannot change them for you. Edit the `resources:` section of your Lovelace configuration and remove the copies you no longer need.\n\nSpook \ud83d\udc7b Your homie.",
       "title": "Dashboard resource listed more than once: {resource}",
       "fix_flow": {
         "step": {

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -568,7 +568,6 @@
       "title": "Dashboard resources point at missing files"
     },
     "lovelace_duplicate_resources": {
-      "description": "Spook has found a ghost in your dashboards \ud83d\udc7b\n\nThis dashboard resource is listed {count} times:\n\n{resources}\n\nThis usually happens when a custom card was updated by adding a resource for the new version instead of editing the one already there. The browser loads both, the card tries to register itself twice, and the second attempt fails, which looks like a broken card rather than a duplicated resource.\n\nThese resources are listed in your YAML configuration, so Spook cannot change them for you. Edit the `resources:` section of your Lovelace configuration and remove the copies you no longer need.\n\nSpook \ud83d\udc7b Your homie.",
       "title": "Dashboard resource listed more than once: {resource}",
       "fix_flow": {
         "step": {
@@ -584,7 +583,8 @@
         },
         "abort": {
           "issue_ignored": "Spook will keep quiet about this resource from now on.",
-          "manage": "You can manage your dashboard resources yourself on the [Resources page](/config/lovelace/resources)."
+          "manage": "You can manage your dashboard resources yourself on the [Resources page](/config/lovelace/resources).",
+          "yaml": "These resources are listed in your YAML configuration, so Spook cannot change them for you. Edit the `resources:` section of your Lovelace configuration and remove the copies of `{resource}` you no longer need."
         }
       }
     },

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -567,6 +567,10 @@
       "description": "Spook has found a ghost in your dashboards 👻\n\nThe following dashboard resources point at files that do not exist:\n\n{resources}\n\n\n\nThis usually happens when a custom card or its files were removed but the resource stayed behind. To fix this error, open Settings > Dashboards > Resources and remove or correct these resources.\n\nSpook 👻 Your homie.",
       "title": "Dashboard resources point at missing files"
     },
+    "lovelace_duplicate_resources": {
+      "description": "Spook has found a ghost in your dashboards \ud83d\udc7b\n\nThe following dashboard resources are listed more than once:\n\n{resources}\n\n\n\nThis usually happens when a custom card was updated by adding a resource for the new version instead of editing the one already there. The browser loads both, the card tries to register itself twice, and the second attempt fails, which looks like a broken card rather than a duplicated resource. To fix this error, open Settings > Dashboards > Resources and remove the copies you no longer need.\n\nSpook \ud83d\udc7b Your homie.",
+      "title": "Dashboard resources listed more than once"
+    },
     "lovelace_unknown_area_references": {
       "description": "Spook has found a ghost in your dashboards 👻\n\nWhile floating around, Spook crossed path with the following dashboard:\n\n{dashboard}\n\nThis dashboard references the following areas, which are unknown to Home Assistant:\n\n{areas}\n\n\n\nThis often happens when an area was renamed or removed. To fix this error, [edit the dashboard]({edit}) and remove the use of these non-existing areas.\n\nSpook 👻 Your homie.",
       "title": "Unknown areas used in dashboard: {dashboard}"

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -346,6 +346,12 @@ Instantly create a new label in your home. _#LabelMaker_
 
 `homeassistant.create_label`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.create_label), [documentation](labels#create-a-label) 📚
 
+## Labels: Update a label
+
+Changes a label without deleting it first, so it stays on everything it was on. _#facelift_
+
+`homeassistant.update_label`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=homeassistant.update_label), [documentation](labels#update-a-label) 📚
+
 ## Labels: Delete a label
 
 Just like that, a whole label is gone. _#RipItOff_

--- a/documentation/integrations/lovelace.md
+++ b/documentation/integrations/lovelace.md
@@ -87,7 +87,15 @@ For a resource served from `/local/` or `/hacsfiles/` the path is a file on disk
 
 For any other resource, only an exact repeat counts. A query string on somebody else's server can be the difference between two genuinely different files, and Spook is not going to guess that it is not.
 
-To resolve the raised issue, open **Settings** > **Dashboards** > **Resources** and remove the copies you no longer need. Spook will automatically remove the repair issue once the issue is fixed.
+Spook raises one repair issue per duplicated resource, so they can be dealt with one at a time. Each one offers three ways out:
+
+- **Clear the extra copies, keep the most recent.** Spook removes every copy but the last one added, which for a card updated by adding a resource instead of editing one is the version you meant to end up with.
+- **Let me fix it myself.** Points you at **Settings** > **Dashboards** > **Resources**, and leaves the issue in place until you have.
+- **Leave them, stop telling me.** Keeps the resources as they are and stops Spook mentioning that one again.
+
+Resources listed in YAML are static, so there is nothing Spook can delete for you there. Those issues are still raised, without the offer to fix them, because the change has to happen in the file.
+
+Spook will automatically remove the repair issue once the issue is fixed.
 
 ## Feature requests, ideas, and support
 

--- a/documentation/integrations/lovelace.md
+++ b/documentation/integrations/lovelace.md
@@ -87,6 +87,8 @@ For a resource served from `/local/` or `/hacsfiles/` the path is a file on disk
 
 For any other resource, only an exact repeat counts. A query string on somebody else's server can be the difference between two genuinely different files, and Spook is not going to guess that it is not.
 
+The resource type is part of the comparison either way. Home Assistant loads a `module` differently from a `css`, so the same URL listed under two types is two instructions rather than one repeated, and Spook leaves those alone.
+
 Spook raises one repair issue per duplicated resource, so they can be dealt with one at a time. Each one offers three ways out:
 
 - **Clear the extra copies, keep the most recent.** Spook removes every copy but the last one added, which for a card updated by adding a resource instead of editing one is the version you meant to end up with.

--- a/documentation/integrations/lovelace.md
+++ b/documentation/integrations/lovelace.md
@@ -75,6 +75,20 @@ A missing local resource usually means a custom card was removed but its resourc
 
 To resolve the raised issue, go to Settings > Dashboards > Resources and remove or correct these resources. Spook will automatically remove the repair issue once the issue is fixed.
 
+### Duplicate dashboard resources
+
+The same resource can be listed more than once, and nothing in Home Assistant stops it: every resource you add is handed a fresh ID without anybody checking what it points at.
+
+The usual way in is updating a custom card. The new version wants a new cache-busting URL, so `/local/some-card.js?v=1` gains a neighbour at `?v=2` instead of being edited. Both stay. The browser treats two URLs as two files and loads both, the card tries to register itself twice, and the second attempt throws. What you see is a broken card, which sends you looking at the card rather than at the resource list.
+
+Spook raises a repair issue naming each resource that appears more than once, and the URLs involved where they differ.
+
+For a resource served from `/local/` or `/hacsfiles/` the path is a file on disk, so two URLs differing only in their query string are the same file and are reported as duplicates.
+
+For any other resource, only an exact repeat counts. A query string on somebody else's server can be the difference between two genuinely different files, and Spook is not going to guess that it is not.
+
+To resolve the raised issue, open **Settings** > **Dashboards** > **Resources** and remove the copies you no longer need. Spook will automatically remove the repair issue once the issue is fixed.
+
 ## Feature requests, ideas, and support
 
 If you have an idea on how to further enhance this integration, for example, by adding a new action entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).

--- a/documentation/integrations/lovelace.md
+++ b/documentation/integrations/lovelace.md
@@ -93,7 +93,7 @@ Spook raises one repair issue per duplicated resource, so they can be dealt with
 - **Let me fix it myself.** Points you at **Settings** > **Dashboards** > **Resources**, and leaves the issue in place until you have.
 - **Leave them, stop telling me.** Keeps the resources as they are and stops Spook mentioning that one again.
 
-Resources listed in YAML are static, so there is nothing Spook can delete for you there. Those issues are still raised, without the offer to fix them, because the change has to happen in the file.
+Resources listed in YAML are static, so there is nothing Spook can delete for you there. Those duplicates are still reported, and choosing to fix one tells you which file to edit rather than offering a button that would quietly do nothing.
 
 Spook will automatically remove the repair issue once the issue is fixed.
 

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import re
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
@@ -313,32 +312,6 @@ async def test_the_issue_is_fixable_and_carries_what_the_flow_needs(
     }
 
 
-async def test_yaml_resources_are_reported_but_not_offered_a_fix(
-    hass: HomeAssistant,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Resources listed in YAML are static and cannot be deleted from here.
-
-    Offering to clear them would be a button that does nothing, so the issue
-    is raised without one and the text points at the file instead.
-    """
-    hass.data["lovelace"] = SimpleNamespace(
-        resources=SimpleNamespace(
-            async_items=lambda: [
-                {"url": "/local/card.js?v=1", "type": "module"},
-                {"url": "/local/card.js?v=2", "type": "module"},
-            ],
-            async_get_info=_no_loading_needed,
-        ),
-    )
-
-    await SpookRepair(hass).async_inspect()
-
-    issue = issue_registry.async_get_issue(DOMAIN, _issue_id("/local/card.js"))
-    assert issue
-    assert not issue.is_fixable
-
-
 def test_lovelace_is_a_hard_dependency() -> None:
     """Both resource repairs read `hass.data["lovelace"]` without a guard.
 
@@ -356,15 +329,14 @@ def test_lovelace_is_a_hard_dependency() -> None:
     assert "lovelace" in manifest["dependencies"]
 
 
-async def test_the_non_fixable_issue_says_something(
+async def test_a_yaml_resource_is_still_reported(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,
 ) -> None:
-    """A YAML issue has no fix flow, so its text is the top-level description.
+    """A duplicate is a duplicate wherever the resources are configured.
 
-    Without one the repairs list shows a title and nothing else: no URLs, no
-    hint that the file is where to go. The fix flow's own text is unreachable
-    for these, since there is no button to open it.
+    The fix flow is what works out that it cannot delete these; the repair
+    reports them either way, so nobody is left without the finding.
     """
     hass.data["lovelace"] = SimpleNamespace(
         resources=SimpleNamespace(
@@ -380,8 +352,16 @@ async def test_the_non_fixable_issue_says_something(
 
     issue = issue_registry.async_get_issue(DOMAIN, _issue_id("/local/card.js"))
     assert issue
-    assert not issue.is_fixable
+    assert issue.is_fixable
 
+
+def test_the_issue_has_a_fix_flow_and_not_a_description() -> None:
+    """Home Assistant treats those two as mutually exclusive.
+
+    Carrying both fails hassfest with "two or more values in the same group of
+    exclusion 'fixable'", which is how the YAML case ended up handled inside
+    the flow rather than by a second block of text.
+    """
     strings = json.loads(
         (
             Path(__file__).parents[4]
@@ -392,9 +372,7 @@ async def test_the_non_fixable_issue_says_something(
         ).read_text()
     )
     block = strings["issues"]["lovelace_duplicate_resources"]
-    assert block.get("description"), "a non-fixable issue shows this or nothing"
 
-    # Everything that text interpolates has to be on the issue.
-    needed = set(re.findall(r"\{(\w+)\}", block["description"]))
-    assert issue.translation_placeholders
-    assert not needed - set(issue.translation_placeholders)
+    assert "fix_flow" in block
+    assert "description" not in block
+    assert "yaml" in block["fix_flow"]["abort"]

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
@@ -3,6 +3,8 @@
 # pylint: disable=wrong-import-order
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
@@ -37,19 +39,21 @@ class _FakeStorageResources:
     produces to be fixable.
     """
 
-    def __init__(self, urls: list[str]) -> None:
+    def __init__(self, urls: list[str], *, loaded: bool = True) -> None:
         """Hold one item per URL, in the order they were added."""
         self.items = [
             {"id": str(index), "url": url, "type": "module"}
             for index, url in enumerate(urls)
         ]
+        self.loaded = loaded
 
     def async_items(self) -> list[dict]:
-        """Return the items, the way the real collection does."""
-        return self.items
+        """Return the items, empty until loaded, as the real one does."""
+        return self.items if self.loaded else []
 
     async def async_get_info(self) -> dict[str, int]:
-        """Stand in for the loading the real collection does on first use."""
+        """Load on first use, the way the real storage collection does."""
+        self.loaded = True
         return {"resources": len(self.items)}
 
     async def async_delete_item(self, item_id: str) -> None:
@@ -256,24 +260,6 @@ async def test_an_exact_repeat_is_named_the_way_it_is_listed(
     assert _reported(issue_registry) == "- `/local/card.js?v=1`, listed 2 times"
 
 
-async def test_running_before_lovelace_exists_is_a_no_op(
-    hass: HomeAssistant,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Lovelace is not always up when this runs.
-
-    Repairs inspect the moment they activate, and again on every component
-    that loads, with nobody checking which component it was. So this runs with
-    no Lovelace in `hass.data` at all, where reaching straight for the key
-    raises.
-    """
-    assert "lovelace" not in hass.data
-
-    await SpookRepair(hass).async_inspect()
-
-    assert _reported(issue_registry) is None
-
-
 async def test_each_duplicated_resource_gets_its_own_issue(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,
@@ -312,6 +298,11 @@ async def test_the_issue_is_fixable_and_carries_what_the_flow_needs(
     assert issue.data == {
         "duplicate_resource_url": "/local/card.js",
         "resource": "/local/card.js",
+        "resources": (
+            "- `/local/card.js`, listed 2 times: `/local/card.js?v=1`, "
+            "`/local/card.js?v=2`"
+        ),
+        "count": "2",
     }
 
 
@@ -339,3 +330,20 @@ async def test_yaml_resources_are_reported_but_not_offered_a_fix(
     issue = issue_registry.async_get_issue(DOMAIN, _issue_id("/local/card.js"))
     assert issue
     assert not issue.is_fixable
+
+
+def test_lovelace_is_a_hard_dependency() -> None:
+    """Both resource repairs read `hass.data["lovelace"]` without a guard.
+
+    That is only safe because Home Assistant sets up a hard dependency before
+    the integration that declares it. Moving Lovelace to `after_dependencies`,
+    or dropping it, makes those reads a crash, so this is the thing holding
+    them up.
+    """
+    manifest = json.loads(
+        (
+            Path(__file__).parents[4] / "custom_components" / "spook" / "manifest.json"
+        ).read_text()
+    )
+
+    assert "lovelace" in manifest["dependencies"]

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 from homeassistant.components.lovelace.resources import RESOURCE_STORAGE_KEY
+from homeassistant.helpers import collection
 from homeassistant.setup import async_setup_component
 
 from custom_components.spook.const import DOMAIN
@@ -57,11 +59,16 @@ class _FakeStorageResources:
         return {"resources": len(self.items)}
 
     async def async_delete_item(self, item_id: str) -> None:
-        """Drop one item, raising like the real one when it is not there."""
+        """Drop one item, raising what the real collection raises.
+
+        `DictStorageCollection` raises `ItemNotFound`, which is a
+        `HomeAssistantError` and not a `KeyError`, so anything catching the
+        wrong one would look fine here and abort the flow in the house.
+        """
         before = len(self.items)
         self.items = [item for item in self.items if item["id"] != item_id]
         if len(self.items) == before:
-            raise KeyError(item_id)
+            raise collection.ItemNotFound(item_id)
 
 
 def _set_resources(hass: HomeAssistant, urls: list[str]) -> _FakeStorageResources:
@@ -347,3 +354,47 @@ def test_lovelace_is_a_hard_dependency() -> None:
     )
 
     assert "lovelace" in manifest["dependencies"]
+
+
+async def test_the_non_fixable_issue_says_something(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """A YAML issue has no fix flow, so its text is the top-level description.
+
+    Without one the repairs list shows a title and nothing else: no URLs, no
+    hint that the file is where to go. The fix flow's own text is unreachable
+    for these, since there is no button to open it.
+    """
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=SimpleNamespace(
+            async_items=lambda: [
+                {"url": "/local/card.js?v=1", "type": "module"},
+                {"url": "/local/card.js?v=2", "type": "module"},
+            ],
+            async_get_info=_no_loading_needed,
+        ),
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id("/local/card.js"))
+    assert issue
+    assert not issue.is_fixable
+
+    strings = json.loads(
+        (
+            Path(__file__).parents[4]
+            / "custom_components"
+            / "spook"
+            / "translations"
+            / "en.json"
+        ).read_text()
+    )
+    block = strings["issues"]["lovelace_duplicate_resources"]
+    assert block.get("description"), "a non-fixable issue shows this or nothing"
+
+    # Everything that text interpolates has to be on the issue.
+    needed = set(re.findall(r"\{(\w+)\}", block["description"]))
+    assert issue.translation_placeholders
+    assert not needed - set(issue.translation_placeholders)

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
@@ -1,0 +1,196 @@
+"""Tests for the Lovelace duplicate resources repair."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from homeassistant.components.lovelace.resources import RESOURCE_STORAGE_KEY
+from homeassistant.setup import async_setup_component
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.lovelace.repairs.duplicate_resources import (
+    SpookRepair,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+_ISSUE_ID = "lovelace_duplicate_resources_lovelace_duplicate_resources"
+
+
+async def _no_loading_needed() -> dict[str, int]:
+    """Stand in for the loading the real collection does on first use."""
+    return {"resources": 0}
+
+
+def _set_resources(hass: HomeAssistant, urls: list[str]) -> None:
+    """Install a fake resource collection with the given URLs."""
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=SimpleNamespace(
+            async_items=lambda: [{"url": url, "type": "module"} for url in urls],
+            async_get_info=_no_loading_needed,
+        ),
+    )
+
+
+def _reported(issue_registry: ir.IssueRegistry) -> str | None:
+    """Return the resource list the repair reported, if it raised one."""
+    if (issue := issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)) is None:
+        return None
+    assert issue.translation_placeholders
+    return issue.translation_placeholders["resources"]
+
+
+async def test_the_same_url_twice_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Nothing stops this: core hands every resource a fresh random ID."""
+    _set_resources(hass, ["/local/card.js", "/local/card.js", "/local/other.js"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) == "- `/local/card.js`, listed 2 times"
+
+
+async def test_a_local_file_behind_two_cache_busters_is_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """The case that actually breaks a card.
+
+    Updating a card by adding a resource for the new version leaves both. The
+    browser treats the two URLs as different files and loads both, so the card
+    registers itself twice and the second attempt throws.
+    """
+    _set_resources(hass, ["/local/card.js?v=1", "/local/card.js?v=2"])
+
+    assert _reported(issue_registry) is None
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) == (
+        "- `/local/card.js`, listed 2 times: `/local/card.js?v=1`, `/local/card.js?v=2`"
+    )
+
+
+async def test_an_external_url_with_a_different_query_is_left_alone(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Somebody else's server may well serve two files from one path.
+
+    A query string on a CDN can be a version that returns genuinely different
+    content, so only an exact repeat counts there. Guessing otherwise would
+    report a setup that is doing nothing wrong.
+    """
+    _set_resources(
+        hass,
+        [
+            "https://cdn.example.com/lib.js?v=1",
+            "https://cdn.example.com/lib.js?v=2",
+        ],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) is None
+
+
+async def test_an_external_url_repeated_exactly_is_still_reported(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """The same URL twice is never intended, wherever it is served from."""
+    _set_resources(
+        hass,
+        ["https://cdn.example.com/lib.js?v=1", "https://cdn.example.com/lib.js?v=1"],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) == (
+        "- `https://cdn.example.com/lib.js?v=1`, listed 2 times"
+    )
+
+
+async def test_it_counts_past_two(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Three versions of one card is the same mistake made twice."""
+    _set_resources(
+        hass, ["/local/card.js?v=1", "/local/card.js?v=2", "/local/card.js?v=3"]
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) == (
+        "- `/local/card.js`, listed 3 times: `/local/card.js?v=1`, "
+        "`/local/card.js?v=2`, `/local/card.js?v=3`"
+    )
+
+
+async def test_resources_that_differ_create_no_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """An ordinary resource list has to stay quiet."""
+    _set_resources(
+        hass,
+        [
+            "/local/card.js",
+            "/local/other.js?v=2",
+            "/hacsfiles/some-card/some-card.js",
+            "https://cdn.example.com/lib.js",
+        ],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) is None
+
+
+async def test_no_resource_collection_is_a_no_op(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a missing resource collection does not error."""
+    hass.data["lovelace"] = SimpleNamespace(resources=None)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) is None
+
+
+async def test_storage_resources_are_loaded_before_they_are_read(
+    hass: HomeAssistant,
+    hass_storage: dict,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """The real collection loads on first use, which is after Spook looks.
+
+    Read straight it is empty, and a duplicate goes unreported.
+    """
+    hass_storage[RESOURCE_STORAGE_KEY] = {
+        "version": 1,
+        "key": RESOURCE_STORAGE_KEY,
+        "data": {
+            "items": [
+                {"id": "1", "type": "module", "url": "/local/card.js?v=1"},
+                {"id": "2", "type": "module", "url": "/local/card.js?v=2"},
+            ]
+        },
+    }
+    assert await async_setup_component(hass, "lovelace", {})
+    await hass.async_block_till_done()
+
+    resources = hass.data["lovelace"].resources
+    assert not resources.loaded, "core changed when it loads these"
+    assert resources.async_items() == [], "and what an unloaded one holds"
+
+    await SpookRepair(hass).async_inspect()
+
+    assert "/local/card.js" in (_reported(issue_registry) or "")

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
@@ -194,3 +194,20 @@ async def test_storage_resources_are_loaded_before_they_are_read(
     await SpookRepair(hass).async_inspect()
 
     assert "/local/card.js" in (_reported(issue_registry) or "")
+
+
+async def test_an_exact_repeat_is_named_the_way_it_is_listed(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """A local resource is grouped by its path, with the query taken off.
+
+    That key is not what is in the resource list when the URL carries a query,
+    so reporting the key would send somebody looking for a URL that is not
+    there.
+    """
+    _set_resources(hass, ["/local/card.js?v=1", "/local/card.js?v=1"])
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) == "- `/local/card.js?v=1`, listed 2 times"

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
@@ -211,3 +211,21 @@ async def test_an_exact_repeat_is_named_the_way_it_is_listed(
     await SpookRepair(hass).async_inspect()
 
     assert _reported(issue_registry) == "- `/local/card.js?v=1`, listed 2 times"
+
+
+async def test_running_before_lovelace_exists_is_a_no_op(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Lovelace is not always up when this runs.
+
+    Repairs inspect the moment they activate, and again on every component
+    that loads, with nobody checking which component it was. So this runs with
+    no Lovelace in `hass.data` at all, where reaching straight for the key
+    raises.
+    """
+    assert "lovelace" not in hass.data
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) is None

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
@@ -18,7 +18,10 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import issue_registry as ir
 
-_ISSUE_ID = "lovelace_duplicate_resources_lovelace_duplicate_resources"
+
+def _issue_id(key: str) -> str:
+    """Return the registry issue ID for one duplicated resource."""
+    return f"lovelace_duplicate_resources_{key}"
 
 
 async def _no_loading_needed() -> dict[str, int]:
@@ -26,20 +29,60 @@ async def _no_loading_needed() -> dict[str, int]:
     return {"resources": 0}
 
 
-def _set_resources(hass: HomeAssistant, urls: list[str]) -> None:
-    """Install a fake resource collection with the given URLs."""
-    hass.data["lovelace"] = SimpleNamespace(
-        resources=SimpleNamespace(
-            async_items=lambda: [{"url": url, "type": "module"} for url in urls],
-            async_get_info=_no_loading_needed,
-        ),
-    )
+class _FakeStorageResources:
+    """Stand-in for the storage-mode collection, which can delete.
+
+    The YAML collection cannot, and the repair tells them apart by exactly
+    that, so this one has to carry `async_delete_item` for the issues it
+    produces to be fixable.
+    """
+
+    def __init__(self, urls: list[str]) -> None:
+        """Hold one item per URL, in the order they were added."""
+        self.items = [
+            {"id": str(index), "url": url, "type": "module"}
+            for index, url in enumerate(urls)
+        ]
+
+    def async_items(self) -> list[dict]:
+        """Return the items, the way the real collection does."""
+        return self.items
+
+    async def async_get_info(self) -> dict[str, int]:
+        """Stand in for the loading the real collection does on first use."""
+        return {"resources": len(self.items)}
+
+    async def async_delete_item(self, item_id: str) -> None:
+        """Drop one item, raising like the real one when it is not there."""
+        before = len(self.items)
+        self.items = [item for item in self.items if item["id"] != item_id]
+        if len(self.items) == before:
+            raise KeyError(item_id)
 
 
-def _reported(issue_registry: ir.IssueRegistry) -> str | None:
-    """Return the resource list the repair reported, if it raised one."""
-    if (issue := issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)) is None:
+def _set_resources(hass: HomeAssistant, urls: list[str]) -> _FakeStorageResources:
+    """Install a fake storage resource collection with the given URLs."""
+    resources = _FakeStorageResources(urls)
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+    return resources
+
+
+def _reported(issue_registry: ir.IssueRegistry, key: str = "") -> str | None:
+    """Return what the repair reported for one resource, if it raised it."""
+    if key:
+        issue = issue_registry.async_get_issue(DOMAIN, _issue_id(key))
+    else:
+        issues = [
+            entry
+            for entry in issue_registry.issues.values()
+            if entry.translation_key == "lovelace_duplicate_resources"
+        ]
+        assert len(issues) <= 1, f"expected at most one issue, got {len(issues)}"
+        issue = issues[0] if issues else None
+
+    if issue is None:
         return None
+
     assert issue.translation_placeholders
     return issue.translation_placeholders["resources"]
 
@@ -229,3 +272,70 @@ async def test_running_before_lovelace_exists_is_a_no_op(
     await SpookRepair(hass).async_inspect()
 
     assert _reported(issue_registry) is None
+
+
+async def test_each_duplicated_resource_gets_its_own_issue(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """One issue per resource, so they can be dealt with one at a time."""
+    _set_resources(
+        hass,
+        [
+            "/local/one.js?v=1",
+            "/local/one.js?v=2",
+            "/local/two.js",
+            "/local/two.js",
+            "/local/fine.js",
+        ],
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry, "/local/one.js")
+    assert _reported(issue_registry, "/local/two.js")
+    assert _reported(issue_registry, "/local/fine.js") is None
+
+
+async def test_the_issue_is_fixable_and_carries_what_the_flow_needs(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """The flow is dispatched on this data key, so it has to be there."""
+    _set_resources(hass, ["/local/card.js?v=1", "/local/card.js?v=2"])
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id("/local/card.js"))
+    assert issue
+    assert issue.is_fixable
+    assert issue.data == {
+        "duplicate_resource_url": "/local/card.js",
+        "resource": "/local/card.js",
+    }
+
+
+async def test_yaml_resources_are_reported_but_not_offered_a_fix(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Resources listed in YAML are static and cannot be deleted from here.
+
+    Offering to clear them would be a button that does nothing, so the issue
+    is raised without one and the text points at the file instead.
+    """
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=SimpleNamespace(
+            async_items=lambda: [
+                {"url": "/local/card.js?v=1", "type": "module"},
+                {"url": "/local/card.js?v=2", "type": "module"},
+            ],
+            async_get_info=_no_loading_needed,
+        ),
+    )
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _issue_id("/local/card.js"))
+    assert issue
+    assert not issue.is_fixable

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources.py
@@ -22,9 +22,14 @@ if TYPE_CHECKING:
     from homeassistant.helpers import issue_registry as ir
 
 
-def _issue_id(key: str) -> str:
+def _key(target: str, resource_type: str = "module") -> str:
+    """Return the grouping key for a resource, which carries its type."""
+    return f"{resource_type}|{target}"
+
+
+def _issue_id(target: str, resource_type: str = "module") -> str:
     """Return the registry issue ID for one duplicated resource."""
-    return f"lovelace_duplicate_resources_{key}"
+    return f"lovelace_duplicate_resources_{_key(target, resource_type)}"
 
 
 async def _no_loading_needed() -> dict[str, int]:
@@ -77,10 +82,14 @@ def _set_resources(hass: HomeAssistant, urls: list[str]) -> _FakeStorageResource
     return resources
 
 
-def _reported(issue_registry: ir.IssueRegistry, key: str = "") -> str | None:
+def _reported(
+    issue_registry: ir.IssueRegistry,
+    target: str = "",
+    resource_type: str = "module",
+) -> str | None:
     """Return what the repair reported for one resource, if it raised it."""
-    if key:
-        issue = issue_registry.async_get_issue(DOMAIN, _issue_id(key))
+    if target:
+        issue = issue_registry.async_get_issue(DOMAIN, _issue_id(target, resource_type))
     else:
         issues = [
             entry
@@ -302,7 +311,7 @@ async def test_the_issue_is_fixable_and_carries_what_the_flow_needs(
     assert issue
     assert issue.is_fixable
     assert issue.data == {
-        "duplicate_resource_url": "/local/card.js",
+        "duplicate_resource_url": _key("/local/card.js"),
         "resource": "/local/card.js",
         "resources": (
             "- `/local/card.js`, listed 2 times: `/local/card.js?v=1`, "
@@ -376,3 +385,46 @@ def test_the_issue_has_a_fix_flow_and_not_a_description() -> None:
     assert "fix_flow" in block
     assert "description" not in block
     assert "yaml" in block["fix_flow"]["abort"]
+
+
+async def test_the_same_url_under_two_types_is_not_a_repeat(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Home Assistant loads a `module` differently from a `css`.
+
+    So the same URL under two types is two instructions, not one repeated.
+    Reporting it would be bad enough on its own; the fix flow clears all but
+    one, so it would take away something that was meant to be there.
+    """
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=_FakeStorageResources([]),
+    )
+    hass.data["lovelace"].resources.items = [
+        {"id": "1", "url": "/local/thing", "type": "module"},
+        {"id": "2", "url": "/local/thing", "type": "css"},
+    ]
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry) is None
+
+
+async def test_a_repeat_within_one_type_is_still_caught(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """The type being part of the identity must not lose the real case."""
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=_FakeStorageResources([]),
+    )
+    hass.data["lovelace"].resources.items = [
+        {"id": "1", "url": "/local/thing", "type": "module"},
+        {"id": "2", "url": "/local/thing", "type": "css"},
+        {"id": "3", "url": "/local/thing", "type": "css"},
+    ]
+
+    await SpookRepair(hass).async_inspect()
+
+    assert _reported(issue_registry, "/local/thing", "css")
+    assert _reported(issue_registry, "/local/thing", "module") is None

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
@@ -14,7 +14,7 @@ from custom_components.spook.repairs import (
     async_create_fix_flow,
 )
 
-from .test_duplicate_resources import _FakeStorageResources
+from .test_duplicate_resources import _FakeStorageResources, _key
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -25,7 +25,7 @@ def _flow(hass: HomeAssistant, key: str) -> DuplicateResourceFixFlow:
     flow = DuplicateResourceFixFlow()
     flow.hass = hass
     flow.issue_id = f"lovelace_duplicate_resources_{key}"
-    flow.data = {"duplicate_resource_url": key, "resource": key}
+    flow.data = {"duplicate_resource_url": key, "resource": key.split("|", 1)[-1]}
     return flow
 
 
@@ -38,8 +38,8 @@ async def test_the_flow_is_chosen_for_this_issue(hass: HomeAssistant) -> None:
     """Dispatch is on the data key, so this is what wires the two together."""
     flow = await async_create_fix_flow(
         hass,
-        "lovelace_duplicate_resources_/local/card.js",
-        {"duplicate_resource_url": "/local/card.js"},
+        f"lovelace_duplicate_resources_{_key('/local/card.js')}",
+        {"duplicate_resource_url": _key("/local/card.js")},
     )
 
     assert isinstance(flow, DuplicateResourceFixFlow)
@@ -56,7 +56,7 @@ async def test_removing_keeps_the_most_recently_added(hass: HomeAssistant) -> No
     )
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 
-    await _flow(hass, "/local/card.js").async_step_remove()
+    await _flow(hass, _key("/local/card.js")).async_step_remove()
 
     assert _urls(resources) == ["/local/card.js?v=2", "/local/other.js"]
 
@@ -68,7 +68,7 @@ async def test_removing_clears_every_extra_copy(hass: HomeAssistant) -> None:
     )
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 
-    await _flow(hass, "/local/card.js").async_step_remove()
+    await _flow(hass, _key("/local/card.js")).async_step_remove()
 
     assert _urls(resources) == ["/local/card.js?v=3"]
 
@@ -85,7 +85,7 @@ async def test_removing_leaves_other_resources_alone(hass: HomeAssistant) -> Non
     )
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 
-    await _flow(hass, "/local/card.js").async_step_remove()
+    await _flow(hass, _key("/local/card.js")).async_step_remove()
 
     assert _urls(resources) == [
         "/local/card.js?v=2",
@@ -124,7 +124,7 @@ async def test_a_copy_removed_underneath_the_flow_does_not_stop_it(
     )
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 
-    result = await _flow(hass, "/local/card.js").async_step_remove()
+    result = await _flow(hass, _key("/local/card.js")).async_step_remove()
 
     assert result["type"] == "create_entry"
     # The one that vanished is still listed here, because this fake only
@@ -139,7 +139,7 @@ async def test_removing_when_there_is_nothing_left_to_remove_still_finishes(
     resources = _FakeStorageResources(["/local/card.js?v=2"])
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 
-    result = await _flow(hass, "/local/card.js").async_step_remove()
+    result = await _flow(hass, _key("/local/card.js")).async_step_remove()
 
     assert result["type"] == "create_entry"
     assert _urls(resources) == ["/local/card.js?v=2"]
@@ -149,7 +149,7 @@ async def test_removing_without_lovelace_still_finishes(hass: HomeAssistant) -> 
     """The flow can be opened long after the resources went away."""
     assert "lovelace" not in hass.data
 
-    result = await _flow(hass, "/local/card.js").async_step_remove()
+    result = await _flow(hass, _key("/local/card.js")).async_step_remove()
 
     assert result["type"] == "create_entry"
 
@@ -164,18 +164,18 @@ async def test_ignoring_keeps_the_issue_so_the_ignore_sticks(
 
     issue_registry.async_get_or_create(
         DOMAIN,
-        "lovelace_duplicate_resources_/local/card.js",
+        f"lovelace_duplicate_resources_{_key('/local/card.js')}",
         is_fixable=True,
         is_persistent=False,
         severity=ir.IssueSeverity.WARNING,
         translation_key="lovelace_duplicate_resources",
     )
 
-    result = await _flow(hass, "/local/card.js").async_step_ignore()
+    result = await _flow(hass, _key("/local/card.js")).async_step_ignore()
 
     assert result["type"] == "abort"
     issue = issue_registry.async_get_issue(
-        DOMAIN, "lovelace_duplicate_resources_/local/card.js"
+        DOMAIN, f"lovelace_duplicate_resources_{_key('/local/card.js')}"
     )
     assert issue
     assert issue.dismissed_version is not None
@@ -188,7 +188,7 @@ async def test_managing_it_yourself_leaves_everything(hass: HomeAssistant) -> No
     resources = _FakeStorageResources(["/local/card.js?v=1", "/local/card.js?v=2"])
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 
-    result = await _flow(hass, "/local/card.js").async_step_manage()
+    result = await _flow(hass, _key("/local/card.js")).async_step_manage()
 
     assert result["type"] == "abort"
     assert result["reason"] == "manage"
@@ -208,7 +208,7 @@ async def test_removing_from_a_cold_collection_still_clears(
     )
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 
-    await _flow(hass, "/local/card.js").async_step_remove()
+    await _flow(hass, _key("/local/card.js")).async_step_remove()
 
     assert _urls(resources) == ["/local/card.js?v=2"]
 
@@ -230,7 +230,7 @@ async def test_a_yaml_collection_is_told_where_the_file_is(
         ),
     )
 
-    result = await _flow(hass, "/local/card.js").async_step_init()
+    result = await _flow(hass, _key("/local/card.js")).async_step_init()
 
     assert result["type"] == "abort"
     assert result["reason"] == "yaml"
@@ -244,7 +244,44 @@ async def test_a_storage_collection_still_gets_the_menu(
     resources = _FakeStorageResources(["/local/card.js?v=1", "/local/card.js?v=2"])
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 
-    result = await _flow(hass, "/local/card.js").async_step_init()
+    result = await _flow(hass, _key("/local/card.js")).async_step_init()
 
     assert result["type"] == "menu"
     assert set(result["menu_options"]) == {"remove", "manage", "ignore"}
+
+
+class _VanishingNewest(_FakeStorageResources):
+    """Somebody removes the copy this was going to keep, mid-clear."""
+
+    def __init__(self, urls: list[str]) -> None:
+        """Start out with nobody having interfered yet."""
+        super().__init__(urls)
+        self._interfered = False
+
+    async def async_delete_item(self, item_id: str) -> None:
+        """Delete as asked, then take the newest away the first time."""
+        await super().async_delete_item(item_id)
+        if not self._interfered:
+            self._interfered = True
+            self.items = self.items[:-1]
+
+
+async def test_it_stops_when_somebody_takes_the_kept_copy_away(
+    hass: HomeAssistant,
+) -> None:
+    """Deleting awaits, so the list can change underneath this.
+
+    Against a snapshot taken once, losing the copy meant to be kept means
+    every copy gets cleared and the card stops loading at all. Working it out
+    again after each deletion leaves whatever is still there.
+    """
+    resources = _VanishingNewest(
+        ["/local/card.js?v=1", "/local/card.js?v=2", "/local/card.js?v=3"]
+    )
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    await _flow(hass, _key("/local/card.js")).async_step_remove()
+
+    # v=1 cleared, v=3 taken by the other client, and v=2 left alone rather
+    # than cleared on the strength of a list that no longer described anything.
+    assert _urls(resources) == ["/local/card.js?v=2"]

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import collection, issue_registry as ir
 
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.repairs import (
@@ -94,10 +94,48 @@ async def test_removing_leaves_other_resources_alone(hass: HomeAssistant) -> Non
     ]
 
 
-async def test_removing_something_already_gone_still_finishes(
+class _RacyResources(_FakeStorageResources):
+    """A collection where one copy vanishes before the flow reaches it."""
+
+    def __init__(self, urls: list[str], *, vanishing: str) -> None:
+        """Remember which item ID somebody else is about to remove."""
+        super().__init__(urls)
+        self._vanishing = vanishing
+
+    async def async_delete_item(self, item_id: str) -> None:
+        """Raise for the vanished one, the way the real collection would."""
+        if item_id == self._vanishing:
+            raise collection.ItemNotFound(item_id)
+        await super().async_delete_item(item_id)
+
+
+async def test_a_copy_removed_underneath_the_flow_does_not_stop_it(
     hass: HomeAssistant,
 ) -> None:
-    """Somebody clearing it themselves first is a fine way for this to end."""
+    """The copies to clear are worked out first, then removed one at a time.
+
+    Somebody removing one in between is a fine way for this to end, but only
+    if the right exception is caught: the collection raises `ItemNotFound`,
+    which is a `HomeAssistantError` and not a `KeyError`.
+    """
+    resources = _RacyResources(
+        ["/local/card.js?v=1", "/local/card.js?v=2", "/local/card.js?v=3"],
+        vanishing="0",
+    )
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    result = await _flow(hass, "/local/card.js").async_step_remove()
+
+    assert result["type"] == "create_entry"
+    # The one that vanished is still listed here, because this fake only
+    # refuses to delete it. The point is that v=2 was still cleared after it.
+    assert _urls(resources) == ["/local/card.js?v=1", "/local/card.js?v=3"]
+
+
+async def test_removing_when_there_is_nothing_left_to_remove_still_finishes(
+    hass: HomeAssistant,
+) -> None:
+    """Somebody clearing them all themselves first is a fine ending too."""
     resources = _FakeStorageResources(["/local/card.js?v=2"])
     hass.data["lovelace"] = SimpleNamespace(resources=resources)
 

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
@@ -1,0 +1,157 @@
+"""Tests for the duplicate dashboard resource fix flow."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.repairs import (
+    DuplicateResourceFixFlow,
+    async_create_fix_flow,
+)
+
+from .test_duplicate_resources import _FakeStorageResources
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _flow(hass: HomeAssistant, key: str) -> DuplicateResourceFixFlow:
+    """Return the flow, wired the way the repairs component wires it."""
+    flow = DuplicateResourceFixFlow()
+    flow.hass = hass
+    flow.issue_id = f"lovelace_duplicate_resources_{key}"
+    flow.data = {"duplicate_resource_url": key, "resource": key}
+    return flow
+
+
+def _urls(resources: _FakeStorageResources) -> list[str]:
+    """Return the URLs still listed."""
+    return [item["url"] for item in resources.async_items()]
+
+
+async def test_the_flow_is_chosen_for_this_issue(hass: HomeAssistant) -> None:
+    """Dispatch is on the data key, so this is what wires the two together."""
+    flow = await async_create_fix_flow(
+        hass,
+        "lovelace_duplicate_resources_/local/card.js",
+        {"duplicate_resource_url": "/local/card.js"},
+    )
+
+    assert isinstance(flow, DuplicateResourceFixFlow)
+
+
+async def test_removing_keeps_the_most_recently_added(hass: HomeAssistant) -> None:
+    """The newest copy is the one somebody meant to end up with.
+
+    A card updated by adding a resource for the new version leaves the old one
+    above it, so keeping the last is keeping the version they installed.
+    """
+    resources = _FakeStorageResources(
+        ["/local/card.js?v=1", "/local/card.js?v=2", "/local/other.js"]
+    )
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    await _flow(hass, "/local/card.js").async_step_remove()
+
+    assert _urls(resources) == ["/local/card.js?v=2", "/local/other.js"]
+
+
+async def test_removing_clears_every_extra_copy(hass: HomeAssistant) -> None:
+    """Three copies means two to clear, not one."""
+    resources = _FakeStorageResources(
+        ["/local/card.js?v=1", "/local/card.js?v=2", "/local/card.js?v=3"]
+    )
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    await _flow(hass, "/local/card.js").async_step_remove()
+
+    assert _urls(resources) == ["/local/card.js?v=3"]
+
+
+async def test_removing_leaves_other_resources_alone(hass: HomeAssistant) -> None:
+    """Only the resource the issue is about is touched."""
+    resources = _FakeStorageResources(
+        [
+            "/local/card.js?v=1",
+            "/local/card.js?v=2",
+            "/local/keep.js?v=1",
+            "/local/keep.js?v=2",
+        ]
+    )
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    await _flow(hass, "/local/card.js").async_step_remove()
+
+    assert _urls(resources) == [
+        "/local/card.js?v=2",
+        "/local/keep.js?v=1",
+        "/local/keep.js?v=2",
+    ]
+
+
+async def test_removing_something_already_gone_still_finishes(
+    hass: HomeAssistant,
+) -> None:
+    """Somebody clearing it themselves first is a fine way for this to end."""
+    resources = _FakeStorageResources(["/local/card.js?v=2"])
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    result = await _flow(hass, "/local/card.js").async_step_remove()
+
+    assert result["type"] == "create_entry"
+    assert _urls(resources) == ["/local/card.js?v=2"]
+
+
+async def test_removing_without_lovelace_still_finishes(hass: HomeAssistant) -> None:
+    """The flow can be opened long after the resources went away."""
+    assert "lovelace" not in hass.data
+
+    result = await _flow(hass, "/local/card.js").async_step_remove()
+
+    assert result["type"] == "create_entry"
+
+
+async def test_ignoring_keeps_the_issue_so_the_ignore_sticks(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """A completed flow deletes the issue, and it would come straight back."""
+    resources = _FakeStorageResources(["/local/card.js?v=1", "/local/card.js?v=2"])
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    issue_registry.async_get_or_create(
+        DOMAIN,
+        "lovelace_duplicate_resources_/local/card.js",
+        is_fixable=True,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="lovelace_duplicate_resources",
+    )
+
+    result = await _flow(hass, "/local/card.js").async_step_ignore()
+
+    assert result["type"] == "abort"
+    issue = issue_registry.async_get_issue(
+        DOMAIN, "lovelace_duplicate_resources_/local/card.js"
+    )
+    assert issue
+    assert issue.dismissed_version is not None
+    # Nothing was cleared: ignoring is not fixing.
+    assert _urls(resources) == ["/local/card.js?v=1", "/local/card.js?v=2"]
+
+
+async def test_managing_it_yourself_leaves_everything(hass: HomeAssistant) -> None:
+    """Aborting keeps the issue, so it stays until actually resolved."""
+    resources = _FakeStorageResources(["/local/card.js?v=1", "/local/card.js?v=2"])
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    result = await _flow(hass, "/local/card.js").async_step_manage()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "manage"
+    assert _urls(resources) == ["/local/card.js?v=1", "/local/card.js?v=2"]

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
@@ -211,3 +211,40 @@ async def test_removing_from_a_cold_collection_still_clears(
     await _flow(hass, "/local/card.js").async_step_remove()
 
     assert _urls(resources) == ["/local/card.js?v=2"]
+
+
+async def test_a_yaml_collection_is_told_where_the_file_is(
+    hass: HomeAssistant,
+) -> None:
+    """Nothing can delete a YAML resource, so the menu would be a lie.
+
+    Offering "clear the extra copies" against a static list is a button that
+    quietly does nothing, so this aborts with the file to edit instead.
+    """
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=SimpleNamespace(
+            async_items=lambda: [
+                {"url": "/local/card.js?v=1", "type": "module"},
+                {"url": "/local/card.js?v=2", "type": "module"},
+            ],
+        ),
+    )
+
+    result = await _flow(hass, "/local/card.js").async_step_init()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "yaml"
+    assert result["description_placeholders"]["resource"] == "/local/card.js"
+
+
+async def test_a_storage_collection_still_gets_the_menu(
+    hass: HomeAssistant,
+) -> None:
+    """The abort above must not swallow the case it was added beside."""
+    resources = _FakeStorageResources(["/local/card.js?v=1", "/local/card.js?v=2"])
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    result = await _flow(hass, "/local/card.js").async_step_init()
+
+    assert result["type"] == "menu"
+    assert set(result["menu_options"]) == {"remove", "manage", "ignore"}

--- a/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
+++ b/tests/ectoplasms/lovelace/repairs/test_duplicate_resources_flow.py
@@ -155,3 +155,21 @@ async def test_managing_it_yourself_leaves_everything(hass: HomeAssistant) -> No
     assert result["type"] == "abort"
     assert result["reason"] == "manage"
     assert _urls(resources) == ["/local/card.js?v=1", "/local/card.js?v=2"]
+
+
+async def test_removing_from_a_cold_collection_still_clears(
+    hass: HomeAssistant,
+) -> None:
+    """A storage collection hands out nothing until it has been loaded.
+
+    Read cold it looks empty, so the flow would clear nothing and still report
+    that it had, which is the worst of the available outcomes.
+    """
+    resources = _FakeStorageResources(
+        ["/local/card.js?v=1", "/local/card.js?v=2"], loaded=False
+    )
+    hass.data["lovelace"] = SimpleNamespace(resources=resources)
+
+    await _flow(hass, "/local/card.js").async_step_remove()
+
+    assert _urls(resources) == ["/local/card.js?v=2"]

--- a/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
@@ -127,21 +127,3 @@ async def test_storage_resources_are_loaded_before_they_are_read(
     issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
     assert issue
     assert "/local/gone.js" in issue.translation_placeholders["resources"]
-
-
-async def test_running_before_lovelace_exists_is_a_no_op(
-    hass: HomeAssistant,
-    issue_registry: ir.IssueRegistry,
-) -> None:
-    """Lovelace is not always up when this runs.
-
-    Repairs inspect the moment they activate, and again on every component
-    that loads, with nobody checking which component it was. So this runs with
-    no Lovelace in `hass.data` at all, where reaching straight for the key
-    raises.
-    """
-    assert "lovelace" not in hass.data
-
-    await SpookRepair(hass).async_inspect()
-
-    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None

--- a/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
@@ -127,3 +127,21 @@ async def test_storage_resources_are_loaded_before_they_are_read(
     issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
     assert issue
     assert "/local/gone.js" in issue.translation_placeholders["resources"]
+
+
+async def test_running_before_lovelace_exists_is_a_no_op(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Lovelace is not always up when this runs.
+
+    Repairs inspect the moment they activate, and again on every component
+    that loads, with nobody checking which component it was. So this runs with
+    no Lovelace in `hass.data` at all, where reaching straight for the key
+    raises.
+    """
+    assert "lovelace" not in hass.data
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None

--- a/tests/ectoplasms/lovelace/repairs/test_resource_watching.py
+++ b/tests/ectoplasms/lovelace/repairs/test_resource_watching.py
@@ -1,0 +1,110 @@
+"""Tests that both resource repairs notice the resource list changing.
+
+`EVENT_LOVELACE_UPDATED` is fired when a dashboard configuration is saved, not
+when a resource is added or removed. Those go to the collection's own
+listeners. A repair watching only the events would look once at startup and
+then never again until something unrelated happened.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.components.lovelace.resources import RESOURCE_STORAGE_KEY
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+import pytest
+
+from custom_components.spook.const import DOMAIN
+from custom_components.spook.ectoplasms.lovelace.repairs import (
+    duplicate_resources,
+    missing_resources,
+)
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import issue_registry as ir
+
+_MODULES = (duplicate_resources, missing_resources)
+
+
+def _ids(module: object) -> str:
+    """Name the parametrised case after its repair."""
+    return module.SpookRepair.repair  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("module", _MODULES, ids=_ids)
+async def test_it_subscribes_to_the_resource_collection(
+    hass: HomeAssistant,
+    hass_storage: dict,
+    module: object,
+) -> None:
+    """Activation has to reach the collection, not just the event bus."""
+    hass_storage[RESOURCE_STORAGE_KEY] = {
+        "version": 1,
+        "key": RESOURCE_STORAGE_KEY,
+        "data": {"items": [{"id": "1", "type": "module", "url": "/local/card.js"}]},
+    }
+    assert await async_setup_component(hass, "lovelace", {})
+    await hass.async_block_till_done()
+
+    resources = hass.data["lovelace"].resources
+    await resources.async_get_info()
+    before = len(resources.listeners)
+
+    repair = module.SpookRepair(hass)  # type: ignore[attr-defined]
+    await repair.async_activate()
+    await hass.async_block_till_done()
+
+    assert len(resources.listeners) == before + 1, (
+        "the repair did not subscribe to resource changes"
+    )
+
+    # And it lets go again, rather than leaving a listener behind.
+    await repair.async_deactivate()
+    assert len(resources.listeners) == before
+
+
+async def test_adding_a_duplicate_resource_raises_the_issue(
+    hass: HomeAssistant,
+    hass_storage: dict,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The whole point: a resource added from Settings is noticed.
+
+    Nothing on the event bus says this happened, so a repair that only listens
+    there would report it for the first time after a restart.
+    """
+    hass_storage[RESOURCE_STORAGE_KEY] = {
+        "version": 1,
+        "key": RESOURCE_STORAGE_KEY,
+        "data": {"items": [{"id": "1", "type": "module", "url": "/local/card.js?v=1"}]},
+    }
+    assert await async_setup_component(hass, "lovelace", {})
+    await hass.async_block_till_done()
+
+    repair = duplicate_resources.SpookRepair(hass)
+    await repair.async_activate()
+    await hass.async_block_till_done()
+
+    issue_id = "lovelace_duplicate_resources_module|/local/card.js"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+    # The same card again, the way the Resources page would add it.
+    resources = hass.data["lovelace"].resources
+    await resources.async_create_item(
+        {"res_type": "module", "url": "/local/card.js?v=2"}
+    )
+    # The inspection is debounced, so let its cooldown run out.
+    freezer.tick(timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id)
+
+    await repair.async_deactivate()

--- a/tests/test_fix_flow_placeholders.py
+++ b/tests/test_fix_flow_placeholders.py
@@ -1,0 +1,83 @@
+"""Every fix flow must supply the placeholders its dialog interpolates.
+
+A dialog whose text names `{count}` while the flow hands over only `{resource}`
+renders with the placeholder still in it. Nothing fails, nothing logs, and the
+only way to find out is to open the repair and look at it.
+"""
+
+# pylint: disable=wrong-import-order,protected-access
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from custom_components.spook.repairs import _REMOVE_OR_IGNORE_FLOWS
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+ROOT = Path(__file__).parents[1]
+STRINGS = json.loads(
+    (ROOT / "custom_components" / "spook" / "translations" / "en.json").read_text()
+)
+
+# Each flow is dispatched on a data key; the issues that use it carry that key.
+_FLOWS = sorted(_REMOVE_OR_IGNORE_FLOWS)
+
+
+def _issues_using(id_key: str) -> list[str]:
+    """Return the issue translation keys whose flow is dispatched on this key."""
+    source = (ROOT / "custom_components" / "spook").rglob("ectoplasms/*/repairs/*.py")
+    using = []
+    for path in source:
+        text = path.read_text()
+        if f'"{id_key}"' not in text:
+            continue
+        if match := re.search(r'^\s+repair = "([^"]+)"', text, re.MULTILINE):
+            using.append(match.group(1))
+    return using
+
+
+def test_there_are_flows_to_check() -> None:
+    """Guard the lookup above, which would otherwise pass by finding none."""
+    assert len(_FLOWS) >= len(_REMOVE_OR_IGNORE_FLOWS)
+    assert _FLOWS
+
+
+@pytest.mark.parametrize("id_key", _FLOWS)
+async def test_the_flow_supplies_what_its_dialog_asks_for(
+    hass: HomeAssistant,
+    id_key: str,
+) -> None:
+    """The init step's text and the flow's placeholders have to line up."""
+    flow = _REMOVE_OR_IGNORE_FLOWS[id_key]
+
+    for repair in _issues_using(id_key):
+        if not (block := STRINGS["issues"].get(repair)):
+            continue
+        if not (fix_flow := block.get("fix_flow")):
+            continue
+        if not (init := fix_flow.get("step", {}).get("init")):
+            continue
+
+        needed = set(
+            re.findall(
+                r"\{(\w+)\}", init.get("description", "") + init.get("title", "")
+            )
+        )
+
+        # What the flow hands over, read off the placeholder builder itself.
+        instance = flow.__new__(flow)
+        instance.hass = hass
+        instance.data = dict.fromkeys(needed | {"resource"}, "x")
+        supplied = set(instance._menu_placeholders())  # noqa: SLF001
+
+        assert not needed - supplied, (
+            f"{repair}: dialog names {sorted(needed - supplied)}, "
+            f"{flow.__name__} supplies {sorted(supplied)}"
+        )

--- a/tests/test_fix_flow_placeholders.py
+++ b/tests/test_fix_flow_placeholders.py
@@ -21,6 +21,10 @@ from custom_components.spook.repairs import _REMOVE_OR_IGNORE_FLOWS
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
+# Spook ships dozens of issue types; anything near this means the file was
+# read wrong rather than that they went away.
+EXPECTED_ISSUES = 20
+
 ROOT = Path(__file__).parents[1]
 STRINGS = json.loads(
     (ROOT / "custom_components" / "spook" / "translations" / "en.json").read_text()
@@ -81,3 +85,28 @@ async def test_the_flow_supplies_what_its_dialog_asks_for(
             f"{repair}: dialog names {sorted(needed - supplied)}, "
             f"{flow.__name__} supplies {sorted(supplied)}"
         )
+
+
+def test_no_issue_carries_both_a_description_and_a_fix_flow() -> None:
+    """Home Assistant treats those as mutually exclusive, and hassfest says so.
+
+    An issue is either fixable, and its text lives in the fix flow, or it is
+    not, and its text is the description. Carrying both fails validation with
+    "two or more values in the same group of exclusion 'fixable'".
+
+    Hassfest lives in the Home Assistant repository and cannot run here, so
+    this stands in for it. Finding this in CI costs a round trip; finding it
+    here costs a second.
+    """
+    both = sorted(
+        key
+        for key, block in STRINGS["issues"].items()
+        if "description" in block and "fix_flow" in block
+    )
+
+    assert not both, f"these carry both, and hassfest will refuse them: {both}"
+
+
+def test_there_are_issues_to_check() -> None:
+    """Guard the check above, which passes happily against an empty file."""
+    assert len(STRINGS["issues"]) > EXPECTED_ISSUES


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a repair that notices the same dashboard resource being listed more than once.

Nothing in Home Assistant stops this. `ResourceStorageCollection._get_suggested_id` hands every resource a fresh `uuid4().hex` and `_process_create_data` only validates the schema, so nothing anywhere looks at what the resource points at. Add the same URL twice and you get two entries.

The usual way in is updating a custom card. The new version wants a new cache-busting URL, so `/local/some-card.js?v=1` gains a neighbour at `?v=2` instead of being edited, and both stay behind. The browser treats two URLs as two files and loads both, the card tries to register itself twice, and the second attempt throws. What the user sees is a broken card, which sends them looking at the card rather than at the resource list.

**The design call worth reviewing.** What counts as "the same resource" depends on who serves it:

- Under `/local/` or `/hacsfiles/` the path *is* a file on disk, so two URLs differing only in their query string are one file listed twice. Certain, and it is the case that actually breaks something.
- Anywhere else, only an exact repeat counts. A query string on somebody else's server can be the difference between two genuinely different files, and Spook is not going to guess that it is not.

Two repairs got deleted 48 hours after shipping because they read a signal ordinary operation also produces. That boundary is where this one would go the same way, so it is drawn deliberately and pinned by a test.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #534, which asked for three things: links to missing resources, loading non-existing resources, and duplicate resources. The first two already ship as `lovelace_missing_resources`. This is the third.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Eight tests, covering both what it reports and what it deliberately does not:

- The same URL twice is reported.
- A local file behind two cache busters is reported, with both URLs named.
- An external URL with a differing query is **not** reported.
- An external URL repeated exactly still is.
- It counts past two.
- An ordinary resource list stays quiet.
- No resource collection is a no-op.
- The real storage collection is loaded before it is read, since it loads on first use and Spook looks long before the dashboard does.

Each guard was mutation tested on its own, and every mutant was caught:

| Mutation | Result |
| --- | --- |
| Strip the query for external URLs too | 2 failed |
| Never strip the query | 3 failed |
| Only report three or more | 4 failed |
| Read the collection without loading it | 1 failed |
| Report the count without the variants | 2 failed |

Also confirmed the repair is actually picked up by the glob-based discovery in `SpookRepairManager.async_setup` rather than just existing on disk: 40 repair modules found, this one among them, registering as `lovelace.lovelace_duplicate_resources`.

Full suite is 1420 passing. Ruff, pylint and prettier clean. The English strings were spliced in as text rather than re-dumped, so the diff on `en.json` is 4 added lines and nothing else.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None. The documentation section has no screenshot, matching the missing-resources section next to it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
