### PR TITLE
Add button to manually check all HACS repositories for updates

### DIFF
--- a/custom_components/spook/ectoplasms/hacs/__init__.py
+++ b/custom_components/spook/ectoplasms/hacs/__init__.py
@@ -1,0 +1,1 @@
+"""Spook - Your homie."""

--- a/custom_components/spook/ectoplasms/hacs/button.py
+++ b/custom_components/spook/ectoplasms/hacs/button.py
@@ -1,0 +1,95 @@
+"""Spook - Your homie. A shortcut past HACS's own update check schedule."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.components.homeassistant import (
+    DOMAIN as HOMEASSISTANT_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory, Platform
+from homeassistant.helpers import entity_registry as er
+
+from ...entity import SpookEntityDescription
+from .entity import HACS_DOMAIN, HACSSpookEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+@dataclass(frozen=True, kw_only=True)
+class HACSSpookButtonEntityDescription(
+    SpookEntityDescription,
+    ButtonEntityDescription,
+):
+    """Class describing Spook HACS button entities."""
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    _entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Spook HACS check-for-updates button.
+
+    Only put up when HACS itself is loaded. Without it there is nothing to
+    ask, and a button that always errors out on press is worse than no
+    button at all.
+    """
+    if HACS_DOMAIN not in hass.config.components:
+        return
+
+    async_add_entities(
+        [
+            HACSCheckForUpdatesButtonEntity(
+                HACSSpookButtonEntityDescription(
+                    key="check_for_updates",
+                    translation_key="hacs_check_for_updates",
+                    entity_id="button.hacs_check_for_updates",
+                    icon="mdi:update",
+                    entity_category=EntityCategory.CONFIG,
+                ),
+            ),
+        ],
+    )
+
+
+class HACSCheckForUpdatesButtonEntity(HACSSpookEntity, ButtonEntity):
+    """Spook button that has HACS look for updates right now.
+
+    Pressing it asks Home Assistant to poll every one of HACS's own update
+    entities straight away: the same as calling `homeassistant.update_entity`
+    on all of them by hand, for whoever would rather not open Developer Tools
+    to do it. HACS decides what counts as an update; this only decides when
+    HACS is asked.
+    """
+
+    entity_description: HACSSpookButtonEntityDescription
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        registry = er.async_get(self.hass)
+        entity_ids = [
+            entry.entity_id
+            for entry in registry.entities.values()
+            if entry.platform == HACS_DOMAIN and entry.domain == Platform.UPDATE
+        ]
+
+        # Nothing tracked yet, so nothing to ask about. Calling the service
+        # with an empty list of entities is not the same as calling it with
+        # none at all: that would poll every update entity Home Assistant
+        # has, HACS's or not, which is not what pressing this button says.
+        if not entity_ids:
+            return
+
+        await self.hass.services.async_call(
+            HOMEASSISTANT_DOMAIN,
+            SERVICE_UPDATE_ENTITY,
+            {ATTR_ENTITY_ID: entity_ids},
+            blocking=True,
+        )

--- a/custom_components/spook/ectoplasms/hacs/button.py
+++ b/custom_components/spook/ectoplasms/hacs/button.py
@@ -77,7 +77,11 @@ class HACSCheckForUpdatesButtonEntity(HACSSpookEntity, ButtonEntity):
         entity_ids = [
             entry.entity_id
             for entry in registry.entities.values()
-            if entry.platform == HACS_DOMAIN and entry.domain == Platform.UPDATE
+            if (
+                entry.platform == HACS_DOMAIN
+                and entry.domain == Platform.UPDATE
+                and entry.disabled_by is None
+           )
         ]
 
         # Nothing tracked yet, so nothing to ask about. Calling the service

--- a/custom_components/spook/ectoplasms/hacs/entity.py
+++ b/custom_components/spook/ectoplasms/hacs/entity.py
@@ -1,0 +1,29 @@
+"""Spook - Your homie."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from ...const import DOMAIN
+from ...entity import SpookEntity, SpookEntityDescription
+
+# HACS is a custom integration, not a part of Home Assistant core, so there is
+# nothing under `homeassistant.components` to import its domain from. Spelled
+# out here rather than imported, so this ectoplasm never needs HACS installed
+# to be imported itself, only to do anything.
+HACS_DOMAIN = "hacs"
+
+
+class HACSSpookEntity(SpookEntity):
+    """Defines a base Spook entity for HACS related entities."""
+
+    def __init__(self, description: SpookEntityDescription) -> None:
+        """Initialize the entity."""
+        super().__init__(description=description)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, HACS_DOMAIN)},
+            manufacturer="HACS",
+            name="HACS",
+            configuration_url="https://hacs.xyz/",
+        )
+        self._attr_unique_id = f"{HACS_DOMAIN}_{description.key}"

--- a/custom_components/spook/manifest.json
+++ b/custom_components/spook/manifest.json
@@ -8,6 +8,7 @@
     "counter",
     "energy",
     "group",
+    "hacs",
     "light",
     "proximity",
     "script",

--- a/custom_components/spook/translations/en.json
+++ b/custom_components/spook/translations/en.json
@@ -281,6 +281,9 @@
   },
   "entity": {
     "button": {
+      "hacs_check_for_updates": {
+        "name": "Check for updates"
+      },
       "homeassistant_reload": {
         "name": "Reload"
       },

--- a/documentation/_toc.yml
+++ b/documentation/_toc.yml
@@ -37,6 +37,7 @@ parts:
       - file: integrations/group
       - file: integrations/cloud
       - file: integrations/energy
+      - file: integrations/hacs
       - file: integrations/homeassistant
       - file: integrations/input_number
       - file: integrations/input_select

--- a/documentation/enhanced_integrations.md
+++ b/documentation/enhanced_integrations.md
@@ -44,6 +44,12 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 [![](https://brands.home-assistant.io/group/icon.png)](integrations/group)
 :::
 
+:::{card} HACS
+:footer: 📚 [Learn more](integrations/hacs)
+
+[![](https://brands.home-assistant.io/hacs/icon.png)](integrations/hacs)
+:::
+
 :::{card} Home Assistant Cloud
 :footer: 📚 [Learn more](integrations/cloud)
 

--- a/documentation/enhanced_integrations.md
+++ b/documentation/enhanced_integrations.md
@@ -47,7 +47,7 @@ Spook enhances the following {term}`Home Assistant` {term}`integrations <integra
 :::{card} HACS
 :footer: 📚 [Learn more](integrations/hacs)
 
-[![](https://brands.home-assistant.io/hacs/icon.png)](integrations/hacs)
+[![HACS brand icon](https://brands.home-assistant.io/hacs/icon.png)](integrations/hacs)
 :::
 
 :::{card} Home Assistant Cloud

--- a/documentation/integrations/hacs.md
+++ b/documentation/integrations/hacs.md
@@ -1,0 +1,58 @@
+---
+subject: Enhanced integrations
+title: HACS
+subtitle: Skip the wait on HACS's own update check.
+description: Spook adds a button that asks Home Assistant to poll every HACS update entity right away, instead of waiting for HACS's own scheduled check.
+date: 2026-09-04T00:00:00+02:00
+---
+
+```{image} https://brands.home-assistant.io/hacs/logo.png
+:alt: The HACS logo
+:width: 250px
+:align: center
+```
+
+<br><br>
+
+[HACS](https://hacs.xyz) is a third-party {term}`integration` that lets you install and track community-made integrations, Lovelace cards, and other add-ons from outside the Home Assistant default repositories. It already creates an {term}`entity` of the {term}`update` {term}`platform` for every repository it tracks, complete with an install button, so those show up in Home Assistant's own updates overview without Spook's help.
+
+HACS checks those repositories for updates on its own schedule, spread out so it does not burn through GitHub's rate limit checking hundreds of repositories at once. That pace is right for HACS as a whole, and the wrong one for somebody who has just pushed a new release of their own integration or card and wants Home Assistant to notice it now, rather than whenever HACS gets around to it.
+
+Spook adds a single button for that: pressing it has Home Assistant poll every one of HACS's update entities immediately, the same as calling the `homeassistant.update_entity` {term}`action` on all of them by hand from Developer Tools.
+
+## Devices & entities
+
+Spook adds a single new device with an entity for this integration to your Home Assistant instance, shown only while HACS itself is set up.
+
+### Buttons
+
+#### Check for updates
+
+_Default {term}`entity ID <Entity ID>`: `button.hacs_check_for_updates`_
+
+Asks Home Assistant to immediately check every HACS-tracked {term}`update` entity for a newer version, instead of waiting for HACS's own scheduled check.
+
+## Actions
+
+Spook does not provide action enhancements for this integration.
+
+## Repairs
+
+Spook has no repair detections for this integration.
+
+## Use cases
+
+Some use cases for the enhancement Spook provides for this integration:
+
+- Press the button right after pushing a release of an integration or card you develop yourself, so it shows up as an available update straight away instead of after HACS's next scheduled scan.
+- Call the button's underlying `button.press` {term}`action` from an automation right after you know a repository you track was updated.
+
+## Blueprints & tutorials
+
+There are currently no known {term}`blueprints <blueprint>` or tutorials for the enhancements Spook provides for this integration. If you created one or stumbled upon one, [please let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+## Feature requests, ideas, and support
+
+If you have an idea on how to further enhance this integration, for example, by adding a new action, entity, or repairs detection; feel free to [let us know in our discussion forums](https://github.com/frenck/spook/discussions).
+
+Are you stuck using these new features? Or maybe you've run into a bug? Please check the [](../support) page on where to go for help.


### PR DESCRIPTION
Description

Adds a new Spook ectoplasm for HACS: a single button entity, button.hacs_check_for_updates, that only appears once HACS itself is set up. Pressing it looks up every update.* entity that belongs to HACS in the entity registry and calls the built-in homeassistant.update_entity action on all of them at once, forcing an immediate check instead of waiting for HACS's own scheduled scan.

Nothing here duplicates HACS itself: HACS 2.0+ already creates clickable, install-able update entities for every tracked integration and frontend card on its own — that part needed no code. The one real gap is that HACS's own recheck schedule is spread out to stay within GitHub's API rate limit, so a repository's own developer who just pushed a new release has no quick way to make Home Assistant notice it without opening Developer Tools and calling the action by hand. This button is that shortcut.
Motivation and Context

Requested to add update-checking for HACS integrations/cards, alongside the update checking Spook already has for blueprints. After confirming HACS already provides clickable per-repository update entities and that homeassistant.update_entity already forces an immediate recheck, the remaining gap (raised directly by the requester, who develops their own integrations) was the day-to-day friction of triggering that recheck without digging into Developer Tools.
How has this been tested?

Home Assistant / pytest-homeassistant-custom-component could not be installed in this sandbox (pinned to Python 3.14.2+, and only a 3.14.0rc2 build is available here), so the full test suite could not be run directly. Instead:

    ruff check and ruff format --check pass clean on the new files.
    pylint was run against the new files and against existing, already-merged files with the same base-class shape (ectoplasms/cloud/entity.py, ectoplasms/homeassistant/button.py); both show the identical import-error/too-few-public-methods findings, confirming these are artifacts of homeassistant not being importable in this sandbox rather than anything specific to this change.
    The logic behind tests/test_documentation_index.py (integration pages vs. cards in enhanced_integrations.md/_toc.yml) and tests/test_translations.py (no blank translation strings) was reproduced manually against the changed files; both pass.
    python -m py_compile on the new modules, and a JSON parse of the updated en.json.

Screenshots (if appropriate):

N/A — a new button entity, no UI beyond a standard entity card.
Types of changes

    Bug fix (non-breaking change which fixes an issue)
    New feature (non-breaking change which adds functionality)
    Breaking change (fix or feature that would cause existing functionality to not work as expected)
    Other

Checklist

    My code follows the code style of this project.
    My change requires a change to the documentation.
    I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxCe47uR5ZAeBUqSdjxvGM

Generated by [Claude Code](https://claude.ai/code/session_01PxCe47uR5ZAeBUqSdjxvGM)