### PR TITLE
Keep an ignored repair ignored

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -147,13 +147,23 @@ class AbstractSpookRepairBase(ABC):
         """Trigger a repair check."""
         raise NotImplementedError
 
-    async def async_deactivate(self) -> None:
-        """Unregister the repair."""
-        if self.hass.is_stopping:
-            return
+    async def async_deactivate(self) -> None:  # noqa: B027
+        """Unregister the repair, and leave what it reported where it is.
 
-        for issue_id in self.issue_ids.copy():
-            self.async_delete_issue(issue_id)
+        Deliberately does nothing, and that is the point of it. Somebody
+        pressing "ignore" has that written on the issue itself, so deleting
+        the issue takes the mark with it and the next inspection puts the same
+        thing back as something nobody has ever seen. Home Assistant keeps an
+        issue over a restart for exactly that reason, as an empty record
+        holding only the mark, and reporting the same thing again finds it and
+        leaves it alone.
+
+        Which makes this a matter of not getting in the way. Every repair
+        already compares what it left in the registry against what it finds
+        when it next looks, and deletes what is no longer there, so the tidying
+        this used to do happens anyway and happens later, when there is
+        something to compare against. #1572.
+        """
 
 
 class AbstractSpookRepair(AbstractSpookRepairBase):
@@ -540,7 +550,28 @@ class SpookRepairManager:
         self._repairs.add(repair)
 
     async def async_on_unload(self) -> None:
-        """Tear down the Spook reapris."""
+        """Tear down the Spook repairs.
+
+        Nothing is removed from the issue registry on the way out, on purpose.
+
+        Somebody pressing "ignore" on a repair has that written down on the
+        issue itself, and deleting the issue throws it away with everything
+        else. Home Assistant is built for it to survive: an issue that is not
+        marked persistent is still kept over a restart as an empty record
+        holding only that, and creating the same issue again finds that record
+        and leaves the mark alone. Which means the way to keep an ignored
+        repair ignored is to not touch it.
+
+        Spook used to clear them all out here, so every reload, every
+        integration reload and every update through HACS quietly undid every
+        ignore anybody had ever pressed.
+
+        Leaving them behind costs nothing. Every repair already looks at what
+        it left in the registry when it next inspects, and deletes whatever it
+        does not find again, which covers the very things this was for: an
+        issue about something that was resolved or removed while Spook was not
+        running.
+        """
         LOGGER.debug("Tearing down Spook repairs")
         for repair in self._repairs:
             LOGGER.debug(
@@ -549,15 +580,6 @@ class SpookRepairManager:
                 repair.repair,
             )
             await repair.async_deactivate()
-
-            if self.hass.is_stopping:
-                continue
-
-            # Remove issues created by this Spook repair. Issue IDs are
-            # created as "<repair>_<issue_id>" (see async_create_issue).
-            for domain, issue_id in list(self.issue_registry.issues):
-                if domain == DOMAIN and issue_id.startswith(f"{repair.repair}_"):
-                    self.issue_registry.async_delete(domain, issue_id)
 
 
 class RestartRequiredFixFlow(RepairsFlow):

--- a/tests/test_repairs_cleanup.py
+++ b/tests/test_repairs_cleanup.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import issue_registry as ir
 
 from custom_components.spook import repairs
 from custom_components.spook.const import DOMAIN
@@ -25,7 +26,6 @@ if TYPE_CHECKING:
     from freezegun.api import FrozenDateTimeFactory
     from homeassistant.config_entries import ConfigEntry, ConfigEntryChange
     from homeassistant.core import HomeAssistant
-    from homeassistant.helpers import issue_registry as ir
 
 
 class MockRepairBase(AbstractSpookRepairBase):
@@ -62,21 +62,15 @@ class MockRepair(AbstractSpookRepair):
         self.inspections += 1
 
 
-async def test_deactivate_deletes_issues_from_snapshot(hass: HomeAssistant) -> None:
-    """Test deactivation can delete issues while mutating the issue ID set."""
-    repair = MockRepairBase(hass)
-    repair.issue_ids = {"one", "two"}
-
-    await repair.async_deactivate()
-
-    assert not repair.issue_ids
-
-
-async def test_deactivate_keeps_issues_registered_when_stopping(
+async def test_deactivate_leaves_what_it_reported_alone(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test shutdown keeps issues for the issue registry to restore."""
+    """Deactivating is not the same as the problem being over.
+
+    It happens on every reload, every integration reload and every update, and
+    taking the issues down took the "ignore" anybody had pressed with them.
+    """
     deleted: list[tuple[str, str]] = []
 
     def async_delete_issue(
@@ -88,7 +82,6 @@ async def test_deactivate_keeps_issues_registered_when_stopping(
         deleted.append((domain, issue_id))
 
     monkeypatch.setattr(repairs.ir, "async_delete_issue", async_delete_issue)
-    monkeypatch.setattr(hass, "is_stopping", True)
 
     repair = MockRepairBase(hass)
     repair.issue_ids = {"one", "two"}
@@ -188,8 +181,14 @@ async def test_inspect_interval_reinspects_over_time(
     assert repair.inspections == EXPECTED_INTERVAL_INSPECTIONS
 
 
-async def test_repair_manager_removes_issues_on_unload(hass: HomeAssistant) -> None:
-    """Test unloading removes issues created by the repair."""
+async def test_unloading_leaves_the_issue_registry_alone(
+    hass: HomeAssistant,
+) -> None:
+    """Unloading happens on every reload, every update, every restart.
+
+    Clearing the issues out here made all of those look like a fresh start,
+    which is the whole of #1572.
+    """
     repair = MockRepair(hass)
     await repair.async_activate()
     manager = repairs.SpookRepairManager(hass)
@@ -199,25 +198,42 @@ async def test_repair_manager_removes_issues_on_unload(hass: HomeAssistant) -> N
 
     await manager.async_on_unload()
 
-    assert (DOMAIN, "mock_repair_one") not in manager.issue_registry.issues
+    assert (DOMAIN, "mock_repair_one") in manager.issue_registry.issues
     assert (DOMAIN, "unrelated_issue") in manager.issue_registry.issues
 
 
-async def test_repair_manager_keeps_issues_on_shutdown(
+async def test_an_ignored_repair_stays_ignored_through_a_reload(
     hass: HomeAssistant,
-    monkeypatch: pytest.MonkeyPatch,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
-    """Test shutdown keeps issues for the issue registry to restore."""
+    """Which is the reason the registry is left alone, spelled out.
+
+    Pressing ignore writes that on the issue. Deleting the issue throws it
+    away, and the next inspection puts the same problem back as something
+    nobody has ever seen. Every reload, every update through HACS.
+    """
     repair = MockRepair(hass)
     await repair.async_activate()
+    repair.async_create_issue(issue_id="one", translation_placeholders={})
+
+    ir.async_ignore_issue(hass, DOMAIN, "mock_repair_one", ignore=True)
+    ignored = issue_registry.async_get_issue(DOMAIN, "mock_repair_one")
+    assert ignored
+    assert ignored.dismissed_version
+
     manager = repairs.SpookRepairManager(hass)
     manager._repairs.add(repair)
-    manager.issue_registry.issues[(DOMAIN, "mock_repair_one")] = None
-    monkeypatch.setattr(hass, "is_stopping", True)
-
     await manager.async_on_unload()
 
-    assert (DOMAIN, "mock_repair_one") in manager.issue_registry.issues
+    # Coming back up, and finding the same thing wrong all over again.
+    await repair.async_activate()
+    repair.async_create_issue(issue_id="one", translation_placeholders={})
+
+    still = issue_registry.async_get_issue(DOMAIN, "mock_repair_one")
+    assert still
+    assert still.dismissed_version == ignored.dismissed_version
+
+    await repair.async_deactivate()
 
 
 class MockCleanupRepair(AbstractSpookRepair):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Pressing **Ignore** on a Spook repair did not stick. It came back, un-ignored, on the next reload of the config entry, the next reload of the integration, and every update through HACS.

Home Assistant writes an ignore on the issue itself, as `dismissed_version`, and is built for that to last. An issue that is not marked persistent is still kept over a restart as an empty record holding only the mark, and reporting the same thing again finds that record and leaves the mark where it is. So keeping an ignore is a matter of not getting in the way.

Spook got in the way twice. The manager cleared out every issue belonging to every repair on unload, and each repair deleted its own on deactivate, which runs from that same unload. Both are gone.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1572, reported with the root cause worked out and the evidence to go with it: ten issues, every one of them undismissed, all carrying the same created timestamp as the reload.

The report found the deletion in the manager. It is also why the first test written against this still failed after that one was removed: `async_deactivate` deletes each repair's own issues, and the manager calls it on the way past.

**What the deletions were for happens anyway.** Every repair already compares what it left in the issue registry against what it finds when it next looks, and deletes what is no longer there. The comment on that comparison says it covers "leftovers from before a restart, including those for items that were removed while Home Assistant was down", which is exactly the tidying being given up here, done later and with something to compare against. All forty repairs do it, sixteen of them through a shared base, so nothing is left without it.

**One consequence worth stating.** Disabling or removing Spook now leaves its repairs on the page until a restart, where they used to go at once. That is what every other integration does, and the alternative was this bug.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two tests, replacing the two that pinned the old behaviour. Both mutation tested: putting either deletion back fails both of them.

The second one is the one that matters, and it does what somebody actually does. Raise a repair, ignore it, unload, come back up, find the same thing wrong all over again, and check the ignore is still there. That is the test that caught the second deletion site.

Full suite is 1604 passing. Ruff and pylint clean.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

None. The change is a repair that stays gone after you tell it to.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
