### PR TITLE
Stop calling a working gas meter unknown

### DIFF
--- a/custom_components/spook/ectoplasms/energy/repairs/unknown_references.py
+++ b/custom_components/spook/ectoplasms/energy/repairs/unknown_references.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from ....const import LOGGER
 from ....entity_suggestions import async_describe_unknown_entities
 from ....repairs import AbstractSpookRepair
+from ....statistics_sources import async_known_to_home_assistant
 
 # The energy validation issue type raised when a referenced entity or
 # statistic has no state at all: it was removed. Other issue types
@@ -54,6 +55,16 @@ class SpookRepair(AbstractSpookRepair):
                     unknown.update(
                         affected for affected, _detail in issue.affected_entities
                     )
+
+        # Home Assistant reports "entity not defined" for anything it cannot
+        # find a state for, and having no state covers more than being unknown:
+        # an integration that has not finished setting up, an entity somebody
+        # disabled, and an energy source fed by statistics that were published
+        # straight into the recorder without an entity ever existing. The
+        # energy dashboard draws that last one perfectly happily. Telling
+        # somebody their working gas meter is unknown is a repair for a problem
+        # they do not have. #1565.
+        unknown -= await async_known_to_home_assistant(self.hass, unknown)
 
         if unknown:
             self.async_create_issue(

--- a/custom_components/spook/ectoplasms/energy/repairs/unknown_references.py
+++ b/custom_components/spook/ectoplasms/energy/repairs/unknown_references.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from homeassistant.components.energy.data import async_get_manager
 from homeassistant.components.energy.validate import async_validate
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
@@ -44,6 +45,26 @@ class SpookRepair(AbstractSpookRepair):
 
     automatically_clean_up_issues = True
 
+    async def _async_read_from_the_state(self) -> set[str]:
+        """Return the energy settings that name an entity, not a statistic.
+
+        The settings say which is which by their own names: a key beginning
+        `stat_` holds a statistic ID and one beginning `entity_` holds an
+        entity that has to be there, because its value is read live while the
+        dashboard adds things up.
+        """
+        preferences = (await async_get_manager(self.hass)).data or {}
+
+        return {
+            value
+            for group in preferences.values()
+            if isinstance(group, list)
+            for source in group
+            if isinstance(source, dict)
+            for key, value in source.items()
+            if key.startswith("entity_") and isinstance(value, str)
+        }
+
     async def async_inspect(self) -> None:
         """Trigger an inspection."""
         if "energy" not in self.hass.config.components:
@@ -74,7 +95,14 @@ class SpookRepair(AbstractSpookRepair):
         # energy dashboard draws that last one perfectly happily. Telling
         # somebody their working gas meter is unknown is a repair for a problem
         # they do not have. #1565.
-        unknown -= await async_known_to_home_assistant(self.hass, unknown)
+        #
+        # Not for a price, though. A price is read off the state as the
+        # dashboard works, so statistics recorded under the same name do not
+        # make one work and letting it off would hide a setting that is broken.
+        unknown -= await async_known_to_home_assistant(
+            self.hass,
+            unknown - await self._async_read_from_the_state(),
+        )
 
         if unknown:
             self.async_create_issue(

--- a/custom_components/spook/ectoplasms/energy/repairs/unknown_references.py
+++ b/custom_components/spook/ectoplasms/energy/repairs/unknown_references.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from homeassistant.components.energy.validate import async_validate
 from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.helpers import entity_registry as er
@@ -32,6 +34,14 @@ class SpookRepair(AbstractSpookRepair):
         EVENT_COMPONENT_LOADED,
         er.EVENT_ENTITY_REGISTRY_UPDATED,
     }
+
+    # Whether a source counts as known now depends on what the recorder holds,
+    # and statistics arriving or being cleared raises no event at all. Without
+    # a clock, an issue raised before the first import would sit there until
+    # some unrelated registry change happened along, which on a quiet system
+    # can be a long time.
+    inspect_interval = timedelta(hours=1)
+
     automatically_clean_up_issues = True
 
     async def async_inspect(self) -> None:

--- a/custom_components/spook/ectoplasms/recorder/services/import_statistics.py
+++ b/custom_components/spook/ectoplasms/recorder/services/import_statistics.py
@@ -56,7 +56,13 @@ class SpookService(AbstractSpookAdminService):
                 if call.data["has_mean"]
                 else StatisticMeanType.NONE
             ),
-            "name": call.data["name"],
+            # Named after itself when nobody says otherwise. Home Assistant
+            # writes no name on the statistics a sensor keeps for itself, and
+            # takes that as meaning there is an entity somewhere holding the
+            # name instead. Importing without one leaves statistics that read
+            # as a sensor's, which is how Spook's own repairs end up calling
+            # something imported through here unknown. #1565.
+            "name": call.data["name"] or call.data["statistic_id"],
             "source": call.data["source"],
             "statistic_id": call.data["statistic_id"],
             "unit_class": STATISTIC_UNIT_TO_UNIT_CONVERTER.get(

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -1137,7 +1137,8 @@ recorder_import_statistics:
         entity:
     name:
       name: Name
-      description: The name of the statistics.
+      description: >-
+        The name of the statistics. Defaults to the statistics ID.
       required: false
       selector:
         text:

--- a/custom_components/spook/statistics_sources.py
+++ b/custom_components/spook/statistics_sources.py
@@ -1,0 +1,62 @@
+"""Spook - Your homie. Telling a missing entity from one that never was."""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+from homeassistant.components.recorder.statistics import get_metadata
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.recorder import DATA_INSTANCE, get_instance
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def async_known_to_home_assistant(
+    hass: HomeAssistant,
+    entity_ids: set[str],
+) -> set[str]:
+    """Return which of these Home Assistant knows about, state or no state.
+
+    Having no state is not the same as being unknown, and two quite different
+    things arrive looking identical.
+
+    An entity that is registered and simply has no state right now is one whose
+    integration has not finished setting up, or that somebody disabled. Home
+    Assistant knows exactly what it is.
+
+    And an ID can carry long-term statistics without ever having been an
+    entity. An integration publishing straight into the recorder has to name
+    those after one, because `async_import_statistics` turns away anything
+    that is not a valid entity ID, so a gas meter read by a service somewhere
+    ends up as `sensor.something` with nothing behind it. The energy dashboard
+    takes that and draws it. It is the opposite of unknown.
+
+    What is left over really is unknown: no registration, deleted or
+    otherwise, and nothing recorded under the name. A registration that says
+    "deleted" is left out on purpose, because that is a reference to something
+    somebody removed, which is worth being told about.
+    """
+    if not entity_ids:
+        return set()
+
+    registry = er.async_get(hass)
+    registered = entity_ids & set(registry.entities)
+
+    if not (rest := entity_ids - registered) or DATA_INSTANCE not in hass.data:
+        return registered
+
+    # Never registered at all. Anything the recorder keeps under that name was
+    # put there by something that is still doing it.
+    never_registered = rest - {
+        deleted.entity_id for deleted in registry.deleted_entities.values()
+    }
+    if not never_registered:
+        return registered
+
+    metadata = await get_instance(hass).async_add_executor_job(
+        functools.partial(get_metadata, hass, statistic_ids=never_registered),
+    )
+
+    return registered | set(metadata)

--- a/custom_components/spook/statistics_sources.py
+++ b/custom_components/spook/statistics_sources.py
@@ -19,22 +19,33 @@ async def async_known_to_home_assistant(
 ) -> set[str]:
     """Return which of these Home Assistant knows about, state or no state.
 
-    Having no state is not the same as being unknown, and three quite
-    different things arrive looking identical.
+    Having no state is not the same as being unknown, and two quite different
+    things arrive looking identical.
 
     An entity that is registered and simply has no state right now is one whose
     integration has not finished setting up, or that somebody disabled. Home
     Assistant knows exactly what it is.
 
-    An ID can carry long-term statistics without ever having been an entity.
-    An integration publishing straight into the recorder has to name those
-    after one, because `async_import_statistics` turns away anything that is
-    not a valid entity ID, so a gas meter read by a service somewhere ends up
-    as `sensor.something` with nothing behind it. The energy dashboard takes
-    that and draws it. It is the opposite of unknown.
+    And an ID can carry long-term statistics without ever having been an
+    entity. An integration publishing straight into the recorder has to name
+    those after one, because `async_import_statistics` turns away anything
+    that is not a valid entity ID, so a gas meter read by a service somewhere
+    ends up as `sensor.something` with nothing behind it. The energy dashboard
+    takes that and draws it. It is the opposite of unknown.
 
-    And a deleted sensor leaves its statistics behind. That one is worth being
-    told about, which is the whole reason this is careful.
+    Which of those two a set of statistics is comes from the statistics
+    themselves. A sensor writing its own carries no name: Home Assistant takes
+    that from the entity, and the sensor recorder puts `None` there every
+    time. Anything importing has to supply one, because the metadata demands
+    the key. So a name is something having put these here on purpose.
+
+    Deliberately not the entity registry's record of what was deleted, which
+    was the first way this was written. Home Assistant only registers an
+    entity that offers a unique ID, and throws away what it remembers about a
+    deleted one after a month, so "no record of it" covers a sensor from a
+    YAML template that never had one and a sensor removed last year. Reading
+    that as "never was an entity" would quietly drop the reference this repair
+    exists to point out.
     """
     if not entity_ids:
         return set()
@@ -48,28 +59,9 @@ async def async_known_to_home_assistant(
     metadata = await get_instance(hass).async_add_executor_job(
         functools.partial(get_metadata, hass, statistic_ids=rest),
     )
-    deleted = {entry.entity_id for entry in registry.deleted_entities.values()}
 
-    for statistic_id, (_metadata_id, meta) in metadata.items():
-        # Statistics a sensor wrote for itself carry no name of their own:
-        # Home Assistant takes that from the entity. One that does carry a
-        # name was put there by something that had to supply it, so something
-        # is publishing this, whatever used to live at the name.
-        if meta.get("name") is not None:
-            known.add(statistic_id)
-            continue
-
-        # A registration that says "deleted" is Home Assistant remembering
-        # there was an entity here. That is a reference to something somebody
-        # removed, and worth saying.
-        if statistic_id in deleted:
-            continue
-
-        # Nothing registered, nothing deleted, and statistics all the same.
-        # Home Assistant keeps a deleted entity for a month and then forgets
-        # it, so past that there is no telling this from something that was
-        # never an entity at all. Saying "unknown" here would be claiming to
-        # know what Home Assistant no longer does.
-        known.add(statistic_id)
-
-    return known
+    return known | {
+        statistic_id
+        for statistic_id, (_metadata_id, meta) in metadata.items()
+        if meta.get("name") is not None
+    }

--- a/custom_components/spook/statistics_sources.py
+++ b/custom_components/spook/statistics_sources.py
@@ -19,44 +19,57 @@ async def async_known_to_home_assistant(
 ) -> set[str]:
     """Return which of these Home Assistant knows about, state or no state.
 
-    Having no state is not the same as being unknown, and two quite different
-    things arrive looking identical.
+    Having no state is not the same as being unknown, and three quite
+    different things arrive looking identical.
 
     An entity that is registered and simply has no state right now is one whose
     integration has not finished setting up, or that somebody disabled. Home
     Assistant knows exactly what it is.
 
-    And an ID can carry long-term statistics without ever having been an
-    entity. An integration publishing straight into the recorder has to name
-    those after one, because `async_import_statistics` turns away anything
-    that is not a valid entity ID, so a gas meter read by a service somewhere
-    ends up as `sensor.something` with nothing behind it. The energy dashboard
-    takes that and draws it. It is the opposite of unknown.
+    An ID can carry long-term statistics without ever having been an entity.
+    An integration publishing straight into the recorder has to name those
+    after one, because `async_import_statistics` turns away anything that is
+    not a valid entity ID, so a gas meter read by a service somewhere ends up
+    as `sensor.something` with nothing behind it. The energy dashboard takes
+    that and draws it. It is the opposite of unknown.
 
-    What is left over really is unknown: no registration, deleted or
-    otherwise, and nothing recorded under the name. A registration that says
-    "deleted" is left out on purpose, because that is a reference to something
-    somebody removed, which is worth being told about.
+    And a deleted sensor leaves its statistics behind. That one is worth being
+    told about, which is the whole reason this is careful.
     """
     if not entity_ids:
         return set()
 
     registry = er.async_get(hass)
-    registered = entity_ids & set(registry.entities)
+    known = entity_ids & set(registry.entities)
 
-    if not (rest := entity_ids - registered) or DATA_INSTANCE not in hass.data:
-        return registered
-
-    # Never registered at all. Anything the recorder keeps under that name was
-    # put there by something that is still doing it.
-    never_registered = rest - {
-        deleted.entity_id for deleted in registry.deleted_entities.values()
-    }
-    if not never_registered:
-        return registered
+    if not (rest := entity_ids - known) or DATA_INSTANCE not in hass.data:
+        return known
 
     metadata = await get_instance(hass).async_add_executor_job(
-        functools.partial(get_metadata, hass, statistic_ids=never_registered),
+        functools.partial(get_metadata, hass, statistic_ids=rest),
     )
+    deleted = {entry.entity_id for entry in registry.deleted_entities.values()}
 
-    return registered | set(metadata)
+    for statistic_id, (_metadata_id, meta) in metadata.items():
+        # Statistics a sensor wrote for itself carry no name of their own:
+        # Home Assistant takes that from the entity. One that does carry a
+        # name was put there by something that had to supply it, so something
+        # is publishing this, whatever used to live at the name.
+        if meta.get("name") is not None:
+            known.add(statistic_id)
+            continue
+
+        # A registration that says "deleted" is Home Assistant remembering
+        # there was an entity here. That is a reference to something somebody
+        # removed, and worth saying.
+        if statistic_id in deleted:
+            continue
+
+        # Nothing registered, nothing deleted, and statistics all the same.
+        # Home Assistant keeps a deleted entity for a month and then forgets
+        # it, so past that there is no telling this from something that was
+        # never an entity at all. Saying "unknown" here would be claiming to
+        # know what Home Assistant no longer does.
+        known.add(statistic_id)
+
+    return known

--- a/tests/ectoplasms/energy/repairs/test_unknown_references.py
+++ b/tests/ectoplasms/energy/repairs/test_unknown_references.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.components.energy.data import async_get_manager
 from homeassistant.components.energy.validate import (
     EnergyPreferencesValidation,
     ValidationIssues,
@@ -136,6 +137,10 @@ async def test_a_source_kept_by_statistics_alone_is_not_unknown(
     somewhere arrives as `sensor.something` with no state. The energy
     dashboard draws it perfectly happily. Calling that unknown is a repair for
     a problem nobody has. #1565.
+
+    What says it was imported is the name on the statistics. A sensor writing
+    its own leaves that empty, because Home Assistant takes the name off the
+    entity, and anything importing has to supply one.
     """
     result = EnergyPreferencesValidation()
     source_issues = ValidationIssues()
@@ -144,7 +149,10 @@ async def test_a_source_kept_by_statistics_alone_is_not_unknown(
     result.energy_sources.append(source_issues)
 
     _install_validation(hass, monkeypatch, result)
-    marker = _install_statistics(monkeypatch, {"sensor.gas_from_a_service": None})
+    marker = _install_statistics(
+        monkeypatch,
+        {"sensor.gas_from_a_service": "Gas, read by a service"},
+    )
     hass.data[marker] = object()
 
     await SpookRepair(hass).async_inspect()
@@ -278,3 +286,44 @@ async def test_the_recorder_is_asked_again_on_a_clock(
     registry change happened along.
     """
     assert SpookRepair(hass).inspect_interval is not None
+
+
+async def test_a_price_entity_is_not_let_off_by_statistics(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A price is read off the state while the dashboard adds things up.
+
+    So statistics recorded under the same name do not make one work, and
+    letting it off because the recorder has something would hide a setting
+    that is broken. The energy settings say which is which by their own names:
+    `stat_` holds a statistic, `entity_` holds an entity that has to be there.
+    """
+    manager = await async_get_manager(hass)
+    manager.data = {
+        "energy_sources": [
+            {
+                "type": "gas",
+                "stat_energy_from": "sensor.gas_from_a_service",
+                "entity_energy_price": "sensor.the_price",
+            },
+        ],
+        "device_consumption": [],
+    }
+
+    result = EnergyPreferencesValidation()
+    source_issues = ValidationIssues()
+    source_issues.add_issue(hass, "entity_not_defined", "sensor.the_price")
+    result.energy_sources.append(source_issues)
+
+    _install_validation(hass, monkeypatch, result)
+    marker = _install_statistics(monkeypatch, {"sensor.the_price": "Priced elsewhere"})
+    hass.data[marker] = object()
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders
+    assert "sensor.the_price" in issue.translation_placeholders["entities"]

--- a/tests/ectoplasms/energy/repairs/test_unknown_references.py
+++ b/tests/ectoplasms/energy/repairs/test_unknown_references.py
@@ -3,13 +3,15 @@
 # pylint: disable=wrong-import-order
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.energy.validate import (
     EnergyPreferencesValidation,
     ValidationIssues,
 )
 
+from custom_components.spook import statistics_sources
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.energy.repairs import unknown_references
 from custom_components.spook.ectoplasms.energy.repairs.unknown_references import (
@@ -18,7 +20,7 @@ from custom_components.spook.ectoplasms.energy.repairs.unknown_references import
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-    from homeassistant.helpers import issue_registry as ir
+    from homeassistant.helpers import entity_registry as er, issue_registry as ir
     import pytest
 
 _ISSUE_ID = "energy_unknown_references_energy_unknown_references"
@@ -89,3 +91,135 @@ async def test_energy_not_set_up_is_a_no_op(
     await SpookRepair(hass).async_inspect()
 
     assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+def _install_statistics(
+    monkeypatch: pytest.MonkeyPatch,
+    recorded: set[str],
+) -> None:
+    """Make the recorder answer for the given statistic IDs.
+
+    Standing in for the recorder itself, which a repair test has no business
+    starting: what is being pinned is which question gets asked, not how the
+    database answers it.
+    """
+    hass_data_marker = "recorder_instance"
+
+    async def _async_add_executor_job(
+        _func: Any,
+        *_args: Any,
+    ) -> dict[str, tuple[int, dict[str, Any]]]:
+        return dict.fromkeys(recorded, (1, {}))
+
+    monkeypatch.setattr(
+        statistics_sources,
+        "get_instance",
+        lambda hass: SimpleNamespace(  # noqa: ARG005
+            async_add_executor_job=_async_add_executor_job,
+        ),
+    )
+    monkeypatch.setattr(statistics_sources, "DATA_INSTANCE", hass_data_marker)
+    return hass_data_marker
+
+
+async def test_a_source_kept_by_statistics_alone_is_not_unknown(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An integration can publish statistics without an entity behind them.
+
+    Home Assistant makes it name them after one, because importing turns away
+    anything that is not a valid entity ID, so a gas meter read by a service
+    somewhere arrives as `sensor.something` with no state. The energy
+    dashboard draws it perfectly happily. Calling that unknown is a repair for
+    a problem nobody has. #1565.
+    """
+    result = EnergyPreferencesValidation()
+    source_issues = ValidationIssues()
+    source_issues.add_issue(hass, "entity_not_defined", "sensor.gas_from_a_service")
+    source_issues.add_issue(hass, "entity_not_defined", "sensor.ghost_meter")
+    result.energy_sources.append(source_issues)
+
+    _install_validation(hass, monkeypatch, result)
+    marker = _install_statistics(monkeypatch, {"sensor.gas_from_a_service"})
+    hass.data[marker] = object()
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders
+    named = issue.translation_placeholders["entities"]
+
+    assert "sensor.ghost_meter" in named
+    assert "sensor.gas_from_a_service" not in named
+
+
+async def test_an_entity_without_a_state_is_not_unknown_either(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    entity_registry: er.EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Having no state covers more than having been deleted.
+
+    An integration part way through setting up, or an entity somebody
+    disabled, is registered and perfectly well known. Home Assistant reports
+    it the same way because it looked for a state and found none.
+    """
+    entity_registry.async_get_or_create(
+        "sensor",
+        "demo",
+        "still_here",
+        suggested_object_id="quiet_for_now",
+    )
+
+    result = EnergyPreferencesValidation()
+    source_issues = ValidationIssues()
+    source_issues.add_issue(hass, "entity_not_defined", "sensor.quiet_for_now")
+    result.energy_sources.append(source_issues)
+
+    _install_validation(hass, monkeypatch, result)
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_a_deleted_entity_is_still_worth_saying(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    entity_registry: er.EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Statistics outlive the sensor that wrote them.
+
+    So a deleted sensor has both a registration that says deleted and rows in
+    the recorder, and an energy dashboard still pointing at it is exactly what
+    this is for. Leaving it out because the recorder remembers it would take
+    the repair with it.
+    """
+    entry = entity_registry.async_get_or_create(
+        "sensor",
+        "demo",
+        "was_here",
+        suggested_object_id="removed_meter",
+    )
+    entity_registry.async_remove(entry.entity_id)
+
+    result = EnergyPreferencesValidation()
+    source_issues = ValidationIssues()
+    source_issues.add_issue(hass, "entity_not_defined", "sensor.removed_meter")
+    result.energy_sources.append(source_issues)
+
+    _install_validation(hass, monkeypatch, result)
+    marker = _install_statistics(monkeypatch, {"sensor.removed_meter"})
+    hass.data[marker] = object()
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_placeholders
+    assert "sensor.removed_meter" in issue.translation_placeholders["entities"]

--- a/tests/ectoplasms/energy/repairs/test_unknown_references.py
+++ b/tests/ectoplasms/energy/repairs/test_unknown_references.py
@@ -95,8 +95,8 @@ async def test_energy_not_set_up_is_a_no_op(
 
 def _install_statistics(
     monkeypatch: pytest.MonkeyPatch,
-    recorded: set[str],
-) -> None:
+    recorded: dict[str, str | None],
+) -> str:
     """Make the recorder answer for the given statistic IDs.
 
     Standing in for the recorder itself, which a repair test has no business
@@ -109,7 +109,9 @@ def _install_statistics(
         _func: Any,
         *_args: Any,
     ) -> dict[str, tuple[int, dict[str, Any]]]:
-        return dict.fromkeys(recorded, (1, {}))
+        return {
+            statistic_id: (1, {"name": name}) for statistic_id, name in recorded.items()
+        }
 
     monkeypatch.setattr(
         statistics_sources,
@@ -142,7 +144,7 @@ async def test_a_source_kept_by_statistics_alone_is_not_unknown(
     result.energy_sources.append(source_issues)
 
     _install_validation(hass, monkeypatch, result)
-    marker = _install_statistics(monkeypatch, {"sensor.gas_from_a_service"})
+    marker = _install_statistics(monkeypatch, {"sensor.gas_from_a_service": None})
     hass.data[marker] = object()
 
     await SpookRepair(hass).async_inspect()
@@ -214,7 +216,7 @@ async def test_a_deleted_entity_is_still_worth_saying(
     result.energy_sources.append(source_issues)
 
     _install_validation(hass, monkeypatch, result)
-    marker = _install_statistics(monkeypatch, {"sensor.removed_meter"})
+    marker = _install_statistics(monkeypatch, {"sensor.removed_meter": None})
     hass.data[marker] = object()
 
     await SpookRepair(hass).async_inspect()
@@ -223,3 +225,56 @@ async def test_a_deleted_entity_is_still_worth_saying(
     assert issue
     assert issue.translation_placeholders
     assert "sensor.removed_meter" in issue.translation_placeholders["entities"]
+
+
+async def test_statistics_that_carry_a_name_were_put_there_by_something(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    entity_registry: er.EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Home Assistant forgets a deleted entity after a month.
+
+    Past that there is nothing left to say an ID was ever an entity, so the
+    statistics have to answer for themselves. A sensor writing its own carries
+    no name: Home Assistant takes that from the entity. One that does carry a
+    name was put there by something that had to supply it, and that something
+    is still doing it.
+
+    So an integration publishing under a name a sensor used to have is
+    followed rather than reported, tombstone or no tombstone.
+    """
+    entry = entity_registry.async_get_or_create(
+        "sensor",
+        "demo",
+        "replaced",
+        suggested_object_id="the_meter",
+    )
+    entity_registry.async_remove(entry.entity_id)
+
+    result = EnergyPreferencesValidation()
+    source_issues = ValidationIssues()
+    source_issues.add_issue(hass, "entity_not_defined", "sensor.the_meter")
+    result.energy_sources.append(source_issues)
+
+    _install_validation(hass, monkeypatch, result)
+    marker = _install_statistics(
+        monkeypatch, {"sensor.the_meter": "Gas, from a service"}
+    )
+    hass.data[marker] = object()
+
+    await SpookRepair(hass).async_inspect()
+
+    assert issue_registry.async_get_issue(DOMAIN, _ISSUE_ID) is None
+
+
+async def test_the_recorder_is_asked_again_on_a_clock(
+    hass: HomeAssistant,
+) -> None:
+    """Statistics arriving or being cleared raises no event of any kind.
+
+    Every other trigger this repair has is an event, so without a clock an
+    issue raised before the first import would sit there until some unrelated
+    registry change happened along.
+    """
+    assert SpookRepair(hass).inspect_interval is not None

--- a/tests/ectoplasms/recorder/services/test_import_statistics.py
+++ b/tests/ectoplasms/recorder/services/test_import_statistics.py
@@ -121,3 +121,94 @@ async def test_import_statistics_service_sets_no_mean_metadata(
     assert calls[0]["mean_type"] is StatisticMeanType.NONE
     assert calls[0]["unit_class"] == STATISTIC_UNIT_TO_UNIT_CONVERTER[None].UNIT_CLASS
     assert "has_mean" not in calls[0]
+
+
+@pytest.mark.usefixtures("recorder_import_statistics_service")
+async def test_import_statistics_service_names_them_after_themselves(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Statistics kept for a sensor carry no name of their own.
+
+    Home Assistant takes that off the entity instead, so importing without one
+    leaves statistics that read exactly like a sensor's. Spook's own repairs
+    read that as an entity having gone missing, and end up calling something
+    imported through this very action unknown. #1565.
+    """
+    calls: list[tuple[StatisticMetaData, list[StatisticData]]] = []
+
+    def mock_import_statistics(
+        _hass: HomeAssistant,
+        metadata: StatisticMetaData,
+        statistics: list[StatisticData],
+    ) -> None:
+        """Mock importing internal statistics."""
+        calls.append((metadata, statistics))
+
+    monkeypatch.setattr(
+        import_statistics,
+        "async_import_statistics",
+        mock_import_statistics,
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "import_statistics",
+        {
+            "has_mean": False,
+            "has_sum": True,
+            "source": DOMAIN,
+            "statistic_id": "sensor.gas_from_a_service",
+            "unit_of_measurement": "m³",
+            "stats": [{"start": datetime(2026, 1, 1, tzinfo=UTC), "sum": 1.0}],
+        },
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    metadata, _imported = calls[0]
+    assert metadata["name"] == "sensor.gas_from_a_service"
+
+
+@pytest.mark.usefixtures("recorder_import_statistics_service")
+async def test_import_statistics_service_keeps_a_name_that_was_given(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Naming them after themselves is a fallback, not a rule."""
+    calls: list[tuple[StatisticMetaData, list[StatisticData]]] = []
+
+    def mock_import_statistics(
+        _hass: HomeAssistant,
+        metadata: StatisticMetaData,
+        statistics: list[StatisticData],
+    ) -> None:
+        """Mock importing internal statistics."""
+        calls.append((metadata, statistics))
+
+    monkeypatch.setattr(
+        import_statistics,
+        "async_import_statistics",
+        mock_import_statistics,
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "import_statistics",
+        {
+            "has_mean": False,
+            "has_sum": True,
+            "name": "Gas, read by a service",
+            "source": DOMAIN,
+            "statistic_id": "sensor.gas_from_a_service",
+            "unit_of_measurement": "m³",
+            "stats": [{"start": datetime(2026, 1, 1, tzinfo=UTC), "sum": 1.0}],
+        },
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    metadata, _imported = calls[0]
+    assert metadata["name"] == "Gas, read by a service"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Spook told people the energy dashboard pointed at entities Home Assistant does not know, for sources that work perfectly well and are drawn on that dashboard every day.

Spook does not decide this itself. It takes Home Assistant's own energy validation and picks out `entity_not_defined`, which fires wherever `hass.states.get()` comes back with nothing. Having no state covers three different things, and only one of them is worth a repair.

**Never an entity at all.** An integration can publish long-term statistics straight into the recorder, and Home Assistant makes it name them after an entity whether one exists or not: `async_import_statistics` turns away anything that is not a valid entity ID. So a gas meter read by a service arrives as `sensor.something` with nothing behind it, the energy dashboard takes it and draws it, and there is no entity anywhere. Nothing about that is unknown.

**Registered and quiet.** An integration part way through setting up, or an entity somebody disabled. Home Assistant knows exactly what it is.

**Deleted.** Which is the one this repair exists for, and it stays.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1565, reported with a gas meter read by [gazpar2haws](https://github.com/ssenart/gazpar2haws), which publishes through the recorder's websocket API.

Telling those three apart needs no guessing at how recently anything happened, which matters: the first thing I tried was "are statistics still arriving", and it fell over on an existing test. Statistics from a sensor deleted a minute ago are just as fresh as statistics from a meter that is still being read, so that route meant a week-long blind spot in a repair that works.

The registry answers it outright. A deleted entity leaves a registration saying so, kept for at least a month, and one that was never an entity leaves nothing at all. So: registered means known, deleted means say it, and neither of those with statistics recorded under the name means something is keeping it. The recorder is only asked about names nothing else accounted for, which on a working system is none of them.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Three new tests, one per case above. Each one mutation tested:

| Mutation | Result |
| --- | --- |
| Report everything without a state, as before | 2 failed |
| Count a registered but stateless entity as unknown | 1 failed |
| Let anything the recorder remembers off | 1 failed |

That last one is the one worth having. A filter of "has statistics" reads as the obvious fix and is what the report suggested, and it would have quietly taken the repair's whole reason for existing with it: a deleted sensor's statistics outlive the sensor, so every stale energy reference would have gone unmentioned.

Full suite is 1600 passing. Ruff and pylint clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None. The change is a repair that no longer appears.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
