### PR TITLE
Reload what was pruned, or nothing changed

### DIFF
--- a/custom_components/spook/repairs.py
+++ b/custom_components/spook/repairs.py
@@ -948,6 +948,14 @@ class GroupUnknownMembersFixFlow(_RemoveOrIgnoreFixFlow):
                 self.hass.config_entries.async_update_entry(
                     entry, options={**entry.options, CONF_ENTITIES: remaining}
                 )
+                # Writing the options is not the end of it. Nothing in the
+                # group integration listens for its own entry changing, so
+                # the group that is running carries on with the list it was
+                # built from until something reloads it. Leave that out and
+                # the button reports success, the member is still in the
+                # group, and the repair goes on reporting it because it reads
+                # the group rather than the stored options.
+                await self.hass.config_entries.async_reload(entry.entry_id)
         return self.async_create_entry(data={})
 
 
@@ -997,6 +1005,11 @@ class MinMaxUnknownSourcesFixFlow(_RemoveOrIgnoreFixFlow):
                 self.hass.config_entries.async_update_entry(
                     entry, options={**entry.options, "entity_ids": remaining}
                 )
+                # Same as above, and here it is worse than a stale reference:
+                # the helper keeps listening to the source somebody just took
+                # out, so if that source comes back it drives the value again
+                # while the configuration says it is gone.
+                await self.hass.config_entries.async_reload(entry.entry_id)
         return self.async_create_entry(data={})
 
 

--- a/tests/ectoplasms/group/repairs/test_unknown_members.py
+++ b/tests/ectoplasms/group/repairs/test_unknown_members.py
@@ -10,6 +10,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM
+from homeassistant.setup import async_setup_component
 
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.group.repairs.unknown_members import SpookRepair
@@ -120,3 +121,49 @@ async def test_fix_flow_remove_yaml_group_aborts(
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "not_editable"
+
+
+async def test_remove_reloads_the_running_group(hass: HomeAssistant) -> None:
+    """Test the group that is running loses the member, not just the options.
+
+    Runs the real group integration rather than a stand-in, because the whole
+    question is whether the entity Home Assistant is serving changed. Nothing
+    in the group integration listens for its own entry changing, so writing
+    the options and stopping there leaves the member in the group until a
+    restart, while the button says it is done.
+    """
+    hass.states.async_set("light.real", "on")
+    assert await async_setup_component(hass, "group", {})
+
+    entry = MockConfigEntry(
+        domain="group",
+        title="Hallway",
+        options={
+            "group_type": "light",
+            "name": "Hallway",
+            "entities": ["light.real", "light.gone"],
+            "hide_members": False,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("light.hallway").attributes["entity_id"] == [
+        "light.real",
+        "light.gone",
+    ]
+
+    flow = GroupUnknownMembersFixFlow()
+    flow.hass = hass
+    flow.data = {
+        "group_entity_id": "light.hallway",
+        "group": "Hallway",
+        "entities": "- `light.gone`",
+    }
+    result = await flow.async_step_remove()
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options["entities"] == ["light.real"]
+    assert hass.states.get("light.hallway").attributes["entity_id"] == ["light.real"]

--- a/tests/ectoplasms/homeassistant/repairs/test_min_max_unknown_sources.py
+++ b/tests/ectoplasms/homeassistant/repairs/test_min_max_unknown_sources.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
 
 from custom_components.spook.const import DOMAIN
 from custom_components.spook.ectoplasms.homeassistant.repairs.min_max_unknown_sources import (
@@ -128,3 +129,52 @@ async def test_fix_flow_remove_keeps_minimum_members(
     assert result["reason"] == "too_few_members"
     # The helper is left untouched.
     assert entry.options["entity_ids"] == ["sensor.known", "sensor.gone"]
+
+
+async def test_remove_stops_the_helper_listening(hass: HomeAssistant) -> None:
+    """Test a source that was removed cannot come back and drive the value.
+
+    Runs the real min/max integration, because the stored options being right
+    is not the same as the helper being right. Without a reload the helper
+    keeps listening to the source somebody just took out, so the day that
+    source returns it decides the value again while the configuration says it
+    is gone.
+    """
+    hass.states.async_set("sensor.one", "10", {"unit_of_measurement": "W"})
+    hass.states.async_set("sensor.two", "20", {"unit_of_measurement": "W"})
+    assert await async_setup_component(hass, "min_max", {})
+
+    entry = MockConfigEntry(
+        domain="min_max",
+        title="Combined",
+        options={
+            "name": "Combined",
+            "entity_ids": ["sensor.one", "sensor.two", "sensor.gone"],
+            "type": "max",
+            "round_digits": 2,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    flow = MinMaxUnknownSourcesFixFlow()
+    flow.hass = hass
+    flow.data = {
+        "min_max_config_entry_id": entry.entry_id,
+        "helper": "Combined",
+        "sources": "- `sensor.gone`",
+    }
+    result = await flow.async_step_remove()
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options["entity_ids"] == ["sensor.one", "sensor.two"]
+    assert hass.states.get("sensor.combined").state == "20.0"
+
+    # The source somebody just took out returns, higher than the two that are
+    # left. If the helper is still listening, it wins.
+    hass.states.async_set("sensor.gone", "99", {"unit_of_measurement": "W"})
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.combined").state == "20.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Both fix flows that prune members wrote the config entry options and stopped there. Nothing in the group or min/max integrations listens for its own entry changing, and `options_flow_reloads` only covers the options flow, not a plain `async_update_entry`. So the thing that is running carries on with the list it was built from until a restart.

For a **group** that means the button reports success and nothing visible happens:

```
issue raised    : True
options now     : ['light.real']                       <- storage is correct
running group   : ['light.real', 'light.ghost']        <- the group is not
issue still up  : True
```

The repair reads the live entity (`entity.tracking`, `entity._entity_ids`, `entity._entities`), so it goes straight back to reporting the member somebody just removed. `inspect_config_entry_changed` even makes that inspection fire right after the fix.

For **min/max** it is quieter and worse. That repair reads the options, so the issue does clear and the configuration looks right, while the helper keeps listening to the source somebody just took out. The day it comes back it decides the value again:

```
options now      : ['sensor.one', 'sensor.two']
state before     : 20.0
sensor.gone returns at 99
state after      : 99.0        <- removed, and still in charge
state after load : 20.0
```

Both now reload the entry after writing it, which is the same thing `spook_inverse` already does when its own options change.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Found while checking whether a `group.add_members` action was feasible: the mechanism it would be built on turned out to fail silently, so this comes first.

No issue reported it, which is worth saying out loud. The group case looks exactly like the complaint in #1576, where somebody pressed fix, was told it was repaired, and found the entry unchanged. That one was a stale frontend cache. This one is real.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

One test per flow, both running the real integration rather than a stand-in, because the stored options being right was never the question. The min/max one pins the consequence instead of the mechanism: the removed source returns higher than the two that are left, and the helper has to stay where it is.

Without the fix both fail. Removing only the group reload fails exactly one of them.

Full suite: 1606 passed.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
