### PR TITLE
Tell me when it came back, not when it blinked

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/flapping.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/flapping.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
 from homeassistant.helpers.trigger import Trigger
 
+from ....target_watching import watchable_target
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -70,30 +72,9 @@ def _window(value: Any) -> timedelta:
     return within
 
 
-# `TARGET_FIELDS` is a plain mapping of schema fields, so it needs compiling
-# before it can validate anything.
-_TARGET_SCHEMA = vol.Schema(cv.TARGET_FIELDS)
-
-
-def _watchable_target(value: Any) -> ConfigType:
-    """Validate the target, and refuse one that names nothing.
-
-    An empty target passes the field validation happily and then watches
-    nothing at all: a trigger that loads and can never fire. Core's own target
-    tracking helper raises on this for the same reason.
-    """
-    target: ConfigType = _TARGET_SCHEMA(value)
-    if not TargetSelection(target).has_any_target:
-        message = (
-            "The target must name at least one entity, device, area, floor or label"
-        )
-        raise vol.Invalid(message)
-    return target
-
-
 _TRIGGER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_TARGET): _watchable_target,
+        vol.Required(CONF_TARGET): watchable_target,
         vol.Required(CONF_OPTIONS): {
             vol.Required(CONF_CHANGES): _flapping_count,
             vol.Required(CONF_WITHIN): _window,

--- a/custom_components/spook/ectoplasms/spook/triggers/recovered.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/recovered.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.helpers.event import EventStateChangedData
     from homeassistant.helpers.trigger import (
         TriggerActionRunner,
         TriggerConfig,
@@ -86,7 +87,9 @@ class _AbsenceTracker(TargetEntityChangeTracker):
         hass: HomeAssistant,
         target_selection: TargetSelection,
         duration: timedelta,
-        on_return: Callable[[str, datetime, timedelta], None],
+        on_return: Callable[
+            [str, Event[EventStateChangedData], datetime, timedelta], None
+        ],
     ) -> None:
         """Initialize the tracker."""
         super().__init__(hass, target_selection, entity_filter=lambda ids: ids)
@@ -183,7 +186,7 @@ class _AbsenceTracker(TargetEntityChangeTracker):
             unsub()
 
     @callback
-    def _entity_changed(self, event: Event) -> None:
+    def _entity_changed(self, event: Event[EventStateChangedData]) -> None:
         """Follow one entity through going away and coming back."""
         entity_id: str = event.data["entity_id"]
 
@@ -212,7 +215,7 @@ class _AbsenceTracker(TargetEntityChangeTracker):
             return
 
         if (gone_for := new_state.last_changed - gone_since) >= self._duration:
-            self._on_return(entity_id, gone_since, gone_for)
+            self._on_return(entity_id, event, gone_since, gone_for)
 
     def _unsubscribe(self) -> None:
         """Unsubscribe from everything, the base class' listeners included."""
@@ -274,18 +277,27 @@ class SpookTrigger(Trigger):
         @callback
         def entity_came_back(
             entity_id: str,
+            event: Event[EventStateChangedData],
             gone_since: datetime,
             gone_for: timedelta,
         ) -> None:
             """Run the action for the entity that returned."""
+            to_state = event.data["new_state"]
+
             run_action(
                 {
                     "entity_id": entity_id,
+                    "from_state": event.data["old_state"],
+                    "to_state": to_state,
                     "for": self._duration,
                     "gone_since": dt_util.as_local(gone_since),
                     "gone_for": gone_for,
                 },
                 f"{entity_id} came back after {gone_for}",
+                # Carried through, so Spook's own context conditions can still
+                # tell whether a person was behind the return. Without it, a
+                # device somebody switched back on reads as nobody's doing.
+                to_state.context if to_state else None,
             )
 
         tracker = _AbsenceTracker(

--- a/custom_components/spook/ectoplasms/spook/triggers/recovered.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/recovered.py
@@ -1,0 +1,297 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_FOR,
+    CONF_OPTIONS,
+    CONF_TARGET,
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import CoreState, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.util import dt as dt_util
+
+from ....target_watching import watchable_target
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
+    from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+# States that are not the entity saying anything about itself. An entity is
+# only back when it reaches something that is neither of these.
+_NOT_A_VALUE = (STATE_UNAVAILABLE, STATE_UNKNOWN)
+
+
+def _a_real_absence(value: Any) -> timedelta:
+    """Validate the duration, and refuse one nothing could be shorter than.
+
+    Zero would fire on every flicker, and a reload of an integration takes
+    every one of its entities through unavailable and back inside a second.
+    That is the noise this trigger exists to filter out, so it cannot be
+    switched off.
+    """
+    duration = cv.positive_time_period(value)
+    if duration <= timedelta(0):
+        message = "The duration must be longer than zero"
+        raise vol.Invalid(message)
+    return duration
+
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TARGET): watchable_target,
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_FOR): _a_real_absence,
+        },
+    }
+)
+
+
+# Everything here is called by the base class or by an event, so there is
+# nothing public to count.
+# pylint: disable-next=too-few-public-methods
+class _AbsenceTracker(TargetEntityChangeTracker):
+    """Watch a target's entities and report the ones that come back.
+
+    Remembers when each entity went unavailable and works out how long it was
+    away when it returns, so there are no timers to keep: the only moment
+    anything has to be decided is the moment it comes back.
+
+    The registry listening and target re-expansion come from the base class,
+    which calls back into `_handle_entities_update` whenever the set of
+    targeted entities moves.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        target_selection: TargetSelection,
+        duration: timedelta,
+        on_return: Callable[[str, datetime, timedelta], None],
+    ) -> None:
+        """Initialize the tracker."""
+        super().__init__(hass, target_selection, entity_filter=lambda ids: ids)
+        self._duration = duration
+        self._on_return = on_return
+        self._tracked: set[str] = set()
+        self._gone_since: dict[str, datetime] = {}
+        self._unsub_changes: list[CALLBACK_TYPE] = []
+        self._unsub_started: CALLBACK_TYPE | None = None
+
+        # Nothing is recorded until Home Assistant is up. A slow integration
+        # sets up minutes into a start, and every entity it brings with it
+        # goes from unavailable to a value at that moment. Recording through
+        # the start would turn that into a recovery for each of them, timed
+        # from whenever the entity was created.
+        # `is_running` is not the question: that is already true while Home
+        # Assistant is starting, which is the half of a start this is here to
+        # sit out.
+        self._recording = hass.state is CoreState.running
+        if not self._recording:
+            self._unsub_started = hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED, self._house_is_up
+            )
+
+    @callback
+    def _house_is_up(self, _event: Event) -> None:
+        """Start recording, taking the entities that are away with us."""
+        self._unsub_started = None
+        self._recording = True
+        self._remember_who_is_away()
+
+    @callback
+    def _handle_entities_update(self, tracked_entities: set[str]) -> None:
+        """Re-aim at the entities the target now covers.
+
+        The base class re-expands the target on every entity, device and area
+        registry event anywhere in the system, and almost none of those move
+        this target. Tearing down and rebuilding the listeners each time would
+        be work for nothing.
+        """
+        if tracked_entities == self._tracked:
+            return
+
+        for entity_id in self._tracked - tracked_entities:
+            self._gone_since.pop(entity_id, None)
+
+        self._tracked = tracked_entities
+        self._relisten()
+        self._remember_who_is_away()
+
+    @callback
+    def _remember_who_is_away(self) -> None:
+        """Note when the entities that are already away went.
+
+        An entity that was unavailable before anybody was watching still has
+        the moment it went in `last_changed`, so an automation reloaded while
+        the device was down still reports how long the device was down, and
+        not how long Spook has been looking.
+
+        One sitting at unknown is left out. That state says nothing about how
+        long it has been there, and guessing would be worse than waiting for
+        the next spell.
+        """
+        if not self._recording:
+            return
+
+        for entity_id in self._tracked:
+            if entity_id in self._gone_since:
+                continue
+            state = self._hass.states.get(entity_id)
+            if state is not None and state.state == STATE_UNAVAILABLE:
+                self._gone_since[entity_id] = state.last_changed
+
+    @callback
+    def _relisten(self) -> None:
+        """Listen for changes to exactly the entities being tracked.
+
+        The new listener goes on before the old one comes off. Home Assistant
+        keeps one shared tracker per event type: drop the last subscriber and
+        it is torn down, taking with it events that have fired but not been
+        dispatched yet. Losing one here is losing the return itself.
+        """
+        previous = self._unsub_changes
+        self._unsub_changes = []
+
+        if self._tracked:
+            self._unsub_changes = [
+                async_track_state_change_event(
+                    self._hass, list(self._tracked), self._entity_changed
+                )
+            ]
+
+        for unsub in previous:
+            unsub()
+
+    @callback
+    def _entity_changed(self, event: Event) -> None:
+        """Follow one entity through going away and coming back."""
+        entity_id: str = event.data["entity_id"]
+
+        if (new_state := event.data["new_state"]) is None:
+            # Removed rather than returned. Whatever it was doing is over.
+            self._gone_since.pop(entity_id, None)
+            return
+
+        if not self._recording:
+            return
+
+        if new_state.state == STATE_UNAVAILABLE:
+            # `setdefault`, so a flip out to unknown and back does not restart
+            # the clock on an absence that never ended.
+            self._gone_since.setdefault(entity_id, new_state.last_changed)
+            return
+
+        if new_state.state == STATE_UNKNOWN:
+            # Reachable again, with nothing to say yet. Not back.
+            return
+
+        if (gone_since := self._gone_since.pop(entity_id, None)) is None:
+            # Never saw it go, so there is no absence to report the end of.
+            # An entity that starts at unknown and gets its first value has
+            # not recovered from anything.
+            return
+
+        if (gone_for := new_state.last_changed - gone_since) >= self._duration:
+            self._on_return(entity_id, gone_since, gone_for)
+
+    def _unsubscribe(self) -> None:
+        """Unsubscribe from everything, the base class' listeners included."""
+        super()._unsubscribe()
+
+        if self._unsub_started is not None:
+            self._unsub_started()
+            self._unsub_started = None
+
+        for unsub in self._unsub_changes:
+            unsub()
+        self._unsub_changes.clear()
+
+        self._gone_since.clear()
+        self._tracked = set()
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when an entity comes back.
+
+    Home Assistant will tell you the moment something goes unavailable, and
+    the moment it returns, but not the difference between a blink and an
+    outage. A router rebooting takes every device in the house through
+    unavailable and back in seconds, which is why an automation on the return
+    is usually more trouble than it is worth.
+
+    This one only counts a return worth hearing about: the entity has to have
+    been away for as long as you asked before coming back says anything.
+    """
+
+    trigger = "recovered"
+
+    _duration: timedelta
+    _target: ConfigType
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,  # noqa: ARG003
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        return _TRIGGER_SCHEMA(config)  # type: ignore[no-any-return]
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._duration = options[CONF_FOR]
+        self._target = config.target or {}
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def entity_came_back(
+            entity_id: str,
+            gone_since: datetime,
+            gone_for: timedelta,
+        ) -> None:
+            """Run the action for the entity that returned."""
+            run_action(
+                {
+                    "entity_id": entity_id,
+                    "for": self._duration,
+                    "gone_since": dt_util.as_local(gone_since),
+                    "gone_for": gone_for,
+                },
+                f"{entity_id} came back after {gone_for}",
+            )
+
+        tracker = _AbsenceTracker(
+            self._hass,
+            TargetSelection(self._target),
+            self._duration,
+            entity_came_back,
+        )
+        return await tracker.async_setup()

--- a/custom_components/spook/ectoplasms/spook/triggers/stale.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/stale.py
@@ -20,6 +20,8 @@ from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelect
 from homeassistant.helpers.trigger import Trigger
 from homeassistant.util import dt as dt_util
 
+from ....target_watching import watchable_target
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from datetime import datetime
@@ -47,30 +49,9 @@ def _quiet_period(value: Any) -> timedelta:
     return duration
 
 
-# `TARGET_FIELDS` is a plain mapping of schema fields, so it needs compiling
-# before it can validate anything.
-_TARGET_SCHEMA = vol.Schema(cv.TARGET_FIELDS)
-
-
-def _watchable_target(value: Any) -> ConfigType:
-    """Validate the target, and refuse one that names nothing.
-
-    An empty target passes the field validation happily and then watches
-    nothing at all: a trigger that loads and can never fire. Core's own
-    target tracking helper raises on this for the same reason.
-    """
-    target: ConfigType = _TARGET_SCHEMA(value)
-    if not TargetSelection(target).has_any_target:
-        message = (
-            "The target must name at least one entity, device, area, floor or label"
-        )
-        raise vol.Invalid(message)
-    return target
-
-
 _TRIGGER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_TARGET): _watchable_target,
+        vol.Required(CONF_TARGET): watchable_target,
         vol.Required(CONF_OPTIONS): {
             vol.Required(CONF_FOR): _quiet_period,
         },

--- a/custom_components/spook/icons.json
+++ b/custom_components/spook/icons.json
@@ -47,6 +47,9 @@
     "stale": {
       "trigger": "mdi:grave-stone"
     },
+    "recovered": {
+      "trigger": "mdi:heart-pulse"
+    },
     "watchdog": {
       "trigger": "mdi:dog"
     },

--- a/custom_components/spook/target_watching.py
+++ b/custom_components/spook/target_watching.py
@@ -1,0 +1,39 @@
+"""Spook - Your homie. Shared rules for triggers that watch a target.
+
+Every trigger that watches a target's entities needs the same thing from the
+configuration before it can start: a target that actually names something. The
+rule lived in two of them and had already begun to drift apart in its wording,
+so it lives here now.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.target import TargetSelection
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.typing import ConfigType
+
+# `TARGET_FIELDS` is a plain mapping of schema fields, so it needs compiling
+# before it can validate anything.
+_TARGET_SCHEMA = vol.Schema(cv.TARGET_FIELDS)
+
+
+def watchable_target(value: Any) -> ConfigType:
+    """Validate the target, and refuse one that names nothing.
+
+    An empty target passes the field validation happily and then watches
+    nothing at all: a trigger that loads and can never fire. Core's own target
+    tracking helper raises on this for the same reason.
+    """
+    target: ConfigType = _TARGET_SCHEMA(value)
+    if not TargetSelection(target).has_any_target:
+        message = (
+            "The target must name at least one entity, device, area, floor or label"
+        )
+        raise vol.Invalid(message)
+    return target

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1,5 +1,15 @@
 {
   "triggers": {
+    "recovered": {
+      "name": "Entity came back",
+      "description": "Fires when an entity comes back after having been unavailable for a while, so a router rebooting does not read as everything in the house recovering.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "How long the entity has to have been away before coming back counts. Anything shorter is a flicker: reloading an integration takes every one of its entities through unavailable and back inside a second."
+        }
+      }
+    },
     "sequence": {
       "name": "Triggers in order",
       "description": "Fires when several triggers happen one after another, in the order given.",

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -16,6 +16,16 @@ stale:
       selector:
         duration:
 
+recovered:
+  target:
+    entity:
+  fields:
+    for:
+      required: true
+      example: "00:15:00"
+      selector:
+        duration:
+
 integration_failed:
   fields:
     for:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -260,6 +260,83 @@ options:
 
 :::
 
+### Entity came back
+
+Fires when an entity returns after having been unavailable for a while.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Entity came back 👻
+* - Trigger name
+  - `spook.recovered`
+* - Targets
+  - {term}`Entities <entity>`, {term}`devices <device>`, {term}`areas <area>`, floors and labels
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `for`
+  - {term}`string <string>`
+  - Yes
+  - `00:15:00`
+```
+
+Home Assistant will tell you the moment something goes unavailable and the moment it returns, but not the difference between a blink and an outage. A router rebooting takes every device in the house through unavailable and back inside seconds, which is why an automation on the plain return is usually more trouble than it is worth.
+
+This one only counts a return worth hearing about. The entity has to have been away for at least as long as you asked before coming back says anything, so the freezer that dropped off the network overnight reaches you and the reload of an integration does not.
+
+The absence starts when the entity goes unavailable and ends when it reaches a state that is neither unavailable nor unknown. A device that reconnects before it has a reading passes through unknown on the way, and that neither ends the absence nor restarts it. An entity that only ever sits at unknown has not been away at all: that is the entity answering rather than the entity missing.
+
+When it fires, `trigger.entity_id` names the entity that came back, `trigger.gone_since` is when it went, `trigger.gone_for` is how long it was away, and `trigger.for` is the minimum you configured.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Anything in the garage that has been gone for a quarter of an hour:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.recovered
+target:
+  area_id: garage
+options:
+  for: "00:15:00"
+```
+
+One freezer, with a longer fuse, because a short outage is not worth waking up for:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.recovered
+target:
+  entity_id: sensor.freezer_temperature
+options:
+  for: "02:00:00"
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Nothing is recorded until Home Assistant has finished starting. An integration that sets itself up minutes into a start brings every one of its entities from unavailable to a value at that moment, and recording through the start would turn each of those into a recovery.
+- An absence that began before the trigger started watching still counts, and is measured from when the entity actually went. That is read from the entity itself, so an automation reloaded while a device was down still reports how long the device was down. A restart of Home Assistant is the exception: nothing survives it, so an absence that spans one is measured from the restart.
+- Only unavailable starts an absence. An entity that reports unknown for an hour never went away, and `spook.stale` is the trigger for a sensor that is reachable but has nothing useful to say.
+- A duration of zero is refused. It would fire on every flicker, which is the noise this trigger exists to filter out.
+- A target that names nothing is refused. An empty target is valid as far as the fields go, and would sit there watching no entities at all.
+- Expanding a device, area or floor covers its primary entities. Configuration and diagnostic entities are left out, the same as every other Home Assistant trigger that takes a target. Name one as an entity and it is always watched, whichever category it is in.
+
+:::
+
 ### Entity fell silent
 
 Fires when nothing has written to an entity for a while.

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -15,6 +15,12 @@ Fires on a crontab schedule, for the times Home Assistant's own time triggers ca
 
 `spook.cron`, [documentation](other-features#cron-schedule) 📚
 
+## Entity came back
+
+Fires when an entity returns after having been unavailable for a while, so a router rebooting does not read as everything in the house recovering. _#recovered_ _#back_ _#unavailable_
+
+`spook.recovered`, [documentation](other-features#entity-came-back) 📚
+
 ## Entity fell silent
 
 Fires when nothing has written to an entity for a while, which catches the device that died quietly instead of going unavailable. _#stale_ _#silent_ _#dead_

--- a/tests/ectoplasms/spook/triggers/test_recovered.py
+++ b/tests/ectoplasms/spook/triggers/test_recovered.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import CoreState
+from homeassistant.core import Context, CoreState
 from homeassistant.helpers.trigger import TriggerConfig
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -409,3 +409,47 @@ async def test_a_spell_of_unknown_is_not_an_absence(
     assert ran == []
 
     await _detach(hass)
+
+
+async def test_the_return_carries_its_own_context(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Whoever caused the return is still on it.
+
+    Spook's own context conditions read the person off the state change that
+    set the trigger off. Hand over a fresh context and a device somebody
+    switched back on themselves reads as nobody's doing, which is worse than
+    saying nothing: `spook.not_triggered_by_user` would pass.
+    """
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+
+    handed: list[tuple[dict, Context | None]] = []
+    trigger = SpookTrigger(
+        hass,
+        TriggerConfig(
+            key="recovered",
+            target={"entity_id": "sensor.probe"},
+            options={"for": QUARTER_OF_AN_HOUR},
+        ),
+    )
+
+    def _run(payload, _description, context=None) -> None:  # noqa: ANN001
+        handed.append((payload, context))
+
+    unsub = await trigger.async_attach_runner(_run)
+
+    freezer.tick(timedelta(minutes=20))
+    theirs = Context(user_id="abc123")
+    hass.states.async_set("sensor.probe", "21.5", context=theirs)
+    await hass.async_block_till_done()
+
+    unsub()
+
+    assert len(handed) == 1
+    payload, context = handed[0]
+    assert context is theirs
+    # The change itself is on the payload too, like every other trigger that
+    # fires on one.
+    assert payload["to_state"].state == "21.5"
+    assert payload["from_state"].state == STATE_UNAVAILABLE

--- a/tests/ectoplasms/spook/triggers/test_recovered.py
+++ b/tests/ectoplasms/spook/triggers/test_recovered.py
@@ -1,0 +1,411 @@
+"""Tests for the spook.recovered trigger."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import CoreState
+from homeassistant.helpers.trigger import TriggerConfig
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers.recovered import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+QUARTER_OF_AN_HOUR = timedelta(minutes=15)
+
+
+async def _automation(
+    hass: HomeAssistant,
+    target: dict,
+    duration: str = "00:15:00",
+) -> list[dict]:
+    """Set up an automation on the trigger and record every run."""
+    ran: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        ran.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "came back",
+                    "trigger": {
+                        "platform": "spook.recovered",
+                        "target": target,
+                        "options": {"for": duration},
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {
+                                "entity_id": "{{ trigger.entity_id }}",
+                                "gone_for": "{{ trigger.gone_for }}",
+                            },
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return ran
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger.
+
+    The harness fails a test that leaves a timer or listener behind, so this
+    doubles as a check that the trigger clears up after itself.
+    """
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.came_back"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "recovered" in await async_get_triggers(hass)
+
+
+async def test_a_target_is_required(hass: HomeAssistant) -> None:
+    """Without a target there is nothing to watch."""
+    with pytest.raises(vol.Invalid):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"for": {"minutes": 15}}}
+        )
+
+
+@pytest.mark.parametrize("duration", [{"minutes": 0}, "00:00:00", 0])
+async def test_a_zero_duration_is_refused(
+    hass: HomeAssistant, duration: object
+) -> None:
+    """Zero would fire on every flicker, which is what this exists to filter."""
+    with pytest.raises(vol.Invalid, match="longer than zero"):
+        await SpookTrigger.async_validate_config(
+            hass,
+            {"target": {"entity_id": "sensor.probe"}, "options": {"for": duration}},
+        )
+
+
+@pytest.mark.parametrize("target", [{}, {"entity_id": []}, {"area_id": None}])
+async def test_a_target_that_names_nothing_is_refused(
+    hass: HomeAssistant,
+    target: dict,
+) -> None:
+    """An empty target would load and then watch nothing at all."""
+    with pytest.raises(vol.Invalid, match="must name at least one"):
+        await SpookTrigger.async_validate_config(
+            hass, {"target": target, "options": {"for": {"minutes": 15}}}
+        )
+
+
+async def test_a_long_absence_fires_when_it_ends(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The point of the whole thing."""
+    hass.states.async_set("sensor.probe", "21.5")
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(hours=1))
+    hass.states.async_set("sensor.probe", "21.7")
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    assert ran[0]["entity_id"] == "sensor.probe"
+    assert ran[0]["gone_for"] == "1:00:00"
+
+    await _detach(hass)
+
+
+async def test_a_flicker_is_not_a_recovery(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Reloading an integration takes its entities away and back in a second.
+
+    Without the duration doing its job, every reload in the house would read
+    as everything in it recovering.
+    """
+    hass.states.async_set("sensor.probe", "21.5")
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(seconds=2))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    assert ran == []
+
+    await _detach(hass)
+
+
+async def test_unknown_on_the_way_back_does_not_end_the_absence(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A device that reconnects before it has a reading is not back yet.
+
+    It also must not restart the clock: the absence began when the entity
+    went unavailable, and it is still going.
+    """
+    hass.states.async_set("sensor.probe", "21.5")
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=20))
+    hass.states.async_set("sensor.probe", STATE_UNKNOWN)
+    await hass.async_block_till_done()
+    assert ran == []
+
+    freezer.tick(timedelta(minutes=1))
+    hass.states.async_set("sensor.probe", "21.7")
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    # Twenty-one minutes, counted from when it went, not from the unknown.
+    assert ran[0]["gone_for"] == "0:21:00"
+
+    await _detach(hass)
+
+
+async def test_a_first_reading_is_not_a_recovery(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An entity that sits at unknown and then gets a value never went away.
+
+    Plenty of entities are unknown for hours after a restart because nothing
+    has reported yet. Treating unknown as gone would fire for every one of
+    them the moment it works.
+    """
+    hass.states.async_set("sensor.probe", STATE_UNKNOWN)
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    freezer.tick(timedelta(hours=2))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    assert ran == []
+
+    await _detach(hass)
+
+
+async def test_an_absence_that_started_before_anybody_watched_still_counts(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An automation reloaded while the device was down still reports the truth.
+
+    The entity carries the moment it went in `last_changed`, so the answer is
+    how long the device was away and not how long Spook has been looking.
+    """
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    freezer.tick(timedelta(hours=3))
+
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    assert ran[0]["gone_for"] == "3:00:00"
+
+    await _detach(hass)
+
+
+async def test_a_slow_start_is_not_a_house_full_of_recoveries(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Nothing is recorded until Home Assistant is up.
+
+    An integration that sets up minutes into a start brings every one of its
+    entities from unavailable to a value at that moment. Recorded through the
+    start, each of those would be a recovery timed from whenever the entity
+    happened to be created.
+    """
+    hass.set_state(CoreState.starting)
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    freezer.tick(timedelta(minutes=30))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    assert ran == []
+
+    # Once the house is up, the next absence is watched as normal.
+    hass.set_state(CoreState.running)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    freezer.tick(timedelta(minutes=20))
+    hass.states.async_set("sensor.probe", "21.7")
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+
+    await _detach(hass)
+
+
+async def test_an_entity_removed_while_away_does_not_report_on_return(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A new entity that happens to reuse the name has recovered from nothing."""
+    hass.states.async_set("sensor.probe", "21.5")
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(hours=1))
+    hass.states.async_remove("sensor.probe")
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.probe", "21.7")
+    await hass.async_block_till_done()
+
+    assert ran == []
+
+    await _detach(hass)
+
+
+async def test_the_payload_carries_when_it_went_and_for_how_long(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """`gone_since` is handed over in local time, like every Spook trigger.
+
+    Attached straight rather than through an automation, because this is
+    about what the trigger hands over and not about what an action makes of
+    it. It also covers the entity being away before the trigger existed.
+    """
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    went = hass.states.get("sensor.probe").last_changed
+
+    fired: list[dict] = []
+    trigger = SpookTrigger(
+        hass,
+        TriggerConfig(
+            key="recovered",
+            target={"entity_id": "sensor.probe"},
+            options={"for": QUARTER_OF_AN_HOUR},
+        ),
+    )
+
+    def _run(payload, _description, _context=None) -> None:  # noqa: ANN001
+        fired.append(payload)
+
+    unsub = await trigger.async_attach_runner(_run)
+
+    freezer.tick(timedelta(minutes=20))
+    hass.states.async_set("sensor.probe", "21.5")
+    await hass.async_block_till_done()
+
+    unsub()
+
+    assert len(fired) == 1
+    assert fired[0]["entity_id"] == "sensor.probe"
+    assert fired[0]["gone_since"] == dt_util.as_local(went)
+    assert fired[0]["gone_for"] == timedelta(minutes=20)
+    assert fired[0]["for"] == QUARTER_OF_AN_HOUR
+
+
+async def test_flipping_back_out_does_not_restart_the_clock(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A device thrashing on the way back is one absence, not several.
+
+    It goes unavailable, comes far enough to say unknown, drops out again,
+    and finally reports. The absence began at the first of those and has not
+    ended since.
+    """
+    hass.states.async_set("sensor.probe", "21.5")
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=10))
+    hass.states.async_set("sensor.probe", STATE_UNKNOWN)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=1))
+    hass.states.async_set("sensor.probe", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=10))
+    hass.states.async_set("sensor.probe", "21.7")
+    await hass.async_block_till_done()
+
+    assert len(ran) == 1
+    # Twenty-one minutes in total, not the ten since the last drop-out.
+    assert ran[0]["gone_for"] == "0:21:00"
+
+    await _detach(hass)
+
+
+async def test_a_spell_of_unknown_is_not_an_absence(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An entity that reports unknown for an hour never went away.
+
+    Unknown is the entity answering: it is reachable and has no value. That
+    is a different complaint from being gone, and `spook.stale` is the one
+    that covers a sensor holding nothing useful. Only unavailable starts an
+    absence here.
+    """
+    hass.states.async_set("sensor.probe", "21.5")
+    ran = await _automation(hass, {"entity_id": "sensor.probe"})
+
+    hass.states.async_set("sensor.probe", STATE_UNKNOWN)
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(hours=1))
+    hass.states.async_set("sensor.probe", "21.7")
+    await hass.async_block_till_done()
+
+    assert ran == []
+
+    await _detach(hass)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A new trigger, `spook.recovered`:

```yaml
trigger: spook.recovered
target:
  area_id: garage
options:
  for: "00:15:00"
```

Home Assistant will tell you the moment something goes unavailable and the moment it returns, but not the difference between a blink and an outage. A router rebooting takes every device in the house through unavailable and back inside seconds, which is why an automation on the plain return is usually more trouble than it is worth. This one only counts a return worth hearing about.

It is the other half of `spook.stale`, on the same target tracker, and it needs no timers at all: it remembers when each entity went and works the rest out at the moment it comes back.

The decisions worth arguing about, each with a test that fails without it:

- **Only `unavailable` starts an absence.** `unknown` is the entity answering rather than the entity missing, and plenty of entities sit at unknown for hours after a restart because nothing has reported yet. Treating that as gone would fire for every one of them the moment it works. This is also the line the community drew in [#4169](https://github.com/home-assistant/feature-requests/discussions/4169).
- **`unknown` on the way back neither ends the absence nor restarts it.** A device that reconnects before it has a reading is not back yet, and a device thrashing on the way back is one absence rather than several.
- **Nothing is recorded until Home Assistant has finished starting.** An integration that sets itself up minutes into a start brings every one of its entities from unavailable to a value at that moment. `hass.is_running` is no good for this: it is already `True` while starting, which is exactly the half of a start that has to be sat out. That cost me a test before it cost anybody else anything.
- **An absence that began before anybody watched still counts**, measured from when the entity actually went, read off `last_changed`. So an automation reloaded during an outage reports the outage and not the reload.

The target validator was already in `stale` and `flapping`, word for word apart from where the docstring wrapped. Rather than let it become a third copy, it moves to `target_watching.py`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`spook.stale` catches the device that died quietly and `spook.flapping` catches the one that will not settle. Nothing said "it is back, and it was gone long enough that you should know".

Checked first that core is not about to ship this: it has a large set of purpose-specific triggers now, and none of them covers availability. The three discussions where the team is designing duration semantics and unavailable flips ([#359](https://github.com/home-assistant/feature-requests/discussions/359), [#4168](https://github.com/home-assistant/feature-requests/discussions/4168), [#4169](https://github.com/home-assistant/feature-requests/discussions/4169)) are about suppressing unavailable flips inside existing triggers, which is the opposite end of the same problem.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Eighteen tests, most of them through a real automation on the trigger so the payload is checked as an action receives it.

Then eight mutations. Seven were caught straight away; the eighth was not, and that is the interesting one:

| Mutation | Failures |
| --- | --- |
| Gate on `hass.is_running` | 1 |
| `unknown` starts an absence too | **0**, then 1 |
| `unknown` ends the absence | 2 |
| Any return counts, however short | 1 |
| Do not remember who was already away | 2 |
| Keep the absence when the entity is removed | 1 |
| A later drop-out restarts the clock | 1 |

"`unknown` starts an absence too" survived because the test that was meant to cover it set the entity to unknown *before* the automation loaded, so the transition never reached the tracker. It only proved that seeding ignores unknown, not that entering unknown does. A test where a watched entity goes from a real value into unknown and back closes it.

Full suite: 1628 passed.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
