### PR TITLE
Home Assistant cannot say "and" over time

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/all_of.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/all_of.py
@@ -1,0 +1,306 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, trigger as trigger_helper
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.util import dt as dt_util
+
+from ....trigger_nesting import async_attach_nested
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
+    from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_TRIGGERS = "triggers"
+CONF_WITHIN = "within"
+
+# One trigger is not a set of things happening together, it is a trigger. Two
+# is the smallest thing this can say something about.
+_MINIMUM_TRIGGERS = 2
+
+# What gets lifted out of the trigger that completed the set and put at the top
+# of the payload, so `trigger.to_state` and friends mean here what they mean
+# everywhere else. It is also what carries the person through: an automation
+# starts a fresh context, so a condition asking who set the run going reads
+# them off `trigger.to_state`.
+#
+# An allowlist on purpose. A nested payload also carries `id`, `idx`,
+# `platform` and `description`, and what is handed to `run_action` overrides
+# those, so merging one wholesale would replace the automation's own
+# `trigger.id` and break every `choose` keyed on it.
+_CARRIED_FROM_THE_LAST = ("entity_id", "from_state", "to_state", "event")
+
+
+def _window(value: Any) -> timedelta:
+    """Validate the window, and refuse one nothing can happen inside."""
+    within = cv.positive_time_period(value)
+    if within <= timedelta(0):
+        message = "The window must be longer than zero"
+        raise vol.Invalid(message)
+    return within
+
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_TRIGGERS): cv.TRIGGER_SCHEMA,
+            vol.Required(CONF_WITHIN): _window,
+        },
+    }
+)
+
+
+class _AllOfWatcher:
+    """Listens to every trigger at once and reports when the set is complete.
+
+    No timers and nothing to arm. Each trigger's last firing is remembered
+    with the moment it happened, anything that has fallen out of the window is
+    forgotten as it goes, and the only question left is whether what remains
+    covers all of them.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        triggers: list[ConfigType],
+        within: timedelta,
+        on_complete: Callable[
+            [list[dict[str, Any]], timedelta, dict[str, Any], Context | None], None
+        ],
+    ) -> None:
+        """Initialize the watcher."""
+        self._hass = hass
+        self._triggers = triggers
+        self._within = within
+        self._on_complete = on_complete
+
+        self._seen: dict[int, tuple[datetime, dict[str, Any]]] = {}
+        self._unsubs: list[CALLBACK_TYPE] = []
+
+        # Stopping is synchronous and attaching is not, so an attach can be
+        # suspended while this is set. See `async_stop`.
+        self._stopped = False
+
+    async def async_start(self) -> CALLBACK_TYPE:
+        """Attach every trigger, and refuse the lot if one will not go on.
+
+        All of them stay attached for the life of the trigger. There is no
+        order to keep, so there is nothing to be gained by listening to them
+        one at a time, and a trigger that fires while its neighbours are still
+        being attached is counted rather than lost.
+        """
+        for index in range(len(self._triggers)):
+            await self._async_attach(index)
+
+            if self._stopped:
+                # Stopped while that was suspended, the same window every
+                # attach in Spook has. `_async_attach` has already let go of
+                # what it took.
+                return self.async_stop
+
+        if len(self._unsubs) != len(self._triggers):
+            # One missing trigger means the set can never be complete, so this
+            # can never fire. Raising is what gets the automation marked
+            # unavailable instead of leaving it looking healthy and silent.
+            self.async_stop()
+            msg = "Could not attach every trigger of an all-of trigger"
+            raise HomeAssistantError(msg)
+
+        return self.async_stop
+
+    async def _async_attach(self, index: int) -> None:
+        """Attach one of the triggers and listen for it."""
+
+        async def _fired(
+            variables: dict[str, Any] | None = None,
+            context: Context | None = None,
+        ) -> None:
+            """Hand this firing over, saying which of the triggers it was.
+
+            A closure rather than a callable object holding the index. Home
+            Assistant decides whether to await an action by inspecting it, and
+            an instance with an async `__call__` is not recognised as
+            awaitable: the coroutine is created, dropped, and nothing is ever
+            counted.
+            """
+            self._async_one_fired(index, variables, context)
+
+        unsub = await async_attach_nested(
+            self._hass,
+            [self._triggers[index]],
+            _fired,
+            f"trigger {index + 1} of an all-of trigger",
+            "so its set can never be complete",
+        )
+
+        if self._stopped:
+            # Stopped while this was suspended. Nobody is holding the handle
+            # any more, so let go of it here.
+            if unsub is not None:
+                unsub()
+            return
+
+        if unsub is not None:
+            self._unsubs.append(unsub)
+
+    @callback
+    def _async_one_fired(
+        self,
+        index: int,
+        variables: dict[str, Any] | None,
+        context: Context | None,
+    ) -> None:
+        """Count one firing, and report if that completed the set.
+
+        Nothing here suspends, so there is no lock: two triggers firing at the
+        same moment cannot interleave halfway through this.
+        """
+        if self._stopped:
+            return
+
+        now = dt_util.utcnow()
+        payload = (variables or {}).get("trigger", {})
+
+        # The newest firing of a trigger replaces its older one. It did happen
+        # again, and the question this answers is whether all of them have
+        # happened recently.
+        self._seen[index] = (now, payload)
+
+        # What fired longer ago than the window is no longer part of what is
+        # happening now. Dropped one at a time rather than the whole lot at
+        # once, so two triggers that fired a moment ago still count towards a
+        # set that a third completes later.
+        cutoff = now - self._within
+        self._seen = {
+            seen_index: seen
+            for seen_index, seen in self._seen.items()
+            if seen[0] >= cutoff
+        }
+
+        if len(self._seen) < len(self._triggers):
+            return
+
+        collected = [self._seen[position][1] for position in range(len(self._triggers))]
+        span = now - min(when for when, _ in self._seen.values())
+
+        # Cleared, so the set has to happen again in full. Left standing, the
+        # next firing of any one of them would complete the same set over and
+        # over, and the trigger would go off on every event instead of once
+        # for the thing it was watching for.
+        self._seen.clear()
+
+        self._on_complete(collected, span, payload, context)
+
+    @callback
+    def async_stop(self) -> None:
+        """Detach everything, and refuse to attach any more.
+
+        Stopping is synchronous while attaching is not, so an attach can be
+        suspended inside `async_initialize_triggers` at this very moment.
+        Whatever that takes afterwards would have nobody left to detach it, so
+        the flag tells it to let go of what it just took.
+        """
+        self._stopped = True
+
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+        self._seen.clear()
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires when several things have all happened.
+
+    Home Assistant cannot say "and" over time. Its triggers are a list of
+    things any one of which sets an automation off, and `for` covers a single
+    state holding still. "These three things have all happened in the last five
+    minutes, in whatever order" is not expressible, and written out by hand it
+    takes a helper entity per thing and an automation to set each one.
+
+    `spook.sequence` already covers the case where the order matters. The
+    difference here is that it does not.
+    """
+
+    trigger = "all_of"
+
+    _triggers: list[ConfigType]
+    _within: timedelta
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        shaped: ConfigType = _TRIGGER_SCHEMA(config)
+        options = shaped[CONF_OPTIONS]
+
+        if len(options[CONF_TRIGGERS]) < _MINIMUM_TRIGGERS:
+            msg = (
+                f"An all-of trigger needs at least {_MINIMUM_TRIGGERS} triggers "
+                f"to have anything to combine, and this one has "
+                f"{len(options[CONF_TRIGGERS])}."
+            )
+            raise vol.Invalid(msg)
+
+        options[CONF_TRIGGERS] = await trigger_helper.async_validate_trigger_config(
+            hass, options[CONF_TRIGGERS]
+        )
+
+        return shaped
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._triggers = options[CONF_TRIGGERS]
+        self._within = options[CONF_WITHIN]
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def completed(
+            triggers: list[dict[str, Any]],
+            span: timedelta,
+            last: dict[str, Any],
+            context: Context | None,
+        ) -> None:
+            """Run the action, the set having come together."""
+            description = last.get("description", "the last of them")
+
+            run_action(
+                {
+                    **{key: last[key] for key in _CARRIED_FROM_THE_LAST if key in last},
+                    "triggers": triggers,
+                    "within": self._within,
+                    "span": span,
+                },
+                f"{description}, completing a set of {len(self._triggers)}",
+                context,
+            )
+
+        watcher = _AllOfWatcher(self._hass, self._triggers, self._within, completed)
+        return await watcher.async_start()

--- a/custom_components/spook/icons.json
+++ b/custom_components/spook/icons.json
@@ -23,6 +23,9 @@
     }
   },
   "triggers": {
+    "all_of": {
+      "trigger": "mdi:checkbox-multiple-marked"
+    },
     "condition_met": {
       "trigger": "mdi:check-circle"
     },

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1,5 +1,19 @@
 {
   "triggers": {
+    "all_of": {
+      "name": "All of these happened",
+      "description": "Fires when every one of several triggers has fired inside the same window of time, in any order. Home Assistant's own triggers are a list where any one of them is enough; this is the other one.",
+      "fields": {
+        "triggers": {
+          "name": "Triggers",
+          "description": "The triggers that all have to have fired. Order does not matter, and a trigger firing again replaces its earlier turn rather than counting twice."
+        },
+        "within": {
+          "name": "Within",
+          "description": "How close together they have to be. The window slides, so a trigger that fired longer ago than this is forgotten while the others carry on counting."
+        }
+      }
+    },
     "recovered": {
       "name": "Entity came back",
       "description": "Fires when an entity comes back after having been unavailable for a while, so a router rebooting does not read as everything in the house recovering.",

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -69,6 +69,17 @@ condition_met:
       required: true
       selector:
         condition:
+all_of:
+  fields:
+    triggers:
+      required: true
+      selector:
+        trigger:
+    within:
+      required: true
+      example: "00:05:00"
+      selector:
+        duration:
 sequence:
   fields:
     steps:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1010,6 +1010,102 @@ options:
 
 :::
 
+### All of these happened
+
+Fires when every one of several triggers has fired inside the same window of time, in any order.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - All of these happened 👻
+* - Trigger name
+  - `spook.all_of`
+* - Targets
+  - No targets
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `triggers`
+  - {term}`list <list>`
+  - Yes
+  - Two or more triggers
+* - `within`
+  - {term}`string <string>`
+  - Yes
+  - `00:05:00`
+```
+
+Home Assistant cannot say "and" over time. The triggers on an automation are a list where any one of them is enough to set it off, and `for` covers a single state holding still. "These three things have all happened in the last five minutes, in whatever order" is not expressible, and written out by hand it takes a helper entity for each thing and an automation to set each one.
+
+[](#triggers-in-order) already covers the case where the order matters. The difference here is that it does not.
+
+The window slides. Each trigger's most recent turn is remembered, anything that happened longer ago than the window is forgotten as time passes, and the trigger fires the moment what is left covers all of them. That means a member going stale does not throw away the others: two things that happened a minute ago still count towards a set that a third completes later.
+
+It fires once per set. After it goes off, every trigger has to have its turn again, or the next turn of any one member would complete the same set over and over.
+
+When it fires, `trigger.triggers` holds each member's own payload in the order you configured them, `trigger.span` is how far apart the oldest and newest actually were, and `trigger.within` is the window you set. The trigger that completed the set is lifted to the top as well, so `trigger.entity_id`, `trigger.to_state` and `trigger.event` mean what they mean in any other trigger, and a condition asking who set the run going still gets an answer.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Somebody arrived and the door opened, in either order, within two minutes. Which is a person coming home, rather than a door opening on its own:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.all_of
+options:
+  within: "00:02:00"
+  triggers:
+    - trigger: state
+      entity_id: device_tracker.phone
+      to: home
+    - trigger: state
+      entity_id: binary_sensor.front_door
+      to: "on"
+```
+
+It nests, so the members can be Spook's own triggers too. Here, two things that both went quiet inside the same hour, which is a bridge dying rather than a sensor dying:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.all_of
+options:
+  within: "01:00:00"
+  triggers:
+    - trigger: spook.stale
+      target:
+        entity_id: sensor.kitchen_temperature
+      options:
+        for: "00:30:00"
+    - trigger: spook.stale
+      target:
+        entity_id: sensor.hallway_temperature
+      options:
+        for: "00:30:00"
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Two triggers is the minimum. One trigger combined with nothing is that trigger, and it is refused rather than accepted as a pointless wrapper.
+- A window is required, and one of zero is refused. Without a window the set would eventually be complete forever, and with a window of zero nothing could ever happen inside it.
+- A member firing twice replaces its earlier turn rather than counting as two members. Every trigger has to have had its own turn.
+- If one of the triggers cannot be attached, the whole thing refuses to load and the automation is marked unavailable. A set missing a member can never be complete, so loading and sitting there silent would be worse.
+- The window is measured from when Spook saw each trigger fire, not from anything inside the event. For a state change those are the same moment; for a trigger that reports something that happened earlier, they are not.
+
+:::
+
 ### Triggers in order
 
 Fires when several triggers happen one after another, in the order given.

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -9,6 +9,12 @@ date: 2026-08-27T21:15:00+02:00
 
 Spook provides new triggers to Home Assistant. This reference page lists them all and points you to the right documentation for that trigger.
 
+## All of these happened
+
+Fires when every one of several triggers has fired inside the same window of time, in any order. Home Assistant's own triggers are a list where any one of them is enough; this is the other one. _#and_ _#together_ _#combination_
+
+`spook.all_of`, [documentation](other-features#all-of-these-happened) 📚
+
 ## Cron schedule
 
 Fires on a crontab schedule, for the times Home Assistant's own time triggers cannot express, like every weekday at seven or the last Friday of the month. _#crontab_

--- a/tests/ectoplasms/spook/triggers/test_all_of.py
+++ b/tests/ectoplasms/spook/triggers/test_all_of.py
@@ -1,19 +1,23 @@
 """Tests for the spook.all_of trigger."""
 
-# pylint: disable=wrong-import-order
+# pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from homeassistant.core import Context
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import trigger as trigger_helper
 from homeassistant.helpers.trigger import TriggerConfig
 from homeassistant.setup import async_setup_component
 import pytest
 import voluptuous as vol
 
+from custom_components.spook import trigger_nesting
+from custom_components.spook.ectoplasms.spook.triggers import all_of as all_of_module
 from custom_components.spook.ectoplasms.spook.triggers.all_of import SpookTrigger
 from custom_components.spook.trigger import async_get_triggers
 
@@ -381,3 +385,92 @@ async def test_a_trigger_that_will_not_attach_refuses_the_lot(
         pytest.raises(HomeAssistantError, match="every trigger"),
     ):
         await trigger.async_attach_runner(_run)
+
+
+async def test_a_spook_trigger_can_be_one_of_the_members(
+    hass: HomeAssistant,
+) -> None:
+    """Nesting Spook's own triggers is advertised, so it is tested.
+
+    A core state trigger and a Spook one go through different routes on the
+    way in: a Spook member is validated through Spook's own discovery and
+    `async_validate_complete_config`, not the generic path. `flapping` is the
+    member here because it needs no timer to fire, only changes.
+    """
+    hass.states.async_set("binary_sensor.motion", "off")
+    runs = await _automation(
+        hass,
+        {
+            "within": "00:05:00",
+            "triggers": [
+                DOOR,
+                {
+                    "trigger": "spook.flapping",
+                    "target": {"entity_id": "binary_sensor.motion"},
+                    "options": {"changes": 2, "within": "00:01:00"},
+                },
+            ],
+        },
+    )
+
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+    assert runs == []
+
+    hass.states.async_set("binary_sensor.motion", "on")
+    hass.states.async_set("binary_sensor.motion", "off")
+    await hass.async_block_till_done()
+
+    assert len(runs) == 1
+    # The nested trigger's own payload is carried like any other member's.
+    assert runs[0]["last"] == "binary_sensor.motion"
+
+    await _detach(hass)
+
+
+async def test_stopping_while_attaching_leaves_nothing_behind(
+    hass: HomeAssistant,
+) -> None:
+    """Stopping is synchronous while attaching is not.
+
+    The same window every attach in Spook has, and the shape of test the
+    watchdog and sequence watchers already carry, because that race turned up
+    in both of them more than once.
+    """
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [DOOR, MOTION], "within": "00:05:00"}}
+    )
+    watcher = all_of_module._AllOfWatcher(  # noqa: SLF001
+        hass,
+        config["options"]["triggers"],
+        FIVE_MINUTES,
+        lambda *_args: None,
+    )
+
+    real = trigger_helper.async_initialize_triggers
+    hold = asyncio.Event()
+    attaching = asyncio.Event()
+
+    async def _suspending(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if "trigger 2" in args[4]:
+            attaching.set()
+            await hold.wait()
+        return await real(*args, **kwargs)
+
+    with patch.object(
+        trigger_nesting.trigger_helper, "async_initialize_triggers", _suspending
+    ):
+        starting = hass.async_create_task(watcher.async_start())
+        async with asyncio.timeout(5):
+            await attaching.wait()
+
+        watcher.async_stop()
+
+        hold.set()
+        async with asyncio.timeout(5):
+            await starting
+        await hass.async_block_till_done()
+
+    assert not watcher._unsubs, "a listener was left behind"  # noqa: SLF001
+
+    watcher.async_stop()

--- a/tests/ectoplasms/spook/triggers/test_all_of.py
+++ b/tests/ectoplasms/spook/triggers/test_all_of.py
@@ -3,23 +3,21 @@
 # pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
-import asyncio
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from homeassistant.core import Context
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import trigger as trigger_helper
 from homeassistant.helpers.trigger import TriggerConfig
 from homeassistant.setup import async_setup_component
 import pytest
 import voluptuous as vol
 
-from custom_components.spook import trigger_nesting
 from custom_components.spook.ectoplasms.spook.triggers import all_of as all_of_module
 from custom_components.spook.ectoplasms.spook.triggers.all_of import SpookTrigger
 from custom_components.spook.trigger import async_get_triggers
+from tests.nested_trigger_helpers import async_stop_while_attaching
 
 # Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
 # loader resolve the integration when it goes looking for the trigger platform.
@@ -447,29 +445,7 @@ async def test_stopping_while_attaching_leaves_nothing_behind(
         lambda *_args: None,
     )
 
-    real = trigger_helper.async_initialize_triggers
-    hold = asyncio.Event()
-    attaching = asyncio.Event()
-
-    async def _suspending(*args: Any, **kwargs: Any):  # noqa: ANN202
-        if "trigger 2" in args[4]:
-            attaching.set()
-            await hold.wait()
-        return await real(*args, **kwargs)
-
-    with patch.object(
-        trigger_nesting.trigger_helper, "async_initialize_triggers", _suspending
-    ):
-        starting = hass.async_create_task(watcher.async_start())
-        async with asyncio.timeout(5):
-            await attaching.wait()
-
-        watcher.async_stop()
-
-        hold.set()
-        async with asyncio.timeout(5):
-            await starting
-        await hass.async_block_till_done()
+    await async_stop_while_attaching(hass, watcher, holding="trigger 2")
 
     assert not watcher._unsubs, "a listener was left behind"  # noqa: SLF001
 

--- a/tests/ectoplasms/spook/triggers/test_all_of.py
+++ b/tests/ectoplasms/spook/triggers/test_all_of.py
@@ -1,0 +1,383 @@
+"""Tests for the spook.all_of trigger."""
+
+# pylint: disable=wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+from homeassistant.core import Context
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.trigger import TriggerConfig
+from homeassistant.setup import async_setup_component
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers.all_of import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+DOOR = {"trigger": "state", "entity_id": "binary_sensor.door", "to": "on"}
+MOTION = {"trigger": "state", "entity_id": "binary_sensor.motion", "to": "on"}
+PHONE = {"trigger": "state", "entity_id": "device_tracker.phone", "to": "home"}
+
+FIVE_MINUTES = timedelta(minutes=5)
+TWO = 2
+
+
+async def _automation(
+    hass: HomeAssistant,
+    options: dict[str, Any] | None = None,
+) -> list[dict]:
+    """Set up an automation on the trigger and record every run."""
+    runs: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        runs.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "all together",
+                    "trigger": {
+                        "platform": "spook.all_of",
+                        "options": options
+                        or {"triggers": [DOOR, MOTION], "within": "00:05:00"},
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {
+                                "count": "{{ trigger.triggers | count }}",
+                                "first": "{{ trigger.triggers[0].entity_id }}",
+                                "last": "{{ trigger.entity_id }}",
+                                "span": "{{ trigger.span }}",
+                            },
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return runs
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger.
+
+    The harness fails a test that leaves a listener behind, and this trigger
+    holds one nested trigger per member, so this doubles as a check that it
+    lets go of all of them.
+    """
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": "automation.all_together"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "all_of" in await async_get_triggers(hass)
+
+
+async def test_one_trigger_is_not_a_set(hass: HomeAssistant) -> None:
+    """One trigger combined with nothing is just that trigger."""
+    with pytest.raises(vol.Invalid, match="at least 2 triggers"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"triggers": [DOOR], "within": "00:05:00"}}
+        )
+
+
+@pytest.mark.parametrize("within", [{"minutes": 0}, "00:00:00", 0])
+async def test_a_zero_window_is_refused(hass: HomeAssistant, within: object) -> None:
+    """Nothing can happen inside no time, so the set could never complete."""
+    with pytest.raises(vol.Invalid, match="longer than zero"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"triggers": [DOOR, MOTION], "within": within}}
+        )
+
+
+async def test_a_window_is_required(hass: HomeAssistant) -> None:
+    """Without one, the set would eventually be complete forever."""
+    with pytest.raises(vol.Invalid):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"triggers": [DOOR, MOTION]}}
+        )
+
+
+async def test_both_inside_the_window_fires_once(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The point of the whole thing."""
+    runs = await _automation(hass)
+
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+    assert runs == []
+
+    freezer.tick(timedelta(minutes=2))
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+    assert len(runs) == 1
+    assert runs[0]["count"] == TWO
+    # In the order they were configured, not the order they fired.
+    assert runs[0]["first"] == "binary_sensor.door"
+    # And the top of the payload is the one that completed the set.
+    assert runs[0]["last"] == "binary_sensor.motion"
+    assert runs[0]["span"] == "0:02:00"
+
+    await _detach(hass)
+
+
+async def test_the_order_does_not_matter(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The whole difference from `spook.sequence`."""
+    runs = await _automation(hass)
+
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=1))
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    assert len(runs) == 1
+    assert runs[0]["last"] == "binary_sensor.door"
+
+    await _detach(hass)
+
+
+async def test_too_far_apart_is_not_a_set(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Two things an hour apart are not two things happening together."""
+    runs = await _automation(hass)
+
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(hours=1))
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+    assert runs == []
+
+    await _detach(hass)
+
+
+async def test_what_fell_out_of_the_window_is_dropped_on_its_own(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """One member going stale does not throw away the others.
+
+    The window slides. The first trigger falls out of it while the other two
+    are still counting, so the set completes when the first one comes round
+    again and the span is measured from the oldest that is still in.
+    """
+    runs = await _automation(
+        hass,
+        {"triggers": [DOOR, MOTION, PHONE], "within": "00:05:00"},
+    )
+
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=4))
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+    # Six minutes in: the door is now too old, so this is not a set of three.
+    freezer.tick(timedelta(minutes=2))
+    hass.states.async_set("device_tracker.phone", "home")
+    await hass.async_block_till_done()
+    assert runs == []
+
+    # The door again, which completes it with the two that are still in.
+    freezer.tick(timedelta(minutes=1))
+    hass.states.async_set("binary_sensor.door", "off")
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    assert len(runs) == 1
+    # Seven minutes in, oldest still counting is the motion at four.
+    assert runs[0]["span"] == "0:03:00"
+
+    await _detach(hass)
+
+
+async def test_it_does_not_fire_again_on_every_firing_after(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Once reported, the set has to happen again in full.
+
+    Left standing, the next turn of any one member would complete the same set
+    over and over and the trigger would go off on every event.
+    """
+    runs = await _automation(hass)
+
+    hass.states.async_set("binary_sensor.door", "on")
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+    assert len(runs) == 1
+
+    freezer.tick(timedelta(minutes=1))
+    hass.states.async_set("binary_sensor.motion", "off")
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+    assert len(runs) == 1
+
+    await _detach(hass)
+
+
+async def test_one_member_firing_twice_is_still_one_member(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Every trigger has to have had its turn, not just some of them twice."""
+    runs = await _automation(hass)
+
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=1))
+    hass.states.async_set("binary_sensor.door", "off")
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+    assert runs == []
+
+    freezer.tick(timedelta(minutes=1))
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+    assert len(runs) == 1
+
+    await _detach(hass)
+
+
+async def test_the_payload_carries_the_change_that_completed_it(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The completing trigger's own context comes through.
+
+    Spook's context conditions read the person off the change that set the run
+    going, so handing over a fresh context would make every set read as
+    nobody's doing.
+    """
+    fired: list[tuple[dict, Context | None]] = []
+
+    # Through the trigger's own validation, which is what shapes the nested
+    # configs and is the only route that exists in a real house.
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [DOOR, MOTION], "within": "00:05:00"}}
+    )
+    trigger = SpookTrigger(hass, TriggerConfig(key="all_of", options=config["options"]))
+
+    def _run(payload, _description, context=None) -> None:  # noqa: ANN001
+        fired.append((payload, context))
+
+    unsub = await trigger.async_attach_runner(_run)
+
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=1))
+    theirs = Context(user_id="abc123")
+    hass.states.async_set("binary_sensor.motion", "on", context=theirs)
+    await hass.async_block_till_done()
+
+    unsub()
+
+    assert len(fired) == 1
+    payload, context = fired[0]
+    assert context is theirs
+    assert payload["to_state"].entity_id == "binary_sensor.motion"
+    assert payload["within"] == FIVE_MINUTES
+    assert payload["span"] == timedelta(minutes=1)
+    assert [item["entity_id"] for item in payload["triggers"]] == [
+        "binary_sensor.door",
+        "binary_sensor.motion",
+    ]
+
+
+async def test_a_members_newest_turn_is_the_one_that_counts(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A trigger firing again replaces its earlier turn rather than keeping it.
+
+    The door went half an hour ago and again just now. What this answers is
+    whether all of them have happened recently, so the recent one is the one
+    that matters. Keeping the first would leave the set stale forever.
+    """
+    runs = await _automation(hass)
+
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=30))
+    hass.states.async_set("binary_sensor.door", "off")
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(minutes=1))
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+    assert len(runs) == 1
+    assert runs[0]["span"] == "0:01:00"
+
+    await _detach(hass)
+
+
+async def test_a_trigger_that_will_not_attach_refuses_the_lot(
+    hass: HomeAssistant,
+) -> None:
+    """One missing member means the set can never be complete.
+
+    Raising is what marks the automation unavailable. Loading it and sitting
+    there silent is the failure this is here to avoid.
+    """
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [DOOR, MOTION], "within": "00:05:00"}}
+    )
+    trigger = SpookTrigger(hass, TriggerConfig(key="all_of", options=config["options"]))
+
+    def _run(_payload, _description, _context=None) -> None:  # noqa: ANN001
+        """Never called."""
+
+    with (
+        patch(
+            "custom_components.spook.ectoplasms.spook.triggers.all_of"
+            ".async_attach_nested",
+            return_value=None,
+        ),
+        pytest.raises(HomeAssistantError, match="every trigger"),
+    ):
+        await trigger.async_attach_runner(_run)

--- a/tests/ectoplasms/spook/triggers/test_sequence.py
+++ b/tests/ectoplasms/spook/triggers/test_sequence.py
@@ -16,12 +16,12 @@ from pytest_homeassistant_custom_component.common import async_fire_time_changed
 import pytest
 import voluptuous as vol
 
-from custom_components.spook import trigger_nesting
 from custom_components.spook.ectoplasms.spook.triggers import (
     sequence as sequence_module,
 )
 from custom_components.spook.ectoplasms.spook.triggers.sequence import SpookTrigger
 from custom_components.spook.trigger import async_get_triggers
+from tests.nested_trigger_helpers import async_stop_while_attaching
 
 # Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
 # loader resolve the integration when it goes looking for the trigger platform.
@@ -815,29 +815,7 @@ async def test_stopping_while_attaching_the_reset_leaves_nothing_behind(
         lambda *_args: None,
     )
 
-    real = trigger_helper.async_initialize_triggers
-    hold = asyncio.Event()
-    attaching = asyncio.Event()
-
-    async def _suspending(*args: Any, **kwargs: Any):  # noqa: ANN202
-        if "reset" in args[4]:
-            attaching.set()
-            await hold.wait()
-        return await real(*args, **kwargs)
-
-    with patch.object(
-        trigger_nesting.trigger_helper, "async_initialize_triggers", _suspending
-    ):
-        starting = hass.async_create_task(watcher.async_start())
-        async with asyncio.timeout(5):
-            await attaching.wait()
-
-        watcher.async_stop()
-
-        hold.set()
-        async with asyncio.timeout(5):
-            await starting
-        await hass.async_block_till_done()
+    await async_stop_while_attaching(hass, watcher, holding="reset")
 
     assert watcher._unsub_reset is None, "a reset listener was left behind"  # noqa: SLF001
     assert watcher._run.unsub_step is None, "a step listener was left behind"  # noqa: SLF001

--- a/tests/ectoplasms/spook/triggers/test_watchdog.py
+++ b/tests/ectoplasms/spook/triggers/test_watchdog.py
@@ -24,6 +24,7 @@ from custom_components.spook.ectoplasms.spook.triggers import (
 )
 from custom_components.spook.ectoplasms.spook.triggers.watchdog import SpookTrigger
 from custom_components.spook.trigger import async_get_triggers
+from tests.nested_trigger_helpers import async_stop_while_attaching
 
 # Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
 # loader resolve the integration when it goes looking for the trigger platform.
@@ -335,33 +336,8 @@ async def test_stopping_while_attaching_leaves_nothing_behind(
         barks.append,
     )
 
-    real = trigger_helper.async_initialize_triggers
-    hold = asyncio.Event()
-    attaching = asyncio.Event()
-
-    async def _suspending(*args: Any, **kwargs: Any):  # noqa: ANN202
-        if "arming" in args[4]:
-            attaching.set()
-            await hold.wait()
-        return await real(*args, **kwargs)
-
-    with patch.object(
-        trigger_nesting.trigger_helper,
-        "async_initialize_triggers",
-        _suspending,
-    ):
-        starting = hass.async_create_task(watchdog.async_start())
-        async with asyncio.timeout(5):
-            await attaching.wait()
-
-        # The automation is turned off while the arming half is being
-        # attached.
-        watchdog.async_stop()
-
-        hold.set()
-        async with asyncio.timeout(5):
-            await starting
-        await hass.async_block_till_done()
+    # Stopped while the arming half is still being attached.
+    await async_stop_while_attaching(hass, watchdog, holding="arming")
 
     assert not watchdog._unsubs, "a listener was left behind"
 

--- a/tests/nested_trigger_helpers.py
+++ b/tests/nested_trigger_helpers.py
@@ -1,0 +1,74 @@
+"""Helpers for the watchers that attach nested triggers.
+
+Every Spook trigger built on other triggers has the same window in it:
+stopping is synchronous and attaching is not, so a stop can land while
+`async_initialize_triggers` is still inside an await. Whatever that takes
+afterwards has nobody left to hand it back to.
+
+Three watchers carry a test for it, all doing the same dance, so the dance
+lives here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Protocol
+from unittest.mock import patch
+
+from homeassistant.helpers import trigger as trigger_helper
+
+from custom_components.spook import trigger_nesting
+
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+
+
+class _Watcher(Protocol):
+    """What this needs of a watcher: a way to start it and a way to stop it."""
+
+    async def async_start(self) -> CALLBACK_TYPE:
+        """Attach whatever it listens to."""
+
+    def async_stop(self) -> None:
+        """Let go of all of it."""
+
+
+async def async_stop_while_attaching(
+    hass: HomeAssistant,
+    watcher: _Watcher,
+    *,
+    holding: str,
+) -> None:
+    """Stop a watcher while one of its attaches is suspended.
+
+    `holding` is matched against the name the watcher gives the attach it is
+    waiting on, which is what picks out which of several to hold open.
+
+    Overlapped on purpose. Awaiting `async_start` and only then stopping never
+    puts the two at the same moment, and a version of the watchdog's test that
+    did exactly that passed against a watchdog which leaked its listener.
+    Review caught it, which is why this shape is the one all three use.
+    """
+    real = trigger_helper.async_initialize_triggers
+    hold = asyncio.Event()
+    attaching = asyncio.Event()
+
+    async def _suspending(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if holding in args[4]:
+            attaching.set()
+            await hold.wait()
+        return await real(*args, **kwargs)
+
+    with patch.object(
+        trigger_nesting.trigger_helper, "async_initialize_triggers", _suspending
+    ):
+        starting = hass.async_create_task(watcher.async_start())
+        async with asyncio.timeout(5):
+            await attaching.wait()
+
+        watcher.async_stop()
+
+        hold.set()
+        async with asyncio.timeout(5):
+            await starting
+        await hass.async_block_till_done()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A new trigger, `spook.all_of`:

```yaml
trigger: spook.all_of
options:
  within: "00:02:00"
  triggers:
    - trigger: state
      entity_id: device_tracker.phone
      to: home
    - trigger: state
      entity_id: binary_sensor.front_door
      to: "on"
```

Somebody arrived and the door opened, in either order, within two minutes. Which is a person coming home rather than a door opening on its own.

Home Assistant cannot say "and" over time. The triggers on an automation are a list where any one of them is enough to set it off, and `for` covers a single state holding still. "These three things have all happened in the last five minutes, in whatever order" is not expressible, and written out by hand it takes a helper entity for each thing plus an automation to set each one.

`spook.sequence` already covers the case where the order matters. The difference here is that it does not.

No timers. Each trigger's most recent turn is remembered with the moment it happened, whatever has fallen out of the window is forgotten as it goes, and the only question left is whether what remains covers all of them. Same shape as `flapping`.

It nests, so the members can be Spook's own triggers. Two `spook.stale` triggers inside the same hour is a bridge dying rather than a sensor dying, and that is the second example in the documentation.

The decisions worth arguing about, each with a test that fails without it:

- **The window slides, and what leaves it goes one at a time** rather than the whole set being dropped. Two things that happened a moment ago still count towards a set that a third completes later.
- **A member's newest turn replaces its older one.** The question is whether they all happened *recently*, so a door that went half an hour ago and again just now counts as just now. Keeping the first turn would leave a set permanently stale.
- **Everything is cleared once it fires.** Left standing, the next turn of any single member would complete the same set over and over and the trigger would go off on every event.
- **One trigger that will not attach refuses the lot**, with an exception, so the automation is marked unavailable. A set missing a member can never be complete, and loading in order to sit there silent is worse than not loading.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The gap it fills is the plain one: there is no AND over time anywhere in Home Assistant. It is also the first of the building-block set, with `spook.debounce` to follow.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Fifteen tests, most of them through a real automation on the trigger so the payload is checked as an action receives it, plus one attached directly to check the context is threaded through.

Then five mutations:

| Mutation | Result |
| --- | --- |
| Drop the whole set when one member falls out of the window | 1 failure |
| Do not clear after firing | 1 failure |
| Keep a member's first turn instead of its newest | 1 failure |
| Fire without waiting for all of them | 8 errors |
| Let attach failures pass quietly | 1 failure |

The fourth is caught by crashing rather than by a clean assertion: without the guard the payload cannot be assembled. Detected, just untidily.

Full suite: 1679 passed.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
