### PR TITLE
Not everybody has a Resources page to open

### DIFF
--- a/custom_components/spook/dashboard_resources.py
+++ b/custom_components/spook/dashboard_resources.py
@@ -96,6 +96,20 @@ def redundant_item_ids(items: Iterable[dict], key: str) -> list[str]:
     return [item["id"] for item in matching[:-1] if item.get("id")]
 
 
+def is_yaml_managed(resources: object) -> bool:
+    """Return whether these resources come from YAML rather than the interface.
+
+    A storage-mode collection can be written to. One built from a `lovelace:`
+    block in the configuration cannot, so anything offering to change it would
+    be a button that quietly does nothing, and anything pointing at the
+    Resources page is sending somebody to a screen that cannot help them.
+
+    Asked by attribute rather than by class, because this is another
+    integration's object and Spook is a guest in it.
+    """
+    return not hasattr(resources, "async_delete_item")
+
+
 def async_watch_resources(
     hass: HomeAssistant,
     on_change: ChangeListener,

--- a/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
+++ b/custom_components/spook/ectoplasms/lovelace/repairs/missing_resources.py
@@ -9,7 +9,7 @@ from homeassistant.components.lovelace import DOMAIN
 from homeassistant.const import EVENT_COMPONENT_LOADED, EVENT_LOVELACE_UPDATED
 
 from ....const import LOGGER
-from ....dashboard_resources import async_watch_resources
+from ....dashboard_resources import async_watch_resources, is_yaml_managed
 from ....repairs import AbstractSpookRepair
 
 if TYPE_CHECKING:
@@ -102,8 +102,14 @@ class SpookRepair(AbstractSpookRepair):
 
         missing = await self.hass.async_add_executor_job(self._find_missing, to_check)
         if missing:
+            # Where to go and fix it depends on where the resources live.
+            # Sending somebody with a YAML configuration to the Resources page
+            # sends them to a screen that cannot change what they came for.
             self.async_create_issue(
                 issue_id=self.repair,
+                translation_key=(
+                    f"{self.repair}_yaml" if is_yaml_managed(resources) else self.repair
+                ),
                 translation_placeholders={
                     "resources": "\n".join(f"- `{url}`" for url in sorted(missing)),
                 },

--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -39,7 +39,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.async_ import create_eager_task
 
 from .const import DOMAIN, LOGGER
-from .dashboard_resources import redundant_item_ids
+from .dashboard_resources import is_yaml_managed, redundant_item_ids
 from .entity_filtering import async_filter_known_entity_ids, async_get_all_entity_ids
 from .entity_suggestions import async_describe_unknown_entities
 
@@ -104,9 +104,17 @@ class AbstractSpookRepairBase(ABC):
         issue_id: str,
         learn_more_url: str | None = None,
         severity: ir.IssueSeverity = ir.IssueSeverity.WARNING,
+        translation_key: str | None = None,
         translation_placeholders: dict[str, str] | None = None,
     ) -> None:
-        """Create an issue."""
+        """Create an issue.
+
+        `translation_key` defaults to the repair's own name, which is what
+        nearly every repair wants. Pass one when the same finding needs to be
+        worded differently depending on what the house looks like, so that the
+        alternative is a translated string of its own rather than a sentence
+        smuggled in through a placeholder.
+        """
         self.issue_ids.add(issue_id)
         ir.async_create_issue(
             self.hass,
@@ -119,7 +127,7 @@ class AbstractSpookRepairBase(ABC):
             issue_id=f"{self.repair}_{issue_id}",
             learn_more_url=learn_more_url,
             severity=severity,
-            translation_key=self.repair,
+            translation_key=translation_key or self.repair,
             translation_placeholders=translation_placeholders,
         )
 
@@ -797,7 +805,7 @@ class DuplicateResourceFixFlow(_RemoveOrIgnoreFixFlow):
         lovelace = self.hass.data.get(lovelace_const.DOMAIN)
         resources = lovelace.resources if lovelace is not None else None
 
-        if resources is not None and not hasattr(resources, "async_delete_item"):
+        if resources is not None and is_yaml_managed(resources):
             return self.async_abort(
                 reason="yaml",
                 description_placeholders=self._menu_placeholders(),

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -564,7 +564,11 @@
       }
     },
     "lovelace_missing_resources": {
-      "description": "Spook has found a ghost in your dashboards 👻\n\nThe following dashboard resources point at files that do not exist:\n\n{resources}\n\n\n\nThis usually happens when a custom card or its files were removed but the resource stayed behind. To fix this error, open Settings > Dashboards > Resources and remove or correct these resources.\n\nSpook 👻 Your homie.",
+      "description": "Spook has found a ghost in your dashboards 👻\n\nThe following dashboard resources point at files that do not exist:\n\n{resources}\n\n\n\nThis usually happens when a custom card or its files were removed but the resource stayed behind. To fix this error, open the [Resources page](/config/lovelace/resources) and remove or correct these resources. It has no tab of its own: on the Dashboards page it is behind the three dots, top right.\n\nSpook 👻 Your homie.",
+      "title": "Dashboard resources point at missing files"
+    },
+    "lovelace_missing_resources_yaml": {
+      "description": "Spook has found a ghost in your dashboards 👻\n\nThe following dashboard resources point at files that do not exist:\n\n{resources}\n\n\n\nThis usually happens when a custom card or its files were removed but the resource stayed behind.\n\nThese resources are listed in your YAML configuration, so the Resources page cannot change them. Edit the `resources:` section of your Lovelace configuration and remove or correct these entries.\n\nSpook 👻 Your homie.",
       "title": "Dashboard resources point at missing files"
     },
     "lovelace_duplicate_resources": {

--- a/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
+++ b/tests/ectoplasms/lovelace/repairs/test_missing_resources.py
@@ -34,14 +34,29 @@ async def _no_loading_needed() -> dict[str, int]:
     return {"resources": 0}
 
 
-def _set_resources(hass: HomeAssistant, urls: list[str]) -> None:
-    """Install a fake resource collection with the given URLs."""
-    hass.data["lovelace"] = SimpleNamespace(
-        resources=SimpleNamespace(
-            async_items=lambda: [{"url": url, "type": "module"} for url in urls],
-            async_get_info=_no_loading_needed,
-        ),
+async def _no_deleting_needed(_item_id: str) -> None:
+    """Stand in for the delete a storage-mode collection offers."""
+
+
+def _set_resources(
+    hass: HomeAssistant,
+    urls: list[str],
+    *,
+    from_yaml: bool = False,
+) -> None:
+    """Install a fake resource collection with the given URLs.
+
+    A storage-mode collection can delete an item and a YAML one cannot, which
+    is the whole difference Spook goes on, so the fake has to carry it.
+    """
+    collection = SimpleNamespace(
+        async_items=lambda: [{"url": url, "type": "module"} for url in urls],
+        async_get_info=_no_loading_needed,
     )
+    if not from_yaml:
+        collection.async_delete_item = _no_deleting_needed
+
+    hass.data["lovelace"] = SimpleNamespace(resources=collection)
 
 
 async def test_missing_local_resource_creates_issue(
@@ -127,3 +142,38 @@ async def test_storage_resources_are_loaded_before_they_are_read(
     issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
     assert issue
     assert "/local/gone.js" in issue.translation_placeholders["resources"]
+
+
+async def test_stored_resources_point_at_the_resources_page(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test resources managed from the interface get the page to go to."""
+    _set_resources(hass, ["/local/gone.js"])
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_key == "lovelace_missing_resources"
+
+
+async def test_yaml_resources_are_told_where_the_file_is(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test resources listed in YAML are not sent to a page that cannot help.
+
+    Nothing can delete a resource that came from the configuration, so the
+    Resources page has nothing to offer somebody in this position.
+    """
+    _set_resources(hass, ["/local/gone.js"], from_yaml=True)
+
+    await SpookRepair(hass).async_inspect()
+
+    issue = issue_registry.async_get_issue(DOMAIN, _ISSUE_ID)
+    assert issue
+    assert issue.translation_key == "lovelace_missing_resources_yaml"
+    # Same finding either way, so the list of what is missing must not differ.
+    assert issue.translation_placeholders
+    assert issue.translation_placeholders["resources"] == "- `/local/gone.js`"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The missing-resources repair ended every report with the same sentence, whoever was reading it:

> To fix this error, open Settings > Dashboards > Resources and remove or correct these resources.

Two things wrong with that. Resources has no tab of its own, it is behind the three dots on the Dashboards page, which is easy to read as "it is not there". And in YAML mode that page cannot change what somebody came to change, because a resource listed in the configuration is not something Home Assistant can delete.

The duplicate-resources repair already knew that difference, through a bare `hasattr` in its fix flow. That check moves to `dashboard_resources` as `is_yaml_managed()`, and both repairs read it from there.

Saying it differently means a repair has to be able to have more than one message, so `async_create_issue` takes an optional `translation_key`, defaulting to the repair's own name as before. The alternative wording is then a translated string of its own rather than an English sentence smuggled in through a placeholder.

Storage mode now links the page and says where it hides. YAML mode is told to edit the `resources:` section instead.

Worth knowing: the existing description changed, so it goes back to needs-editing in all sixteen languages, and `lovelace_missing_resources_yaml` starts untranslated.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reported in #1578: "I go to Settings > Dashboards but I don't see Resources". The repair was right about the resource and useless about what to do next.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Two tests added, one per mode, each pinning the translation key that comes out, plus an assertion that the list of missing files does not differ between them.

The existing fixture built a collection without `async_delete_item`, so it was modelling YAML mode by accident. Left alone, every existing test would have quietly moved to the new wording and nothing would have failed. `_set_resources` now takes `from_yaml` and defaults to storage.

Then broke it three ways to check the tests hold: never using the YAML message (1 failure), always using it (1 failure), and inverting the check itself (2 failures).

Full suite: 1606 passed.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
