### PR TITLE
Give the triggers and conditions an icon

### DIFF
--- a/custom_components/spook/icons.json
+++ b/custom_components/spook/icons.json
@@ -33,7 +33,7 @@
       "trigger": "mdi:sine-wave"
     },
     "integration_failed": {
-      "trigger": "mdi:puzzle-remove"
+      "trigger": "mdi:trophy-broken"
     },
     "repair_issue_created": {
       "trigger": "mdi:wrench"
@@ -48,7 +48,7 @@
       "trigger": "mdi:signal-off"
     },
     "watchdog": {
-      "trigger": "mdi:timer-alert"
+      "trigger": "mdi:dog"
     },
     "while": {
       "trigger": "mdi:repeat"

--- a/custom_components/spook/icons.json
+++ b/custom_components/spook/icons.json
@@ -30,7 +30,7 @@
       "trigger": "mdi:calendar-clock"
     },
     "flapping": {
-      "trigger": "mdi:sine-wave"
+      "trigger": "mdi:bird"
     },
     "integration_failed": {
       "trigger": "mdi:trophy-broken"

--- a/custom_components/spook/icons.json
+++ b/custom_components/spook/icons.json
@@ -1,0 +1,57 @@
+{
+  "conditions": {
+    "chance": {
+      "condition": "mdi:dice-multiple"
+    },
+    "cooldown": {
+      "condition": "mdi:timer-sand"
+    },
+    "not_triggered_by_user": {
+      "condition": "mdi:account-off"
+    },
+    "quota": {
+      "condition": "mdi:gauge"
+    },
+    "repair_issue_present": {
+      "condition": "mdi:wrench-clock"
+    },
+    "triggered_by_automation": {
+      "condition": "mdi:robot"
+    },
+    "triggered_by_user": {
+      "condition": "mdi:account"
+    }
+  },
+  "triggers": {
+    "condition_met": {
+      "trigger": "mdi:check-circle"
+    },
+    "cron": {
+      "trigger": "mdi:calendar-clock"
+    },
+    "flapping": {
+      "trigger": "mdi:sine-wave"
+    },
+    "integration_failed": {
+      "trigger": "mdi:puzzle-remove"
+    },
+    "repair_issue_created": {
+      "trigger": "mdi:wrench"
+    },
+    "repair_issue_removed": {
+      "trigger": "mdi:wrench-check"
+    },
+    "sequence": {
+      "trigger": "mdi:format-list-numbered"
+    },
+    "stale": {
+      "trigger": "mdi:signal-off"
+    },
+    "watchdog": {
+      "trigger": "mdi:timer-alert"
+    },
+    "while": {
+      "trigger": "mdi:repeat"
+    }
+  }
+}

--- a/custom_components/spook/icons.json
+++ b/custom_components/spook/icons.json
@@ -16,7 +16,7 @@
       "condition": "mdi:wrench-clock"
     },
     "triggered_by_automation": {
-      "condition": "mdi:robot"
+      "condition": "mdi:robot-happy"
     },
     "triggered_by_user": {
       "condition": "mdi:account"

--- a/custom_components/spook/icons.json
+++ b/custom_components/spook/icons.json
@@ -45,7 +45,7 @@
       "trigger": "mdi:format-list-numbered"
     },
     "stale": {
-      "trigger": "mdi:signal-off"
+      "trigger": "mdi:grave-stone"
     },
     "watchdog": {
       "trigger": "mdi:dog"

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,0 +1,58 @@
+"""Tests that every trigger and condition Spook adds has an icon.
+
+Spook shipped ten triggers and seven conditions with no `icons.json` at all,
+so every one of them rendered without an icon. Nothing failed and nothing
+logged: the only way to notice was to open the automation editor and look.
+"""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+import pytest
+
+SPOOK = Path(__file__).parents[1] / "custom_components" / "spook"
+ICONS = json.loads((SPOOK / "icons.json").read_text())
+STRINGS = json.loads((SPOOK / "translations" / "en.json").read_text())
+
+# Home Assistant keys these by kind, and the value names the kind again.
+_SECTIONS = (("triggers", "trigger"), ("conditions", "condition"))
+
+# An `mdi:` name, lowercase with single hyphens, which is all Material Design
+# Icons uses. A typo here renders as an empty square rather than an error.
+_MDI = re.compile(r"\Amdi:[a-z0-9]+(-[a-z0-9]+)*\Z")
+
+
+def test_there_is_something_to_check() -> None:
+    """Guard the lookups, which would pass happily against an empty file."""
+    assert ICONS
+    for section, _ in _SECTIONS:
+        assert STRINGS[section], section
+
+
+@pytest.mark.parametrize(("section", "kind"), _SECTIONS)
+def test_everything_translated_also_has_an_icon(section: str, kind: str) -> None:
+    """The translations are the list of what Spook actually adds."""
+    described = set(STRINGS[section])
+    iconed = set(ICONS.get(section, {}))
+
+    assert not described - iconed, (
+        f"{section} without an icon: {sorted(described - iconed)}"
+    )
+    assert not iconed - described, (
+        f"{section} with an icon and nothing else: {sorted(iconed - described)}"
+    )
+
+    for key, entry in ICONS[section].items():
+        assert kind in entry, f"{section}.{key} does not name its {kind}"
+
+
+@pytest.mark.parametrize(("section", "kind"), _SECTIONS)
+def test_every_icon_is_shaped_like_an_mdi_name(section: str, kind: str) -> None:
+    """A misspelled icon shows an empty square, which nothing reports."""
+    for key, entry in ICONS[section].items():
+        icon = entry[kind]
+        assert _MDI.match(icon), f"{section}.{key} has {icon!r}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Spook adds ten triggers and seven conditions and had no `icons.json` at all, so every one of them drew without an icon. Nothing failed and nothing logged it. The only way to notice was to open the automation editor and look, which is how Frenck found it.

Each icon is picked for what the thing does, taken from its own description in the translations rather than from its name:

| Trigger | Icon | | Condition | Icon |
| --- | --- | --- | --- | --- |
| `condition_met` | `mdi:check-circle` | | `chance` | `mdi:dice-multiple` |
| `cron` | `mdi:calendar-clock` | | `cooldown` | `mdi:timer-sand` |
| `flapping` | `mdi:bird` | | `not_triggered_by_user` | `mdi:account-off` |
| `integration_failed` | `mdi:trophy-broken` | | `quota` | `mdi:gauge` |
| `repair_issue_created` | `mdi:wrench` | | `repair_issue_present` | `mdi:wrench-clock` |
| `repair_issue_removed` | `mdi:wrench-check` | | `triggered_by_automation` | `mdi:robot-happy` |
| `sequence` | `mdi:format-list-numbered` | | `triggered_by_user` | `mdi:account` |
| `stale` | `mdi:grave-stone` | | | |
| `watchdog` | `mdi:dog` | | | |
| `while` | `mdi:repeat` | | | |

The three repair ones share the wrench family the repairs sensors already use, `triggered_by_user` borrows the account Home Assistant uses for people, and `stale` gets a gravestone because its own description says what a silent entity usually means: "a device that died quietly".

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reported by Frenck from his own instance: no icons on any of the new triggers or conditions.

Two of the first picks were wrong for the same reason and both are worth recording. `mdi:sine-wave` for `flapping` turned out to be an electronics icon, keywords "audio, alternating-current, analog, frequency, amplitude", nothing to do with something that will not sit still. `mdi:signal-off` for `stale` read as weak reception rather than silence. Checking what an icon is actually *for* matters as much as whether it exists.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

**Every one of the seventeen names was checked against the icon set the frontend ships**, off a real installation's `hass_frontend/static/mdi/iconList.json`, 7447 icons. A misspelled name renders as an empty square and reports nothing, so "it exists" is not something to take on trust. All seventeen are there.

New `tests/test_icons.py` compares `icons.json` against the translations in **both** directions, so the next trigger added either gets an icon or fails the build, and an icon for something that no longer exists fails too. It also checks each entry names its own kind (`trigger` / `condition`) and that every value is shaped like an `mdi:` name.

Five mutations, all caught:

| Mutation | Result |
| --- | --- |
| Drop a trigger's icon | 1 failed |
| Drop a condition's icon | 1 failed |
| Misspell an icon (`mdi:Calendar_Clock`) | 1 failed |
| Name the wrong kind (`trigger` under conditions) | 2 failed |
| Add an icon for a trigger that does not exist | 1 failed |

Full suite is 1539 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None from me, the icons show up in the automation editor's trigger and condition pickers.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
