### PR TITLE
Name a blueprint update after the blueprint

### DIFF
--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -36,8 +36,7 @@ from homeassistant.components.update import (
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_ON
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import yaml as yaml_util
@@ -364,8 +363,27 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         """Begin once the blueprint domains have registered themselves."""
         await self._async_begin()
 
+    @callback
+    def _async_forget_the_old_device(self) -> None:
+        """Remove the device these entities used to hang off.
+
+        They had one called "Blueprints", which is what made every row on the
+        updates page read the same. Dropping it leaves the device itself behind
+        with nothing on it, and a device that is not a device and holds nothing
+        is just something to wonder about later.
+        """
+        registry = dr.async_get(self.hass)
+        if (
+            device := registry.async_get_device(
+                identifiers={(DOMAIN, blueprint.DOMAIN)},
+            )
+        ) is not None:
+            LOGGER.debug("Spook is removing the old blueprints device")
+            registry.async_remove_device(device.id)
+
     async def _async_begin(self) -> None:
         """Take stock, then arrange to keep looking."""
+        self._async_forget_the_old_device()
         await self._async_take_stock()
         self._async_schedule(
             random.uniform(  # noqa: S311
@@ -519,11 +537,13 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         self.blueprint_path = blueprint_path
 
         self._attr_unique_id = f"blueprint_{blueprint_domain}_{blueprint_path}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, blueprint.DOMAIN)},
-            manufacturer="Home Assistant",
-            name="Blueprints",
-        )
+
+        # Deliberately no device. These used to hang off one called
+        # "Blueprints", and the updates page shows the device a row belongs to,
+        # so twenty blueprints read "Blueprints" twenty times over with no way
+        # to tell which was which. A device each would have fixed the reading
+        # and filled the device list with twenty entries that are not devices.
+        # A blueprint is a file, not a thing with firmware.
 
         self._said = said
         self._fetched: blueprint.Blueprint | None = None

--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -338,6 +338,10 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         """
         entry.async_on_unload(self._stop)
 
+        # Nothing to do with the rounds below. These entities used to sit on a
+        # device, and whoever ran that version still has it.
+        self._async_forget_the_old_device(entry.entry_id)
+
         if self.hass.state is CoreState.running:
             await self._async_begin()
             return
@@ -364,7 +368,7 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         await self._async_begin()
 
     @callback
-    def _async_forget_the_old_device(self) -> None:
+    def _async_forget_the_old_device(self, entry_id: str) -> None:
         """Remove the device these entities used to hang off.
 
         They had one called "Blueprints", which is what made every row on the
@@ -372,18 +376,38 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         with nothing on it, and a device that is not a device and holds nothing
         is just something to wonder about later.
         """
-        registry = dr.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
         if (
-            device := registry.async_get_device(
-                identifiers={(DOMAIN, blueprint.DOMAIN)},
+            device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, blueprint.DOMAIN),
+                entry_id,
             )
-        ) is not None:
-            LOGGER.debug("Spook is removing the old blueprints device")
-            registry.async_remove_device(device.id)
+        ) is None:
+            return
+
+        # Taken off the device first. Home Assistant deletes the registration
+        # of every entity on a device when the device goes, and both are ours
+        # here, so it would. It hands the registration straight back when the
+        # same unique ID turns up again, which is later in this same setup, so
+        # nothing is lost by letting it happen. The churn is the reason not to:
+        # a dozen repairs re-inspect on any entity registry change, and an
+        # entity going and coming back gives them nothing to find.
+        entity_registry = er.async_get(self.hass)
+        for registration in er.async_entries_for_device(
+            entity_registry,
+            device.id,
+            include_disabled_entities=True,
+        ):
+            entity_registry.async_update_entity(
+                registration.entity_id,
+                device_id=None,
+            )
+
+        LOGGER.debug("Spook is removing the old blueprints device")
+        device_registry.async_remove_device(device.id)
 
     async def _async_begin(self) -> None:
         """Take stock, then arrange to keep looking."""
-        self._async_forget_the_old_device()
         await self._async_take_stock()
         self._async_schedule(
             random.uniform(  # noqa: S311

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -29,11 +29,11 @@ Spook adds an action to import Blueprints directly from an URL.
 
 ## Devices & entities
 
-Spook adds a Blueprints {term}`device <device>`, holding one update {term}`entity <entity>` for every {term}`automation <automation>` or {term}`script <script>` blueprint you imported from a URL.
+Spook adds one update {term}`entity <entity>` for every {term}`automation <automation>` or {term}`script <script>` blueprint you imported from a URL. No {term}`device <device>`: a blueprint is a file, and the updates page reads a row by the device it belongs to, so putting them all on one would leave every row saying the same thing.
 
 ### Updates
 
-_Default {term}`entity ID <Entity ID>`: `update.blueprints_<blueprint name>`\_
+_Default {term}`entity ID <Entity ID>`: `update.<blueprint name>`_
 
 When you import a {term}`blueprint <blueprint>`, Home Assistant writes down where it came from. Nothing ever looks at that address again. The blueprint's author can fix a bug in it a week later and you would have no way of knowing, short of opening the forum topic and reading the YAML yourself.
 

--- a/tests/ectoplasms/blueprint/conftest.py
+++ b/tests/ectoplasms/blueprint/conftest.py
@@ -208,8 +208,17 @@ def imported_from(raw: str, *, source: str = SOURCE) -> ImportedBlueprint:
     return ImportedBlueprint("spook/blueprint", body, item)
 
 
-async def async_set_up(hass: HomeAssistant) -> ConfigEntry:
-    """Set up automations, scripts and Spook's update platform."""
+async def async_set_up(
+    hass: HomeAssistant,
+    entry: MockConfigEntry | None = None,
+) -> ConfigEntry:
+    """Set up automations, scripts and Spook's update platform.
+
+    An entry can be handed in by a test that has to put something in the
+    registries under the same ownership before any of this is set up. It is
+    expected to have been added to hass already, because a device cannot be
+    linked to a config entry Home Assistant does not know yet.
+    """
     assert await async_setup_component(hass, "automation", {"automation": []})
     assert await async_setup_component(hass, "script", {"script": {}})
     await hass.async_block_till_done()
@@ -246,8 +255,10 @@ async def async_set_up(hass: HomeAssistant) -> ConfigEntry:
         """A config flow that does nothing."""
 
     with mock_config_flow("fake", _Flow):
-        entry = MockConfigEntry(domain="fake")
-        entry.add_to_hass(hass)
+        if entry is None:
+            entry = MockConfigEntry(domain="fake")
+            entry.add_to_hass(hass)
+
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -21,8 +21,12 @@ from annotatedyaml.objects import Input
 import aiohttp
 import pytest
 import voluptuous as vol
-from pytest_homeassistant_custom_component.common import async_fire_time_changed
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
+from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.blueprint import update as update_module
 from custom_components.spook.ectoplasms.blueprint.update import (
     _canonical,
@@ -57,6 +61,7 @@ from .conftest import (
 )
 
 if TYPE_CHECKING:
+    from homeassistant.helpers import device_registry as dr
     from collections.abc import Callable
 
     from freezegun.api import FrozenDateTimeFactory
@@ -68,7 +73,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import entity_registry as er
 
-_ENTITY = "update.blueprints_spooky_motion_light"
+_ENTITY = "update.spooky_motion_light"
 _FETCH = "custom_components.spook.ectoplasms.blueprint.update.fetch_blueprint_from_url"
 _BOTH_OF_THEM = 2
 _NOBODY_SAW_IT_COMING = "something nobody saw coming"
@@ -426,7 +431,7 @@ async def test_a_blueprint_nobody_dumped_back_out_still_matches(
     write_by_hand(hass, "automation", "fixed.yaml", NO_INPUTS)
     await async_set_up(hass)
 
-    entity_id = "update.blueprints_spooky_fixed_automation"
+    entity_id = "update.spooky_fixed_automation"
     assert hass.states.get(entity_id) is not None
 
     with _source_says(NO_INPUTS):
@@ -754,7 +759,7 @@ async def test_a_script_blueprint_gets_one_too(
         {"notify_target": "mobile_app_phone"},
     )
 
-    entity_id = "update.blueprints_spooky_confirmable_notification"
+    entity_id = "update.spooky_confirmable_notification"
     assert hass.states.get(entity_id) is not None
 
     with _source_says(A_SCRIPT_BLUEPRINT_CHANGED):
@@ -793,7 +798,7 @@ async def test_a_script_that_would_be_left_short_stops_the_install(
     )
     before = file.read_text(encoding="utf-8")
 
-    entity_id = "update.blueprints_spooky_confirmable_notification"
+    entity_id = "update.spooky_confirmable_notification"
     with _source_says(A_SCRIPT_BLUEPRINT_WITH_NEW_INPUT):
         await _check(hass, freezer)
 
@@ -1131,7 +1136,7 @@ async def test_a_script_update_that_would_not_load_is_refused(
     )
     before = file.read_text(encoding="utf-8")
 
-    entity_id = "update.blueprints_spooky_confirmable_notification"
+    entity_id = "update.spooky_confirmable_notification"
     with _source_says(A_SCRIPT_BLUEPRINT_WITH_A_BAD_STEP):
         await _check(hass, freezer)
 
@@ -1564,3 +1569,60 @@ actions:
     other = Blueprint(yaml_util.parse_yaml(written_out), schema=BLUEPRINT_SCHEMA)
 
     assert _fingerprint(one) == _fingerprint(other)
+
+
+async def test_the_name_is_the_blueprint_and_nothing_else(
+    hass: HomeAssistant,
+) -> None:
+    """The updates page reads a row by the device it belongs to.
+
+    These used to hang off one device called "Blueprints", so twenty rows all
+    said "Blueprints" and none of them said which blueprint. Without a device
+    the name is the blueprint's own.
+    """
+    write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    state = hass.states.get(_ENTITY)
+    assert state
+    assert state.attributes["friendly_name"] == "Spooky motion light"
+    assert state.attributes["title"] == "Spooky motion light"
+
+
+async def test_no_device_is_made_for_these(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """A blueprint is a file. It has no firmware and it is not a device."""
+    write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    assert hass.states.get(_ENTITY)
+    # Iterated rather than looked up: mapping access on this is deprecated.
+    assert not list(device_registry.devices)
+
+
+async def test_the_old_blueprints_device_is_cleared_away(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Anybody who ran an earlier version has one of these sitting there.
+
+    Dropping the device off the entities leaves it behind holding nothing, and
+    a device that is not a device and has nothing on it is only something to
+    wonder about later.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry.add_to_hass(hass)
+    left_behind = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "blueprint")},
+        manufacturer="Home Assistant",
+        name="Blueprints",
+    )
+    assert device_registry.async_get(left_behind.id)
+
+    write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
+    await async_set_up(hass)
+
+    assert device_registry.async_get(left_behind.id) is None

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -12,9 +12,10 @@ from unittest.mock import patch
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.components.update import UpdateEntityFeature
-from homeassistant.core import CoreState
+from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.components.blueprint import BLUEPRINT_SCHEMA, Blueprint
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import yaml as yaml_util
 from annotatedyaml.objects import Input
@@ -70,8 +71,7 @@ if TYPE_CHECKING:
         WebSocketGenerator,
     )
 
-    from homeassistant.core import HomeAssistant
-    from homeassistant.helpers import entity_registry as er
+    from homeassistant.core import Event, HomeAssistant
 
 _ENTITY = "update.spooky_motion_light"
 _FETCH = "custom_components.spook.ectoplasms.blueprint.update.fetch_blueprint_from_url"
@@ -1605,24 +1605,72 @@ async def test_no_device_is_made_for_these(
 async def test_the_old_blueprints_device_is_cleared_away(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Anybody who ran an earlier version has one of these sitting there.
 
     Dropping the device off the entities leaves it behind holding nothing, and
     a device that is not a device and has nothing on it is only something to
     wonder about later.
+
+    Home Assistant deletes the registration of every entity on a device when
+    the device goes, and both belong to the same config entry here, so this
+    reaches for that. What it asserts is that it never happens: the entity is
+    taken off the device first. Home Assistant would in fact hand the whole
+    registration back the moment the same unique ID turned up again, a few
+    lines further into the same setup, so nothing would be lost either way.
+    The point is the churn. A dozen repairs re-inspect on any entity registry
+    change, and this would tell them all that an entity had gone and come back
+    for no reason at all.
+
+    So the config entry is handed to the setup rather than made up on the
+    spot. Under two entries Home Assistant never compares them as equal, this
+    would not reach the removal at all, and it would pass while doing nothing.
     """
-    entry = MockConfigEntry(domain=DOMAIN, title="Your homie", data={})
+    entry = MockConfigEntry(domain="fake")
     entry.add_to_hass(hass)
+
     left_behind = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, "blueprint")},
         manufacturer="Home Assistant",
         name="Blueprints",
     )
-    assert device_registry.async_get(left_behind.id)
+    was_there = entity_registry.async_get_or_create(
+        "update",
+        "fake",
+        "blueprint_automation_spooky.yaml",
+        config_entry=entry,
+        device_id=left_behind.id,
+        suggested_object_id="blueprints_spooky_motion_light",
+    )
+    entity_registry.async_update_entity(
+        was_there.entity_id,
+        icon="mdi:ghost",
+        name="The one I renamed myself",
+    )
+
+    dropped: list[str] = []
+
+    @callback
+    def _note_what_goes(event: Event[er.EventEntityRegistryUpdatedData]) -> None:
+        if event.data["action"] == "remove":
+            dropped.append(event.data["entity_id"])
+
+    hass.bus.async_listen(er.EVENT_ENTITY_REGISTRY_UPDATED, _note_what_goes)
 
     write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
-    await async_set_up(hass)
+    await async_set_up(hass, entry=entry)
 
     assert device_registry.async_get(left_behind.id) is None
+    assert not dropped
+
+    kept = entity_registry.async_get(was_there.entity_id)
+    assert kept is not None
+    assert kept.device_id is None
+    assert kept.name == "The one I renamed myself"
+    assert kept.icon == "mdi:ghost"
+
+    # And it is the entity that is actually there, rather than a registration
+    # sitting next to one that came back under a name of its own.
+    assert hass.states.get(was_there.entity_id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The blueprint update entities hung off a single device called "Blueprints", and the updates page reads a row by the device it belongs to. So somebody with twenty blueprints saw twenty rows saying "Blueprints", with nothing to say which one each row was about.

Measured before and after, on the same blueprint:

```
with a device    : friendly_name='Blueprints Sensor Light'
without a device : friendly_name='Sensor Light'
```

The device is gone rather than split up. One device per blueprint would have read correctly and filled the device list with twenty entries that are not devices: a blueprint is a file, with no firmware and nothing to connect to. Without a device the entity's own name stands on its own, and that name is the blueprint's.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Spotted on a screenshot in #1548, where the rows were indistinguishable.

Two consequences worth stating plainly, because neither is free.

**The entity ID loses its prefix on a fresh install.** `update.<name>` where it used to be `update.blueprints_<name>`. Anybody who already has these keeps the old ID, because the entity is taken off the device before the device is removed, so the registration is never dropped. Two installations therefore differ depending on when they first ran this, which is not tidy. Bringing them into line is a decision of its own and not this PR: it would rename an entity somebody may reference.

**The old device is now empty**, so it is removed at setup. A device that is not a device and holds nothing is only something to wonder about later.

**Removing a device is not free**, which review was right to raise. Home Assistant deletes the registration of every entity on a device when the device goes, and both belong to Spook here, so it reached for exactly that. It also hands the whole registration back the moment the same unique ID turns up again, which is later in the same setup, with the entity ID, name, icon, area, aliases, labels and hidden state all still on it. So nothing was being lost, but a dozen repairs re-inspect on any entity registry change and an entity that goes and comes back gives every one of them nothing to find. Taking the entity off the device first avoids the round trip entirely.

**One deprecation went with it.** Looking a device up by its identifiers alone is deprecated, since identifiers are no longer unique across config entries, and it warns with a request to open a bug report against Spook. The replacement wants to know whose device it is, so the cleanup now runs from `async_start`, where the config entry already was, once at setup rather than on every round.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Three new tests: the name and title are the blueprint's, no device is created at all, and a device left over from an earlier version gets cleared away without taking anything with it.

That last one seeds the registration the way v5.3.0 left it, renamed and with an icon set by hand, and asserts that no entity is dropped at all. It hands its own config entry to the setup rather than making up a second one: under two entries Home Assistant never compares the two as equal, never reaches the removal, and the test would pass while proving nothing. It did exactly that on the first attempt.

Five entity IDs in the existing tests moved with the change, which is the same rename users will see on a fresh install.

Every part is mutation tested:

| Mutation | Result |
| --- | --- |
| Put the device back | 40 failed |
| Skip the cleanup of the old device | 1 failed |
| Leave the entity on the device | 1 failed |
| Look the device up under the wrong config entry | 1 failed |

The forty is the existing suite noticing the entity IDs shift back, which is a fair way to find out the device is what drives them.

Full suite is 1537 passing. Ruff, pylint and prettier clean.

One documentation line was quietly broken before this and is fixed here: the default entity ID line read `\_Default ...` rather than italics, because the old ID contained an underscore that prettier had to escape. With the prefix gone the escape goes too.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None from me. The change shows up on **Settings** > **Updates**, where each row now names its blueprint.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

