### PR TITLE
Do not iterate the entity list while handing back control

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -409,7 +409,19 @@ class AbstractSpookEntityComponentUnknownReferencesRepair(AbstractSpookRepair, A
 
         await self._async_setup_inspection()
 
-        for index, entity in enumerate(entity_component.entities):
+        # Taken as a snapshot, because this loop gives the event loop a turn
+        # every so often and an automation being added or removed during one of
+        # those turns changes the collection underneath it. Home Assistant says
+        # so itself: "callers that iterate over this asynchronously should make
+        # a copy". Without it the whole inspection dies on a `RuntimeError` and
+        # takes the round with it, since nothing above catches that. #1558.
+        #
+        # An entity that arrives while a round is running is missed until the
+        # next one, which is minutes away and no worse than arriving a moment
+        # after the round finished.
+        entities = list(entity_component.entities)
+
+        for index, entity in enumerate(entities):
             if index and index % INSPECTION_YIELD_INTERVAL == 0:
                 # Inspections are CPU-bound; periodically yield to the event
                 # loop so large installations do not stall it.

--- a/tests/test_repairs_yields.py
+++ b/tests/test_repairs_yields.py
@@ -73,3 +73,53 @@ async def test_component_inspection_yields_to_event_loop(
     await repair.async_inspect()
 
     assert calls == [0] * EXPECTED_YIELDS
+
+
+async def test_an_entity_arriving_mid_inspection_does_not_kill_the_round(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The inspection hands the event loop a turn every fifty entities.
+
+    Home Assistant is free to load or remove an automation during one of those
+    turns, and the collection behind `component.entities` is the live one. Core
+    says as much: "callers that iterate over this asynchronously should make a
+    copy". Iterating it directly raised `RuntimeError: dictionary changed size
+    during iteration`, which nothing above catches, so one badly timed reload
+    took out the whole round rather than one entity. Reported as #1558.
+    """
+    live = {
+        f"automation.spooky_{index}": SimpleNamespace(
+            entity_id=f"automation.spooky_{index}"
+        )
+        for index in range(ENTITY_COUNT)
+    }
+
+    class _LiveComponent:  # pylint: disable=too-few-public-methods
+        """Stands in for `EntityComponent`, whose `entities` is a live view."""
+
+        @property
+        def entities(self) -> Any:
+            """Return the live view, not a copy of it."""
+            return live.values()
+
+    hass.data.setdefault(DATA_INSTANCES, {})["automation"] = _LiveComponent()
+
+    # An automation loads the first time the inspection gives up control.
+    original_sleep = asyncio.sleep
+    added = False
+
+    async def _sleep_and_add(delay: float, result: object = None) -> object:
+        nonlocal added
+        if not added:
+            added = True
+            live["automation.arrived_late"] = SimpleNamespace(
+                entity_id="automation.arrived_late"
+            )
+        return await original_sleep(delay, result)
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep_and_add)
+
+    await _ReferencesRepair(hass).async_inspect()
+
+    assert added, "the inspection never yielded, so nothing was tested"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Every unknown-reference repair walks `component.entities`, and gives the event loop a turn every fifty entities so a large installation does not stall:

```python
for index, entity in enumerate(entity_component.entities):
    if index and index % INSPECTION_YIELD_INTERVAL == 0:
        await asyncio.sleep(0)
```

That collection is the live one. An automation loading or being removed during one of those turns changes it underneath the loop, and the next step raises `RuntimeError: dictionary changed size during iteration`. Nothing above catches it, so a badly timed reload takes out the whole round rather than one entity.

Home Assistant warns about this in the docstring of the property itself:

> As the underlying dicts may change when async context is lost, callers that iterate over this asynchronously should make a copy

It takes a snapshot now. The cost is that an entity arriving mid round is missed until the next one, which is minutes away and no worse than arriving a moment after a round finished.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1558. The reporter's traceback points straight at the line, and their reading of the cause was right.

This is not one repair. It is the base class every unknown-reference repair inherits, so it affects automations, scripts, scenes and template helpers alike. The reporter saw it once; an installation with many automations and a reload at the wrong moment will see it more.

I checked the other twelve places in Spook that walk a registry or a component for the same shape. Three looked suspect and none were: two finish iterating before anything awaits, and the third re-reads the collection each time round on purpose. This loop is the only one that hands back control halfway through.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

One test that drives it the way it actually happens: a live mapping behind the `entities` property, and an automation added the first time the inspection yields. It asserts the yield happened, so it cannot pass by never reaching the interesting moment.

Putting the live iteration back raises the same `RuntimeError` from the report:

```
custom_components/spook/repairs.py:422: RuntimeError
FAILED tests/test_repairs_yields.py::test_an_entity_arriving_mid_inspection_does_not_kill_the_round
```

Full suite is 1535 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
