### PR TITLE
Drop the update entities of blueprints that are gone

### DIFF
--- a/custom_components/spook/ectoplasms/blueprint/update.py
+++ b/custom_components/spook/ectoplasms/blueprint/update.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 import os
 import random
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import aiohttp
 from annotatedyaml.objects import Input
@@ -33,7 +33,7 @@ from homeassistant.components.update import (
     UpdateEntityDescription,
     UpdateEntityFeature,
 )
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_ON
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_ON, Platform
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -135,13 +135,46 @@ _WOULD_BE_REFUSED = (
 )
 
 
+def _unique_id(blueprint_domain: str, blueprint_path: str) -> str:
+    """Return the unique ID of the entity following a blueprint."""
+    return f"blueprint_{blueprint_domain}_{blueprint_path}"
+
+
+def _blueprint_behind(unique_id: str) -> tuple[str, str] | None:
+    """Return the blueprint a unique ID of ours is about, if it is one.
+
+    Matched against the domains themselves rather than split on the
+    separator, because a blueprint path is free to hold underscores of its
+    own and a domain is not.
+    """
+    for blueprint_domain in _USES_BLUEPRINTS:
+        prefix = _unique_id(blueprint_domain, "")
+        if unique_id.startswith(prefix):
+            return blueprint_domain, unique_id.removeprefix(prefix)
+
+    return None
+
+
+class _Found(NamedTuple):
+    """What a look at the blueprint folders turned up."""
+
+    files: dict[tuple[str, str], Path]
+    """The file behind every blueprint Home Assistant could load."""
+
+    listed: set[tuple[str, str]]
+    """Every blueprint Home Assistant named, loadable or not."""
+
+    domains: set[str]
+    """The domains that were there to be asked. Absence is not emptiness."""
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up an update entity for every blueprint that came from a URL."""
-    await _BlueprintUpdates(hass, async_add_entities).async_start(entry)
+    await _BlueprintUpdates(hass, entry, async_add_entities).async_start()
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -318,16 +351,18 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
     def __init__(
         self,
         hass: HomeAssistant,
+        entry: ConfigEntry,
         async_add_entities: AddEntitiesCallback,
     ) -> None:
         """Initialize the manager."""
         self.hass = hass
+        self._entry = entry
         self._async_add_entities = async_add_entities
         self._entities: dict[tuple[str, str], BlueprintUpdateEntity] = {}
         self._stopped = False
         self._cancel: CALLBACK_TYPE | None = None
 
-    async def async_start(self, entry: ConfigEntry) -> None:
+    async def async_start(self) -> None:
         """Begin now, or once Home Assistant is up.
 
         Nothing is scheduled before then either. Starting up can take longer
@@ -336,17 +371,17 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         arriving, and goes out to the internet while the house is still
         getting dressed.
         """
-        entry.async_on_unload(self._stop)
+        self._entry.async_on_unload(self._stop)
 
         # Nothing to do with the rounds below. These entities used to sit on a
         # device, and whoever ran that version still has it.
-        self._async_forget_the_old_device(entry.entry_id)
+        self._async_forget_the_old_device()
 
         if self.hass.state is CoreState.running:
             await self._async_begin()
             return
 
-        entry.async_on_unload(
+        self._entry.async_on_unload(
             async_listen_once_tracked(
                 self.hass,
                 EVENT_HOMEASSISTANT_STARTED,
@@ -368,7 +403,7 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         await self._async_begin()
 
     @callback
-    def _async_forget_the_old_device(self, entry_id: str) -> None:
+    def _async_forget_the_old_device(self) -> None:
         """Remove the device these entities used to hang off.
 
         They had one called "Blueprints", which is what made every row on the
@@ -380,7 +415,7 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         if (
             device := device_registry.async_get_device_by_identifier(
                 (DOMAIN, blueprint.DOMAIN),
-                entry_id,
+                self._entry.entry_id,
             )
         ) is None:
             return
@@ -426,15 +461,15 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
 
     async def _async_take_stock(self) -> None:
         """Match the entities to the blueprints that are on disk."""
-        files = await self._async_look()
+        found = await self._async_look()
         on_disk = await self.hass.async_add_executor_job(
             _read_files,
-            list(files.values()),
+            list(found.files.values()),
         )
 
         followed: dict[tuple[str, str], _OnDisk] = {}
         unreadable: set[tuple[str, str]] = set()
-        for key, said in zip(files, on_disk, strict=True):
+        for key, said in zip(found.files, on_disk, strict=True):
             if said is None:
                 unreadable.add(key)
             elif said.source_url is not None:
@@ -445,6 +480,8 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         # longer names a source is somebody asking to be left alone, and that
         # one goes.
         await self._async_forget(set(self._entities) - set(followed) - unreadable)
+
+        self._async_drop_what_is_not_there(found, followed, unreadable)
 
         added: list[BlueprintUpdateEntity] = []
         for key in sorted(followed):
@@ -459,28 +496,98 @@ class _BlueprintUpdates:  # pylint: disable=too-few-public-methods
         if added:
             self._async_add_entities(added)
 
-    async def _async_look(self) -> dict[tuple[str, str], Path]:
-        """Return the file behind every blueprint Home Assistant can load."""
+    async def _async_look(self) -> _Found:
+        """Return what the blueprint folders hold.
+
+        Which domains were asked is part of the answer. A domain that has not
+        registered itself says nothing about its blueprints, and reading that
+        silence as "there are none" is how a tidy-up turns into a clear-out.
+        """
         files: dict[tuple[str, str], Path] = {}
+        listed: set[tuple[str, str]] = set()
         domain_blueprints: dict[str, blueprint.DomainBlueprints] = self.hass.data.get(
             blueprint.DOMAIN,
             {},
         )
+
+        domains = {domain for domain in domain_blueprints if domain in _USES_BLUEPRINTS}
 
         for domain, domain_blueprint in sorted(domain_blueprints.items()):
             if domain not in _USES_BLUEPRINTS:
                 continue
 
             for path, item in (await domain_blueprint.async_get_blueprints()).items():
-                # Failed to load, or Home Assistant's own examples.
-                if not isinstance(item, blueprint.Blueprint):
-                    continue
+                # Home Assistant's own examples are not somebody's blueprints.
                 if path.startswith(_HOME_ASSISTANTS_OWN):
+                    continue
+
+                listed.add((domain, path))
+
+                # Failed to load. Named, so it is there, but nothing can be
+                # read out of it.
+                if not isinstance(item, blueprint.Blueprint):
                     continue
 
                 files[(domain, path)] = domain_blueprint.blueprint_folder / path
 
-        return files
+        return _Found(files=files, listed=listed, domains=domains)
+
+    @callback
+    def _async_drop_what_is_not_there(
+        self,
+        found: _Found,
+        followed: dict[tuple[str, str], _OnDisk],
+        unreadable: set[tuple[str, str]],
+    ) -> None:
+        """Remove registrations left behind by blueprints that have gone.
+
+        Blueprints fire no events, so one deleted while Home Assistant was
+        stopped is noticed by nobody. The round that would have caught it
+        compares against the entities of this run, and on the first round
+        there are none, so the registration sits there for good: an entity in
+        the list with nothing behind it and no way to work out why.
+
+        This is that same comparison, put to the registry instead.
+
+        What it will not do is take a registration on a guess. A blueprint can
+        be sitting right there and still not be followed, so being followed is
+        not the question. Being gone is.
+        """
+        registry = er.async_get(self.hass)
+
+        # Named but not loadable: broken YAML, most likely mid-edit. It is
+        # there, and nothing can be read out of it to say otherwise.
+        keep = found.listed - set(found.files)
+
+        # Read, and asked to be left alone or unreadable just now.
+        keep |= set(followed) | unreadable
+
+        wanted = {_unique_id(*key) for key in keep}
+
+        for registration in er.async_entries_for_config_entry(
+            registry,
+            self._entry.entry_id,
+        ):
+            if registration.domain != Platform.UPDATE:
+                continue
+
+            if (behind := _blueprint_behind(registration.unique_id)) is None:
+                continue
+
+            # A domain that was not there to be asked. Its blueprints are out
+            # of sight rather than gone, and the difference is every
+            # registration it has.
+            if behind[0] not in found.domains:
+                continue
+
+            if registration.unique_id in wanted:
+                continue
+
+            LOGGER.debug(
+                "Spook is dropping %s, left behind by a blueprint that is gone",
+                registration.entity_id,
+            )
+            registry.async_remove(registration.entity_id)
 
     async def _async_forget(self, keys: set[tuple[str, str]]) -> None:
         """Drop the entities of blueprints that are no longer being followed."""
@@ -560,7 +667,7 @@ class BlueprintUpdateEntity(  # pylint: disable=too-many-instance-attributes
         self.blueprint_domain = blueprint_domain
         self.blueprint_path = blueprint_path
 
-        self._attr_unique_id = f"blueprint_{blueprint_domain}_{blueprint_path}"
+        self._attr_unique_id = _unique_id(blueprint_domain, blueprint_path)
 
         # Deliberately no device. These used to hang off one called
         # "Blueprints", and the updates page shows the device a row belongs to,

--- a/documentation/integrations/blueprint.md
+++ b/documentation/integrations/blueprint.md
@@ -43,6 +43,8 @@ Only blueprints that came from a URL get one. A blueprint you wrote yourself has
 
 Only automation and script blueprints, too. Those are the only two kinds whose users Home Assistant can list, and without that list there is no way to tell whether an update would leave one of them unable to load. An install button that cannot promise that is worse than no button at all, so template blueprints are left out until there is a way to check them.
 
+Delete a blueprint, or take the source address back out of it, and the update {term}`entity <entity>` goes with it. Blueprints raise no events, so nothing notices at the moment it happens: the next round does. One deleted while Home Assistant was stopped is caught the next time Spook starts, so you are not left with an entity in the list and no blueprint behind it.
+
 #### What the update dialog tells you
 
 Every other update dialog in Home Assistant shows you release notes. This one cannot, because there are none: a blueprint has no changelog, and the author is under no obligation to say anything anywhere.

--- a/tests/ectoplasms/blueprint/test_update.py
+++ b/tests/ectoplasms/blueprint/test_update.py
@@ -14,7 +14,11 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.components.blueprint import BLUEPRINT_SCHEMA, Blueprint
+from homeassistant.components.blueprint import (
+    BLUEPRINT_SCHEMA,
+    DOMAIN as BLUEPRINT_DOMAIN,
+    Blueprint,
+)
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import yaml as yaml_util
@@ -1674,3 +1678,173 @@ async def test_the_old_blueprints_device_is_cleared_away(
     # And it is the entity that is actually there, rather than a registration
     # sitting next to one that came back under a name of its own.
     assert hass.states.get(was_there.entity_id)
+
+
+async def test_a_registration_left_behind_by_a_deleted_blueprint_is_dropped(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A blueprint deleted while Home Assistant was stopped tells nobody.
+
+    The round that would have caught it compares against the entities of this
+    run, and on the first round there are none, so without this the
+    registration sits in the list for good with nothing behind it.
+
+    Seeded in the shape the released version wrote it, on purpose: the whole
+    point is reading what an older Spook left, so a literal is the only honest
+    way to write it down.
+    """
+    entry = MockConfigEntry(domain="fake")
+    entry.add_to_hass(hass)
+
+    left_over = entity_registry.async_get_or_create(
+        "update",
+        "fake",
+        "blueprint_automation_i_deleted_this.yaml",
+        config_entry=entry,
+        suggested_object_id="blueprints_something_i_deleted",
+    )
+
+    write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
+    await async_set_up(hass, entry=entry)
+
+    assert entity_registry.async_get(left_over.entity_id) is None
+
+    # The blueprint that is there keeps everything it had.
+    assert entity_registry.async_get(_ENTITY) is not None
+    assert hass.states.get(_ENTITY)
+
+
+async def test_a_domain_that_is_out_of_sight_keeps_its_registrations(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A domain that has not registered says nothing about its blueprints.
+
+    Reading that silence as "there are none" would take every registration it
+    has, on a round that happened to land while the integration was still
+    setting up. So the domains that were there to be asked are part of what a
+    look reports, and a domain that was not is left alone entirely.
+    """
+    entry = MockConfigEntry(domain="fake")
+    entry.add_to_hass(hass)
+
+    write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
+    await async_set_up(hass, entry=entry)
+
+    out_of_sight = entity_registry.async_get_or_create(
+        "update",
+        "fake",
+        "blueprint_script_gone_fishing.yaml",
+        config_entry=entry,
+        suggested_object_id="blueprints_gone_fishing",
+    )
+
+    without_scripts = {
+        domain: item
+        for domain, item in hass.data[BLUEPRINT_DOMAIN].items()
+        if domain != "script"
+    }
+    with (
+        patch.dict(hass.data, {BLUEPRINT_DOMAIN: without_scripts}),
+        _source_says(MOTION_LIGHT),
+    ):
+        await _check(hass, freezer)
+
+    assert entity_registry.async_get(out_of_sight.entity_id) is not None
+
+    # And it was the looking away that saved it. With the domain back, the
+    # same registration goes, which is the only way to know the round would
+    # otherwise have taken it.
+    with _source_says(MOTION_LIGHT):
+        await _check(hass, freezer)
+
+    assert entity_registry.async_get(out_of_sight.entity_id) is None
+
+
+async def test_a_blueprint_that_will_not_load_keeps_its_registration(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Home Assistant names a blueprint it could not load, and so it is there.
+
+    Most likely somebody is halfway through editing it. Nothing can be read
+    out of it to say whether it still comes from anywhere, and a file being
+    unreadable is not a file being gone.
+    """
+    entry = MockConfigEntry(domain="fake")
+    entry.add_to_hass(hass)
+
+    mid_edit = entity_registry.async_get_or_create(
+        "update",
+        "fake",
+        "blueprint_automation_halfway.yaml",
+        config_entry=entry,
+        suggested_object_id="blueprints_halfway",
+    )
+
+    write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
+    write_by_hand(hass, "automation", "halfway.yaml", "nope: not a blueprint\n")
+    await async_set_up(hass, entry=entry)
+
+    assert entity_registry.async_get(mid_edit.entity_id) is not None
+
+
+async def test_a_blueprint_that_dropped_its_source_loses_its_registration(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Taking the source URL out is asking to be left alone.
+
+    Which the round already honours for an entity it has. Done while Home
+    Assistant was stopped it never had one, so the registration is the only
+    thing left saying Spook was ever interested.
+    """
+    entry = MockConfigEntry(domain="fake")
+    entry.add_to_hass(hass)
+
+    on_its_own = entity_registry.async_get_or_create(
+        "update",
+        "fake",
+        "blueprint_automation_on_its_own.yaml",
+        config_entry=entry,
+        suggested_object_id="blueprints_on_its_own",
+    )
+
+    write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
+    write_by_hand(
+        hass,
+        "automation",
+        "on_its_own.yaml",
+        MOTION_LIGHT.replace("  source_url: {source}\n", ""),
+    )
+    await async_set_up(hass, entry=entry)
+
+    assert entity_registry.async_get(on_its_own.entity_id) is None
+
+
+async def test_a_registration_that_is_not_about_a_blueprint_is_left_alone(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Spook is free to put other updates on this config entry.
+
+    Nothing here knows anything about those, and a tidy-up that cannot tell
+    what a unique ID is about has no business touching it.
+    """
+    entry = MockConfigEntry(domain="fake")
+    entry.add_to_hass(hass)
+
+    somebody_elses = entity_registry.async_get_or_create(
+        "update",
+        "fake",
+        "nothing_to_do_with_blueprints",
+        config_entry=entry,
+        suggested_object_id="spook_itself",
+    )
+
+    write_by_hand(hass, "automation", "spooky.yaml", MOTION_LIGHT)
+    await async_set_up(hass, entry=entry)
+
+    assert entity_registry.async_get(somebody_elses.entity_id) is not None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Blueprints raise no events, so nothing announces one being deleted. The round that notices compares against the entities of this run, which means a blueprint deleted while Home Assistant was stopped is never noticed at all: on the first round there are no entities to compare with, and the registration stays in the entity list for good, with nothing behind it and no way to work out why.

So the same comparison is now put to the entity registry as well, on every round.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Getting this wrong deletes somebody's entity along with whatever they set on it, so it will not act on a guess. Being followed is not the question. Being gone is. Three ways a blueprint can be sitting right there without being followed, and each one keeps what it has.

**A domain that has not registered itself is left alone entirely.** Its blueprints are out of sight rather than gone, and a round landing while the integration is still setting up would otherwise take every registration it has. Which domains were there to be asked is now part of what a look reports, rather than being inferred from an empty result.

**A blueprint Home Assistant named but could not load stays.** Somebody is halfway through editing it, and a file being unreadable is not a file being gone.

**A blueprint that was read fine and no longer names a source goes**, because that is somebody asking to be left alone, which the round already honours for an entity it has.

Raised in review on #1561, where removing the old device happened to clear these up as a side effect. It was never the device's job, and on `main` before that PR the leftover stayed as well, so this is the gap itself rather than the accident that briefly covered it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Five new tests, one per case above, plus the leftover being dropped and a unique ID that is not about a blueprint at all being left alone. Each seeds a registration in the shape the released version wrote it, because reading what an older Spook left behind is the whole point.

Every guard is mutation tested on its own:

| Mutation | Result |
| --- | --- |
| Never prune at all | 3 failed |
| Drop the out-of-sight domain guard | 1 failed |
| Keep only what is listed, ignoring a dropped source URL | 1 failed |
| Forget that an unloadable blueprint is still there | 1 failed |
| Prune anything on the entry, blueprint-shaped or not | 1 failed |

Each one fails exactly the test written for it.

Full suite is 1548 passing. Ruff, pylint and prettier clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None. The whole change is an entity that is no longer in a list it had no business being in.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
