### PR TITLE
Being named counts, not just being targeted

### DIFF
--- a/custom_components/spook/ectoplasms/homeassistant/repairs/empty_areas.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/empty_areas.py
@@ -70,8 +70,10 @@ class SpookRepair(AbstractSpookRepair):
                 continue
             if area.id in mentioned:
                 # Named somewhere in an automation or script without
-                # being a target of it, so removing it would break
-                # something. Not ours to offer up.
+                # being a target of it. That is not proof it is in use: the
+                # collector takes every string it finds and a coincidence
+                # counts the same as a reference. It is enough to stop
+                # offering to delete it, which is all this decides.
                 continue
 
             self.async_create_issue(

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/empty_areas.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/empty_areas.py
@@ -15,6 +15,7 @@ from homeassistant.helpers import (
 from homeassistant.util import dt as dt_util
 
 from ....const import LOGGER
+from ....reference_extraction import async_collect_mentioned_strings
 from ....repairs import AbstractSpookRepair
 
 # Give a freshly created area time to be filled before nagging about it.
@@ -46,6 +47,8 @@ class SpookRepair(AbstractSpookRepair):
         """Trigger an inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
+        mentioned = async_collect_mentioned_strings(self.hass)
+
         area_registry = ar.async_get(self.hass)
         device_registry = dr.async_get(self.hass)
         entity_registry = er.async_get(self.hass)
@@ -64,6 +67,11 @@ class SpookRepair(AbstractSpookRepair):
             if automations_with_area(self.hass, area.id):
                 continue
             if scripts_with_area(self.hass, area.id):
+                continue
+            if area.id in mentioned:
+                # Named somewhere in an automation or script without
+                # being a target of it, so removing it would break
+                # something. Not ours to offer up.
                 continue
 
             self.async_create_issue(

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/empty_floors.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/empty_floors.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import (
 from homeassistant.util import dt as dt_util
 
 from ....const import LOGGER
+from ....reference_extraction import async_collect_mentioned_strings
 from ....repairs import AbstractSpookRepair
 
 # Give a freshly created floor time to get areas assigned before nagging.
@@ -42,6 +43,8 @@ class SpookRepair(AbstractSpookRepair):
         """Trigger an inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
+        mentioned = async_collect_mentioned_strings(self.hass)
+
         floor_registry = fr.async_get(self.hass)
         area_registry = ar.async_get(self.hass)
 
@@ -57,6 +60,11 @@ class SpookRepair(AbstractSpookRepair):
             if automations_with_floor(self.hass, floor.floor_id):
                 continue
             if scripts_with_floor(self.hass, floor.floor_id):
+                continue
+            if floor.floor_id in mentioned:
+                # Named somewhere in an automation or script without
+                # being a target of it, so removing it would break
+                # something. Not ours to offer up.
                 continue
 
             self.async_create_issue(

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/empty_floors.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/empty_floors.py
@@ -63,8 +63,10 @@ class SpookRepair(AbstractSpookRepair):
                 continue
             if floor.floor_id in mentioned:
                 # Named somewhere in an automation or script without
-                # being a target of it, so removing it would break
-                # something. Not ours to offer up.
+                # being a target of it. That is not proof it is in use: the
+                # collector takes every string it finds and a coincidence
+                # counts the same as a reference. It is enough to stop
+                # offering to delete it, which is all this decides.
                 continue
 
             self.async_create_issue(

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unused_labels.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unused_labels.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import (
 from homeassistant.util import dt as dt_util
 
 from ....const import LOGGER
+from ....reference_extraction import async_collect_mentioned_strings
 from ....repairs import AbstractSpookRepair
 
 # Give a freshly created label time to be applied before nagging about it.
@@ -46,6 +47,8 @@ class SpookRepair(AbstractSpookRepair):
         """Trigger an inspection."""
         LOGGER.debug("Spook is inspecting: %s", self.repair)
 
+        mentioned = async_collect_mentioned_strings(self.hass)
+
         label_registry = lr.async_get(self.hass)
         area_registry = ar.async_get(self.hass)
         device_registry = dr.async_get(self.hass)
@@ -67,6 +70,11 @@ class SpookRepair(AbstractSpookRepair):
             if automations_with_label(self.hass, label.label_id):
                 continue
             if scripts_with_label(self.hass, label.label_id):
+                continue
+            if label.label_id in mentioned:
+                # Named somewhere in an automation or script without
+                # being a target of it, so removing it would break
+                # something. Not ours to offer up.
                 continue
 
             self.async_create_issue(

--- a/custom_components/spook/ectoplasms/homeassistant/repairs/unused_labels.py
+++ b/custom_components/spook/ectoplasms/homeassistant/repairs/unused_labels.py
@@ -73,8 +73,10 @@ class SpookRepair(AbstractSpookRepair):
                 continue
             if label.label_id in mentioned:
                 # Named somewhere in an automation or script without
-                # being a target of it, so removing it would break
-                # something. Not ours to offer up.
+                # being a target of it. That is not proof it is in use: the
+                # collector takes every string it finds and a coincidence
+                # counts the same as a reference. It is enough to stop
+                # offering to delete it, which is all this decides.
                 continue
 
             self.async_create_issue(

--- a/custom_components/spook/reference_extraction.py
+++ b/custom_components/spook/reference_extraction.py
@@ -13,13 +13,19 @@ never to replace it.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import ENTITY_MATCH_ALL, ENTITY_MATCH_NONE
+from homeassistant.core import callback
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 
 from .template_extraction import is_template_string
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 # Direct reference keys, mapped to their reference type.
 # What the device registry hands out: `random_uuid_hex`, so 32 hex characters.
@@ -204,4 +210,53 @@ def extract_platform_keys_from_config(config: Any) -> ExtractedPlatformKeys:
     """
     found = ExtractedPlatformKeys()
     _walk_platform_keys(config, found)
+    return found
+
+
+# Only automations and scripts carry a raw configuration worth reading here.
+_CONFIGURED_DOMAINS = ("automation", "script")
+
+
+def _collect_every_string(node: Any, found: set[str]) -> None:
+    """Collect every string anywhere in a configuration, keys included.
+
+    Deliberately indiscriminate. This is not working out what a configuration
+    means; it is answering whether something is mentioned in it at all.
+    """
+    if isinstance(node, str):
+        found.add(node)
+    elif isinstance(node, Mapping):
+        for key, value in node.items():
+            if isinstance(key, str):
+                found.add(key)
+            _collect_every_string(value, found)
+    elif isinstance(node, (list, tuple, set)):
+        for item in node:
+            _collect_every_string(item, found)
+
+
+@callback
+def async_collect_mentioned_strings(hass: HomeAssistant) -> set[str]:
+    """Return every string appearing in any automation or script.
+
+    For deciding whether something is referenced, `referenced_areas` and
+    Spook's own target extraction are the right tools: they know what a
+    reference is.
+
+    This is for the other question, the one asked before offering to delete
+    something. An area listed in a `repeat` `for_each` is a target of nothing,
+    and neither extraction reports it, but it is plainly in use and removing
+    it would break the script. Anything named anywhere is enough to leave it
+    alone.
+    """
+    found: set[str] = set()
+
+    for domain in _CONFIGURED_DOMAINS:
+        if not (component := hass.data.get(DATA_INSTANCES, {}).get(domain)):
+            continue
+
+        for entity in component.entities:
+            if raw_config := getattr(entity, "raw_config", None):
+                _collect_every_string(raw_config, found)
+
     return found

--- a/custom_components/spook/reference_extraction.py
+++ b/custom_components/spook/reference_extraction.py
@@ -217,14 +217,26 @@ def extract_platform_keys_from_config(config: Any) -> ExtractedPlatformKeys:
 _CONFIGURED_DOMAINS = ("automation", "script")
 
 
+# Quoted literals inside a template, as in `{{ ['study', 'loft'] }}`.
+_QUOTED = re.compile(r"""['"]([^'"]+)['"]""")
+
+
 def _collect_every_string(node: Any, found: set[str]) -> None:
     """Collect every string anywhere in a configuration, keys included.
 
     Deliberately indiscriminate. This is not working out what a configuration
     means; it is answering whether something is mentioned in it at all.
+
+    A template counts as one string and also as the literals inside it, since
+    `for_each: "{{ ['study'] }}"` names `study` as plainly as a list would.
+    Matching on substrings instead would be far too eager: an area called
+    `kitchen` would be found in `sensor.kitchen_temperature` and nothing would
+    ever be reported again.
     """
     if isinstance(node, str):
         found.add(node)
+        if is_template_string(node):
+            found.update(_QUOTED.findall(node))
     elif isinstance(node, Mapping):
         for key, value in node.items():
             if isinstance(key, str):

--- a/custom_components/spook/reference_extraction.py
+++ b/custom_components/spook/reference_extraction.py
@@ -256,10 +256,14 @@ def async_collect_mentioned_strings(hass: HomeAssistant) -> set[str]:
     reference is.
 
     This is for the other question, the one asked before offering to delete
-    something. An area listed in a `repeat` `for_each` is a target of nothing,
-    and neither extraction reports it, but it is plainly in use and removing
-    it would break the script. Anything named anywhere is enough to leave it
-    alone.
+    something: might this be in use? An area listed in a `repeat` `for_each`
+    is a target of nothing and neither extraction reports it, yet the script
+    plainly needs it.
+
+    The answer is deliberately loose. A string that happens to match counts
+    the same as a real reference, so this proves nothing about what is in use.
+    It only decides whether Spook keeps quiet, and on something that offers to
+    delete, a coincidence is a fine reason to.
     """
     found: set[str] = set()
 

--- a/documentation/integrations/homeassistant.md
+++ b/documentation/integrations/homeassistant.md
@@ -66,17 +66,23 @@ An {term}`area` with no devices, no entities, and no automation or script target
 
 Spook checks references as well as contents, so an area that is deliberately empty because an automation targets it is left alone. The raised issue is fixable: Spook can remove the area for you.
 
+Being named anywhere in an automation or script counts, not only being targeted by one. An area listed in a `repeat` block's `for_each` is the target of nothing, and Home Assistant does not report it as a reference, but a script plainly needs it. Since this issue offers to delete the area, a mention anywhere is enough for Spook to leave it be.
+
 ### Empty floors
 
 A {term}`floor` exists to group areas. One with no areas at all, and no automation or script targeting it, is not doing that.
 
 The raised issue is fixable: Spook can remove the floor for you.
 
+Being named anywhere in an automation or script counts, not only being targeted by one. A floor listed in a `repeat` block's `for_each` is the target of nothing, and Home Assistant does not report it as a reference, but a script plainly needs it. Since this issue offers to delete the floor, a mention anywhere is enough for Spook to leave it be.
+
 ### Unused labels
 
 A {term}`label` that is applied to no entity, device or area, and that no automation or script targets, is not doing anything either.
 
 The raised issue is fixable: Spook can remove the label for you.
+
+Being named anywhere in an automation or script counts, not only being targeted by one. A label listed in a `repeat` block's `for_each` is the target of nothing, and Home Assistant does not report it as a reference, but a script plainly needs it. Since this issue offers to delete the label, a mention anywhere is enough for Spook to leave it be.
 
 ### Unused blueprints
 

--- a/documentation/integrations/homeassistant.md
+++ b/documentation/integrations/homeassistant.md
@@ -62,27 +62,27 @@ This one is fixable by pruning rather than removing: Spook can drop the missing 
 
 ### Empty areas
 
-An {term}`area` with no devices, no entities, and no automation or script targeting it is not doing anything.
+An {term}`area` with no devices, no entities, and no mention anywhere in an automation or script is not doing anything.
 
-Spook checks references as well as contents, so an area that is deliberately empty because an automation targets it is left alone. The raised issue is fixable: Spook can remove the area for you.
+Spook checks references as well as contents, so an area that is deliberately empty because something uses it is left alone. Being mentioned is enough: it does not have to be _targeted_. An area listed in a `repeat` block's `for_each` is the target of nothing, and Home Assistant does not report it as a reference, but a script plainly needs it. Since this issue offers to delete the area, anything naming it is reason enough to leave it be.
 
-Being named anywhere in an automation or script counts, not only being targeted by one. An area listed in a `repeat` block's `for_each` is the target of nothing, and Home Assistant does not report it as a reference, but a script plainly needs it. Since this issue offers to delete the area, a mention anywhere is enough for Spook to leave it be.
+The raised issue is fixable: Spook can remove the area for you.
 
 ### Empty floors
 
-A {term}`floor` exists to group areas. One with no areas at all, and no automation or script targeting it, is not doing that.
+A {term}`floor` exists to group areas. One with no areas at all, and no mention anywhere in an automation or script, is not doing that.
+
+As with empty areas, being mentioned is enough and it does not have to be targeted, because this issue offers to delete the floor.
 
 The raised issue is fixable: Spook can remove the floor for you.
 
-Being named anywhere in an automation or script counts, not only being targeted by one. A floor listed in a `repeat` block's `for_each` is the target of nothing, and Home Assistant does not report it as a reference, but a script plainly needs it. Since this issue offers to delete the floor, a mention anywhere is enough for Spook to leave it be.
-
 ### Unused labels
 
-A {term}`label` that is applied to no entity, device or area, and that no automation or script targets, is not doing anything either.
+A {term}`label` that is applied to no entity, device or area, and that nothing anywhere in an automation or script mentions, is not doing anything either.
+
+As with empty areas, being mentioned is enough and it does not have to be targeted, because this issue offers to delete the label.
 
 The raised issue is fixable: Spook can remove the label for you.
-
-Being named anywhere in an automation or script counts, not only being targeted by one. A label listed in a `repeat` block's `for_each` is the target of nothing, and Home Assistant does not report it as a reference, but a script plainly needs it. Since this issue offers to delete the label, a mention anywhere is enough for Spook to leave it be.
 
 ### Unused blueprints
 

--- a/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
 
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.homeassistant.repairs import empty_areas
@@ -216,3 +217,85 @@ async def test_fix_flow_remove_survives_already_removed_area(
     result = await flow.async_step_remove()
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert area_registry.async_get_area("gone") is None
+
+
+async def test_an_area_only_named_in_a_repeat_is_not_reported(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The shape from the report: areas that exist so a script can list them.
+
+    A `repeat` `for_each` list is not a target of anything. Home Assistant's
+    `referenced_areas` reports the template rather than the list it walks, and
+    Spook's own target extraction skips templates, so neither sees the area at
+    all. It is plainly in use, and this repair offers to delete it.
+    """
+    area = area_registry.async_create("Vacuum Only")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "clean_upstairs": {
+                    "sequence": [
+                        {
+                            "repeat": {
+                                "for_each": [area.id],
+                                "sequence": [
+                                    {
+                                        "action": "vacuum.clean_area",
+                                        "target": {"area_id": "{{ repeat.item }}"},
+                                    }
+                                ],
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id)) is None
+
+
+async def test_an_area_nobody_mentions_at_all_is_still_reported(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """So the check above cannot pass by never reporting anything again."""
+    area_registry.async_create("Mentioned")
+    forgotten = area_registry.async_create("Forgotten")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "clean": {
+                    "sequence": [
+                        {
+                            "repeat": {
+                                "for_each": ["mentioned"],
+                                "sequence": [{"action": "vacuum.start", "target": {}}],
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(forgotten.id))

--- a/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
@@ -299,3 +299,45 @@ async def test_an_area_nobody_mentions_at_all_is_still_reported(
     await SpookRepair(hass).async_inspect()
 
     assert issue_registry.async_get_issue(DOMAIN, _issue_id(forgotten.id))
+
+
+async def test_an_automation_naming_it_counts_the_same_as_a_script(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The collector reads both, and only one of them was being tested.
+
+    Automations and scripts hold their configuration in different components,
+    so a wrong domain name or a missing `raw_config` on one of them would go
+    unnoticed while every other test here stayed green.
+    """
+    area = area_registry.async_create("Vacuum Only")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "Clean upstairs",
+                    "trigger": [],
+                    "action": [
+                        {
+                            "repeat": {
+                                "for_each": [area.id],
+                                "sequence": [{"action": "vacuum.start", "target": {}}],
+                            }
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id)) is None

--- a/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_empty_areas.py
@@ -341,3 +341,76 @@ async def test_an_automation_naming_it_counts_the_same_as_a_script(
     await SpookRepair(hass).async_inspect()
 
     assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id)) is None
+
+
+async def test_an_area_named_only_inside_a_template_is_not_reported(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A template is one string, and the ID is buried inside it.
+
+    `for_each: "{{ ['study'] }}"` names the area as plainly as a list would,
+    but an exact match against the whole template never finds it.
+    """
+    area = area_registry.async_create("Study")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "clean": {
+                    "sequence": [
+                        {
+                            "repeat": {
+                                "for_each": "{{ ['" + area.id + "'] }}",
+                                "sequence": [{"action": "vacuum.start", "target": {}}],
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id)) is None
+
+
+async def test_quotes_in_ordinary_text_are_not_a_mention(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Only templates get taken apart, and this is what that costs otherwise.
+
+    Prising literals out of every string would let a quoted word in an alias
+    keep an area alive. Being over-careful is the right way to be wrong here,
+    but not so careless that prose counts as a reference.
+    """
+    area = area_registry.async_create("Study")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "notes": {
+                    "alias": f"Somebody once mentioned '{area.id}' in passing",
+                    "sequence": [{"action": "vacuum.start", "target": {}}],
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(area.id))

--- a/tests/ectoplasms/homeassistant/repairs/test_empty_floors.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_empty_floors.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
 from homeassistant.helpers import area_registry as ar, floor_registry as fr
 
 from custom_components.spook.const import DOMAIN
@@ -149,3 +150,78 @@ async def test_fix_flow_ignore_option_dismisses_issue(
     issue = issue_registry.async_get_issue(DOMAIN, _issue_id(floor.floor_id))
     assert issue is not None
     assert issue.dismissed_version is not None
+
+
+async def test_a_floor_only_named_in_a_repeat_is_not_reported(
+    hass: HomeAssistant,
+    floor_registry: fr.FloorRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A `repeat` `for_each` list is a target of nothing.
+
+    Neither Home Assistant's own extraction nor Spook's sees it, and this
+    repair offers to delete what it finds, so being named anywhere is enough
+    to leave it alone.
+    """
+    floor = floor_registry.async_create("Attic")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "walk": {
+                    "sequence": [
+                        {
+                            "repeat": {
+                                "for_each": [floor.floor_id],
+                                "sequence": [{"action": "light.turn_on", "target": {}}],
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(floor.floor_id)) is None
+
+
+async def test_a_floor_nobody_mentions_at_all_is_still_reported(
+    hass: HomeAssistant,
+    floor_registry: fr.FloorRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """So the check above cannot pass by never reporting anything again."""
+    forgotten = floor_registry.async_create("Forgotten")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "walk": {
+                    "sequence": [
+                        {
+                            "repeat": {
+                                "for_each": ["something_else"],
+                                "sequence": [{"action": "light.turn_on", "target": {}}],
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(forgotten.floor_id))

--- a/tests/ectoplasms/homeassistant/repairs/test_unused_labels.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_unused_labels.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
 from homeassistant.helpers import (
     area_registry as ar,
     entity_registry as er,
@@ -192,3 +193,78 @@ async def test_fix_flow_ignore_option_dismisses_issue(
     issue = issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id))
     assert issue is not None
     assert issue.dismissed_version is not None
+
+
+async def test_a_label_only_named_in_a_repeat_is_not_reported(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A `repeat` `for_each` list is a target of nothing.
+
+    Neither Home Assistant's own extraction nor Spook's sees it, and this
+    repair offers to delete what it finds, so being named anywhere is enough
+    to leave it alone.
+    """
+    label = label_registry.async_create("Seasonal")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "walk": {
+                    "sequence": [
+                        {
+                            "repeat": {
+                                "for_each": [label.label_id],
+                                "sequence": [{"action": "light.turn_on", "target": {}}],
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(label.label_id)) is None
+
+
+async def test_a_label_nobody_mentions_at_all_is_still_reported(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """So the check above cannot pass by never reporting anything again."""
+    forgotten = label_registry.async_create("Forgotten")
+    freezer.tick(_AGED)
+
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "walk": {
+                    "sequence": [
+                        {
+                            "repeat": {
+                                "for_each": ["something_else"],
+                                "sequence": [{"action": "light.turn_on", "target": {}}],
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _issue_id(forgotten.label_id))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The three repairs that find unused areas, floors and labels all asked the same question: does an automation or script *target* this? That is the right question for reporting a broken reference. It is the wrong question before offering to delete something.

A `repeat` block's `for_each` list is the target of nothing. Home Assistant's `referenced_areas` reports the `{{ repeat.item }}` template it walks with, and Spook's own target extraction skips templates, so between the two of them nobody sees the list itself. The area sits in plain sight in the script and neither extraction is looking at it.

Measured on four shapes, to be sure which one actually leaks:

| Script shape | `referenced_areas` | `extract_targets_from_config` |
| --- | --- | --- |
| `target: {area_id: kitchen}` | `kitchen` | `kitchen` |
| `data: {area_id: [study]}` | `study` | `study` |
| `repeat: {for_each: [hallway]}` | `{{ repeat.item }}` | nothing |
| area id in a `variables:` block | `{{ rooms }}` | nothing |

So there is now a second, blunt question asked only by these three: every string in every automation and script configuration, keys included, and a match anywhere is enough to leave the thing alone. For deciding whether something is *referenced*, both extractions stay as careful as they were.

**This makes the three repairs deliberately more conservative.** An area whose ID happens to appear as a loose string somewhere in a script will no longer be reported. That seems the right direction to be wrong in for an action that deletes, but it is a choice worth seeing.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1539.

The reporter keeps areas that hold nothing so a robot vacuum can be told to clean them, listed in a script. Spook offered to delete them.

The same hole was in all three repairs, so all three are fixed rather than leaving two of them to be found the same way later.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Six new tests, two per repair: the reported shape is left alone, and something nobody mentions at all is still reported. The second half matters, because a guard that is too wide would silently stop the repair doing anything and every remaining test would still pass.

Each guard was mutation tested in both directions:

| Mutation | Result |
| --- | --- |
| Remove the guard from `empty_areas` | 1 failed |
| Remove the guard from `empty_floors` | 1 failed |
| Remove the guard from `unused_labels` | 1 failed |
| Make the guard always fire (report nothing, ever) | 3 failed |
| Match on the area's name instead of its ID | 1 failed |

Full suite is 1485 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
