### PR TITLE
Fingerprint what a blueprint says, not how it is written

### DIFF
--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -173,23 +173,32 @@ def _normalize(raw: str) -> blueprint.Blueprint | None:
         return None
 
 
-def _plain(value: Any) -> Any:
-    """Return the same data with nothing of Home Assistant's own left on it.
+def _canonical(value: Any) -> Any:
+    """Return a form in which no two different things can look the same.
 
-    The loader hands back its own string, list and mapping classes, which
-    carry the line they came from, and `!input` arrives as an object. None of
-    that says anything about what the blueprint does, and all of it would
-    change how the value serializes.
+    Every value carries what kind of thing it is. Without that, a mapping
+    somebody wrote by hand could serialize exactly like an `!input`, and
+    swapping one for the other changes what a blueprint does while leaving the
+    fingerprint alone.
+
+    Mappings become ordered lists of pairs rather than objects, which keeps
+    their order in the hash. That order is not decoration: a `variables:`
+    block is rendered one entry at a time with earlier results available to
+    later ones, so `{a: 1, b: "{{ a }}"}` and the same two the other way round
+    are different scripts.
+
+    The loader's own string and mapping classes go too. They carry the line
+    they came from, which says nothing about what the blueprint does.
     """
     if isinstance(value, Input):
-        return {"__input__": str(value.name)}
+        return ["input", str(value.name)]
     if isinstance(value, Mapping):
-        return {str(key): _plain(item) for key, item in value.items()}
+        return ["map", [[str(key), _canonical(item)] for key, item in value.items()]]
     if isinstance(value, (list, tuple)):
-        return [_plain(item) for item in value]
+        return ["seq", [_canonical(item) for item in value]]
     if isinstance(value, str):
-        return str(value)
-    return value
+        return ["str", str(value)]
+    return ["value", value]
 
 
 def _fingerprint(item: blueprint.Blueprint) -> str:
@@ -199,29 +208,30 @@ def _fingerprint(item: blueprint.Blueprint) -> str:
     `blueprint:` block turns away keys it does not know, so an author has
     nowhere to put one. That leaves the content itself as the version.
 
-    Taken off the parsed data rather than off the YAML, which was the first
-    way round and the wrong one. Hashing `item.yaml()` hashes how Home
-    Assistant chose to lay the file out, and that moves for reasons that have
-    nothing to do with the blueprint:
+    Taken off the parsed data rather than off the YAML, which was the first way
+    round and the wrong one. Hashing `item.yaml()` hashes how Home Assistant
+    chose to lay the file out, and that moves for reasons that have nothing to
+    do with the blueprint:
 
-    - Whether libyaml is installed. `annotatedyaml` picks `CSafeDumper` when
-      it can and falls back to Python's `SafeDumper`, and the two disagree on
-      5761 lines of one real blueprint: 596495 bytes against 605097, unicode
-      escaped or not, folded differently.
-    - Line width, quoting style and key order, which any PyYAML release is
-      free to change.
+    - Whether libyaml is installed. `annotatedyaml` picks `CSafeDumper` when it
+      can and falls back to Python's `SafeDumper`, and the two disagree on 5761
+      lines of one real blueprint: 596495 bytes against 605097, unicode escaped
+      or not, folded differently.
+    - Line width and quoting style, which any PyYAML release is free to change.
 
-    The source URL comes out for the same reason. Where a blueprint was
-    fetched from is not part of what it does, and Home Assistant writes it
-    into the data on the way in, so leaving it in made a trailing slash on the
-    URL look like a new version.
+    The source URL comes out for the same reason. Where a blueprint was fetched
+    from is not part of what it does, and Home Assistant writes it into the
+    data on the way in, so leaving it in made a trailing slash on the URL look
+    like a new version.
     """
-    data = _plain(item.data)
-    if isinstance(metadata := data.get(CONF_BLUEPRINT), dict):
+    data = dict(item.data)
+    if isinstance(metadata := data.get(CONF_BLUEPRINT), Mapping):
+        metadata = dict(metadata)
         metadata.pop(CONF_SOURCE_URL, None)
+        data[CONF_BLUEPRINT] = metadata
 
     return hashlib.sha256(
-        json.dumps(data, sort_keys=True, ensure_ascii=True).encode()
+        json.dumps(_canonical(data), ensure_ascii=True).encode()
     ).hexdigest()[:8]
 
 

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -191,6 +191,10 @@ def _canonical(value: Any) -> Any:
     floats as keys, so `{1: a}` and `{"1": a}` are different mappings and
     stringifying both would have hidden the difference.
 
+    Anything JSON cannot hold is named by its type and written out as text. An
+    unquoted date in a blueprint arrives as a `datetime.date`, and that used
+    to take the whole round down with a `TypeError`.
+
     The loader's own string and mapping classes go too. They carry the line
     they came from, which says nothing about what the blueprint does.
     """
@@ -203,9 +207,28 @@ def _canonical(value: Any) -> Any:
         ]
     if isinstance(value, (list, tuple)):
         return ["seq", [_canonical(item) for item in value]]
+    if isinstance(value, (set, frozenset)):
+        # A set carries no order of its own, and Python's iteration order for
+        # one is not stable between runs, so the members are sorted once
+        # encoded. `!!set` is rare in a blueprint but it parses.
+        return ["set", sorted(json.dumps(_canonical(item)) for item in value)]
+
+    return _canonical_scalar(value)
+
+
+def _canonical_scalar(value: Any) -> Any:
+    """Return the encoded form of something that holds nothing else."""
     if isinstance(value, str):
         return ["str", str(value)]
-    return ["value", value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return ["value", value]
+
+    # A date, a datetime, a `!!binary`: things YAML produces that JSON cannot
+    # take. Without this the whole round died on a `TypeError` from a blueprint
+    # holding an unquoted date. Named by their type so two different kinds
+    # cannot look alike, and written out as text because that is all JSON can
+    # hold.
+    return [f"other:{type(value).__name__}", str(value)]
 
 
 def _fingerprint(item: blueprint.Blueprint) -> str:

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
 import hashlib
+import json
 import os
 import random
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
+from annotatedyaml.objects import Input
 import voluptuous as vol
 
 from homeassistant.components import blueprint
@@ -19,7 +22,7 @@ from homeassistant.components.automation import (
     config as automation_config,
 )
 from homeassistant.components.blueprint import BLUEPRINT_SCHEMA
-from homeassistant.components.blueprint.const import CONF_SOURCE_URL
+from homeassistant.components.blueprint.const import CONF_BLUEPRINT, CONF_SOURCE_URL
 from homeassistant.components.blueprint.importer import fetch_blueprint_from_url
 from homeassistant.components.script import (
     config as script_config,
@@ -170,14 +173,56 @@ def _normalize(raw: str) -> blueprint.Blueprint | None:
         return None
 
 
+def _plain(value: Any) -> Any:
+    """Return the same data with nothing of Home Assistant's own left on it.
+
+    The loader hands back its own string, list and mapping classes, which
+    carry the line they came from, and `!input` arrives as an object. None of
+    that says anything about what the blueprint does, and all of it would
+    change how the value serializes.
+    """
+    if isinstance(value, Input):
+        return {"__input__": str(value.name)}
+    if isinstance(value, Mapping):
+        return {str(key): _plain(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain(item) for item in value]
+    if isinstance(value, str):
+        return str(value)
+    return value
+
+
 def _fingerprint(item: blueprint.Blueprint) -> str:
     """Return a short hash of what a blueprint says.
 
     Blueprints carry no version and cannot be given one: the schema for the
     `blueprint:` block turns away keys it does not know, so an author has
     nowhere to put one. That leaves the content itself as the version.
+
+    Taken off the parsed data rather than off the YAML, which was the first
+    way round and the wrong one. Hashing `item.yaml()` hashes how Home
+    Assistant chose to lay the file out, and that moves for reasons that have
+    nothing to do with the blueprint:
+
+    - Whether libyaml is installed. `annotatedyaml` picks `CSafeDumper` when
+      it can and falls back to Python's `SafeDumper`, and the two disagree on
+      5761 lines of one real blueprint: 596495 bytes against 605097, unicode
+      escaped or not, folded differently.
+    - Line width, quoting style and key order, which any PyYAML release is
+      free to change.
+
+    The source URL comes out for the same reason. Where a blueprint was
+    fetched from is not part of what it does, and Home Assistant writes it
+    into the data on the way in, so leaving it in made a trailing slash on the
+    URL look like a new version.
     """
-    return hashlib.sha256(item.yaml().encode()).hexdigest()[:8]
+    data = _plain(item.data)
+    if isinstance(metadata := data.get(CONF_BLUEPRINT), dict):
+        metadata.pop(CONF_SOURCE_URL, None)
+
+    return hashlib.sha256(
+        json.dumps(data, sort_keys=True, ensure_ascii=True).encode()
+    ).hexdigest()[:8]
 
 
 def _read_files(files: list[Path]) -> list[_OnDisk | None]:

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -187,13 +187,20 @@ def _canonical(value: Any) -> Any:
     later ones, so `{a: 1, b: "{{ a }}"}` and the same two the other way round
     are different scripts.
 
+    Keys go through here too. YAML hands back real integers, booleans and
+    floats as keys, so `{1: a}` and `{"1": a}` are different mappings and
+    stringifying both would have hidden the difference.
+
     The loader's own string and mapping classes go too. They carry the line
     they came from, which says nothing about what the blueprint does.
     """
     if isinstance(value, Input):
         return ["input", str(value.name)]
     if isinstance(value, Mapping):
-        return ["map", [[str(key), _canonical(item)] for key, item in value.items()]]
+        return [
+            "map",
+            [[_canonical(key), _canonical(item)] for key, item in value.items()],
+        ]
     if isinstance(value, (list, tuple)):
         return ["seq", [_canonical(item) for item in value]]
     if isinstance(value, str):

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -63,7 +63,7 @@ So Spook uses a fingerprint of the contents instead. Same fingerprint, same blue
 
 The fingerprint is taken from what a blueprint says, not from how the file is laid out. Home Assistant does not keep the bytes it downloaded: it parses a blueprint and writes it back out in its own formatting, and that formatting is free to differ between installations and Home Assistant releases. Line width, quoting, whether an emoji is written out or escaped, all of it. None of that changes what the blueprint does, so none of it changes the fingerprint. Neither does the address it came from, which Home Assistant stores inside the blueprint on the way in.
 
-Comments and indentation are not part of it. Somebody tidying up their YAML does not count as an update.
+Comments and indentation are not part of it either, since neither survives being parsed. Reordering keys is, though. Home Assistant renders some of them in the order they are written, a `variables:` block among them, so moving two keys around can change what a blueprint does. Spook keeps that order rather than trying to work out which mappings are the executable ones, because guessing wrong there would mean missing a real update rather than mentioning an extra one.
 
 #### When an update would break your automations
 

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -33,7 +33,7 @@ Spook adds a Blueprints {term}`device <device>`, holding one update {term}`entit
 
 ### Updates
 
-_Default {term}`entity ID <Entity ID>`: `update.blueprints_<blueprint name>`_
+_Default {term}`entity ID <Entity ID>`: `update.blueprints_<blueprint name>`\_
 
 When you import a {term}`blueprint <blueprint>`, Home Assistant writes down where it came from. Nothing ever looks at that address again. The blueprint's author can fix a bug in it a week later and you would have no way of knowing, short of opening the forum topic and reading the YAML yourself.
 
@@ -60,6 +60,8 @@ Matter and ZHA put much the same warning in front of a firmware update, for much
 They look like `a1b2c3d4`, and that is not Spook being clever. Blueprints have no version. There is nowhere in a blueprint to put one, because the format turns away anything it does not recognise, so no author can add one even if they wanted to.
 
 So Spook uses a fingerprint of the contents instead. Same fingerprint, same blueprint. A different one means something in it changed. It cannot tell you whether that change is newer or better, only that it is not what you have.
+
+The fingerprint is taken from what a blueprint says, not from how the file is laid out. Home Assistant does not keep the bytes it downloaded: it parses a blueprint and writes it back out in its own formatting, and that formatting is free to differ between installations and Home Assistant releases. Line width, quoting, whether an emoji is written out or escaped, all of it. None of that changes what the blueprint does, so none of it changes the fingerprint. Neither does the address it came from, which Home Assistant stores inside the blueprint on the way in.
 
 Comments and indentation are not part of it. Somebody tidying up their YAML does not count as an update.
 

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -16,14 +16,15 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.components.blueprint import BLUEPRINT_SCHEMA, Blueprint
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import yaml as yaml_util
+from annotatedyaml.objects import Input
 import aiohttp
 import pytest
-import yaml
 import voluptuous as vol
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.spook.ectoplasms.blueprint import update as update_module
 from custom_components.spook.ectoplasms.blueprint.update import (
+    _canonical,
     _fingerprint,
     _CHECK_INTERVAL,
     _SPREAD,
@@ -1244,38 +1245,36 @@ def test_the_fingerprint_ignores_how_the_yaml_was_laid_out() -> None:
     folding and line width. On one real blueprint that was 5761 differing
     lines. Hashing their output made the version depend on which one happened
     to be available.
+
+    Written out as two fixed texts rather than by running both dumpers,
+    because `CSafeDumper` does not exist in the very environment this is
+    about, and the test would then fail there for the wrong reason.
     """
-    data = {
-        "blueprint": {
-            "name": "Sensor Light",
-            "domain": "automation",
-            "description": "Lights 💡 and a very long line that a dumper is free "
-            "to fold wherever it likes, which is the whole point of this test.",
-        },
-        "triggers": [{"trigger": "state", "entity_id": "binary_sensor.motion"}],
-    }
-
-    # The same data, laid out by each dumper in turn.
-    c_text = yaml.dump(
-        data,
-        default_flow_style=False,
-        allow_unicode=True,
-        sort_keys=False,
-        Dumper=yaml.CSafeDumper,
+    escaped = (
+        "blueprint:\n"
+        "  name: Sensor Light\n"
+        "  domain: automation\n"
+        '  description: "Lights \\U0001F4A1 and a line long enough that a dumper\n'
+        '    is free to fold it wherever it likes."\n'
+        "triggers: []\n"
     )
-    py_text = yaml.dump(
-        data,
-        default_flow_style=False,
-        allow_unicode=True,
-        sort_keys=False,
-        Dumper=yaml.SafeDumper,
+    literal = (
+        "blueprint:\n"
+        "  name: Sensor Light\n"
+        "  domain: automation\n"
+        "  description: Lights 💡 and a line long enough that a dumper is free to fold\n"
+        "    it wherever it likes.\n"
+        "triggers: []\n"
     )
-    assert c_text != py_text, "the dumpers agree here, so this proves nothing"
+    assert escaped != literal, "the two layouts are the same, so this proves nothing"
 
-    from_c = Blueprint(yaml_util.parse_yaml(c_text), schema=BLUEPRINT_SCHEMA)
-    from_py = Blueprint(yaml_util.parse_yaml(py_text), schema=BLUEPRINT_SCHEMA)
+    one = Blueprint(yaml_util.parse_yaml(escaped), schema=BLUEPRINT_SCHEMA)
+    other = Blueprint(yaml_util.parse_yaml(literal), schema=BLUEPRINT_SCHEMA)
 
-    assert _fingerprint(from_c) == _fingerprint(from_py)
+    assert (
+        one.data["blueprint"]["description"] == other.data["blueprint"]["description"]
+    )
+    assert _fingerprint(one) == _fingerprint(other)
 
 
 def test_the_fingerprint_ignores_where_it_came_from() -> None:
@@ -1351,3 +1350,88 @@ actions:
     )
 
     assert _fingerprint(before) != _fingerprint(after)
+
+
+def test_the_fingerprint_notices_variables_swapping_places() -> None:
+    """A `variables:` block is rendered one entry at a time.
+
+    Earlier results are available to later ones, so the order of those keys is
+    executable rather than decoration. Sorting keys before hashing, which is
+    what the first version of this did, made a reordering that changes what a
+    script does look like no change at all.
+    """
+    raw = """
+blueprint:
+  name: T
+  domain: automation
+triggers: []
+actions:
+  - variables:
+      first: 1
+      second: "{{ first }}"
+"""
+    swapped = """
+blueprint:
+  name: T
+  domain: automation
+triggers: []
+actions:
+  - variables:
+      second: "{{ first }}"
+      first: 1
+"""
+    before = Blueprint(yaml_util.parse_yaml(raw), schema=BLUEPRINT_SCHEMA)
+    after = Blueprint(yaml_util.parse_yaml(swapped), schema=BLUEPRINT_SCHEMA)
+
+    assert _fingerprint(before) != _fingerprint(after)
+
+
+@pytest.mark.parametrize(
+    ("one", "other"),
+    [
+        pytest.param(Input("light"), {"__input__": "light"}, id="input-vs-mapping"),
+        pytest.param(Input("light"), ["input", "light"], id="input-vs-sequence"),
+        pytest.param({"a": "b"}, [["a", "b"]], id="mapping-vs-pairs"),
+        pytest.param(
+            {"a": "b"}, [["map", [["a", ["str", "b"]]]]], id="mapping-vs-own-form"
+        ),
+        pytest.param("x", ["x"], id="string-vs-sequence"),
+        pytest.param("1", 1, id="string-vs-number"),
+        pytest.param({"a": "b", "c": "d"}, {"c": "d", "a": "b"}, id="order-swapped"),
+    ],
+)
+def test_the_encoding_keeps_different_things_apart(one: object, other: object) -> None:
+    """Nothing may serialize the same as anything else it is not.
+
+    Two blueprints that behave differently and fingerprint the same would be
+    an update Spook never mentions, which is worse than one it mentions twice.
+    A mapping somebody wrote by hand must not come out looking like an
+    `!input`, an ordered mapping must not come out looking like the list of
+    pairs it is encoded as, and swapping two keys must show.
+
+    Tested on the encoding rather than through a pair of blueprints, because
+    at that level it takes three separate mistakes at once to produce a
+    collision, and a test that needs all three is a test that catches none.
+    """
+    assert _canonical(one) != _canonical(other)
+
+
+@pytest.mark.parametrize(
+    ("value", "kind"),
+    [
+        pytest.param(Input("light"), "input", id="input"),
+        pytest.param({"a": "b"}, "map", id="mapping"),
+        pytest.param(["a"], "seq", id="sequence"),
+        pytest.param("a", "str", id="string"),
+        pytest.param(1, "value", id="number"),
+    ],
+)
+def test_every_kind_of_value_says_what_it_is(value: object, kind: str) -> None:
+    """Each kind carries its own tag, and that is what keeps them apart.
+
+    Asserted on the shape rather than by finding two values that collide,
+    because a collision needs several of these tags dropped at once. A test
+    that only fails when three mistakes are made together catches none of
+    them on its own.
+    """
+    assert _canonical(value)[0] == kind

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -13,14 +13,18 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.core import CoreState
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.components.blueprint import BLUEPRINT_SCHEMA, Blueprint
 from homeassistant.helpers.entity_component import DATA_INSTANCES
+from homeassistant.util import yaml as yaml_util
 import aiohttp
 import pytest
+import yaml
 import voluptuous as vol
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.spook.ectoplasms.blueprint import update as update_module
 from custom_components.spook.ectoplasms.blueprint.update import (
+    _fingerprint,
     _CHECK_INTERVAL,
     _SPREAD,
     BlueprintUpdateEntity,
@@ -1230,3 +1234,120 @@ async def test_where_a_blueprint_came_from_is_not_told_to_everybody(
 
     # Still in front of the people allowed to see it, though.
     assert "hunter2" in await _entity(hass).async_release_notes()
+
+
+def test_the_fingerprint_ignores_how_the_yaml_was_laid_out() -> None:
+    """It used to hash `blueprint.yaml()`, which is a formatting decision.
+
+    `annotatedyaml` picks `CSafeDumper` when libyaml is installed and Python's
+    `SafeDumper` when it is not, and the two disagree about unicode escaping,
+    folding and line width. On one real blueprint that was 5761 differing
+    lines. Hashing their output made the version depend on which one happened
+    to be available.
+    """
+    data = {
+        "blueprint": {
+            "name": "Sensor Light",
+            "domain": "automation",
+            "description": "Lights 💡 and a very long line that a dumper is free "
+            "to fold wherever it likes, which is the whole point of this test.",
+        },
+        "triggers": [{"trigger": "state", "entity_id": "binary_sensor.motion"}],
+    }
+
+    # The same data, laid out by each dumper in turn.
+    c_text = yaml.dump(
+        data,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+        Dumper=yaml.CSafeDumper,
+    )
+    py_text = yaml.dump(
+        data,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+        Dumper=yaml.SafeDumper,
+    )
+    assert c_text != py_text, "the dumpers agree here, so this proves nothing"
+
+    from_c = Blueprint(yaml_util.parse_yaml(c_text), schema=BLUEPRINT_SCHEMA)
+    from_py = Blueprint(yaml_util.parse_yaml(py_text), schema=BLUEPRINT_SCHEMA)
+
+    assert _fingerprint(from_c) == _fingerprint(from_py)
+
+
+def test_the_fingerprint_ignores_where_it_came_from() -> None:
+    """Home Assistant writes the source URL into the data on the way in.
+
+    So the URL was part of the version, and a trailing slash on it read as a
+    new release of the blueprint. Where something was fetched from is not part
+    of what it does.
+    """
+    raw = """
+blueprint:
+  name: Sensor Light
+  domain: automation
+triggers: []
+"""
+    url = "https://gist.github.com/somebody/abc123"
+
+    plain = Blueprint(yaml_util.parse_yaml(raw), schema=BLUEPRINT_SCHEMA)
+
+    tagged = Blueprint(yaml_util.parse_yaml(raw), schema=BLUEPRINT_SCHEMA)
+    tagged.update_metadata(source_url=url)
+
+    slashed = Blueprint(yaml_util.parse_yaml(raw), schema=BLUEPRINT_SCHEMA)
+    slashed.update_metadata(source_url=url + "/")
+
+    assert _fingerprint(plain) == _fingerprint(tagged) == _fingerprint(slashed)
+
+
+def test_the_fingerprint_still_moves_when_the_blueprint_does() -> None:
+    """So the checks above cannot pass by never changing at all."""
+    raw = """
+blueprint:
+  name: Sensor Light
+  domain: automation
+triggers: []
+"""
+    before = Blueprint(yaml_util.parse_yaml(raw), schema=BLUEPRINT_SCHEMA)
+    after = Blueprint(
+        yaml_util.parse_yaml(raw.replace("Sensor Light", "Sensor Lights")),
+        schema=BLUEPRINT_SCHEMA,
+    )
+
+    assert _fingerprint(before) != _fingerprint(after)
+
+
+def test_the_fingerprint_notices_a_step_pointing_at_another_input() -> None:
+    """`!input` arrives as an object, and objects flatten too far too easily.
+
+    Both inputs are declared in both versions, so the `input:` block is
+    identical and the only thing that moves is which one an action points at.
+    Renaming an input instead would have changed that block as well, and then
+    this would pass even if the reference were thrown away entirely.
+    """
+    raw = """
+blueprint:
+  name: Sensor Light
+  domain: automation
+  input:
+    light:
+      name: Light
+    lamp:
+      name: Lamp
+triggers: []
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: !input light
+"""
+    before = Blueprint(yaml_util.parse_yaml(raw), schema=BLUEPRINT_SCHEMA)
+    after = Blueprint(
+        yaml_util.parse_yaml(raw.replace("!input light", "!input lamp")),
+        schema=BLUEPRINT_SCHEMA,
+    )
+
+    assert _fingerprint(before) != _fingerprint(after)

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
@@ -1438,3 +1439,46 @@ def test_every_kind_of_value_says_what_it_is(value: object, kind: str) -> None:
     them on its own.
     """
     assert _canonical(value)[0] == kind
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("a: 2026-01-01", id="date"),
+        pytest.param("a: 2026-01-01 10:00:00", id="datetime"),
+        pytest.param("a: !!binary aGk=", id="binary"),
+        pytest.param("a: !!set {x: null, y: null}", id="set"),
+    ],
+)
+def test_the_encoding_survives_what_yaml_hands_back(text: str) -> None:
+    """YAML produces things JSON has never heard of.
+
+    An unquoted date arrives as a `datetime.date`, and passing that to
+    `json.dumps` raises `TypeError`, which took the whole round of checks down
+    with it rather than one blueprint.
+    """
+    json.dumps(_canonical(yaml_util.parse_yaml(text)))
+
+
+def test_a_date_and_the_same_date_written_out_are_not_the_same() -> None:
+    """Rendering these as text must not let two kinds collide."""
+    as_date = yaml_util.parse_yaml("a: 2026-01-01")
+    as_string = yaml_util.parse_yaml('a: "2026-01-01"')
+
+    assert _canonical(as_date) != _canonical(as_string)
+
+
+def test_a_set_is_encoded_in_a_fixed_order() -> None:
+    """Two runs of Home Assistant must fingerprint a `!!set` the same.
+
+    A set has no order of its own and Python iterates one by hash, which
+    depends on `PYTHONHASHSEED` and so differs between processes. Within a
+    single test the order never varies, so this asserts the encoding is sorted
+    rather than trying to catch a difference that cannot happen here. Without
+    it a blueprint holding a `!!set` would report an update on some restarts
+    and not others, which is the least debuggable kind of wrong.
+    """
+    encoded = _canonical(yaml_util.parse_yaml("a: !!set {x: null, y: null, a: null}"))
+    members = encoded[1][0][1][1]
+
+    assert members == sorted(members)

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -1482,3 +1482,35 @@ def test_a_set_is_encoded_in_a_fixed_order() -> None:
     members = encoded[1][0][1][1]
 
     assert members == sorted(members)
+
+
+def test_a_whole_blueprint_holding_awkward_values_fingerprints() -> None:
+    """The same values, but buried in action data where the schema is loosest.
+
+    The checks above hand `_canonical` a value on its own. This goes through
+    `_fingerprint` on a blueprint that would really load, because it was the
+    round of checks that died on this and not the encoding in isolation.
+    """
+    text = """
+blueprint:
+  name: T
+  domain: automation
+triggers: []
+actions:
+  - action: notify.persistent_notification
+    data:
+      message: hi
+      when: 2026-01-01
+      at: 2026-01-01 10:00:00
+      blob: !!binary aGk=
+"""
+    blueprint_with = Blueprint(yaml_util.parse_yaml(text), schema=BLUEPRINT_SCHEMA)
+    fingerprint = _fingerprint(blueprint_with)
+    assert fingerprint
+
+    # A date and the text of that date are different values.
+    quoted = Blueprint(
+        yaml_util.parse_yaml(text.replace("when: 2026-01-01", 'when: "2026-01-01"')),
+        schema=BLUEPRINT_SCHEMA,
+    )
+    assert _fingerprint(quoted) != fingerprint

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -26,6 +26,7 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 from custom_components.spook.ectoplasms.blueprint import update as update_module
 from custom_components.spook.ectoplasms.blueprint.update import (
     _canonical,
+    _normalize,
     _fingerprint,
     _CHECK_INTERVAL,
     _SPREAD,
@@ -1514,3 +1515,52 @@ actions:
         schema=BLUEPRINT_SCHEMA,
     )
     assert _fingerprint(quoted) != fingerprint
+
+
+def test_a_cyclic_alias_never_reaches_the_encoding() -> None:
+    """The encoding recurses without tracking what it has seen.
+
+    Which is safe only because Home Assistant's loader refuses a recursive
+    node while parsing, long before any of this. Worth pinning, because if
+    that ever changed the encoding would hit a `RecursionError` and
+    `_read_files` catches only `OSError`, so one file would take the whole
+    round of checks with it.
+    """
+    assert _normalize("a: &s [*s]") is None
+    assert _normalize("a: &m {k: *m}") is None
+
+
+def test_an_alias_fingerprints_the_same_as_writing_it_out() -> None:
+    """A shared alias is two names for one value, not a cycle, and it parses.
+
+    Two blueprints saying the same thing, one using an anchor and one spelling
+    it out twice, are the same blueprint. The old fingerprint went through
+    PyYAML's dumper, which writes anchors back out as `&id001`, so those two
+    used to disagree.
+    """
+    aliased = """
+blueprint:
+  name: T
+  domain: automation
+triggers: []
+actions:
+  - action: light.turn_on
+    target: &t {entity_id: light.a}
+  - action: light.turn_off
+    target: *t
+"""
+    written_out = """
+blueprint:
+  name: T
+  domain: automation
+triggers: []
+actions:
+  - action: light.turn_on
+    target: {entity_id: light.a}
+  - action: light.turn_off
+    target: {entity_id: light.a}
+"""
+    one = Blueprint(yaml_util.parse_yaml(aliased), schema=BLUEPRINT_SCHEMA)
+    other = Blueprint(yaml_util.parse_yaml(written_out), schema=BLUEPRINT_SCHEMA)
+
+    assert _fingerprint(one) == _fingerprint(other)

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -1398,6 +1398,9 @@ actions:
         pytest.param("x", ["x"], id="string-vs-sequence"),
         pytest.param("1", 1, id="string-vs-number"),
         pytest.param({"a": "b", "c": "d"}, {"c": "d", "a": "b"}, id="order-swapped"),
+        pytest.param({1: "a"}, {"1": "a"}, id="number-key-vs-string-key"),
+        pytest.param({True: "a"}, {"True": "a"}, id="bool-key-vs-string-key"),
+        pytest.param({1.5: "a"}, {"1.5": "a"}, id="float-key-vs-string-key"),
     ],
 )
 def test_the_encoding_keeps_different_things_apart(one: object, other: object) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The blueprint fingerprint hashed `blueprint.yaml()`, so it hashed Home Assistant's formatting choices rather than the blueprint. That surface turned out to be enormous.

**`annotatedyaml` picks its dumper at import time:**

```python
try:
    from yaml import CSafeDumper as FastestAvailableSafeDumper
except ImportError:
    from yaml import SafeDumper as FastestAvailableSafeDumper
```

On the blueprint from the report those two are not interchangeable:

```
C dumper (libyaml) : 596495 bytes  ->  4e56af05
Python dumper      : 605097 bytes  ->  d7371b5a
5761 differing lines
```

Unicode escaped or not, strings folded in other places, different line breaks. Line width, quoting and key order are equally free to move with any PyYAML release, and all of it was in the version number.

**The source URL was in there too**, which is worse, because Home Assistant writes it into the blueprint data during the import. A trailing slash on the URL read as a new release.

Measured before and after, on the real blueprint:

| Same blueprint, arriving differently | Before | After |
| --- | --- | --- |
| Raw, never through Home Assistant | `4e56af05` | `6844d25c` |
| After an import, with source_url | `53e43b90` | `6844d25c` |
| Source URL with a trailing slash | `5115ab3c` | `6844d25c` |
| Written to disk and read back | `53e43b90` | `6844d25c` |

The hash now goes over the parsed data, canonicalised. Every value carries what kind of thing it is, so nothing can pass for something it is not: `!input light` and a mapping spelling out the same shape are different, and so are `{1: a}` and `{"1": a}`. Mappings become ordered lists of pairs, keys go through the same encoding as values, the source URL is dropped, and anything JSON cannot hold (a `date`, a `datetime`, `bytes` from `!!binary`) is named by its type and written out as text.

**Mapping order is kept, deliberately.** The first version of this sorted keys, which was wrong: a `variables:` block is rendered one entry at a time with earlier results available to later ones, so `{a: 1, b: "{{ a }}"}` and the same two the other way round are different scripts. Sorting made a reordering that changes behaviour look like no change at all.

The cost is that a cosmetic key reorder does read as an update. That is the side to be wrong on: sorting only the mappings whose order is not executable means working out which ones those are, and a `variables:` key inside arbitrary service data is not a script variables block. Guessing wrong there means missing a real update, which leaves somebody sitting on a blueprint whose fix already exists. The documentation says so now, next to the warning that already covered editing an imported blueprint by hand.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Towards #1548, where three people report blueprints permanently showing an update that is already installed, one of them across 18 blueprints.

I cannot yet point at which of these hit them specifically, and I would rather say that plainly than claim a fix I have not proven end to end on their setup. What this does is remove the whole class: the version now moves only when the blueprint does.

Worth recording, because it came up in that thread: Home Assistant genuinely does not keep the bytes it downloaded. `_create_file` does `path.write_text(blueprint.yaml())`. On this blueprint that turns 11136 lines into 11706 across 290 diff hunks. So "the file on disk does not match GitHub" is expected and not evidence that an update failed.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Four new tests, and the first one is the point: it dumps the same data with `CSafeDumper` and `SafeDumper`, asserts the two texts differ (so the test fails loudly rather than quietly if they ever agree), and then asserts both fingerprint the same.

The others cover the source URL, that a real change still moves the hash, and that a step pointing at another input moves it.

Mutations, all caught:

| Mutation | Result |
| --- | --- |
| Hash `item.yaml()` again | 1 failed |
| Leave the source URL in | 1 failed |
| Flatten `!input` to `None` | 1 failed |

That last one **survived my first attempt at the test**, which renamed an input in both the `input:` block and the step using it. The block moved as well, so the test passed with the `!input` value thrown away entirely. It now declares both inputs in both versions and moves only the reference.

Full suite is 1509 passing. Ruff, pylint and prettier clean.

One unrelated line in the documentation diff is prettier's: the hook pins 2.7.1, which escapes a trailing underscore where 3.x leaves it, and it rewrites that line as soon as the file is touched.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

