### PR TITLE
Only report things shaped like a device ID

### DIFF
--- a/custom_components/spook/entity_filtering.py
+++ b/custom_components/spook/entity_filtering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import automation, script
@@ -382,6 +383,29 @@ def async_get_all_device_ids(hass: HomeAssistant) -> set[str]:
     return device_ids | async_get_child_device_ids(device_registry)
 
 
+# A device ID is a `uuid4().hex`, which the registry hands out itself: nothing
+# else can set one. Home Assistant has no equivalent of `valid_entity_id` for
+# these, so the shape is written out here.
+#
+# Worth checking because `device_id` is not always a Home Assistant device.
+# Integrations take a field of that name meaning their own hardware, and RFLink
+# is one: `device_id: ev1527_0ddf80_0e` is a protocol address. Home Assistant's
+# own reference extraction reads `device_id` out of every action's data and
+# hands it over regardless, so without this the address comes back as a device
+# that has gone missing. #1536.
+#
+# A real device that was removed still leaves a `uuid4().hex` behind, so this
+# gives up nothing that matters: the references worth reporting are all shaped
+# like one.
+_DEVICE_ID_SHAPE = re.compile(r"\A[0-9a-f]{32}\Z")
+
+
+@callback
+def is_device_id_shaped(value: str) -> bool:
+    """Return whether this could be a device ID Home Assistant handed out."""
+    return bool(_DEVICE_ID_SHAPE.match(value))
+
+
 @callback
 def async_filter_known_device_ids(
     hass: HomeAssistant,
@@ -395,7 +419,7 @@ def async_filter_known_device_ids(
     return {
         device_id
         for device_id in device_ids - known_device_ids
-        if device_id and isinstance(device_id, str)
+        if device_id and isinstance(device_id, str) and is_device_id_shaped(device_id)
     }
 
 

--- a/documentation/integrations/automation.md
+++ b/documentation/integrations/automation.md
@@ -212,6 +212,8 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 
 Automations are inspected for the use of devices. If an automation is using a device that does not exist, Spook will raise a repair issue. The repairs issue raised will contain the name of the automation and the device that is referenced but not found.
 
+Only values shaped like a device ID are considered. Home Assistant hands those out itself and they are always thirty-two hexadecimal characters. Integrations are free to take a field called `device_id` meaning their own hardware, and some do: RFLink's `device_id` is a protocol address. Those are not devices Home Assistant knows about and never will be, so Spook leaves them alone. A real device that was removed still leaves an ID of the right shape behind, so nothing worth finding is given up.
+
 ```{figure} ../images/integrations/automation/unknown_device.png
 :name: Spook found an issue with an automation that is using a non-existing device.
 :alt: Screenshot showing a repair raised by Spook for an automation.

--- a/documentation/integrations/script.md
+++ b/documentation/integrations/script.md
@@ -57,6 +57,8 @@ To resolve the raised issue, you can either remove the reference to the non-exis
 
 Scripts are inspected for the use of devices. If a script is using a device that does not exist, Spook will raise a repair issue. The repairs issue raised will contain the name of the script and the device that is referenced but not found.
 
+As with automations, only values shaped like a device ID are considered: thirty-two hexadecimal characters, which is what Home Assistant hands out. An integration taking a `device_id` that means its own hardware, such as RFLink's protocol address, is left alone.
+
 ```{figure} ../images/integrations/script/unknown_device.png
 :name: Spook found an issue with a script that is using a non-existing device.
 :alt: Screenshot showing a repair raised by Spook for a script.

--- a/tests/ectoplasms/automation/repairs/test_template_device_references.py
+++ b/tests/ectoplasms/automation/repairs/test_template_device_references.py
@@ -18,11 +18,17 @@ import pytest
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
+# Written out as the registry would hand them over, a `uuid4().hex`. A
+# placeholder like `ghost_device` is not shaped like a device ID and is
+# skipped before it can be reported, which is the point of that check.
+_KNOWN_DEVICE = "1d2fc0cc8c2d37b91a80aba97ed69adc"
+_GHOST_DEVICE = "052b668647129b431b1f10448e96e8ec"
+
 _RAW_CONFIG = {
     "actions": [
         {
             "action": "light.turn_on",
-            "target": {"entity_id": "{{ device_entities('ghost_device') }}"},
+            "target": {"entity_id": f"{{{{ device_entities('{_GHOST_DEVICE}') }}}}"},
         },
     ],
 }
@@ -50,8 +56,8 @@ async def test_template_device_entities_reference_is_detected(
 ) -> None:
     """Test a stale device_entities() device ID in a template is reported."""
     repair = repair_class(hass)
-    repair._known_device_ids = {"known_device"}
+    repair._known_device_ids = {_KNOWN_DEVICE}
 
     entity = SimpleNamespace(raw_config=_RAW_CONFIG, **entity_kwargs)
 
-    assert await repair._async_compute_unknown_references(entity) == {"ghost_device"}
+    assert await repair._async_compute_unknown_references(entity) == {_GHOST_DEVICE}

--- a/tests/test_device_id_shape.py
+++ b/tests/test_device_id_shape.py
@@ -1,0 +1,108 @@
+"""Tests that only things shaped like a device ID get reported as one.
+
+A device ID is a `uuid4().hex` handed out by the registry, and nothing else
+can set one. Integrations are free to take a field called `device_id` meaning
+their own hardware, and Home Assistant's reference extraction reads that field
+out of every action's data regardless of who it belongs to.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.script import Script
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+import pytest
+import yaml
+
+from custom_components.spook.entity_filtering import (
+    async_filter_known_device_ids,
+    is_device_id_shaped,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import device_registry as dr
+
+# What the registry actually hands out, and what it never would.
+_REAL = "a7ee7cb9ca6f01fd7462a7d88a17e20f"
+_RFLINK = "ev1527_0ddf80_0e"
+
+
+@pytest.mark.parametrize("value", [_REAL], ids=repr)
+def test_these_are_shaped_like_a_device_id(value: str) -> None:
+    """Exactly thirty-two lowercase hex characters, and nothing else."""
+    assert is_device_id_shaped(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        _RFLINK,
+        "",
+        "abc",
+        _REAL.upper(),
+        _REAL[:-1],
+        _REAL + "0",
+        f" {_REAL}",
+        f"{_REAL}\n",
+    ],
+    ids=repr,
+)
+def test_these_are_not(value: str) -> None:
+    """Anchored at both ends, so neither padding nor a newline slips through."""
+    assert not is_device_id_shaped(value)
+
+
+async def test_a_real_registry_id_matches_the_shape(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """The rule is only worth anything if it agrees with the registry."""
+    entry = MockConfigEntry(domain="test")
+    entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("test", "one")},
+        name="A device",
+    )
+
+    assert is_device_id_shaped(device.id)
+
+
+async def test_the_rflink_address_from_the_report_is_not_reported(
+    hass: HomeAssistant,
+) -> None:
+    """RFLink takes `device_id` meaning a protocol address, not a device.
+
+    Home Assistant's own extraction reads it out of the action data and hands
+    it over as a referenced device, so this is the only thing stopping it.
+    """
+    sequence = yaml.safe_load(
+        """
+        - data:
+            device_id: ev1527_0ddf80_0e
+            command: 'on'
+          action: rflink.send_command
+        """,
+    )
+    script = Script(hass, sequence, "rflink", "script")
+
+    assert _RFLINK in script.referenced_devices, (
+        "core stopped handing this over, so this no longer tests anything"
+    )
+    assert not async_filter_known_device_ids(
+        hass, device_ids=set(script.referenced_devices)
+    )
+
+
+async def test_a_device_that_really_is_gone_is_still_reported(
+    hass: HomeAssistant,
+) -> None:
+    """Removing a device leaves its ID behind, still shaped like one.
+
+    Which is the whole point: this gives up nothing worth finding.
+    """
+    assert async_filter_known_device_ids(hass, device_ids={_REAL}) == {_REAL}

--- a/tests/test_entity_filtering.py
+++ b/tests/test_entity_filtering.py
@@ -112,8 +112,8 @@ def test_registered_device_ids_are_known(
     assert device.id in async_get_all_device_ids(hass)
     assert async_filter_known_device_ids(
         hass,
-        device_ids={device.id, "not-a-device"},
-    ) == {"not-a-device"}
+        device_ids={device.id, "052b668647129b431b1f10448e96e8ec"},
+    ) == {"052b668647129b431b1f10448e96e8ec"}
 
 
 def test_composite_device_ids_are_known(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

RFLink takes a `device_id` meaning a protocol address. `ev1527_0ddf80_0e` is a doorbell, not a device Home Assistant has ever heard of.

Home Assistant's own reference extraction reads `device_id` out of every action's data and hands it over as a referenced device, regardless of whose field it is. So Spook reported the doorbell as a device that had gone missing:

```
core hands over: ['ev1527_0ddf80_0e']
spook reports  : ['ev1527_0ddf80_0e']
```

Core's extraction stays trusted. What it hands over is now checked for shape first, the same way entity IDs already go through `valid_entity_id`. A device ID is a `uuid4().hex` handed out by the registry itself, so thirty-two lowercase hex characters and nothing else. Home Assistant has no equivalent check to borrow, so it is written out here.

**This gives up nothing worth having.** A device that was removed leaves an ID of exactly that shape behind, so those are still reported. What it drops is strings that could never have been a device at all:

```
core hands over: ['ev1527_0ddf80_0e']
spook reports  : []
a removed real device still reported: True
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1536.

The shape was confirmed against a real registry before anything was built on it: three devices created through `async_get_or_create` all came back as thirty-two lowercase hex, matching `random_uuid_hex()`, and nothing in `DeviceEntry` lets an integration set its own.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

New `tests/test_device_id_shape.py`: what counts as the shape and what does not, that a real registry ID agrees with the rule, that the RFLink address from the report is dropped, and that a removed real device is still reported.

The RFLink test asserts core still hands the address over before checking Spook drops it, so it fails loudly rather than quietly passing if core ever stops doing that.

Six mutations, all caught:

| Mutation | Result |
| --- | --- |
| Drop the shape check from the filter | 1 failed |
| Unanchor the pattern | 2 failed |
| Allow uppercase | 1 failed |
| Any length instead of exactly 32 | 3 failed |

**Two existing tests broke, and deserved to.** `tests/test_entity_filtering.py` used `not-a-device` and the template device test used `ghost_device`. Neither is shaped like a device ID, so both had been pinning behaviour on values that cannot occur. They now use what the registry would really hand over, which is what they meant in the first place. Both still fail if the repair stops reporting unknown devices, so they still guard what they were written for.

Full suite is 1505 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
