### PR TITLE
A motion sensor does not report motion once

### DIFF
--- a/custom_components/spook/ectoplasms/spook/triggers/debounce.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/debounce.py
@@ -32,17 +32,21 @@ if TYPE_CHECKING:
 
 CONF_TRIGGERS = "triggers"
 
-# What gets lifted out of the last firing of a burst and put at the top of the
-# payload, so `trigger.to_state` and friends mean here what they mean
-# everywhere else. It is also what carries the person through: an automation
-# starts a fresh context, so a condition asking who set the run going reads
-# them off `trigger.to_state`.
+# What the last firing of a burst may not bring to the top of the payload.
+# Home Assistant lays the automation's own `id`, `idx` and `alias` under what a
+# trigger hands over, with `platform` and the description, and what is handed
+# over wins. A nested payload carries all five too, so merging it wholesale
+# would replace the automation's `trigger.id` with the nested trigger's and
+# break every `choose` keyed on it.
 #
-# An allowlist on purpose. A nested payload also carries `id`, `idx`,
-# `platform` and `description`, and what is handed to `run_action` overrides
-# those, so merging one wholesale would replace the automation's own
-# `trigger.id` and break every `choose` keyed on it.
-_CARRIED_FROM_THE_LAST = ("entity_id", "from_state", "to_state", "event")
+# Everything else comes through. `spook.all_of` and `spook.sequence` hand over
+# every payload in a list and lift only the common keys, but this one keeps no
+# list, so the last firing is the only payload there is: `trigger.to_state`
+# means what it means everywhere else, and so does an MQTT trigger's `payload`
+# or a calendar trigger's `calendar_event`. It is also what carries the person
+# through: an automation starts a fresh context, so a condition asking who set
+# the run going reads them off `trigger.to_state`.
+_THE_AUTOMATIONS_OWN = frozenset({"id", "idx", "alias", "platform", "description"})
 
 
 def _a_real_pause(value: Any) -> timedelta:
@@ -83,10 +87,10 @@ class _Burst:
 class _BurstWatcher:
     """Listens to the triggers and reports once they have stopped.
 
-    Only counts are kept, not every payload. A burst has no ceiling: a sensor
-    that will not settle can fire hundreds of times, and holding all of that
-    to hand over is a memory cost for something nobody reads. The last firing
-    is the one worth having.
+    The firings before the last are counted, not kept. A burst has no ceiling:
+    a sensor that will not settle can fire hundreds of times, and holding all
+    of that to hand over is a memory cost for something nobody reads. The last
+    firing is the one worth having, and it is kept whole.
     """
 
     def __init__(
@@ -282,6 +286,14 @@ class SpookTrigger(Trigger):
         shaped: ConfigType = _TRIGGER_SCHEMA(config)
         options = shaped[CONF_OPTIONS]
 
+        if not options[CONF_TRIGGERS]:
+            # `cv.TRIGGER_SCHEMA` is content with an empty list, and so would
+            # `async_start` be: nothing to attach is nothing that can fail.
+            # What that leaves is an automation that looks healthy and can
+            # never fire.
+            msg = "A debounce trigger needs at least one trigger to wait out"
+            raise vol.Invalid(msg)
+
         options[CONF_TRIGGERS] = await trigger_helper.async_validate_trigger_config(
             hass, options[CONF_TRIGGERS]
         )
@@ -314,7 +326,13 @@ class SpookTrigger(Trigger):
 
             run_action(
                 {
-                    **{key: last[key] for key in _CARRIED_FROM_THE_LAST if key in last},
+                    **{
+                        key: value
+                        for key, value in last.items()
+                        if key not in _THE_AUTOMATIONS_OWN
+                    },
+                    # After the merge on purpose: a nested state trigger has a
+                    # `for` of its own, and this one is the quiet period.
                     "count": count,
                     "span": span,
                     "for": self._pause,

--- a/custom_components/spook/ectoplasms/spook/triggers/debounce.py
+++ b/custom_components/spook/ectoplasms/spook/triggers/debounce.py
@@ -1,0 +1,327 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_FOR, CONF_OPTIONS
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, trigger as trigger_helper
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.util import dt as dt_util
+
+from ....trigger_nesting import async_attach_nested
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
+    from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_TRIGGERS = "triggers"
+
+# What gets lifted out of the last firing of a burst and put at the top of the
+# payload, so `trigger.to_state` and friends mean here what they mean
+# everywhere else. It is also what carries the person through: an automation
+# starts a fresh context, so a condition asking who set the run going reads
+# them off `trigger.to_state`.
+#
+# An allowlist on purpose. A nested payload also carries `id`, `idx`,
+# `platform` and `description`, and what is handed to `run_action` overrides
+# those, so merging one wholesale would replace the automation's own
+# `trigger.id` and break every `choose` keyed on it.
+_CARRIED_FROM_THE_LAST = ("entity_id", "from_state", "to_state", "event")
+
+
+def _a_real_pause(value: Any) -> timedelta:
+    """Validate the quiet period, and refuse one nothing could be quieter than.
+
+    Zero would fire on the first thing to happen and collapse nothing at all,
+    which is the trigger it was given, only slower.
+    """
+    duration = cv.positive_time_period(value)
+    if duration <= timedelta(0):
+        message = "The quiet period must be longer than zero"
+        raise vol.Invalid(message)
+    return duration
+
+
+_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): {
+            vol.Required(CONF_TRIGGERS): cv.TRIGGER_SCHEMA,
+            vol.Required(CONF_FOR): _a_real_pause,
+        },
+    }
+)
+
+
+@dataclass(slots=True)
+class _Burst:
+    """One run of firings that have not finished arriving yet."""
+
+    started: datetime
+    last_at: datetime
+    last: dict[str, Any] = field(default_factory=dict)
+    context: Context | None = None
+    count: int = 1
+    unsub: CALLBACK_TYPE | None = None
+
+
+class _BurstWatcher:
+    """Listens to the triggers and reports once they have stopped.
+
+    Only counts are kept, not every payload. A burst has no ceiling: a sensor
+    that will not settle can fire hundreds of times, and holding all of that
+    to hand over is a memory cost for something nobody reads. The last firing
+    is the one worth having.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        triggers: list[ConfigType],
+        pause: timedelta,
+        on_quiet: Callable[[int, timedelta, dict[str, Any], Context | None], None],
+    ) -> None:
+        """Initialize the watcher."""
+        self._hass = hass
+        self._triggers = triggers
+        self._pause = pause
+        self._on_quiet = on_quiet
+
+        self._burst: _Burst | None = None
+        self._unsubs: list[CALLBACK_TYPE] = []
+
+        # Stopping is synchronous and attaching is not, so an attach can be
+        # suspended while this is set. See `async_stop`.
+        self._stopped = False
+
+    async def async_start(self) -> CALLBACK_TYPE:
+        """Attach every trigger, and refuse the lot if one will not go on."""
+        for index in range(len(self._triggers)):
+            await self._async_attach(index)
+
+            if self._stopped:
+                # Stopped while that was suspended, the same window every
+                # attach in Spook has. `_async_attach` has already let go of
+                # what it took.
+                return self.async_stop
+
+        if len(self._unsubs) != len(self._triggers):
+            # A trigger that is not listening is one that can never start a
+            # burst, so what this reports would be missing the thing somebody
+            # asked about. Raising is what gets the automation marked
+            # unavailable instead of leaving it looking healthy and silent.
+            self.async_stop()
+            msg = "Could not attach every trigger of a debounce trigger"
+            raise HomeAssistantError(msg)
+
+        return self.async_stop
+
+    async def _async_attach(self, index: int) -> None:
+        """Attach one of the triggers and listen for it."""
+
+        async def _fired(
+            variables: dict[str, Any] | None = None,
+            context: Context | None = None,
+        ) -> None:
+            """Take one firing.
+
+            A closure rather than a callable object. Home Assistant decides
+            whether to await an action by inspecting it, and an instance with
+            an async `__call__` is not recognised as awaitable: the coroutine
+            is created, dropped, and nothing is ever counted.
+            """
+            self._async_one_fired(variables, context)
+
+        unsub = await async_attach_nested(
+            self._hass,
+            [self._triggers[index]],
+            _fired,
+            f"trigger {index + 1} of a debounce trigger",
+            "so what it does will go unnoticed",
+        )
+
+        if self._stopped:
+            # Stopped while this was suspended. Nobody is holding the handle
+            # any more, so let go of it here.
+            if unsub is not None:
+                unsub()
+            return
+
+        if unsub is not None:
+            self._unsubs.append(unsub)
+
+    @callback
+    def _async_one_fired(
+        self,
+        variables: dict[str, Any] | None,
+        context: Context | None,
+    ) -> None:
+        """Count one firing and start the wait for quiet over again.
+
+        Nothing here suspends, so there is no lock: two firings at the same
+        moment cannot interleave halfway through this.
+        """
+        if self._stopped:
+            return
+
+        now = dt_util.utcnow()
+        payload = (variables or {}).get("trigger", {})
+
+        if self._burst is None:
+            self._burst = _Burst(started=now, last_at=now)
+        else:
+            self._burst.count += 1
+            self._burst.last_at = now
+
+        self._burst.last = payload
+        self._burst.context = context
+
+        self._async_drop_wait()
+        self._async_start_wait()
+
+    @callback
+    def _async_start_wait(self) -> None:
+        """Wait out the quiet period, on the burst that is running now.
+
+        The wait is tied to the burst that set it. A due callback that arrives
+        after that burst was reported, or after a fresh one started, is
+        answering a question nobody is asking any more.
+        """
+        if (burst := self._burst) is None:
+            return
+
+        @callback
+        def _quiet(_now: datetime) -> None:
+            """Nothing more arrived, so this burst is over."""
+            if self._stopped or self._burst is not burst:
+                return
+
+            # Cleared on the burst this belongs to, so it cannot wipe a newer
+            # one's handle and leave that timer behind.
+            burst.unsub = None
+            self._burst = None
+
+            self._on_quiet(
+                burst.count,
+                burst.last_at - burst.started,
+                burst.last,
+                burst.context,
+            )
+
+        burst.unsub = async_call_later(self._hass, self._pause.total_seconds(), _quiet)
+
+    @callback
+    def _async_drop_wait(self) -> None:
+        """Drop the pending wait, if there is one."""
+        if self._burst is not None and self._burst.unsub is not None:
+            self._burst.unsub()
+            self._burst.unsub = None
+
+    @callback
+    def async_stop(self) -> None:
+        """Detach everything, and refuse to attach any more.
+
+        Stopping is synchronous while attaching is not, so an attach can be
+        suspended inside `async_initialize_triggers` at this very moment.
+        Whatever that takes afterwards would have nobody left to detach it, so
+        the flag tells it to let go of what it just took.
+        """
+        self._stopped = True
+
+        self._async_drop_wait()
+        self._burst = None
+
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+
+
+class SpookTrigger(Trigger):
+    """Spook trigger that fires once something has stopped happening.
+
+    A motion sensor in a hallway does not report motion, it reports motion
+    twenty times. A power meter crossing a threshold crosses it back and forth
+    for a minute. Acting on the first of those is usually wrong and acting on
+    every one of them is always wrong, and what you wanted was to hear about
+    it once, after it settled.
+
+    Written out by hand that is a helper entity and a second automation to
+    turn it off again, which is the most rebuilt pattern on the forum.
+
+    Not the same as `spook.watchdog`, which is about something that never
+    happened at all.
+    """
+
+    trigger = "debounce"
+
+    _triggers: list[ConfigType]
+    _pause: timedelta
+
+    @classmethod
+    async def async_validate_config(
+        cls,
+        hass: HomeAssistant,
+        config: ConfigType,
+    ) -> ConfigType:
+        """Validate the trigger config."""
+        shaped: ConfigType = _TRIGGER_SCHEMA(config)
+        options = shaped[CONF_OPTIONS]
+
+        options[CONF_TRIGGERS] = await trigger_helper.async_validate_trigger_config(
+            hass, options[CONF_TRIGGERS]
+        )
+
+        return shaped
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        options: dict[str, Any] = config.options or {}
+        self._triggers = options[CONF_TRIGGERS]
+        self._pause = options[CONF_FOR]
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,  # noqa: ARG002
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to an action runner."""
+
+        @callback
+        def settled(
+            count: int,
+            span: timedelta,
+            last: dict[str, Any],
+            context: Context | None,
+        ) -> None:
+            """Run the action, the burst having stopped."""
+            description = last.get("description", "it")
+
+            run_action(
+                {
+                    **{key: last[key] for key in _CARRIED_FROM_THE_LAST if key in last},
+                    "count": count,
+                    "span": span,
+                    "for": self._pause,
+                },
+                f"{description}, having settled after {count} in {span}",
+                context,
+            )
+
+        watcher = _BurstWatcher(self._hass, self._triggers, self._pause, settled)
+        return await watcher.async_start()

--- a/custom_components/spook/icons.json
+++ b/custom_components/spook/icons.json
@@ -32,6 +32,9 @@
     "cron": {
       "trigger": "mdi:calendar-clock"
     },
+    "debounce": {
+      "trigger": "mdi:sine-wave"
+    },
     "flapping": {
       "trigger": "mdi:bird"
     },

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -1,5 +1,19 @@
 {
   "triggers": {
+    "debounce": {
+      "name": "Once it settles",
+      "description": "Fires once a trigger has stopped firing for a while, so a burst of them arrives as one. A motion sensor does not report motion once, it reports it twenty times.",
+      "fields": {
+        "triggers": {
+          "name": "Triggers",
+          "description": "The triggers to wait out. Any of them firing starts a burst and any of them firing again keeps it going, so several triggers are collapsed together rather than one at a time."
+        },
+        "for": {
+          "name": "For",
+          "description": "How long it has to have been quiet before this fires. Every firing starts that wait over, so something that never stops firing never gets reported."
+        }
+      }
+    },
     "all_of": {
       "name": "All of these happened",
       "description": "Fires when every one of several triggers has fired inside the same window of time, in any order. Home Assistant's own triggers are a list where any one of them is enough; this is the other one.",

--- a/custom_components/spook/triggers.yaml
+++ b/custom_components/spook/triggers.yaml
@@ -69,6 +69,17 @@ condition_met:
       required: true
       selector:
         condition:
+debounce:
+  fields:
+    triggers:
+      required: true
+      selector:
+        trigger:
+    for:
+      required: true
+      example: "00:00:30"
+      selector:
+        duration:
 all_of:
   fields:
     triggers:

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1148,7 +1148,7 @@ Every firing starts the quiet period over. When it finally runs out, the trigger
 
 Give it more than one trigger and they are waited out together: any of them starts a burst, any of them keeps it going, and the lot arrives as a single report.
 
-When it fires, `trigger.count` is how many firings were collapsed, `trigger.span` is how long the burst lasted from its first firing to its last, not counting the quiet after it, and `trigger.for` is the quiet period you set. The last firing of the burst is lifted to the top, so `trigger.entity_id`, `trigger.to_state` and `trigger.event` mean what they mean in any other trigger, and a condition asking who set the run going still gets an answer.
+When it fires, `trigger.count` is how many firings were collapsed, `trigger.span` is how long the burst lasted from its first firing to its last, not counting the quiet after it, and `trigger.for` is the quiet period you set. The last firing of the burst is lifted to the top, all of it: `trigger.entity_id` and `trigger.to_state` mean what they mean in any other trigger, an MQTT trigger's `trigger.payload` or a calendar trigger's `trigger.calendar_event` are there too, and a condition asking who set the run going still gets an answer. What stays the automation's own is `trigger.id`, `trigger.platform` and the description, and `trigger.for` is always the quiet period, not the `for` of a nested state trigger.
 
 :::{seealso} Example trigger in {term}`YAML`
 :class: dropdown
@@ -1186,7 +1186,7 @@ options:
 :class: dropdown
 
 - Something that never stops firing is never reported. That is what waiting for quiet means, and it is worth knowing before you point this at a sensor that fires every ten seconds all day with a quiet period of a minute.
-- Only counts are kept, not every payload. A burst has no ceiling, and holding hundreds of firings to hand over would be a memory cost for something nobody reads. The last firing is the one you get.
+- The firings before the last are counted, not kept. A burst has no ceiling, and holding hundreds of payloads to hand over would be a memory cost for something nobody reads. The last firing is the one you get, and you get all of it.
 - It fires on the way out, never on the way in. If you want to act on the first of a burst and ignore the rest, that is a different thing and this is not it.
 - A quiet period of zero is refused. It would report the first thing to happen and collapse nothing, which is the trigger you already had, only later.
 - If one of the triggers cannot be attached, the whole thing refuses to load and the automation is marked unavailable. A trigger that is not listening cannot start the burst you asked about.

--- a/documentation/other_features.md
+++ b/documentation/other_features.md
@@ -1106,6 +1106,93 @@ options:
 
 :::
 
+### Once it settles
+
+Fires once a trigger has stopped firing for a while, so a burst of them arrives as one.
+
+```{list-table}
+:header-rows: 1
+* - Trigger properties
+* - Trigger
+  - Once it settles 👻
+* - Trigger name
+  - `spook.debounce`
+* - Targets
+  - No targets
+* - {term}`Spook's influence <influence of spook>`
+  - Newly added trigger
+```
+
+```{list-table}
+:header-rows: 2
+* - Trigger options
+* - Attribute
+  - Type
+  - Required
+  - Default / Example
+* - `triggers`
+  - {term}`list <list>`
+  - Yes
+  - One or more triggers
+* - `for`
+  - {term}`string <string>`
+  - Yes
+  - `00:00:30`
+```
+
+A motion sensor in a hallway does not report motion, it reports motion twenty times. A power meter crossing a threshold crosses it back and forth for a minute. Acting on the first of those is usually wrong and acting on every one of them is always wrong, and what you wanted was to hear about it once, after it settled.
+
+Written out by hand that takes a helper entity and a second automation to turn it off again, which is the most rebuilt pattern on the forum.
+
+Every firing starts the quiet period over. When it finally runs out, the trigger fires once for the whole burst. It is not [](#watchdog), which is about something that never happened at all.
+
+Give it more than one trigger and they are waited out together: any of them starts a burst, any of them keeps it going, and the lot arrives as a single report.
+
+When it fires, `trigger.count` is how many firings were collapsed, `trigger.span` is how long the burst lasted from its first firing to its last, not counting the quiet after it, and `trigger.for` is the quiet period you set. The last firing of the burst is lifted to the top, so `trigger.entity_id`, `trigger.to_state` and `trigger.event` mean what they mean in any other trigger, and a condition asking who set the run going still gets an answer.
+
+:::{seealso} Example trigger in {term}`YAML`
+:class: dropdown
+
+Motion in the hallway, reported once, thirty seconds after it stopped:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.debounce
+options:
+  for: "00:00:30"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.hallway_motion
+      to: "on"
+```
+
+Somebody is finished at the front door, whichever way they left it:
+
+```{code-block} yaml
+:linenos:
+trigger: spook.debounce
+options:
+  for: "00:01:00"
+  triggers:
+    - trigger: state
+      entity_id: binary_sensor.front_door
+    - trigger: state
+      entity_id: lock.front_door
+```
+
+:::
+
+:::{attention} Known limitations
+:class: dropdown
+
+- Something that never stops firing is never reported. That is what waiting for quiet means, and it is worth knowing before you point this at a sensor that fires every ten seconds all day with a quiet period of a minute.
+- Only counts are kept, not every payload. A burst has no ceiling, and holding hundreds of firings to hand over would be a memory cost for something nobody reads. The last firing is the one you get.
+- It fires on the way out, never on the way in. If you want to act on the first of a burst and ignore the rest, that is a different thing and this is not it.
+- A quiet period of zero is refused. It would report the first thing to happen and collapse nothing, which is the trigger you already had, only later.
+- If one of the triggers cannot be attached, the whole thing refuses to load and the automation is marked unavailable. A trigger that is not listening cannot start the burst you asked about.
+
+:::
+
 ### Triggers in order
 
 Fires when several triggers happen one after another, in the order given.

--- a/documentation/triggers.md
+++ b/documentation/triggers.md
@@ -39,6 +39,12 @@ Fires when a configuration entry has been unable to set itself up for a while, p
 
 `spook.integration_failed`, [documentation](other-features#integration-failed-to-set-up) 📚
 
+## Once it settles
+
+Fires once a trigger has stopped firing for a while, so a burst of them arrives as one. A motion sensor does not report motion once, it reports it twenty times. _#debounce_ _#burst_ _#quiet_
+
+`spook.debounce`, [documentation](other-features#once-it-settles) 📚
+
 ## Repair issue created
 
 Fires when a new repair issue turns up, so you hear about one without visiting the repairs page. Can be narrowed by integration and severity. _#repairs_ _#issue_

--- a/tests/ectoplasms/spook/triggers/test_debounce.py
+++ b/tests/ectoplasms/spook/triggers/test_debounce.py
@@ -1,0 +1,369 @@
+"""Tests for the spook.debounce trigger."""
+
+# pylint: disable=protected-access,wrong-import-order
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+from homeassistant.core import Context
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.trigger import TriggerConfig
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+import pytest
+import voluptuous as vol
+
+from custom_components.spook.ectoplasms.spook.triggers import (
+    debounce as debounce_module,
+)
+from custom_components.spook.ectoplasms.spook.triggers.debounce import SpookTrigger
+from custom_components.spook.trigger import async_get_triggers
+from tests.nested_trigger_helpers import async_stop_while_attaching
+
+# Importing Spook puts it in `sys.modules`, which is what lets Home Assistant's
+# loader resolve the integration when it goes looking for the trigger platform.
+import custom_components.spook  # noqa: F401  # pylint: disable=unused-import
+
+if TYPE_CHECKING:
+    from freezegun.api import FrozenDateTimeFactory
+
+    from homeassistant.core import HomeAssistant
+
+MOTION = {"trigger": "state", "entity_id": "binary_sensor.motion", "to": "on"}
+DOOR = {"trigger": "state", "entity_id": "binary_sensor.door", "to": "on"}
+
+HALF_A_MINUTE = timedelta(seconds=30)
+THREE = 3
+TWO = 2
+
+
+async def _automation(
+    hass: HomeAssistant,
+    options: dict[str, Any] | None = None,
+) -> list[dict]:
+    """Set up an automation on the trigger and record every run."""
+    runs: list[dict] = []
+
+    async def _mark(call) -> None:  # noqa: ANN001
+        runs.append(dict(call.data))
+
+    hass.services.async_register("test", "mark", _mark)
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "alias": "settled",
+                    "trigger": {
+                        "platform": "spook.debounce",
+                        "options": options or {"triggers": [MOTION], "for": "00:00:30"},
+                    },
+                    "action": [
+                        {
+                            "action": "test.mark",
+                            "data": {
+                                "count": "{{ trigger.count }}",
+                                "span": "{{ trigger.span }}",
+                                "entity_id": "{{ trigger.entity_id }}",
+                            },
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    return runs
+
+
+async def _detach(hass: HomeAssistant) -> None:
+    """Turn the automation off, which detaches its trigger.
+
+    The harness fails a test that leaves a timer or listener behind, and this
+    trigger holds both, so this doubles as a check that it clears up.
+    """
+    await hass.services.async_call(
+        "automation", "turn_off", {"entity_id": "automation.settled"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+
+async def _wait_out(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
+    """Let the quiet period pass with nothing happening in it."""
+    freezer.tick(timedelta(seconds=31))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+async def _motion(hass: HomeAssistant) -> None:
+    """Report motion once."""
+    hass.states.async_set("binary_sensor.motion", "off")
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+
+async def test_the_trigger_is_discovered(hass: HomeAssistant) -> None:
+    """The trigger turns up in Spook's discovery, under a plain key."""
+    assert "debounce" in await async_get_triggers(hass)
+
+
+@pytest.mark.parametrize("pause", [{"seconds": 0}, "00:00:00", 0])
+async def test_a_zero_pause_is_refused(hass: HomeAssistant, pause: object) -> None:
+    """Zero collapses nothing: it is the trigger it was given, only slower."""
+    with pytest.raises(vol.Invalid, match="longer than zero"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"triggers": [MOTION], "for": pause}}
+        )
+
+
+async def test_a_pause_is_required(hass: HomeAssistant) -> None:
+    """Without one there is nothing to wait out."""
+    with pytest.raises(vol.Invalid):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"triggers": [MOTION]}}
+        )
+
+
+async def test_one_firing_is_reported_once_the_quiet_has_passed(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Nothing is reported while it might still be a burst."""
+    runs = await _automation(hass)
+
+    await _motion(hass)
+    assert runs == []
+
+    await _wait_out(hass, freezer)
+
+    assert len(runs) == 1
+    assert runs[0]["count"] == 1
+    assert runs[0]["entity_id"] == "binary_sensor.motion"
+
+    await _detach(hass)
+
+
+async def test_a_burst_arrives_as_one(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The point of the whole thing."""
+    runs = await _automation(hass)
+
+    await _motion(hass)
+    freezer.tick(timedelta(seconds=5))
+    await _motion(hass)
+    freezer.tick(timedelta(seconds=5))
+    await _motion(hass)
+    assert runs == []
+
+    await _wait_out(hass, freezer)
+
+    assert len(runs) == 1
+    assert runs[0]["count"] == THREE
+    # From the first of the burst to the last, not counting the quiet after.
+    assert runs[0]["span"] == "0:00:10"
+
+    await _detach(hass)
+
+
+async def test_every_firing_starts_the_wait_over(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A burst that keeps going is not reported at its first deadline.
+
+    Twenty seconds in, motion again. The original deadline passes with nothing
+    reported, because the quiet period restarted and has not run out yet.
+    """
+    runs = await _automation(hass)
+
+    await _motion(hass)
+
+    freezer.tick(timedelta(seconds=20))
+    await _motion(hass)
+
+    # Past the deadline the first firing would have had.
+    freezer.tick(timedelta(seconds=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert runs == []
+
+    await _wait_out(hass, freezer)
+    assert len(runs) == 1
+
+    await _detach(hass)
+
+
+async def test_two_bursts_are_two_reports(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Once reported, the next firing starts something new."""
+    runs = await _automation(hass)
+
+    await _motion(hass)
+    await _wait_out(hass, freezer)
+    assert len(runs) == 1
+
+    await _motion(hass)
+    await _wait_out(hass, freezer)
+
+    assert len(runs) == TWO
+    assert runs[1]["count"] == 1
+
+    await _detach(hass)
+
+
+async def test_several_triggers_are_collapsed_together(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Any of them keeps the burst going, and the lot arrives as one report."""
+    runs = await _automation(hass, {"triggers": [MOTION, DOOR], "for": "00:00:30"})
+
+    await _motion(hass)
+    freezer.tick(timedelta(seconds=20))
+    hass.states.async_set("binary_sensor.door", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(seconds=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert runs == []
+
+    await _wait_out(hass, freezer)
+
+    assert len(runs) == 1
+    # The last one to fire is the one at the top of the payload.
+    assert runs[0]["entity_id"] == "binary_sensor.door"
+
+    await _detach(hass)
+
+
+async def test_the_payload_comes_from_the_last_firing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Including its context, so Spook's context conditions still work.
+
+    Handing over a fresh context would make every settled burst read as
+    nobody's doing, even when a person was behind the last of it.
+    """
+    fired: list[tuple[dict, Context | None]] = []
+
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [MOTION], "for": "00:00:30"}}
+    )
+    trigger = SpookTrigger(
+        hass, TriggerConfig(key="debounce", options=config["options"])
+    )
+
+    def _run(payload, _description, context=None) -> None:  # noqa: ANN001
+        fired.append((payload, context))
+
+    unsub = await trigger.async_attach_runner(_run)
+
+    hass.states.async_set("binary_sensor.motion", "off")
+    hass.states.async_set("binary_sensor.motion", "on")
+    await hass.async_block_till_done()
+
+    freezer.tick(timedelta(seconds=5))
+    hass.states.async_set("binary_sensor.motion", "off")
+    theirs = Context(user_id="abc123")
+    hass.states.async_set("binary_sensor.motion", "on", context=theirs)
+    await hass.async_block_till_done()
+
+    await _wait_out(hass, freezer)
+    unsub()
+
+    assert len(fired) == 1
+    payload, context = fired[0]
+    assert context is theirs
+    assert payload["to_state"].context is theirs
+    assert payload["count"] == TWO
+    assert payload["for"] == HALF_A_MINUTE
+
+
+async def test_a_trigger_that_will_not_attach_refuses_the_lot(
+    hass: HomeAssistant,
+) -> None:
+    """A trigger that is not listening cannot start the burst somebody asked about."""
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [MOTION], "for": "00:00:30"}}
+    )
+    trigger = SpookTrigger(
+        hass, TriggerConfig(key="debounce", options=config["options"])
+    )
+
+    def _run(_payload, _description, _context=None) -> None:  # noqa: ANN001
+        """Never called."""
+
+    with (
+        patch(
+            "custom_components.spook.ectoplasms.spook.triggers.debounce"
+            ".async_attach_nested",
+            return_value=None,
+        ),
+        pytest.raises(HomeAssistantError, match="every trigger"),
+    ):
+        await trigger.async_attach_runner(_run)
+
+
+async def test_stopping_while_attaching_leaves_nothing_behind(
+    hass: HomeAssistant,
+) -> None:
+    """The same window every attach in Spook has."""
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [MOTION, DOOR], "for": "00:00:30"}}
+    )
+    watcher = debounce_module._BurstWatcher(  # noqa: SLF001
+        hass, config["options"]["triggers"], HALF_A_MINUTE, lambda *_args: None
+    )
+
+    await async_stop_while_attaching(hass, watcher, holding="trigger 2")
+
+    assert not watcher._unsubs, "a listener was left behind"  # noqa: SLF001
+
+    watcher.async_stop()
+
+
+async def test_a_wait_left_over_from_a_gone_burst_reports_nothing(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The wait is tied to the burst that set it.
+
+    Reached directly, because nothing in normal running can produce it: the
+    pending wait is always dropped before a new one starts, and a cancelled
+    timer cannot fire. It is a net under the case where a wait outlives the
+    burst it belongs to, and a net nobody has pulled on is not a net.
+    """
+    reported: list[int] = []
+
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [MOTION], "for": "00:00:30"}}
+    )
+    watcher = debounce_module._BurstWatcher(  # noqa: SLF001
+        hass,
+        config["options"]["triggers"],
+        HALF_A_MINUTE,
+        lambda count, *_args: reported.append(count),
+    )
+    stop = await watcher.async_start()
+
+    await _motion(hass)
+    assert watcher._burst is not None, "the firing started no burst"  # noqa: SLF001
+
+    # The burst goes, its wait does not. That is the shape this guards.
+    watcher._burst = None  # noqa: SLF001
+
+    await _wait_out(hass, freezer)
+
+    assert not reported
+
+    stop()

--- a/tests/ectoplasms/spook/triggers/test_debounce.py
+++ b/tests/ectoplasms/spook/triggers/test_debounce.py
@@ -3,18 +3,21 @@
 # pylint: disable=protected-access,wrong-import-order
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from homeassistant.core import Context
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import trigger as trigger_helper
 from homeassistant.helpers.trigger import TriggerConfig
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 import pytest
 import voluptuous as vol
 
+from custom_components.spook import trigger_nesting
 from custom_components.spook.ectoplasms.spook.triggers import (
     debounce as debounce_module,
 )
@@ -33,6 +36,12 @@ if TYPE_CHECKING:
 
 MOTION = {"trigger": "state", "entity_id": "binary_sensor.motion", "to": "on"}
 DOOR = {"trigger": "state", "entity_id": "binary_sensor.door", "to": "on"}
+POWER_THRESHOLD = 100
+POWER = {
+    "trigger": "numeric_state",
+    "entity_id": "sensor.power",
+    "above": POWER_THRESHOLD,
+}
 
 HALF_A_MINUTE = timedelta(seconds=30)
 THREE = 3
@@ -60,6 +69,7 @@ async def _automation(
                     "alias": "settled",
                     "trigger": {
                         "platform": "spook.debounce",
+                        "id": "settled",
                         "options": options or {"triggers": [MOTION], "for": "00:00:30"},
                     },
                     "action": [
@@ -69,6 +79,8 @@ async def _automation(
                                 "count": "{{ trigger.count }}",
                                 "span": "{{ trigger.span }}",
                                 "entity_id": "{{ trigger.entity_id }}",
+                                "id": "{{ trigger.id }}",
+                                "platform": "{{ trigger.platform }}",
                             },
                         }
                     ],
@@ -117,6 +129,18 @@ async def test_a_zero_pause_is_refused(hass: HomeAssistant, pause: object) -> No
     with pytest.raises(vol.Invalid, match="longer than zero"):
         await SpookTrigger.async_validate_config(
             hass, {"options": {"triggers": [MOTION], "for": pause}}
+        )
+
+
+async def test_no_triggers_at_all_is_refused(hass: HomeAssistant) -> None:
+    """Nothing to attach is nothing that can fail, and nothing that can ever fire.
+
+    Home Assistant's own trigger schema lets an empty list through, so without
+    this the automation would load, look healthy, and stay silent for good.
+    """
+    with pytest.raises(vol.Invalid, match="at least one trigger"):
+        await SpookTrigger.async_validate_config(
+            hass, {"options": {"triggers": [], "for": "00:00:30"}}
         )
 
 
@@ -241,6 +265,10 @@ async def test_several_triggers_are_collapsed_together(
     assert len(runs) == 1
     # The last one to fire is the one at the top of the payload.
     assert runs[0]["entity_id"] == "binary_sensor.door"
+    # But not its `id` and `platform`. Those are the automation's own, and a
+    # `choose` keyed on `trigger.id` has to keep working.
+    assert runs[0]["id"] == "settled"
+    assert runs[0]["platform"] == "spook.debounce"
 
     await _detach(hass)
 
@@ -289,6 +317,46 @@ async def test_the_payload_comes_from_the_last_firing(
     assert payload["for"] == HALF_A_MINUTE
 
 
+async def test_the_whole_of_the_last_firing_comes_through(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Not just the four keys every trigger has.
+
+    The other nested triggers hand over every payload in a list and lift only
+    the common keys to the top. This one keeps no list, so the last firing is
+    the only payload there is, and an automation asking what value settled
+    would otherwise have nowhere to look.
+    """
+    fired: list[dict] = []
+
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [POWER], "for": "00:00:30"}}
+    )
+    trigger = SpookTrigger(
+        hass, TriggerConfig(key="debounce", options=config["options"])
+    )
+
+    def _run(payload, _description, _context=None) -> None:  # noqa: ANN001
+        fired.append(payload)
+
+    unsub = await trigger.async_attach_runner(_run)
+
+    hass.states.async_set("sensor.power", "50")
+    hass.states.async_set("sensor.power", "150")
+    await hass.async_block_till_done()
+
+    await _wait_out(hass, freezer)
+    unsub()
+
+    assert len(fired) == 1
+    # `above` is the numeric_state trigger's own, and it is there.
+    assert fired[0]["above"] == POWER_THRESHOLD
+    assert fired[0]["entity_id"] == "sensor.power"
+    # What Home Assistant lays underneath for the automation is left to it.
+    assert debounce_module._THE_AUTOMATIONS_OWN.isdisjoint(fired[0])  # noqa: SLF001
+
+
 async def test_a_trigger_that_will_not_attach_refuses_the_lot(
     hass: HomeAssistant,
 ) -> None:
@@ -312,6 +380,66 @@ async def test_a_trigger_that_will_not_attach_refuses_the_lot(
         pytest.raises(HomeAssistantError, match="every trigger"),
     ):
         await trigger.async_attach_runner(_run)
+
+
+async def test_a_firing_that_lands_mid_attach_goes_with_a_failed_attach(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A trigger already attached can fire while a later one is still attaching.
+
+    That firing is counted, as it is in `spook.all_of` and in a plain list of
+    triggers, which Home Assistant attaches side by side. The question is what
+    becomes of the wait it started when the later attach then fails: the lot is
+    refused, and the wait has to go with it rather than report a burst on
+    behalf of a trigger that no longer exists.
+    """
+    reported: list[int] = []
+
+    config = await SpookTrigger.async_validate_config(
+        hass, {"options": {"triggers": [MOTION, DOOR], "for": "00:00:30"}}
+    )
+    watcher = debounce_module._BurstWatcher(  # noqa: SLF001
+        hass,
+        config["options"]["triggers"],
+        HALF_A_MINUTE,
+        lambda count, *_args: reported.append(count),
+    )
+
+    real = trigger_helper.async_initialize_triggers
+    hold = asyncio.Event()
+    attaching = asyncio.Event()
+
+    async def _second_one_fails(*args: Any, **kwargs: Any):  # noqa: ANN202
+        if "trigger 2" not in args[4]:
+            return await real(*args, **kwargs)
+        attaching.set()
+        await hold.wait()
+        return None
+
+    with patch.object(
+        trigger_nesting.trigger_helper, "async_initialize_triggers", _second_one_fails
+    ):
+        starting = hass.async_create_task(watcher.async_start())
+        async with asyncio.timeout(5):
+            await attaching.wait()
+
+        # Trigger 1 is listening and trigger 2 is not yet. Motion, right now.
+        hass.states.async_set("binary_sensor.motion", "off")
+        hass.states.async_set("binary_sensor.motion", "on")
+        assert watcher._burst is not None, "the firing was not counted"  # noqa: SLF001
+
+        hold.set()
+        with pytest.raises(HomeAssistantError, match="every trigger"):
+            async with asyncio.timeout(5):
+                await starting
+        await hass.async_block_till_done()
+
+    assert watcher._burst is None, "the wait outlived the refusal"  # noqa: SLF001
+    assert not watcher._unsubs, "a listener was left behind"  # noqa: SLF001
+
+    await _wait_out(hass, freezer)
+    assert not reported
 
 
 async def test_stopping_while_attaching_leaves_nothing_behind(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A new trigger, `spook.debounce`:

```yaml
trigger: spook.debounce
options:
  for: "00:00:30"
  triggers:
    - trigger: state
      entity_id: binary_sensor.hallway_motion
      to: "on"
```

A motion sensor in a hallway does not report motion, it reports motion twenty times. A power meter crossing a threshold crosses it back and forth for a minute. Acting on the first of those is usually wrong and acting on every one of them is always wrong, and what you wanted was to hear about it once, after it settled. Written out by hand that takes a helper entity plus a second automation to turn it off again, which is the most rebuilt pattern on the forum.

Every firing starts the quiet period over. Give it more than one trigger and they are waited out together: any of them starts a burst, any of them keeps it going, and the lot arrives as a single report. It is not `spook.watchdog`, which is about something that never happened at all.

The decisions worth arguing about:

- **The firings before the last are counted, not kept.** Unlike `spook.all_of`, where the members bound the collection, a burst has no ceiling: a sensor that will not settle can fire hundreds of times, and holding all of that to hand over is a memory cost for something nobody reads. What comes out is `count`, `span` and the last firing, whole, with that firing's context so the context conditions still work. Whole is the word review changed: the other nested triggers lift four common keys and hand the rest over in a list, and this one has no list, so an MQTT `payload` or a calendar `calendar_event` would simply have been gone. Everything comes through now except the five keys Home Assistant lays down for the automation itself (`id`, `idx`, `alias`, `platform` and the description), which a nested payload must not overwrite, and `for` is set after the merge so it stays the quiet period rather than a nested state trigger's own.
- **An empty list of triggers is refused.** `cv.TRIGGER_SCHEMA` lets one through, and nothing to attach is nothing that can fail, so the automation would have loaded, looked healthy and never fired. Review caught it.
- **It fires on the way out, never on the way in.** A leading-edge variant is a different trigger and this is not it.
- **Something that never stops firing is never reported.** That is what waiting for quiet means, and it is in the documented limitations rather than papered over with a maximum wait.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Second of the building-block set, after #1584.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Seventeen tests, most through a real automation so the payload is checked as an action receives it, plus the stop-during-attach test on the shared harness from #1584.

Three mutations, and the third is the one worth reading:

| Mutation | Result |
| --- | --- |
| Do not restart the wait on a later firing | 2 failures |
| Never clear the burst, so a second one continues the first | 1 failure |
| Drop the burst-identity guard on the pending wait | **nothing**, at first |
| Drop the empty-list refusal | 1 failure |
| Back to the four-key allowlist | 1 failure |
| Merge the nested payload wholesale | 2 failures |
| A refused attach no longer drops the pending wait | 1 failure, and the harness catching the timer it left behind |

That third guard could not be reached: the pending wait is always dropped before a new one starts, and a cancelled timer cannot fire, so nothing in normal running produces a wait that outlives its burst. Rather than delete a net or ship an unexercised branch, there is now a test that reaches the state directly and pulls on it.

Review also asked about a trigger firing while a later one is still attaching. That firing is counted, the same as in `spook.all_of` and in a plain list of triggers, which Home Assistant attaches side by side and acts on whichever is already listening. What matters is that the wait it starts goes with a refused attach, and there is now a test that holds the second attach open, fires the first trigger, fails the second, and checks nothing is reported and nothing is left behind.

Full suite: 1699 passed. Whole-tree pylint is clean, which I checked this time rather than scoping it to the files I touched, per the lesson from #1584.

**One thing I left alone, and you may disagree.** `_BurstWatcher` and `_AllOfWatcher` share about 25 identical lines of attach lifecycle: attach each trigger, guard against being stopped mid-attach, refuse the lot if one will not go on. The case for extracting it is that this exact race has been found at several different attach sites in this codebase, one review round at a time, and one place would be tested once. The case against is that two users is under the bar I have been holding elsewhere today, and what differs between them is the naming and the consequence, which is the part that carries the meaning. Pylint does not flag it. Happy to pull it out if you would rather.

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

