### PR TITLE
Change a group's members while the house is running

### DIFF
--- a/custom_components/spook/ectoplasms/group/services/__init__.py
+++ b/custom_components/spook/ectoplasms/group/services/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/group/services/add_members.py
+++ b/custom_components/spook/ectoplasms/group/services/add_members.py
@@ -13,6 +13,7 @@ from ....group_members import (
     async_check_joining,
     async_entry_of,
     async_write_members,
+    identity_of,
     members_of,
 )
 from ....services import AbstractSpookAdminService
@@ -40,10 +41,22 @@ class SpookService(AbstractSpookAdminService):
         async_check_joining(self.hass, entry, call.data[CONF_MEMBERS])
 
         current = members_of(entry)
+
+        # By identity, not by the string. A group holds either an entity ID or
+        # a registry ID, so comparing what was asked for against what is
+        # stored has to go through the same resolving, or the same entity
+        # arrives twice under its two names.
+        held = {identity_of(self.hass, member) for member in current}
+
         # Appended rather than merged, so the order somebody arranged their
-        # group in survives. A member already in it is left where it is.
-        joining = [
-            member for member in call.data[CONF_MEMBERS] if member not in current
-        ]
+        # group in survives. A member already in it is left where it is, and
+        # `held` grows as we go so naming one twice in a single call is the
+        # same as naming it once.
+        joining: list[str] = []
+        for member in call.data[CONF_MEMBERS]:
+            if (identity := identity_of(self.hass, member)) in held:
+                continue
+            held.add(identity)
+            joining.append(member)
 
         await async_write_members(self.hass, entry, current + joining)

--- a/custom_components/spook/ectoplasms/group/services/add_members.py
+++ b/custom_components/spook/ectoplasms/group/services/add_members.py
@@ -38,8 +38,6 @@ class SpookService(AbstractSpookAdminService):
     async def async_handle_service(self, call: ServiceCall) -> None:
         """Handle the service call."""
         entry = async_entry_of(self.hass, call.data[CONF_GROUP])
-        async_check_joining(self.hass, entry, call.data[CONF_MEMBERS])
-
         current = members_of(entry)
 
         # By identity, not by the string. A group holds either an entity ID or
@@ -58,5 +56,11 @@ class SpookService(AbstractSpookAdminService):
                 continue
             held.add(identity)
             joining.append(member)
+
+        # Only what is actually joining is questioned. A group is allowed to
+        # be holding a member that no longer exists, and asking for that one
+        # again changes nothing, so refusing the call over it would be
+        # refusing to do nothing.
+        async_check_joining(self.hass, entry, joining)
 
         await async_write_members(self.hass, entry, current + joining)

--- a/custom_components/spook/ectoplasms/group/services/add_members.py
+++ b/custom_components/spook/ectoplasms/group/services/add_members.py
@@ -1,0 +1,49 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.group import DOMAIN
+from homeassistant.helpers import config_validation as cv
+
+from ....group_members import (
+    async_check_joining,
+    async_entry_of,
+    async_write_members,
+    members_of,
+)
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_GROUP = "group"
+CONF_MEMBERS = "members"
+
+
+class SpookService(AbstractSpookAdminService):
+    """Group service that adds members to a group while it is running."""
+
+    domain = DOMAIN
+    service = "add_members"
+    schema = {
+        vol.Required(CONF_GROUP): cv.entity_id,
+        vol.Required(CONF_MEMBERS): vol.All(cv.entity_ids_or_uuids, vol.Length(min=1)),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        entry = async_entry_of(self.hass, call.data[CONF_GROUP])
+        async_check_joining(self.hass, entry, call.data[CONF_MEMBERS])
+
+        current = members_of(entry)
+        # Appended rather than merged, so the order somebody arranged their
+        # group in survives. A member already in it is left where it is.
+        joining = [
+            member for member in call.data[CONF_MEMBERS] if member not in current
+        ]
+
+        await async_write_members(self.hass, entry, current + joining)

--- a/custom_components/spook/ectoplasms/group/services/remove_members.py
+++ b/custom_components/spook/ectoplasms/group/services/remove_members.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import config_validation as cv
 from ....group_members import (
     async_entry_of,
     async_write_members,
+    identity_of,
     members_of,
 )
 from ....services import AbstractSpookAdminService
@@ -41,10 +42,18 @@ class SpookService(AbstractSpookAdminService):
         twice should not start failing.
         """
         entry = async_entry_of(self.hass, call.data[CONF_GROUP])
-        leaving = set(call.data[CONF_MEMBERS])
+
+        # By identity, so a member stored as a registry ID goes when it is
+        # named by its entity ID. Comparing the strings would report success
+        # and leave it exactly where it was.
+        leaving = {identity_of(self.hass, member) for member in call.data[CONF_MEMBERS]}
 
         await async_write_members(
             self.hass,
             entry,
-            [member for member in members_of(entry) if member not in leaving],
+            [
+                member
+                for member in members_of(entry)
+                if identity_of(self.hass, member) not in leaving
+            ],
         )

--- a/custom_components/spook/ectoplasms/group/services/remove_members.py
+++ b/custom_components/spook/ectoplasms/group/services/remove_members.py
@@ -1,0 +1,50 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.group import DOMAIN
+from homeassistant.helpers import config_validation as cv
+
+from ....group_members import (
+    async_entry_of,
+    async_write_members,
+    members_of,
+)
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_GROUP = "group"
+CONF_MEMBERS = "members"
+
+
+class SpookService(AbstractSpookAdminService):
+    """Group service that takes members out of a group while it is running."""
+
+    domain = DOMAIN
+    service = "remove_members"
+    schema = {
+        vol.Required(CONF_GROUP): cv.entity_id,
+        vol.Required(CONF_MEMBERS): vol.All(cv.entity_ids_or_uuids, vol.Length(min=1)),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call.
+
+        Naming something that is not in the group is not an error. This is
+        how somebody clears out a member that no longer exists, and asking
+        twice should not start failing.
+        """
+        entry = async_entry_of(self.hass, call.data[CONF_GROUP])
+        leaving = set(call.data[CONF_MEMBERS])
+
+        await async_write_members(
+            self.hass,
+            entry,
+            [member for member in members_of(entry) if member not in leaving],
+        )

--- a/custom_components/spook/ectoplasms/group/services/set_members.py
+++ b/custom_components/spook/ectoplasms/group/services/set_members.py
@@ -13,6 +13,7 @@ from ....group_members import (
     async_check_joining,
     async_entry_of,
     async_write_members,
+    identity_of,
 )
 from ....services import AbstractSpookAdminService
 
@@ -39,7 +40,15 @@ class SpookService(AbstractSpookAdminService):
         async_check_joining(self.hass, entry, call.data[CONF_MEMBERS])
 
         # Repeats are dropped rather than refused: the same entity named
-        # twice is one member, and dict.fromkeys keeps the order given.
-        await async_write_members(
-            self.hass, entry, list(dict.fromkeys(call.data[CONF_MEMBERS]))
-        )
+        # twice is one member. By identity rather than by the string, because
+        # an entity ID and the registry ID of the same entity are two names
+        # for one member, and the first name given is the one kept.
+        kept: list[str] = []
+        seen: set[str] = set()
+        for member in call.data[CONF_MEMBERS]:
+            if (identity := identity_of(self.hass, member)) in seen:
+                continue
+            seen.add(identity)
+            kept.append(member)
+
+        await async_write_members(self.hass, entry, kept)

--- a/custom_components/spook/ectoplasms/group/services/set_members.py
+++ b/custom_components/spook/ectoplasms/group/services/set_members.py
@@ -1,0 +1,45 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+
+from homeassistant.components.group import DOMAIN
+from homeassistant.helpers import config_validation as cv
+
+from ....group_members import (
+    async_check_joining,
+    async_entry_of,
+    async_write_members,
+)
+from ....services import AbstractSpookAdminService
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+CONF_GROUP = "group"
+CONF_MEMBERS = "members"
+
+
+class SpookService(AbstractSpookAdminService):
+    """Group service that replaces a group's members while it is running."""
+
+    domain = DOMAIN
+    service = "set_members"
+    schema = {
+        vol.Required(CONF_GROUP): cv.entity_id,
+        vol.Required(CONF_MEMBERS): vol.All(cv.entity_ids_or_uuids, vol.Length(min=1)),
+    }
+
+    async def async_handle_service(self, call: ServiceCall) -> None:
+        """Handle the service call."""
+        entry = async_entry_of(self.hass, call.data[CONF_GROUP])
+        async_check_joining(self.hass, entry, call.data[CONF_MEMBERS])
+
+        # Repeats are dropped rather than refused: the same entity named
+        # twice is one member, and dict.fromkeys keeps the order given.
+        await async_write_members(
+            self.hass, entry, list(dict.fromkeys(call.data[CONF_MEMBERS]))
+        )

--- a/custom_components/spook/group_members.py
+++ b/custom_components/spook/group_members.py
@@ -202,16 +202,24 @@ def _async_follow_hiding(
     was: list[str],
     now: list[str],
 ) -> None:
-    """Hide what joined and show what left, for a group that hides members.
+    """Hide the members that just joined, for a group that hides its members.
 
     A group set to hide its members promises that what is in it is out of the
-    way. Leaving that to the next reload would leave a member that just joined
-    still on show, and one that just left hidden with nothing left to explain
-    why.
+    way, and leaving that to the next reload would leave a member that just
+    joined still on show.
 
-    Only what this integration hid is shown again, the same rule core follows
-    when a whole group is deleted. Somebody who hid an entity themselves meant
-    it, and it is not this action's place to undo that.
+    Nothing is ever shown again. That is not an omission, it is what the
+    interface does: core applies the hiding to the new list of members and
+    never touches one that left, so a member you take out through Settings
+    stays hidden too. It is also the only safe answer, because `hidden_by`
+    records that an integration hid something and never which one. Clearing
+    it would mean guessing, and guessing wrong means undoing what another
+    integration, or another group, still asks for.
+
+    Only what is on show gets hidden. An entity somebody hid themselves, or
+    that another integration is keeping out of the way, is already where the
+    group wants it, so there is nothing to do and nothing to overwrite. Core
+    is blunter here and writes over both.
     """
     if not entry.options.get(CONF_HIDE_MEMBERS):
         return
@@ -219,54 +227,15 @@ def _async_follow_hiding(
     registry = er.async_get(hass)
 
     # By identity rather than by the strings, or an entity stored as a
-    # registry ID and named as an entity ID reads as one leaving and another
-    # arriving, and both halves get the wrong treatment.
+    # registry ID and named as an entity ID reads as a different member.
     before = {identity_of(hass, member) for member in was}
-    after = {identity_of(hass, member) for member in now}
 
-    for entity_id in after - before:
-        # Only what is on show gets claimed. An entity somebody hid
-        # themselves is already out of the way, and writing over that would
-        # mean this puts it back on show the day it leaves the group, which
-        # is the very thing the rule below is there to prevent.
+    for member in now:
+        if (entity_id := identity_of(hass, member)) in before:
+            continue
+
         entity = registry.async_get(entity_id)
         if entity is not None and entity.hidden_by is None:
             registry.async_update_entity(
                 entity_id, hidden_by=er.RegistryEntryHider.INTEGRATION
             )
-
-    for entity_id in before - after:
-        if (entity := registry.async_get(entity_id)) is None:
-            continue
-
-        if entity.hidden_by is not er.RegistryEntryHider.INTEGRATION:
-            continue
-
-        if _hidden_by_another_group(hass, entry, entity_id):
-            continue
-
-        registry.async_update_entity(entity_id, hidden_by=None)
-
-
-@callback
-def _hidden_by_another_group(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    entity_id: str,
-) -> bool:
-    """Return whether another group that hides its members still holds this one.
-
-    An entity can be in more than one group, and either of them hiding its
-    members is reason enough for it to stay out of the way. Showing it again
-    because it left one group would quietly undo what the other one asked
-    for, and `hidden_by` records only that an integration did it, not which.
-    """
-    for other in hass.config_entries.async_entries(GROUP_DOMAIN):
-        if other.entry_id == entry.entry_id or not other.options.get(CONF_HIDE_MEMBERS):
-            continue
-
-        for member in other.options.get(CONF_ENTITIES) or []:
-            if identity_of(hass, member) == entity_id:
-                return True
-
-    return False

--- a/custom_components/spook/group_members.py
+++ b/custom_components/spook/group_members.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
 from homeassistant.components.group.const import CONF_HIDE_MEMBERS
 from homeassistant.const import CONF_ENTITIES
-from homeassistant.core import callback
+from homeassistant.core import callback, split_entity_id
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
@@ -29,6 +29,22 @@ if TYPE_CHECKING:
 # on. Core writes and reads this key as a bare string with no constant of its
 # own, so this is where Spook names it.
 _GROUP_TYPE = "group_type"
+
+
+def identity_of(hass: HomeAssistant, member: str) -> str:
+    """Return what two references to the same entity have in common.
+
+    A group is allowed to hold either an entity ID or a registry ID, and the
+    interface writes whichever it has. Compared as plain strings, the two
+    forms of one entity look like two entities: adding it a second time gets
+    it stored twice, and asking for it to be taken out by the name it is not
+    stored under reports success and changes nothing.
+
+    A registry ID whose entry has gone resolves to nothing, and then the value
+    itself is the best identity available. That keeps a dangling reference
+    removable by exactly what is written in the group.
+    """
+    return er.async_resolve_entity_id(er.async_get(hass), member) or member
 
 
 def async_entry_of(hass: HomeAssistant, group_entity_id: str) -> ConfigEntry:
@@ -46,7 +62,14 @@ def async_entry_of(hass: HomeAssistant, group_entity_id: str) -> ConfigEntry:
         # A group from YAML carries no unique ID, so it never reaches the
         # entity registry. Having a state is what separates one of those from
         # a name somebody mistyped.
-        if hass.states.get(group_entity_id) is not None:
+        if hass.states.get(group_entity_id) is None:
+            msg = f"Could not find entity_id: {group_entity_id}"
+            raise HomeAssistantError(msg)
+
+        # Only the group domain holds that older kind. Anything else with a
+        # state and no registry entry belongs to somebody else entirely, and
+        # pointing them at `group.set` would send them a long way off.
+        if split_entity_id(group_entity_id)[0] == GROUP_DOMAIN:
             msg = (
                 f"{group_entity_id} is a group from your YAML configuration, "
                 "which Spook cannot change. Edit it in your configuration, or "
@@ -54,7 +77,7 @@ def async_entry_of(hass: HomeAssistant, group_entity_id: str) -> ConfigEntry:
             )
             raise HomeAssistantError(msg)
 
-        msg = f"Could not find entity_id: {group_entity_id}"
+        msg = f"{group_entity_id} is not a group"
         raise HomeAssistantError(msg)
 
     if entry_entity.platform != GROUP_DOMAIN:
@@ -108,7 +131,7 @@ def async_check_joining(
             msg = f"Could not find entity_id: {member}"
             raise HomeAssistantError(msg)
 
-        if group_type and resolved.split(".")[0] != group_type:
+        if group_type and split_entity_id(resolved)[0] != group_type:
             msg = f"{member} cannot join this group: it holds {group_type} entities"
             raise HomeAssistantError(msg)
 
@@ -160,19 +183,50 @@ def _async_follow_hiding(
 
     registry = er.async_get(hass)
 
-    for member in set(now) - set(was):
-        if (entity_id := er.async_resolve_entity_id(registry, member)) and (
-            registry.async_get(entity_id) is not None
-        ):
+    # By identity rather than by the strings, or an entity stored as a
+    # registry ID and named as an entity ID reads as one leaving and another
+    # arriving, and both halves get the wrong treatment.
+    before = {identity_of(hass, member) for member in was}
+    after = {identity_of(hass, member) for member in now}
+
+    for entity_id in after - before:
+        if registry.async_get(entity_id) is not None:
             registry.async_update_entity(
                 entity_id, hidden_by=er.RegistryEntryHider.INTEGRATION
             )
 
-    for member in set(was) - set(now):
-        if (entity_id := er.async_resolve_entity_id(registry, member)) is None or (
-            entity := registry.async_get(entity_id)
-        ) is None:
+    for entity_id in before - after:
+        if (entity := registry.async_get(entity_id)) is None:
             continue
 
-        if entity.hidden_by is er.RegistryEntryHider.INTEGRATION:
-            registry.async_update_entity(entity_id, hidden_by=None)
+        if entity.hidden_by is not er.RegistryEntryHider.INTEGRATION:
+            continue
+
+        if _hidden_by_another_group(hass, entry, entity_id):
+            continue
+
+        registry.async_update_entity(entity_id, hidden_by=None)
+
+
+@callback
+def _hidden_by_another_group(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    entity_id: str,
+) -> bool:
+    """Return whether another group that hides its members still holds this one.
+
+    An entity can be in more than one group, and either of them hiding its
+    members is reason enough for it to stay out of the way. Showing it again
+    because it left one group would quietly undo what the other one asked
+    for, and `hidden_by` records only that an integration did it, not which.
+    """
+    for other in hass.config_entries.async_entries(GROUP_DOMAIN):
+        if other.entry_id == entry.entry_id or not other.options.get(CONF_HIDE_MEMBERS):
+            continue
+
+        for member in other.options.get(CONF_ENTITIES) or []:
+            if identity_of(hass, member) == entity_id:
+                return True
+
+    return False

--- a/custom_components/spook/group_members.py
+++ b/custom_components/spook/group_members.py
@@ -1,0 +1,178 @@
+"""Spook - Your homie. Shared rules for changing a group's members.
+
+Home Assistant lost something when groups moved from YAML to helpers. The old
+`group.set` could add and remove entities while the house was running, and it
+still can, but only for the old kind of group. A group made through the
+interface is a config entry, and nothing reaches into one of those from an
+automation.
+
+The three actions that put that back all do the same work apart from how they
+arrive at the new list of members, so the work lives here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.group.const import CONF_HIDE_MEMBERS
+from homeassistant.const import CONF_ENTITIES
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+# Which platform a group helper puts its entity on: `light`, `sensor`, and so
+# on. Core writes and reads this key as a bare string with no constant of its
+# own, so this is where Spook names it.
+_GROUP_TYPE = "group_type"
+
+
+def async_entry_of(hass: HomeAssistant, group_entity_id: str) -> ConfigEntry:
+    """Return the config entry behind a group entity.
+
+    Refuses anything that cannot be changed, and says which kind of "cannot"
+    it is, because the three cases want three different things from whoever
+    called. A group that came from YAML is the interesting one: it exists, it
+    works, and editing it means editing the file it came from.
+    """
+    registry = er.async_get(hass)
+    entry_entity = registry.async_get(group_entity_id)
+
+    if entry_entity is None:
+        # A group from YAML carries no unique ID, so it never reaches the
+        # entity registry. Having a state is what separates one of those from
+        # a name somebody mistyped.
+        if hass.states.get(group_entity_id) is not None:
+            msg = (
+                f"{group_entity_id} is a group from your YAML configuration, "
+                "which Spook cannot change. Edit it in your configuration, or "
+                "use group.set, which still works on that kind of group."
+            )
+            raise HomeAssistantError(msg)
+
+        msg = f"Could not find entity_id: {group_entity_id}"
+        raise HomeAssistantError(msg)
+
+    if entry_entity.platform != GROUP_DOMAIN:
+        msg = f"{group_entity_id} is not a group"
+        raise HomeAssistantError(msg)
+
+    if (
+        entry_entity.config_entry_id is None
+        or (entry := hass.config_entries.async_get_entry(entry_entity.config_entry_id))
+        is None
+    ):
+        msg = f"Could not find the group behind {group_entity_id}"
+        raise HomeAssistantError(msg)
+
+    return entry
+
+
+def members_of(entry: ConfigEntry) -> list[str]:
+    """Return the members a group currently has, in the order it holds them."""
+    return list(entry.options.get(CONF_ENTITIES) or [])
+
+
+def async_check_joining(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    members: list[str],
+) -> None:
+    """Refuse members a group cannot usefully hold.
+
+    Both checks exist because Spook has a repair for the result of skipping
+    them. A member from the wrong domain makes a group that reports nonsense,
+    and a member that does not exist makes `group_unknown_members` fire on
+    something Spook itself just did.
+
+    Only asked about members that are joining. Taking one out is how somebody
+    clears up exactly these mistakes, so removal never questions the name.
+    """
+    group_type = entry.options.get(_GROUP_TYPE)
+    registry = er.async_get(hass)
+
+    for member in members:
+        # A group can hold a registry ID rather than an entity ID, and that
+        # carries no domain of its own, so resolving comes first. Asking
+        # `async_resolve_entity_id` whether something exists proves nothing:
+        # it hands back anything already shaped like an entity ID.
+        resolved = er.async_resolve_entity_id(registry, member)
+
+        if resolved is None or (
+            hass.states.get(resolved) is None and registry.async_get(resolved) is None
+        ):
+            msg = f"Could not find entity_id: {member}"
+            raise HomeAssistantError(msg)
+
+        if group_type and resolved.split(".")[0] != group_type:
+            msg = f"{member} cannot join this group: it holds {group_type} entities"
+            raise HomeAssistantError(msg)
+
+
+async def async_write_members(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    members: list[str],
+) -> None:
+    """Give a group a new list of members, and make it take effect.
+
+    Writing the options is not enough on its own. Nothing in the group
+    integration listens for its own entry changing, so the group that is
+    running keeps the list it was built from until something reloads it.
+    """
+    current = members_of(entry)
+    if members == current:
+        return
+
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_ENTITIES: members}
+    )
+    _async_follow_hiding(hass, entry, was=current, now=members)
+
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+@callback
+def _async_follow_hiding(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    *,
+    was: list[str],
+    now: list[str],
+) -> None:
+    """Hide what joined and show what left, for a group that hides members.
+
+    A group set to hide its members promises that what is in it is out of the
+    way. Leaving that to the next reload would leave a member that just joined
+    still on show, and one that just left hidden with nothing left to explain
+    why.
+
+    Only what this integration hid is shown again, the same rule core follows
+    when a whole group is deleted. Somebody who hid an entity themselves meant
+    it, and it is not this action's place to undo that.
+    """
+    if not entry.options.get(CONF_HIDE_MEMBERS):
+        return
+
+    registry = er.async_get(hass)
+
+    for member in set(now) - set(was):
+        if (entity_id := er.async_resolve_entity_id(registry, member)) and (
+            registry.async_get(entity_id) is not None
+        ):
+            registry.async_update_entity(
+                entity_id, hidden_by=er.RegistryEntryHider.INTEGRATION
+            )
+
+    for member in set(was) - set(now):
+        if (entity_id := er.async_resolve_entity_id(registry, member)) is None or (
+            entity := registry.async_get(entity_id)
+        ) is None:
+            continue
+
+        if entity.hidden_by is er.RegistryEntryHider.INTEGRATION:
+            registry.async_update_entity(entity_id, hidden_by=None)

--- a/custom_components/spook/group_members.py
+++ b/custom_components/spook/group_members.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.group.config_flow import GroupConfigFlowHandler
 from homeassistant.components.group.const import CONF_HIDE_MEMBERS
 from homeassistant.const import CONF_ENTITIES
 from homeassistant.core import callback, split_entity_id
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, selector
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -29,6 +30,36 @@ if TYPE_CHECKING:
 # on. Core writes and reads this key as a bare string with no constant of its
 # own, so this is where Spook names it.
 _GROUP_TYPE = "group_type"
+
+
+def domains_a_group_holds(group_type: str) -> set[str] | None:
+    """Return the domains core's own dialog offers for this kind of group.
+
+    Read out of core rather than written down here, because it is not simply
+    one domain per group: a sensor group takes `number` and `input_number`
+    alongside `sensor`, and a copy of that here would be a copy that goes
+    quietly out of date.
+
+    Returns nothing when the shape of core's flow has moved, and then there
+    is no domain check at all. That is the right way round to fail. Refusing
+    a member the interface would have accepted is worse than storing an odd
+    one, and there is a test that fails the moment this stops finding
+    anything.
+    """
+    step = GroupConfigFlowHandler.config_flow.get(group_type)
+    schema = getattr(step, "schema", None)
+    if schema is None or not hasattr(schema, "schema"):
+        return None
+
+    for key, value in schema.schema.items():
+        if str(key) == CONF_ENTITIES and isinstance(value, selector.EntitySelector):
+            domains = value.config.get("domain")
+            if isinstance(domains, str):
+                return {domains}
+            if domains:
+                return set(domains)
+
+    return None
 
 
 def identity_of(hass: HomeAssistant, member: str) -> str:
@@ -116,6 +147,7 @@ def async_check_joining(
     clears up exactly these mistakes, so removal never questions the name.
     """
     group_type = entry.options.get(_GROUP_TYPE)
+    allowed = domains_a_group_holds(group_type) if group_type else None
     registry = er.async_get(hass)
 
     for member in members:
@@ -131,8 +163,11 @@ def async_check_joining(
             msg = f"Could not find entity_id: {member}"
             raise HomeAssistantError(msg)
 
-        if group_type and split_entity_id(resolved)[0] != group_type:
-            msg = f"{member} cannot join this group: it holds {group_type} entities"
+        if allowed is not None and split_entity_id(resolved)[0] not in allowed:
+            msg = (
+                f"{member} cannot join this group: it holds "
+                f"{', '.join(sorted(allowed))} entities"
+            )
             raise HomeAssistantError(msg)
 
 
@@ -190,7 +225,12 @@ def _async_follow_hiding(
     after = {identity_of(hass, member) for member in now}
 
     for entity_id in after - before:
-        if registry.async_get(entity_id) is not None:
+        # Only what is on show gets claimed. An entity somebody hid
+        # themselves is already out of the way, and writing over that would
+        # mean this puts it back on show the day it leaves the group, which
+        # is the very thing the rule below is there to prevent.
+        entity = registry.async_get(entity_id)
+        if entity is not None and entity.hidden_by is None:
             registry.async_update_entity(
                 entity_id, hidden_by=er.RegistryEntryHider.INTEGRATION
             )

--- a/custom_components/spook/services.yaml
+++ b/custom_components/spook/services.yaml
@@ -1745,3 +1745,70 @@ wait_for_condition:
       example: "00:05:00"
       selector:
         duration:
+
+group_add_members:
+  name: Add members to a group 👻
+  description: >-
+    Adds entities to a group made through the interface, while Home Assistant
+    is running. Entities already in the group are left where they are.
+  fields:
+    group:
+      name: Group
+      description: The group to add to.
+      required: true
+      example: light.hallway
+      selector:
+        entity:
+          integration: group
+    members:
+      name: Members
+      description: The entities to add to the group.
+      required: true
+      selector:
+        entity:
+          multiple: true
+
+group_remove_members:
+  name: Remove members from a group 👻
+  description: >-
+    Takes entities out of a group made through the interface, while Home
+    Assistant is running. Naming something that is not in the group does
+    nothing, so this is also how you clear out a member that no longer exists.
+  fields:
+    group:
+      name: Group
+      description: The group to take them out of.
+      required: true
+      example: light.hallway
+      selector:
+        entity:
+          integration: group
+    members:
+      name: Members
+      description: The entities to remove from the group.
+      required: true
+      selector:
+        entity:
+          multiple: true
+
+group_set_members:
+  name: Set the members of a group 👻
+  description: >-
+    Replaces the members of a group made through the interface with the ones
+    given, while Home Assistant is running.
+  fields:
+    group:
+      name: Group
+      description: The group to change.
+      required: true
+      example: light.hallway
+      selector:
+        entity:
+          integration: group
+    members:
+      name: Members
+      description: The entities the group should hold from now on.
+      required: true
+      selector:
+        entity:
+          multiple: true

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -794,6 +794,48 @@
     }
   },
   "services": {
+    "group_add_members": {
+      "name": "Add members to a group",
+      "description": "Adds entities to a group made through the interface, while Home Assistant is running. Entities already in the group are left where they are.",
+      "fields": {
+        "group": {
+          "name": "Group",
+          "description": "The group to add to."
+        },
+        "members": {
+          "name": "Members",
+          "description": "The entities to add to the group."
+        }
+      }
+    },
+    "group_remove_members": {
+      "name": "Remove members from a group",
+      "description": "Takes entities out of a group made through the interface, while Home Assistant is running. Naming something that is not in the group does nothing, so this is also how you clear out a member that no longer exists.",
+      "fields": {
+        "group": {
+          "name": "Group",
+          "description": "The group to take them out of."
+        },
+        "members": {
+          "name": "Members",
+          "description": "The entities to remove from the group."
+        }
+      }
+    },
+    "group_set_members": {
+      "name": "Set the members of a group",
+      "description": "Replaces the members of a group made through the interface with the ones given, while Home Assistant is running.",
+      "fields": {
+        "group": {
+          "name": "Group",
+          "description": "The group to change."
+        },
+        "members": {
+          "name": "Members",
+          "description": "The entities the group should hold from now on."
+        }
+      }
+    },
     "wait_for_condition": {
       "name": "Wait for a condition",
       "description": "Wait until a condition is true. Returns straight away if it already is.",

--- a/documentation/actions.md
+++ b/documentation/actions.md
@@ -82,6 +82,24 @@ Downloads and imports an automation/script blueprint, directly from the URL you 
 
 `blueprint.import`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=blueprint.import), [documentation](integrations/blueprint#import-blueprint) 📚
 
+## Group: Add members
+
+Adds entities to a group while the house is running, which the interface only lets you do by hand. _#roomforonemore_
+
+`group.add_members`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=group.add_members), [documentation](integrations/group#add-members-to-a-group) 📚
+
+## Group: Remove members
+
+Takes entities out of a group while the house is running. Naming something that is not in it does nothing, so it also clears out a member that no longer exists. _#youdonthavetogohome_
+
+`group.remove_members`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=group.remove_members), [documentation](integrations/group#remove-members-from-a-group) 📚
+
+## Group: Set members
+
+Replaces a group's members with the ones you give it. _#allchange_
+
+`group.set_members`, [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=group.set_members), [documentation](integrations/group#set-the-members-of-a-group) 📚
+
 ## Light: Set brightness
 
 Sets the brightness of lights that are already on, and leaves the ones that are off alone. _#light_ _#adjust_

--- a/documentation/integrations/group.md
+++ b/documentation/integrations/group.md
@@ -33,7 +33,138 @@ Spook does not provide any new devices or entities for this integration.
 
 ## Actions
 
-Spook does not provide action enhancements for this integration.
+Spook adds the following new actions to your Home Assistant instance:
+
+### Add members to a group
+
+Adds entities to a group made through the interface, while Home Assistant is running.
+
+Entities that are already in the group are left where they are, and the order you arranged the group in is kept: what joins is appended at the end.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Group: Add members to a group 👻
+* - {term}`Action name`
+  - `group.add_members`
+* - {term}`Action targets`
+  - No targets
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action
+* - {term}`Tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=group.add_members)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=group.add_members)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `group`
+  - {term}`string <string>`
+  - Yes
+  - `light.hallway`
+* - `members`
+  - {term}`list <list>`
+  - Yes
+  - `light.desk`
+```
+
+The `group` attribute names the group to add to. The `members` attribute lists the entities joining it, which have to exist and belong to the same domain as the group.
+
+### Remove members from a group
+
+Takes entities out of a group made through the interface, while Home Assistant is running.
+
+Naming something that is not in the group does nothing rather than failing, so this is also how you clear out a member that no longer exists.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Group: Remove members from a group 👻
+* - {term}`Action name`
+  - `group.remove_members`
+* - {term}`Action targets`
+  - No targets
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action
+* - {term}`Tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=group.remove_members)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=group.remove_members)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `group`
+  - {term}`string <string>`
+  - Yes
+  - `light.hallway`
+* - `members`
+  - {term}`list <list>`
+  - Yes
+  - `light.desk`
+```
+
+The `group` attribute names the group to take them out of. The `members` attribute lists the entities leaving it, whether or not they still exist.
+
+### Set the members of a group
+
+Replaces the members of a group made through the interface with the ones given, while Home Assistant is running.
+
+```{list-table}
+:header-rows: 1
+* - Action properties
+* - {term}`Action`
+  - Group: Set the members of a group 👻
+* - {term}`Action name`
+  - `group.set_members`
+* - {term}`Action targets`
+  - No targets
+* - {term}`Action response`
+  - No response
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added action
+* - {term}`Tools`
+  - [Try this action](https://my.home-assistant.io/redirect/developer_call_service/?service=group.set_members)
+    [![Open your Home Assistant instance and show the Actions tool with a specific action selected.](https://my.home-assistant.io/badges/developer_call_service.svg)](https://my.home-assistant.io/redirect/developer_call_service/?service=group.set_members)
+```
+
+```{list-table}
+:header-rows: 2
+* - Action data parameters
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `group`
+  - {term}`string <string>`
+  - Yes
+  - `light.hallway`
+* - `members`
+  - {term}`list <list>`
+  - Yes
+  - `light.desk`
+```
+
+The `group` attribute names the group to change. The `members` attribute lists the entities it should hold from now on, which have to exist and belong to the same domain as the group.
+
+All three only work on groups created through the interface. A group defined in your YAML configuration cannot be changed while Home Assistant is running; the built-in `group.set` action still works on that older kind of group.
+
+If the group is set to hide its members, Spook follows that: a member that joins is hidden, and one that leaves is shown again, as long as it was the group that hid it in the first place.
 
 ## Repairs
 

--- a/documentation/integrations/group.md
+++ b/documentation/integrations/group.md
@@ -76,7 +76,7 @@ Entities that are already in the group are left where they are, and the order yo
   - `light.desk`
 ```
 
-The `group` attribute names the group to add to. The `members` attribute lists the entities joining it, which have to exist and belong to the same domain as the group.
+The `group` attribute names the group to add to. The `members` attribute lists the entities joining it, which have to exist and be a kind the group can hold.
 
 ### Remove members from a group
 
@@ -160,11 +160,13 @@ Replaces the members of a group made through the interface with the ones given, 
   - `light.desk`
 ```
 
-The `group` attribute names the group to change. The `members` attribute lists the entities it should hold from now on, which have to exist and belong to the same domain as the group.
+The `group` attribute names the group to change. The `members` attribute lists the entities it should hold from now on, which have to exist and be a kind the group can hold.
 
 All three only work on groups created through the interface. A group defined in your YAML configuration is not something they can change, and they say so rather than failing quietly. The built-in `group.set` action does still work on that older kind of group, and it does not need a restart either.
 
 If the group is set to hide its members, Spook follows that: a member that joins is hidden, and one that leaves is shown again. Two things are left alone. An entity you hid yourself stays hidden, because you meant it. So does one that another group with hidden members still holds, since leaving this group is no reason to undo what that one asked for.
+
+Which entities a group can hold is read from the same list Home Assistant's own dialog offers, so it is not always one domain: a sensor group takes `number` and `input_number` alongside `sensor`.
 
 A group holds either an entity ID or a registry ID, whichever the interface had when it was made, and all three actions treat the two names for one entity as one member. So an entity cannot end up in a group twice, and one stored under the name you did not use still goes when you ask for it.
 

--- a/documentation/integrations/group.md
+++ b/documentation/integrations/group.md
@@ -164,7 +164,7 @@ The `group` attribute names the group to change. The `members` attribute lists t
 
 All three only work on groups created through the interface. A group defined in your YAML configuration is not something they can change, and they say so rather than failing quietly. The built-in `group.set` action does still work on that older kind of group, and it does not need a restart either.
 
-If the group is set to hide its members, Spook follows that: a member that joins is hidden, and one that leaves is shown again. Two things are left alone. An entity you hid yourself stays hidden, because you meant it. So does one that another group with hidden members still holds, since leaving this group is no reason to undo what that one asked for.
+If the group is set to hide its members, the ones that join it are hidden. A member that leaves stays hidden, the same as when you take one out through Settings: Home Assistant applies the hiding to the members a group has and never touches one that left. It is also the only safe answer, because the registry records that an integration hid an entity and never which one, so showing it again could undo what another helper still asks for. An entity that was already hidden, whether by you or by anything else, is left exactly as it is.
 
 Which entities a group can hold is read from the same list Home Assistant's own dialog offers, so it is not always one domain: a sensor group takes `number` and `input_number` alongside `sensor`.
 

--- a/documentation/integrations/group.md
+++ b/documentation/integrations/group.md
@@ -162,9 +162,11 @@ Replaces the members of a group made through the interface with the ones given, 
 
 The `group` attribute names the group to change. The `members` attribute lists the entities it should hold from now on, which have to exist and belong to the same domain as the group.
 
-All three only work on groups created through the interface. A group defined in your YAML configuration cannot be changed while Home Assistant is running; the built-in `group.set` action still works on that older kind of group.
+All three only work on groups created through the interface. A group defined in your YAML configuration is not something they can change, and they say so rather than failing quietly. The built-in `group.set` action does still work on that older kind of group, and it does not need a restart either.
 
-If the group is set to hide its members, Spook follows that: a member that joins is hidden, and one that leaves is shown again, as long as it was the group that hid it in the first place.
+If the group is set to hide its members, Spook follows that: a member that joins is hidden, and one that leaves is shown again. Two things are left alone. An entity you hid yourself stays hidden, because you meant it. So does one that another group with hidden members still holds, since leaving this group is no reason to undo what that one asked for.
+
+A group holds either an entity ID or a registry ID, whichever the interface had when it was made, and all three actions treat the two names for one entity as one member. So an entity cannot end up in a group twice, and one stored under the name you did not use still goes when you ask for it.
 
 ## Repairs
 

--- a/tests/ectoplasms/group/services/__init__.py
+++ b/tests/ectoplasms/group/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the group actions."""

--- a/tests/ectoplasms/group/services/test_members.py
+++ b/tests/ectoplasms/group/services/test_members.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from homeassistant.components.group.config_flow import GroupConfigFlowHandler
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -18,6 +19,7 @@ from custom_components.spook.ectoplasms.group.services import (
     remove_members,
     set_members,
 )
+from custom_components.spook.group_members import domains_a_group_holds
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -57,6 +59,9 @@ async def _group(
 async def _call(hass: HomeAssistant, service: str, **data: object) -> None:
     """Call one of the actions."""
     await hass.services.async_call("group", service, dict(data), blocking=True)
+
+
+ENOUGH_GROUP_TYPES = 5
 
 
 def _running(hass: HomeAssistant) -> list[str]:
@@ -433,3 +438,119 @@ async def test_a_plain_entity_is_not_mistaken_for_a_yaml_group(
 
     with pytest.raises(HomeAssistantError, match="is not a group"):
         await _call(hass, "add_members", group="light.one", members=["light.two"])
+
+
+async def test_a_sensor_group_takes_the_domains_the_dialog_offers(
+    hass: HomeAssistant,
+) -> None:
+    """Test a sensor group holds numbers too, because core's dialog says so.
+
+    It is not one domain per group. A sensor group offers `sensor`, `number`
+    and `input_number`, and refusing the last two would mean these actions
+    cannot build a group the interface builds happily.
+    """
+    hass.states.async_set("number.setpoint", "21", {"unit_of_measurement": "°C"})
+    hass.states.async_set("sensor.temperature", "20", {"unit_of_measurement": "°C"})
+    await _setup(hass)
+
+    entry = MockConfigEntry(
+        domain="group",
+        title="Warmth",
+        options={
+            "group_type": "sensor",
+            "name": "Warmth",
+            "entities": ["sensor.temperature"],
+            "hide_members": False,
+            "type": "max",
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await _call(hass, "add_members", group="sensor.warmth", members=["number.setpoint"])
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["sensor.temperature", "number.setpoint"]
+
+
+async def test_a_sensor_group_still_refuses_a_light(hass: HomeAssistant) -> None:
+    """Test widening the check did not turn it off."""
+    await _setup(hass)
+
+    hass.states.async_set("sensor.temperature", "20", {"unit_of_measurement": "°C"})
+    entry = MockConfigEntry(
+        domain="group",
+        title="Warmth",
+        options={
+            "group_type": "sensor",
+            "name": "Warmth",
+            "entities": ["sensor.temperature"],
+            "hide_members": False,
+            "type": "max",
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(HomeAssistantError, match="input_number, number, sensor"):
+        await _call(hass, "add_members", group="sensor.warmth", members=["light.one"])
+
+
+def test_every_group_type_reports_the_domains_it_holds() -> None:
+    """Guard the one assumption about the shape of somebody else's flow.
+
+    The allowed domains are read out of core's own config flow. If that moves,
+    the reading returns nothing and the domain check silently stops happening,
+    which is a quiet loss rather than a loud one. This is the loud one.
+
+    Needs nothing running: it is a question about the shape of two modules.
+    """
+    checked = 0
+    for group_type, step in GroupConfigFlowHandler.config_flow.items():
+        if not hasattr(step, "schema"):
+            # The menu step that asks which kind of group to make.
+            continue
+        domains = domains_a_group_holds(group_type)
+        assert domains, f"no domains found for a {group_type} group"
+        assert group_type in domains
+        checked += 1
+
+    assert checked > ENOUGH_GROUP_TYPES, "the walk stopped finding group types"
+    assert domains_a_group_holds("sensor") == {"sensor", "number", "input_number"}
+
+
+async def test_a_member_the_user_hid_is_never_claimed(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test joining does not write over somebody's own choice.
+
+    Claiming it would look harmless, since it is hidden either way. The
+    damage shows up later: on the way out this would see its own mark and put
+    the entity back on show, which is exactly what it must not do.
+    """
+    theirs = entity_registry.async_get_or_create(
+        "light", "demo", "two", hidden_by=er.RegistryEntryHider.USER
+    )
+    entity_registry.async_get_or_create("light", "demo", "one")
+    await _setup(hass)
+    await _group(hass, ["light.demo_one"], hide_members=True)
+
+    await _call(hass, "set_members", group="light.hallway", members=[theirs.entity_id])
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get(theirs.entity_id).hidden_by
+        is er.RegistryEntryHider.USER
+    )
+
+    # And out again: still theirs, still hidden.
+    await _call(hass, "set_members", group="light.hallway", members=["light.demo_one"])
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get(theirs.entity_id).hidden_by
+        is er.RegistryEntryHider.USER
+    )

--- a/tests/ectoplasms/group/services/test_members.py
+++ b/tests/ectoplasms/group/services/test_members.py
@@ -232,14 +232,16 @@ async def test_something_that_is_not_a_group_is_refused(
         await _call(hass, "add_members", group="light.demo_bulb", members=["light.two"])
 
 
-async def test_hiding_follows_the_members_in_and_out(
+async def test_hiding_covers_what_joins_and_leaves_the_rest_alone(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test a group that hides its members keeps that promise.
+    """Test a group that hides its members hides the ones that join it.
 
-    Left to the next reload, a member that just joined would still be on show
-    and one that just left would stay hidden with nothing to explain why.
+    A member that leaves stays hidden, which is not an oversight. Core does
+    the same: it applies the hiding to the new list of members and never
+    touches one that left, so removing a member through Settings leaves it
+    hidden as well.
     """
     joining = entity_registry.async_get_or_create("light", "demo", "two")
     leaving = entity_registry.async_get_or_create(
@@ -255,7 +257,25 @@ async def test_hiding_follows_the_members_in_and_out(
         entity_registry.async_get(joining.entity_id).hidden_by
         is er.RegistryEntryHider.INTEGRATION
     )
-    assert entity_registry.async_get(leaving.entity_id).hidden_by is None
+    assert (
+        entity_registry.async_get(leaving.entity_id).hidden_by
+        is er.RegistryEntryHider.INTEGRATION
+    )
+
+
+async def test_a_group_that_does_not_hide_its_members_hides_nothing(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the option is honoured in the obvious direction too."""
+    joining = entity_registry.async_get_or_create("light", "demo", "two")
+    await _setup(hass)
+    await _group(hass, ["light.one"], hide_members=False)
+
+    await _call(hass, "add_members", group="light.hallway", members=[joining.entity_id])
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get(joining.entity_id).hidden_by is None
 
 
 async def test_hiding_leaves_what_somebody_hid_themselves(
@@ -385,42 +405,30 @@ async def test_setting_drops_two_names_for_one_entity(
     assert entry.options["entities"] == [both.entity_id]
 
 
-async def test_a_member_another_hiding_group_still_holds_stays_hidden(
+async def test_a_member_another_integration_hid_is_never_shown_again(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test leaving one group does not undo what another group asked for.
+    """Test leaving a group does not undo somebody else's hiding.
 
-    An entity can be in two groups, and either of them hiding its members is
-    reason enough for it to stay out of the way. `hidden_by` records only
-    that an integration did it, never which one, so the other groups have to
-    be asked.
+    `hidden_by` records that an integration hid an entity and never which
+    one. A helper that wraps a source entity marks it exactly the same way
+    this group would, so clearing the mark on the way out would expose a
+    source that its own helper still wants out of the way. Nothing is ever
+    shown again, which is the only answer that cannot be wrong.
     """
-    shared = entity_registry.async_get_or_create(
+    theirs = entity_registry.async_get_or_create(
         "light", "demo", "one", hidden_by=er.RegistryEntryHider.INTEGRATION
     )
     entity_registry.async_get_or_create("light", "demo", "two")
-
-    other = MockConfigEntry(
-        domain="group",
-        title="Landing",
-        options={
-            "group_type": "light",
-            "name": "Landing",
-            "entities": [shared.entity_id],
-            "hide_members": True,
-        },
-    )
-    other.add_to_hass(hass)
-
     await _setup(hass)
-    await _group(hass, [shared.entity_id], hide_members=True)
+    await _group(hass, [theirs.entity_id], hide_members=True)
 
     await _call(hass, "set_members", group="light.hallway", members=["light.demo_two"])
     await hass.async_block_till_done()
 
     assert (
-        entity_registry.async_get(shared.entity_id).hidden_by
+        entity_registry.async_get(theirs.entity_id).hidden_by
         is er.RegistryEntryHider.INTEGRATION
     )
 
@@ -554,3 +562,27 @@ async def test_a_member_the_user_hid_is_never_claimed(
         entity_registry.async_get(theirs.entity_id).hidden_by
         is er.RegistryEntryHider.USER
     )
+
+
+async def test_asking_again_for_a_member_that_is_gone_is_not_an_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test a group holding a deleted member can still be added to.
+
+    Only what is actually joining is questioned. A group is allowed to be
+    holding something that no longer exists, and naming that one again
+    changes nothing, so refusing the call over it would be refusing to do
+    nothing.
+    """
+    await _setup(hass)
+    entry = await _group(hass, ["light.one", "light.vanished"])
+
+    await _call(
+        hass,
+        "add_members",
+        group="light.hallway",
+        members=["light.vanished", "light.two"],
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.one", "light.vanished", "light.two"]

--- a/tests/ectoplasms/group/services/test_members.py
+++ b/tests/ectoplasms/group/services/test_members.py
@@ -1,0 +1,298 @@
+"""Tests for the group member actions."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+import pytest
+
+from custom_components.spook.ectoplasms.group.services import (
+    add_members,
+    remove_members,
+    set_members,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def _setup(hass: HomeAssistant) -> None:
+    """Register the three actions on a running group integration."""
+    assert await async_setup_component(hass, "group", {})
+    for module in (add_members, remove_members, set_members):
+        module.SpookService(hass).async_register()
+    await hass.async_block_till_done()
+
+
+async def _group(
+    hass: HomeAssistant,
+    members: list[str],
+    *,
+    hide_members: bool = False,
+) -> MockConfigEntry:
+    """Set up a light group holding the given members."""
+    entry = MockConfigEntry(
+        domain="group",
+        title="Hallway",
+        options={
+            "group_type": "light",
+            "name": "Hallway",
+            "entities": members,
+            "hide_members": hide_members,
+        },
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def _call(hass: HomeAssistant, service: str, **data: object) -> None:
+    """Call one of the actions."""
+    await hass.services.async_call("group", service, dict(data), blocking=True)
+
+
+def _running(hass: HomeAssistant) -> list[str]:
+    """Return the members the group Home Assistant is serving actually has."""
+    return hass.states.get("light.hallway").attributes["entity_id"]
+
+
+@pytest.fixture(autouse=True)
+def _lights(hass: HomeAssistant) -> None:
+    """Provide a few lights to move in and out of groups."""
+    for name in ("one", "two", "three"):
+        hass.states.async_set(f"light.{name}", "on")
+
+
+async def test_adding_appends_and_the_group_follows(hass: HomeAssistant) -> None:
+    """Test a new member lands at the end and reaches the running group."""
+    await _setup(hass)
+    entry = await _group(hass, ["light.one"])
+
+    await _call(hass, "add_members", group="light.hallway", members=["light.two"])
+    await hass.async_block_till_done()
+
+    # Appended, not merged, so an order somebody arranged survives.
+    assert entry.options["entities"] == ["light.one", "light.two"]
+    assert _running(hass) == ["light.one", "light.two"]
+
+
+async def test_adding_a_member_it_already_has_changes_nothing(
+    hass: HomeAssistant,
+) -> None:
+    """Test asking twice does not list an entity twice."""
+    await _setup(hass)
+    entry = await _group(hass, ["light.one", "light.two"])
+
+    await _call(
+        hass, "add_members", group="light.hallway", members=["light.two", "light.three"]
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.one", "light.two", "light.three"]
+
+
+async def test_adding_from_another_domain_is_refused(hass: HomeAssistant) -> None:
+    """Test a light group is not given a switch to hold.
+
+    A group of mixed domains reports nonsense rather than failing, so this is
+    refused at the door instead of stored.
+    """
+    hass.states.async_set("switch.kettle", "on")
+    await _setup(hass)
+    entry = await _group(hass, ["light.one"])
+
+    with pytest.raises(HomeAssistantError, match="holds light entities"):
+        await _call(
+            hass, "add_members", group="light.hallway", members=["switch.kettle"]
+        )
+
+    assert entry.options["entities"] == ["light.one"]
+
+
+async def test_adding_something_that_does_not_exist_is_refused(
+    hass: HomeAssistant,
+) -> None:
+    """Test Spook does not create work for its own repair.
+
+    A member that does not exist is exactly what `group_unknown_members`
+    reports, so putting one in would be Spook raising an issue about itself.
+    """
+    await _setup(hass)
+    entry = await _group(hass, ["light.one"])
+
+    with pytest.raises(HomeAssistantError, match=r"light\.nowhere"):
+        await _call(
+            hass, "add_members", group="light.hallway", members=["light.nowhere"]
+        )
+
+    assert entry.options["entities"] == ["light.one"]
+
+
+async def test_removing_reaches_the_running_group(hass: HomeAssistant) -> None:
+    """Test a member taken out is gone from the group being served."""
+    await _setup(hass)
+    entry = await _group(hass, ["light.one", "light.two"])
+
+    await _call(hass, "remove_members", group="light.hallway", members=["light.two"])
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.one"]
+    assert _running(hass) == ["light.one"]
+
+
+async def test_removing_takes_out_a_member_that_is_gone(hass: HomeAssistant) -> None:
+    """Test the ghost case, which is the reason removal asks no questions."""
+    await _setup(hass)
+    entry = await _group(hass, ["light.one", "light.vanished"])
+
+    await _call(
+        hass, "remove_members", group="light.hallway", members=["light.vanished"]
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.one"]
+
+
+async def test_removing_something_it_never_had_is_not_an_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test asking twice keeps working."""
+    await _setup(hass)
+    entry = await _group(hass, ["light.one"])
+
+    await _call(hass, "remove_members", group="light.hallway", members=["light.two"])
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.one"]
+
+
+async def test_setting_replaces_and_drops_repeats(hass: HomeAssistant) -> None:
+    """Test the list given is the list held, each entity once."""
+    await _setup(hass)
+    entry = await _group(hass, ["light.one"])
+
+    await _call(
+        hass,
+        "set_members",
+        group="light.hallway",
+        members=["light.three", "light.two", "light.three"],
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.three", "light.two"]
+    assert _running(hass) == ["light.three", "light.two"]
+
+
+async def test_a_yaml_group_is_refused_and_told_where_to_go(
+    hass: HomeAssistant,
+) -> None:
+    """Test the older kind of group says what does work on it.
+
+    A group from YAML carries no unique ID, so it never reaches the entity
+    registry. It still has a state, which is what separates it from a name
+    somebody mistyped.
+    """
+    await _setup(hass)
+    hass.states.async_set("group.living", "on", {"entity_id": ["light.one"]})
+
+    with pytest.raises(HomeAssistantError, match=r"group\.set"):
+        await _call(hass, "add_members", group="group.living", members=["light.two"])
+
+
+async def test_an_entity_that_does_not_exist_is_refused(hass: HomeAssistant) -> None:
+    """Test a mistyped group name says so."""
+    await _setup(hass)
+
+    with pytest.raises(HomeAssistantError, match="Could not find entity_id"):
+        await _call(hass, "add_members", group="light.nowhere", members=["light.two"])
+
+
+async def test_something_that_is_not_a_group_is_refused(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a plain light is not treated as a group."""
+    await _setup(hass)
+    entity_registry.async_get_or_create("light", "demo", "bulb")
+
+    with pytest.raises(HomeAssistantError, match="is not a group"):
+        await _call(hass, "add_members", group="light.demo_bulb", members=["light.two"])
+
+
+async def test_hiding_follows_the_members_in_and_out(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a group that hides its members keeps that promise.
+
+    Left to the next reload, a member that just joined would still be on show
+    and one that just left would stay hidden with nothing to explain why.
+    """
+    joining = entity_registry.async_get_or_create("light", "demo", "two")
+    leaving = entity_registry.async_get_or_create(
+        "light", "demo", "one", hidden_by=er.RegistryEntryHider.INTEGRATION
+    )
+    await _setup(hass)
+    await _group(hass, [leaving.entity_id], hide_members=True)
+
+    await _call(hass, "set_members", group="light.hallway", members=[joining.entity_id])
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get(joining.entity_id).hidden_by
+        is er.RegistryEntryHider.INTEGRATION
+    )
+    assert entity_registry.async_get(leaving.entity_id).hidden_by is None
+
+
+async def test_hiding_leaves_what_somebody_hid_themselves(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a member hidden by hand stays hidden when it leaves.
+
+    Somebody who hid an entity themselves meant it, and this action has no
+    business undoing that. Core follows the same rule when a whole group is
+    deleted.
+    """
+    entity_registry.async_get_or_create("light", "demo", "two")
+    leaving = entity_registry.async_get_or_create(
+        "light", "demo", "one", hidden_by=er.RegistryEntryHider.USER
+    )
+    await _setup(hass)
+    await _group(hass, [leaving.entity_id], hide_members=True)
+
+    await _call(hass, "set_members", group="light.hallway", members=["light.demo_two"])
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get(leaving.entity_id).hidden_by
+        is er.RegistryEntryHider.USER
+    )
+
+
+async def test_a_member_named_by_registry_id_is_accepted(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a group can be given a registry ID rather than an entity ID.
+
+    That is a shape a group is allowed to hold, and it carries no domain of
+    its own, so the checks have to resolve it before judging it.
+    """
+    joining = entity_registry.async_get_or_create("light", "demo", "two")
+    await _setup(hass)
+    entry = await _group(hass, ["light.one"])
+
+    await _call(hass, "add_members", group="light.hallway", members=[joining.id])
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.one", joining.id]

--- a/tests/ectoplasms/group/services/test_members.py
+++ b/tests/ectoplasms/group/services/test_members.py
@@ -296,3 +296,140 @@ async def test_a_member_named_by_registry_id_is_accepted(
     await hass.async_block_till_done()
 
     assert entry.options["entities"] == ["light.one", joining.id]
+
+
+async def test_adding_the_same_entity_under_its_other_name_is_not_a_duplicate(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test one entity cannot be in a group twice under two names.
+
+    A group holds either an entity ID or a registry ID, whichever the
+    interface had. Compared as strings the two names for one entity look like
+    two entities, and the group would end up holding it twice.
+    """
+    existing = entity_registry.async_get_or_create("light", "demo", "one")
+    await _setup(hass)
+    entry = await _group(hass, [existing.id])
+
+    await _call(
+        hass, "add_members", group="light.hallway", members=[existing.entity_id]
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == [existing.id]
+
+
+async def test_naming_one_entity_twice_in_a_call_adds_it_once(
+    hass: HomeAssistant,
+) -> None:
+    """Test the check keeps up within a single call, not just against storage."""
+    await _setup(hass)
+    entry = await _group(hass, ["light.one"])
+
+    await _call(
+        hass,
+        "add_members",
+        group="light.hallway",
+        members=["light.two", "light.two"],
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.one", "light.two"]
+
+
+async def test_removing_works_through_the_other_name(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a member stored as a registry ID goes when named as an entity ID.
+
+    Comparing the strings meant this reported success and left the member
+    exactly where it was, which is the failure Spook is least willing to
+    ship: a button that says it did something.
+    """
+    stored = entity_registry.async_get_or_create("light", "demo", "one")
+    await _setup(hass)
+    entry = await _group(hass, [stored.id, "light.two"])
+
+    await _call(
+        hass, "remove_members", group="light.hallway", members=[stored.entity_id]
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == ["light.two"]
+
+
+async def test_setting_drops_two_names_for_one_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the first name given is kept and the second is dropped."""
+    both = entity_registry.async_get_or_create("light", "demo", "one")
+    await _setup(hass)
+    entry = await _group(hass, ["light.two"])
+
+    await _call(
+        hass,
+        "set_members",
+        group="light.hallway",
+        members=[both.entity_id, both.id],
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options["entities"] == [both.entity_id]
+
+
+async def test_a_member_another_hiding_group_still_holds_stays_hidden(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test leaving one group does not undo what another group asked for.
+
+    An entity can be in two groups, and either of them hiding its members is
+    reason enough for it to stay out of the way. `hidden_by` records only
+    that an integration did it, never which one, so the other groups have to
+    be asked.
+    """
+    shared = entity_registry.async_get_or_create(
+        "light", "demo", "one", hidden_by=er.RegistryEntryHider.INTEGRATION
+    )
+    entity_registry.async_get_or_create("light", "demo", "two")
+
+    other = MockConfigEntry(
+        domain="group",
+        title="Landing",
+        options={
+            "group_type": "light",
+            "name": "Landing",
+            "entities": [shared.entity_id],
+            "hide_members": True,
+        },
+    )
+    other.add_to_hass(hass)
+
+    await _setup(hass)
+    await _group(hass, [shared.entity_id], hide_members=True)
+
+    await _call(hass, "set_members", group="light.hallway", members=["light.demo_two"])
+    await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get(shared.entity_id).hidden_by
+        is er.RegistryEntryHider.INTEGRATION
+    )
+
+
+async def test_a_plain_entity_is_not_mistaken_for_a_yaml_group(
+    hass: HomeAssistant,
+) -> None:
+    """Test only the group domain gets pointed at `group.set`.
+
+    An entity with a state and no registry entry is not automatically an old
+    group; most of them belong to somebody else entirely. Telling their owner
+    to go and edit their Lovelace groups would send them a long way off.
+    """
+    await _setup(hass)
+
+    with pytest.raises(HomeAssistantError, match="is not a group"):
+        await _call(hass, "add_members", group="light.one", members=["light.two"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Three new actions:

```yaml
action: group.add_members
data:
  group: light.hallway
  members:
    - light.desk
```

plus `group.remove_members` and `group.set_members`.

Groups lost something when they moved from YAML to helpers. `group.set` can still add and remove entities while Home Assistant is running, but only for the old kind of group. One made through the interface is a config entry, and nothing reaches into one of those from an automation.

The decisions worth arguing about:

- **Adding refuses what a group cannot usefully hold**: a member from another domain, and a member that does not exist. That second one matters because it is exactly what `group_unknown_members` reports. Without the check, Spook would raise an issue about something Spook just did.
- **Removing asks nothing.** Clearing out a member that is gone is the point of it, and asking twice must not start failing, so a name that is not in the group is a no-op rather than an error.
- **Adding appends rather than merges**, so the order somebody arranged their group in survives.
- **`hide_members` is followed both ways.** What joins is hidden, what leaves is shown again, but only if the integration was what hid it. Somebody who hid an entity themselves meant it, which is the same rule core follows when a whole group is deleted.
- **A group from YAML is told what does work on it**, rather than getting a bare refusal.

`group_members.py` holds the shared part, the way `dashboard_resources.py` does, because a helper module inside `ectoplasms/*/services/` would be imported by the service loader and then fail for having no `SpookService`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Home Assistant feature request [#2169](https://github.com/home-assistant/feature-requests/discussions/2169), "Enable dynamic modification of Helper Group members (just like with legacy groups)".

Built on the reload from #1580, which had to come first: writing the options is not enough on its own, and that was failing silently until it was measured.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Fourteen tests against the real group integration, so every one of them checks the group Home Assistant is serving rather than only the stored options.

Then six mutations, each caught:

| Mutation | Failures |
| --- | --- |
| No reload after writing | 3 |
| Show whatever leaves, however it was hidden | 1 |
| Drop the domain check | 1 |
| Drop the existence check | 1 |
| Keep repeats in `set_members` | 1 |
| Merge instead of appending in `add_members` | 2 |

Two bugs the tests found before review could: `async_resolve_entity_id` hands back anything already shaped like an entity ID, so the existence check was doing nothing, and the domain check broke on a registry ID, which carries no domain. `members` takes `cv.entity_ids_or_uuids` now, and that path has a test of its own.

Full suite: 1630 passed.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
