### PR TITLE
Stop the placeholder tests grading their own homework

### DIFF
--- a/tests/test_never_an_entity.py
+++ b/tests/test_never_an_entity.py
@@ -80,9 +80,25 @@ mode: restart
 """
 
 
+# Written out here rather than read from the code under test. Reading the very
+# set these tests are about means that taking an entry out of it takes it out
+# of the yardstick too, and every assertion below keeps passing while the thing
+# it guards is broken.
+_THE_TWO = frozenset({"trigger.entity_id", "this.entity_id"})
+
+
 def _named(found: set[str]) -> set[str]:
     """Return anything reported that is one of the two variables."""
-    return {e for e in found if e in template_extraction.NEVER_AN_ENTITY}
+    return {e for e in found if e in _THE_TWO}
+
+
+def test_the_yardstick_still_matches_the_code() -> None:
+    """The copy above is deliberate, so say when it stops describing reality.
+
+    A third placeholder worth excluding should be added to both. This failing
+    is the reminder, not a bug in itself.
+    """
+    assert set(template_extraction.NEVER_AN_ENTITY) == _THE_TWO
 
 
 async def test_no_way_of_writing_them_reads_as_an_entity(
@@ -272,6 +288,50 @@ async def test_a_dashboard_does_not_report_them_either(
     )
 
     assert not _named(unknown), f"a dashboard reported {sorted(unknown)}"
+
+
+async def test_the_card_from_the_auto_entities_report_stays_quiet(
+    hass: HomeAssistant,
+) -> None:
+    """The exact card from #1538, reported after the fix had already shipped.
+
+    It was already quiet, but only by luck of the last gate: the walk does
+    descend into `options:` inside a `filter:`, because that block is real
+    card configuration rather than a matcher. So the placeholder is collected
+    here and the filter is the only thing stopping it, which is worth pinning
+    against the shape somebody actually wrote.
+    """
+    card = yaml.safe_load(
+        """
+        type: custom:auto-entities
+        card:
+          card:
+            type: grid
+            columns: 1
+          card_param: cards
+        filter:
+          include:
+            - options:
+                type: custom:bubble-card
+                card_type: button
+                tap_action: toggle
+                entity_id: this.entity_id
+              entity_id: scene.szenen*
+        """,
+    )
+
+    extracted = extract_entities_from_dashboard_node(card)
+    assert "this.entity_id" in extracted, (
+        "the walk stopped collecting it, so this no longer tests the filter"
+    )
+
+    unknown = async_filter_known_entity_ids(
+        hass,
+        entity_ids=extracted,
+        known_entity_ids=set(),
+    )
+
+    assert "this.entity_id" not in unknown, f"a dashboard reported {sorted(unknown)}"
 
 
 async def test_a_dashboard_still_reports_an_entity_that_really_is_gone(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

#1538 reports `this.entity_id` from an auto-entities card being flagged as an unknown entity. It does not reproduce, and the fix for it was already in the version the reporter is running. What went looking for it found something worse: most of the tests guarding that fix could not have told me otherwise.

`_named()`, the helper nearly every assertion in `tests/test_never_an_entity.py` goes through, decided what counted as a placeholder by reading `NEVER_AN_ENTITY` itself. So taking `this.entity_id` out of that set took it out of the yardstick as well, and the assertions carried on passing while the thing they guard was broken. The tests were grading their own homework.

The helper now holds its own copy of the two placeholders, with a test saying so when the copy stops matching the code, since that is a reminder to update both rather than a bug in itself.

The card from the report is pinned as a test of its own. The walk does descend into the `options:` block inside a `filter:`, because that block is real card configuration rather than a matcher, so the placeholder is collected there and the filter is the only thing stopping it. That is worth having against the shape somebody actually wrote, and it asserts on the literal rather than through the helper.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Investigating #1538. The report itself needs no code fix:

- The exclusion is in the **v5.2.0 tag itself**, and the reporter is on 5.2.
- The issue was opened four hours after 5.2.0 was released.
- Running the exact card through the real repair, nested inside a vertical-stack the way a dashboard carries it, collects `this.entity_id` and reports nothing. The repair has a single path to an issue, so there is no second place it could leak from.

Most likely the repair was still there from before the update. The issue stays open until the reporter confirms.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

By mutation, which is the only thing that shows this class of problem.

Taking `this.entity_id` out of `NEVER_AN_ENTITY` is the regression these tests exist to catch. Before this change **one** test failed on it. After, **six** do:

| | Before | After |
| --- | --- | --- |
| `test_home_assistant_handing_them_over_does_not_count_either` | passed | fails |
| `test_they_stay_out_even_if_the_domains_ever_let_them_in` | passed | fails |
| `test_a_dashboard_does_not_report_them_either` | passed | fails |
| `test_a_dashboard_still_reports_an_entity_that_really_is_gone` | fails | fails |
| `test_the_card_from_the_auto_entities_report_stays_quiet` | new | fails |
| `test_the_yardstick_still_matches_the_code` | new | fails |

The dashboard test being in the blind group is the awkward part, since dashboards are exactly where this was reported from.

Full suite is 1481 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None, this is tests only.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
