### PR TITLE
Fix generated documentation URLs

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -38,8 +38,16 @@ jobs:
 
       - name: 🔗 Correct generated site origin
         run: |
-          grep -RIlZ "http://localhost:3000" ./documentation/_build/html \
-            | xargs -0 -r sed -i "s|http://localhost:3000|${SITE_ORIGIN}|g"
+          files=$(mktemp)
+          trap 'rm -f "$files"' EXIT
+          if grep -RIlZ "http://localhost:3000" ./documentation/_build/html > "$files"; then
+            xargs -0 sed -i "s|http://localhost:3000|${SITE_ORIGIN}|g" < "$files"
+          else
+            status=$?
+            if [ "$status" -ne 1 ]; then
+              exit "$status"
+            fi
+          fi
 
       - name: 🔍 Verify generated site origin
         run: |

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -38,6 +38,10 @@ jobs:
 
       - name: 🔗 Correct generated site origin
         run: |
+          # Required until MyST fixes static sitemap/robots origins:
+          # https://github.com/jupyter-book/mystmd/issues/2695
+          # https://github.com/jupyter-book/myst-theme/issues/669
+          # Remove this step once those issues are fixed upstream.
           files=$(mktemp)
           trap 'rm -f "$files"' EXIT
           if grep -RIlZ "http://localhost:3000" ./documentation/_build/html > "$files"; then

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      SITE_ORIGIN: https://spook.boo
     permissions:
       actions: write
       contents: read
@@ -33,6 +35,18 @@ jobs:
 
       - name: ©️ Public folder
         run: cp ./documentation/public/* ./documentation/_build/html/
+
+      - name: 🔗 Correct generated site origin
+        run: |
+          grep -RIlZ "http://localhost:3000" ./documentation/_build/html \
+            | xargs -0 -r sed -i "s|http://localhost:3000|${SITE_ORIGIN}|g"
+
+      - name: 🔍 Verify generated site origin
+        run: |
+          if grep -RIl "http://localhost:3000" ./documentation/_build/html; then
+            echo "Found localhost URLs in the generated documentation"
+            exit 1
+          fi
 
       - name: 🆙 Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -42,10 +42,20 @@ jobs:
           # https://github.com/jupyter-book/mystmd/issues/2695
           # https://github.com/jupyter-book/myst-theme/issues/669
           # Remove this step once those issues are fixed upstream.
+          sed -i "s|http://localhost:3000|${SITE_ORIGIN}|g" \
+            ./documentation/_build/html/robots.txt \
+            ./documentation/_build/html/sitemap.xml
+
           files=$(mktemp)
           trap 'rm -f "$files"' EXIT
-          if grep -RIlZ "http://localhost:3000" ./documentation/_build/html > "$files"; then
-            xargs -0 sed -i "s|http://localhost:3000|${SITE_ORIGIN}|g" < "$files"
+          if grep -RIlZ \
+            --include='*.html' \
+            --include='*.json' \
+            '"domain":"http://localhost:3000"' \
+            ./documentation/_build/html > "$files"; then
+            xargs -0 sed -i \
+              "s|\"domain\":\"http://localhost:3000\"|\"domain\":\"${SITE_ORIGIN}\"|g" \
+              < "$files"
           else
             status=$?
             if [ "$status" -ne 1 ]; then
@@ -55,9 +65,30 @@ jobs:
 
       - name: 🔍 Verify generated site origin
         run: |
-          if grep -RIl "http://localhost:3000" ./documentation/_build/html; then
-            echo "Found localhost URLs in the generated documentation"
+          if grep -q "http://localhost:3000" \
+            ./documentation/_build/html/robots.txt \
+            ./documentation/_build/html/sitemap.xml; then
+            echo "Found localhost URLs in generated SEO metadata"
             exit 1
+          else
+            status=$?
+            if [ "$status" -ne 1 ]; then
+              exit "$status"
+            fi
+          fi
+
+          if grep -RIl \
+            --include='*.html' \
+            --include='*.json' \
+            '"domain":"http://localhost:3000"' \
+            ./documentation/_build/html; then
+            echo "Found localhost URLs in generated page metadata"
+            exit 1
+          else
+            status=$?
+            if [ "$status" -ne 1 ]; then
+              exit "$status"
+            fi
           fi
 
       - name: 🆙 Upload artifact

--- a/documentation/myst.yml
+++ b/documentation/myst.yml
@@ -9,8 +9,6 @@ site:
       url: https://my.home-assistant.io/redirect/hacs_repository/?owner=frenck&repository=spook&category=integrations
     - title: 💬 Support
       url: https://github.com/frenck/spook/discussions
-  domains:
-    - "frenck.github.io"
   options:
     logo: ./images/logo.png
     logo_dark: ./images/logo_dark.png


### PR DESCRIPTION
## Description

Correct the MyST static-build origin in the uploaded documentation artifact.

The static renderer generates `robots.txt`, `sitemap.xml`, and serialized page metadata with `http://localhost:3000`.
<img width="665" height="474" alt="image" src="https://github.com/user-attachments/assets/12536660-c192-4ed9-bd76-2134a6413798" />
<img width="338" height="129" alt="image" src="https://github.com/user-attachments/assets/dc203b23-7e64-4fcd-9899-6514c4bc12bc" />


The workflow now replaces that build-time origin with `$SITE_ORIGIN` before upload and verifies none remain. It also removes the obsolete `frenck.github.io` `site.domains` entry; MyST rejects `spook.boo` in that field because it is not a subdomain-style deployment domain.

## Motivation and Context

The invalid sitemap and robots URL prevent search engines from discovering the public documentation URLs reliably.
Like the "[conditions](https://spook.boo/conditions/)" page which, unfortunately, isn't on Google (check with `site:spook.boo inurl:conditions`)
<img width="837" height="197" alt="image" src="https://github.com/user-attachments/assets/5f46786f-0005-4fee-9222-1b44048f3c34" />


This is an upstream MyST static-export issue. I'm proposing fixes there in parallel.

- https://github.com/jupyter-book/mystmd/issues/2695 -> https://github.com/jupyter-book/mystmd/pull/3042
- https://github.com/jupyter-book/myst-theme/issues/669 -> https://github.com/jupyter-book/myst-theme/pull/950



## How has this been tested?

- Ran `npm ci --ignore-scripts`.
- Ran `./node_modules/.bin/myst build --html`.
- Applied the workflow's post-build replacement to the generated artifact and verified:
  - `robots.txt` references `https://spook.boo/sitemap.xml`;
  - sitemap entries use `https://spook.boo/`;
  - page metadata contains `"domain":"https://spook.boo"`;
  - no `http://localhost:3000` references remain.

## Screenshots (if appropriate):

Not applicable; this changes generated deployment metadata only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.