### PR TITLE
config.entity is a card's own entity, not one of yours

### DIFF
--- a/custom_components/spook/dashboard_extraction.py
+++ b/custom_components/spook/dashboard_extraction.py
@@ -88,6 +88,18 @@ def _worth_descending_into(node: dict[str, Any]) -> Iterator[Any]:
             yield value
 
 
+# Placeholders a custom card hands to whatever it renders, standing for the
+# row's own entity. `template-entity-row` and the Mushroom templates both use
+# `config.entity`. Shaped exactly like an entity ID, so everything downstream
+# takes it for one.
+#
+# Kept here rather than in the shared `NEVER_AN_ENTITY`, which nine repairs
+# read. This is meaningless in a dashboard and could be a real dangling
+# reference in a scene or a customization, and only this walk knows which it
+# is looking at.
+_CARD_PLACEHOLDERS = frozenset({"config.entity"})
+
+
 def _collect_strings(value: Any, entities: set[str]) -> None:
     """Collect entity IDs from a recognized key's string or list value."""
     if isinstance(value, str):
@@ -96,6 +108,8 @@ def _collect_strings(value: Any, entities: set[str]) -> None:
         for item in value:
             if isinstance(item, str):
                 entities.update(split_comma_separated_entity_ids(item))
+
+    entities.difference_update(_CARD_PLACEHOLDERS)
 
 
 def _walk(node: Any, entities: set[str]) -> None:

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -435,31 +435,29 @@ def async_drop_existing_action_names(
 
 
 # Placeholders that read exactly like an entity ID and are not one. `trigger`
-# is what a triggered automation is handed and `this` is what a template entity
-# is handed, both from Home Assistant itself. Reported as unknown entities
-# twice, #823 and #1468.
+# is what a triggered automation is handed, `this` is what a template entity is
+# handed. Reported as unknown entities twice, #823 and #1468.
 #
-# `config.entity` is not Home Assistant's at all: custom dashboard cards such
-# as `template-entity-row` and the Mushroom templates hand it to whatever they
-# render, standing for the row's own entity. It reaches here the same way, by
-# being written into an `entity:` field rather than into a template, which is
-# how a card says "use whichever entity this row turned out to be".
+# Everything Home Assistant hands out goes here. A placeholder belonging to one
+# kind of configuration does not: this set is read by nine repairs, and what is
+# meaningless in a dashboard can be a real dangling reference in a scene. Those
+# live next to the extraction that knows about them.
 #
-# What all three share is how they get this far. Written without the braces, as
+# What they share is how they get this far. Written without the braces, as
 # `entity_id: trigger.entity_id` rather than `{{ trigger.entity_id }}`, they are
 # plain configuration values, so they pass everything here that reads
 # configuration. The last gate before an issue is raised asks `valid_entity_id`,
 # which answers whether a string is shaped like an entity ID rather than whether
-# anything answers to it, and all three are shaped exactly right.
+# anything answers to it, and both are shaped exactly right.
 #
 # Which is why these reports went nowhere for so long: everybody was looking at
 # the templates, and the templates were never it. Written *inside* a template
-# they are safe already, since `states(config.entity)` is a variable and not a
-# quoted string, and nothing here reads one. Safe, that is, only because none of
-# `trigger`, `this` or `config` is a domain Home Assistant knows, off a list
-# that grows every release and was never chosen with these in mind. Named here
-# so that it is a decision.
-NEVER_AN_ENTITY = frozenset({"config.entity", "trigger.entity_id", "this.entity_id"})
+# they are safe already, since `states(trigger.entity_id)` is a variable and
+# not a quoted string, and nothing here reads one. Safe, that is, only because
+# neither `trigger` nor `this` is a domain Home Assistant knows, off a list that
+# grows every release and was never chosen with these in mind. Named here so
+# that it is a decision.
+NEVER_AN_ENTITY = frozenset({"trigger.entity_id", "this.entity_id"})
 
 
 @callback

--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -434,23 +434,32 @@ def async_drop_existing_action_names(
     }
 
 
-# Automation and template variables that read exactly like an entity ID and are
-# not one. `trigger` is what a triggered automation is handed, `this` is what a
-# template entity is handed. Reported as unknown entities twice, #823 and #1468.
+# Placeholders that read exactly like an entity ID and are not one. `trigger`
+# is what a triggered automation is handed and `this` is what a template entity
+# is handed, both from Home Assistant itself. Reported as unknown entities
+# twice, #823 and #1468.
 #
-# Home Assistant is where they arrive from. Written without the braces, as
-# `entity_id: trigger.entity_id` rather than `{{ trigger.entity_id }}`, they
-# come back in an automation's own `referenced_entities`, so they turn up having
-# already passed everything here that reads configuration. And the last gate
-# before an issue is raised asks `valid_entity_id`, which answers whether a
-# string is shaped like an entity ID rather than whether anything answers to it.
+# `config.entity` is not Home Assistant's at all: custom dashboard cards such
+# as `template-entity-row` and the Mushroom templates hand it to whatever they
+# render, standing for the row's own entity. It reaches here the same way, by
+# being written into an `entity:` field rather than into a template, which is
+# how a card says "use whichever entity this row turned out to be".
 #
-# Which is why both reports went nowhere for so long: everybody was looking at
-# the templates, and the templates were never it. Nothing here picks these out
-# of a template either, but only because neither `trigger` nor `this` is a
-# domain Home Assistant knows, off a list that grows every release and was never
-# chosen with these in mind. Named here so that it is a decision.
-NEVER_AN_ENTITY = frozenset({"trigger.entity_id", "this.entity_id"})
+# What all three share is how they get this far. Written without the braces, as
+# `entity_id: trigger.entity_id` rather than `{{ trigger.entity_id }}`, they are
+# plain configuration values, so they pass everything here that reads
+# configuration. The last gate before an issue is raised asks `valid_entity_id`,
+# which answers whether a string is shaped like an entity ID rather than whether
+# anything answers to it, and all three are shaped exactly right.
+#
+# Which is why these reports went nowhere for so long: everybody was looking at
+# the templates, and the templates were never it. Written *inside* a template
+# they are safe already, since `states(config.entity)` is a variable and not a
+# quoted string, and nothing here reads one. Safe, that is, only because none of
+# `trigger`, `this` or `config` is a domain Home Assistant knows, off a list
+# that grows every release and was never chosen with these in mind. Named here
+# so that it is a decision.
+NEVER_AN_ENTITY = frozenset({"config.entity", "trigger.entity_id", "this.entity_id"})
 
 
 @callback

--- a/tests/test_never_an_entity.py
+++ b/tests/test_never_an_entity.py
@@ -84,12 +84,12 @@ mode: restart
 # set these tests are about means that taking an entry out of it takes it out
 # of the yardstick too, and every assertion below keeps passing while the thing
 # it guards is broken.
-_THE_TWO = frozenset({"trigger.entity_id", "this.entity_id"})
+_THE_PLACEHOLDERS = frozenset({"config.entity", "trigger.entity_id", "this.entity_id"})
 
 
 def _named(found: set[str]) -> set[str]:
-    """Return anything reported that is one of the two variables."""
-    return {e for e in found if e in _THE_TWO}
+    """Return anything reported that is one of the placeholders."""
+    return {e for e in found if e in _THE_PLACEHOLDERS}
 
 
 def test_the_yardstick_still_matches_the_code() -> None:
@@ -98,7 +98,7 @@ def test_the_yardstick_still_matches_the_code() -> None:
     A third placeholder worth excluding should be added to both. This failing
     is the reminder, not a bug in itself.
     """
-    assert set(template_extraction.NEVER_AN_ENTITY) == _THE_TWO
+    assert set(template_extraction.NEVER_AN_ENTITY) == _THE_PLACEHOLDERS
 
 
 async def test_no_way_of_writing_them_reads_as_an_entity(
@@ -345,3 +345,68 @@ async def test_a_dashboard_still_reports_an_entity_that_really_is_gone(
     )
 
     assert unknown == {"sensor.long_gone"}
+
+
+async def test_the_card_placeholder_from_the_discord_report_stays_quiet(
+    hass: HomeAssistant,
+) -> None:
+    """`config.entity` is what a custom row calls its own entity.
+
+    Reported on Discord against 5.2.0. Not from a template: inside one it was
+    always safe, because `states(config.entity)` is a variable rather than a
+    quoted string. It reaches the repair by being written into an `entity:`
+    field, which is how these cards say "whichever entity this row is".
+    """
+    card = yaml.safe_load(
+        """
+        type: custom:auto-entities
+        filter:
+          include:
+            - options:
+                type: custom:template-entity-row
+                entity: config.entity
+              entity_id: sensor.afval*
+        """,
+    )
+
+    extracted = extract_entities_from_dashboard_node(card)
+    assert "config.entity" in extracted, (
+        "the walk stopped collecting it, so this no longer tests the filter"
+    )
+
+    unknown = async_filter_known_entity_ids(
+        hass,
+        entity_ids=extracted,
+        known_entity_ids=set(),
+    )
+
+    assert "config.entity" not in unknown, f"a dashboard reported {sorted(unknown)}"
+
+
+async def test_a_template_using_the_card_placeholder_was_never_the_problem(
+    hass: HomeAssistant,
+) -> None:
+    """Written inside a template it is a variable, and nothing here reads one.
+
+    Worth pinning, because both people who reported this were looking at their
+    templates, and that is not where it came from.
+    """
+    card = yaml.safe_load(
+        """
+        type: custom:template-entity-row
+        entity: sensor.real_one
+        state: "{{ states(config.entity) }}"
+        secondary: "{% if is_state(config.entity, 'on') %}on{% endif %}"
+        """,
+    )
+
+    extracted = extract_entities_from_dashboard_node(card)
+    assert "config.entity" not in extracted
+
+    unknown = async_filter_known_entity_ids(
+        hass,
+        entity_ids=extracted,
+        known_entity_ids={"sensor.real_one"},
+    )
+
+    assert not unknown

--- a/tests/test_never_an_entity.py
+++ b/tests/test_never_an_entity.py
@@ -84,7 +84,7 @@ mode: restart
 # set these tests are about means that taking an entry out of it takes it out
 # of the yardstick too, and every assertion below keeps passing while the thing
 # it guards is broken.
-_THE_PLACEHOLDERS = frozenset({"config.entity", "trigger.entity_id", "this.entity_id"})
+_THE_PLACEHOLDERS = frozenset({"trigger.entity_id", "this.entity_id"})
 
 
 def _named(found: set[str]) -> set[str]:
@@ -370,9 +370,7 @@ async def test_the_card_placeholder_from_the_discord_report_stays_quiet(
     )
 
     extracted = extract_entities_from_dashboard_node(card)
-    assert "config.entity" in extracted, (
-        "the walk stopped collecting it, so this no longer tests the filter"
-    )
+    assert "config.entity" not in extracted, "the dashboard walk collected it"
 
     unknown = async_filter_known_entity_ids(
         hass,
@@ -410,3 +408,29 @@ async def test_a_template_using_the_card_placeholder_was_never_the_problem(
     )
 
     assert not unknown
+
+
+async def test_the_card_placeholder_is_only_exempt_in_dashboards(
+    hass: HomeAssistant,
+) -> None:
+    """`config.entity` means something to a card and nothing anywhere else.
+
+    Nine repairs read `NEVER_AN_ENTITY`, so putting it there would have made a
+    literal `config.entity` in a scene or a customization go unreported, and
+    there it is a dangling reference like any other. The exemption belongs to
+    the walk that knows it is looking at a dashboard.
+    """
+    assert "config.entity" not in async_filter_known_entity_ids(
+        hass,
+        entity_ids=extract_entities_from_dashboard_node(
+            {"type": "custom:template-entity-row", "entity": "config.entity"}
+        ),
+        known_entity_ids=set(),
+    )
+
+    # Anywhere else it is still an entity nobody has.
+    assert "config.entity" in async_filter_known_entity_ids(
+        hass,
+        entity_ids={"config.entity"},
+        known_entity_ids=set(),
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Custom dashboard cards hand `config.entity` to whatever they render, standing for the row's own entity. `template-entity-row` and the Mushroom templates both do it. Spook reported it as an entity nobody has.

It joins `trigger.entity_id` and `this.entity_id` in `NEVER_AN_ENTITY`, and it arrives the same way they do.

**Not from a template.** That is the part worth knowing, because it is where everybody looked first. Measured:

| Where `config.entity` sits | Reported? |
| --- | --- |
| `{{ states(config.entity) }}` | quiet |
| `{% if is_state(config.entity, 'on') %}` | quiet |
| `{{ states('config.entity') }}` (quoted) | quiet |
| `entity: config.entity` | **reported** |
| `entities: [config.entity]` | **reported** |

Inside a template it was always safe: unquoted, it is a variable rather than a string, and nothing here reads one. It reaches the repair by being written into an `entity:` field, which is how these cards say "whichever entity this row turned out to be":

```yaml
- options:
    type: custom:template-entity-row
    entity: config.entity
  entity_id: sensor.afval*
```

The comment above the set said all of these come from Home Assistant. This one does not, so it says so now.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reported on Discord against 5.2.0, with two example cards. Neither of the two pasted examples is actually the cause: both only use `config.entity` inside templates, which was already quiet. The reporter suspected as much ("not 100% sure if it is that one, because that dashboard contains other configs with `config.entity` also") and was right to.

One idea from that conversation is deliberately **not** implemented here: not raising a missing entity when the domain does not exist. That would throw away the findings this repair is for. An integration that gets removed leaves a domain with no entities behind, and the references into it are exactly the broken ones worth reporting.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two new tests: the card shape that actually causes it stays quiet, and the template shapes that never caused it are pinned as such, since that is where two separate reporters went looking.

`test_the_yardstick_still_matches_the_code`, added in #1540, failed the moment the set grew, which is what it is for. The yardstick is updated rather than read from the code under test, so these assertions still cannot grade their own homework.

Taking `config.entity` back out of the set fails 2 tests.

Full suite is 1492 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
